### PR TITLE
Update the end screen warning text based on the available actions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.formentry
 
 import android.content.Context
 import android.view.LayoutInflater
+import android.view.View
 import androidx.core.view.isVisible
 import androidx.core.widget.NestedScrollView
 import org.odk.collect.android.R
@@ -28,8 +29,22 @@ class FormEndView(
         binding.finalize.setOnClickListener {
             listener.onSaveClicked(true)
         }
-        if (formEndViewModel.shouldFormBeSentAutomatically()) {
+
+        val shouldFormBeSentAutomatically = formEndViewModel.shouldFormBeSentAutomatically()
+        if (shouldFormBeSentAutomatically) {
             binding.finalize.text = context.getString(R.string.send)
+        }
+
+        if (!binding.saveAsDraft.isVisible && !shouldFormBeSentAutomatically) {
+            binding.formEditsWarningMessage.setText(R.string.form_edits_warning_only_finalize_enabled)
+        } else if (binding.saveAsDraft.isVisible && binding.finalize.isVisible) {
+            if (shouldFormBeSentAutomatically) {
+                binding.formEditsWarningMessage.setText(R.string.form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled)
+            } else {
+                binding.formEditsWarningMessage.setText(R.string.form_edits_warning_save_as_draft_and_finalize_enabled)
+            }
+        } else {
+            binding.formEditsWarning.visibility = View.GONE
         }
     }
 

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -64,14 +64,15 @@ the specific language governing permissions and limitations under the License.
                     app:tint="?colorPrimary" />
 
                 <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/form_edits_warning_message"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin"
-                    android:text="@string/form_edits_warning"
                     android:textAppearance="?textAppearanceBodyLarge"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/instance_name_info_icon"
-                    app:layout_constraintTop_toTopOf="@id/instance_name_info_icon" />
+                    app:layout_constraintTop_toTopOf="@id/instance_name_info_icon"
+                    tools:text="@string/form_edits_warning_save_as_draft_and_finalize_enabled"/>
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -31,7 +31,7 @@ the specific language governing permissions and limitations under the License.
             android:textSize="21sp"
             android:textStyle="bold"
             app:layout_constraintBottom_toTopOf="@+id/form_edits_warning"
-            app:layout_constraintStart_toStartOf="@id/form_edits_warning"
+            app:layout_constraintStart_toStartOf="@id/buttons_container"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_chainStyle="packed"
             tools:text="You are at the end of All widgets" />
@@ -81,9 +81,10 @@ the specific language governing permissions and limitations under the License.
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="64dp"
+            app:layout_constraintWidth_max="640dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@id/form_edits_warning"
-            app:layout_constraintStart_toStartOf="@id/form_edits_warning"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/form_edits_warning">
 
             <com.google.android.material.button.MaterialButton

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
@@ -6,6 +6,8 @@ import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.textview.MaterialTextView
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
@@ -86,5 +88,57 @@ class FormEndViewTest {
         whenever(formEndViewModel.shouldFormBeSentAutomatically()).thenReturn(true)
         val view = FormEndView(context, "blah", formEndViewModel, listener)
         assertThat(view.findViewById<MaterialButton>(R.id.finalize).text, equalTo(context.getString(R.string.send)))
+    }
+
+    @Test
+    fun `when only 'Save as draft' button is visible do not display the warning`() {
+        whenever(formEndViewModel.isSaveDraftEnabled()).thenReturn(true)
+
+        val view = FormEndView(context, "blah", formEndViewModel, listener)
+
+        assertThat(view.findViewById<MaterialCardView>(R.id.form_edits_warning).visibility, equalTo(View.GONE))
+    }
+
+    @Test
+    fun `when only 'Finalize' button is visible display the warning with an appropriate message`() {
+        whenever(formEndViewModel.isFinalizeEnabled()).thenReturn(true)
+
+        val view = FormEndView(context, "blah", formEndViewModel, listener)
+
+        assertThat(view.findViewById<MaterialCardView>(R.id.form_edits_warning).visibility, equalTo(View.VISIBLE))
+        assertThat(view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text, equalTo(context.getString(R.string.form_edits_warning_only_finalize_enabled)))
+    }
+
+    @Test
+    fun `when only 'Send' button is visible do not display the warning`() {
+        whenever(formEndViewModel.isFinalizeEnabled()).thenReturn(true)
+        whenever(formEndViewModel.shouldFormBeSentAutomatically()).thenReturn(true)
+
+        val view = FormEndView(context, "blah", formEndViewModel, listener)
+
+        assertThat(view.findViewById<MaterialCardView>(R.id.form_edits_warning).visibility, equalTo(View.GONE))
+    }
+
+    @Test
+    fun `when 'Save as draft' and 'Finalize' buttons are visible display the warning with an appropriate message`() {
+        whenever(formEndViewModel.isSaveDraftEnabled()).thenReturn(true)
+        whenever(formEndViewModel.isFinalizeEnabled()).thenReturn(true)
+
+        val view = FormEndView(context, "blah", formEndViewModel, listener)
+
+        assertThat(view.findViewById<MaterialCardView>(R.id.form_edits_warning).visibility, equalTo(View.VISIBLE))
+        assertThat(view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text, equalTo(context.getString(R.string.form_edits_warning_save_as_draft_and_finalize_enabled)))
+    }
+
+    @Test
+    fun `when 'Save as draft' and 'Send' buttons are visible display the warning with an appropriate message`() {
+        whenever(formEndViewModel.isSaveDraftEnabled()).thenReturn(true)
+        whenever(formEndViewModel.isFinalizeEnabled()).thenReturn(true)
+        whenever(formEndViewModel.shouldFormBeSentAutomatically()).thenReturn(true)
+
+        val view = FormEndView(context, "blah", formEndViewModel, listener)
+
+        assertThat(view.findViewById<MaterialCardView>(R.id.form_edits_warning).visibility, equalTo(View.VISIBLE))
+        assertThat(view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text, equalTo(context.getString(R.string.form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled)))
     }
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -152,7 +152,9 @@
     <string name="survey_internal_error">Internal error: step to prompt failed.</string>
 
     <string name="save_enter_data_description">You are at the end of %s.</string>
-    <string name="form_edits_warning">You will not be able to make edits once you finalize. If you need to make changes, \"Save as draft\" until you\'re ready to send.</string>
+    <string name="form_edits_warning_only_finalize_enabled">You will not be able to make edits once you finalize.</string>
+    <string name="form_edits_warning_save_as_draft_and_finalize_enabled">You will not be able to make edits once you finalize. If you need to make changes, \"Save as draft\" until you\'re ready to send.</string>
+    <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">You will not be able to make edits once you send. If you need to make changes, \"Save as draft\" until you\'re ready to send.</string>
     <string name="save_as_draft">Save as draft</string>
     <string name="finalize">Finalize</string>
     <string name="send">Send</string>


### PR DESCRIPTION
Closes #5584 

#### What has been done to verify that this works as intended?
I've tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
This is what we discussed in the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just verify the warning is displayed according to the available actions as described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
