### PR TITLE
Fix list view heights for delete lists

### DIFF
--- a/collect_app/src/main/res/layout/delete_blank_form_layout.xml
+++ b/collect_app/src/main/res/layout/delete_blank_form_layout.xml
@@ -7,7 +7,7 @@
     <org.odk.collect.android.formlists.FormListRecyclerView
         android:id="@+id/list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@id/buttons"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/collect_app/src/main/res/layout/file_manager_list.xml
+++ b/collect_app/src/main/res/layout/file_manager_list.xml
@@ -22,7 +22,7 @@ the License.
     <ListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@id/buttons"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/DeleteBlankFormFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/DeleteBlankFormFragmentTest.kt
@@ -43,8 +43,8 @@ import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.MultiSelectViewModel
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.testshared.RecyclerViewMatcher.Companion.withRecyclerView
-import org.odk.collect.testshared.clickOnItemWith
-import org.odk.collect.testshared.recyclerView
+import org.odk.collect.testshared.ViewActions.clickOnItemWith
+import org.odk.collect.testshared.ViewMatchers.recyclerView
 
 @RunWith(AndroidJUnit4::class)
 class DeleteBlankFormFragmentTest {

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/DeleteBlankFormFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/DeleteBlankFormFragmentTest.kt
@@ -43,6 +43,8 @@ import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.MultiSelectViewModel
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.testshared.RecyclerViewMatcher
+import org.odk.collect.testshared.clickOnItemWith
+import org.odk.collect.testshared.recyclerView
 
 @RunWith(AndroidJUnit4::class)
 class DeleteBlankFormFragmentTest {
@@ -101,8 +103,8 @@ class DeleteBlankFormFragmentTest {
             blankFormListItem(databaseId = 3, formName = "Form 3")
         )
 
-        onView(withText("Form 1")).perform(click())
-        onView(withText("Form 3")).perform(click())
+        onView(recyclerView()).perform(clickOnItemWith(withText("Form 1")))
+        onView(recyclerView()).perform(clickOnItemWith(withText("Form 3")))
 
         assertThat(multiSelectViewModel.getSelected().value, equalTo(setOf<Long>(1, 3)))
     }
@@ -115,10 +117,10 @@ class DeleteBlankFormFragmentTest {
             blankFormListItem(databaseId = 2, formName = "Form 2")
         )
 
-        onView(withText("Form 1")).perform(click())
-        onView(withText("Form 2")).perform(click())
+        onView(recyclerView()).perform(clickOnItemWith(withText("Form 1")))
+        onView(recyclerView()).perform(clickOnItemWith(withText("Form 2")))
 
-        onView(withText("Form 2")).perform(click())
+        onView(recyclerView()).perform(clickOnItemWith(withText("Form 2")))
 
         assertThat(multiSelectViewModel.getSelected().value, equalTo(setOf<Long>(1)))
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/DeleteBlankFormFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/DeleteBlankFormFragmentTest.kt
@@ -42,7 +42,7 @@ import org.odk.collect.android.formlists.blankformlist.DeleteBlankFormFragment
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.MultiSelectViewModel
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
-import org.odk.collect.testshared.RecyclerViewMatcher
+import org.odk.collect.testshared.RecyclerViewMatcher.Companion.withRecyclerView
 import org.odk.collect.testshared.clickOnItemWith
 import org.odk.collect.testshared.recyclerView
 
@@ -90,8 +90,8 @@ class DeleteBlankFormFragmentTest {
 
         multiSelectViewModel.select(2)
 
-        onView(RecyclerViewMatcher.withRecyclerView(R.id.list).atPositionOnView(1, R.id.form_title)).check(matches(withText("Form 2")))
-        onView(RecyclerViewMatcher.withRecyclerView(R.id.list).atPositionOnView(1, R.id.checkbox)).check(matches(isChecked()))
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.form_title)).check(matches(withText("Form 2")))
+        onView(withRecyclerView(R.id.list).atPositionOnView(1, R.id.checkbox)).check(matches(isChecked()))
     }
 
     @Test

--- a/testshared/build.gradle
+++ b/testshared/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation Dependencies.robolectric
     implementation Dependencies.junit
     implementation Dependencies.androidx_test_espresso_intents
+    implementation Dependencies.androidx_test_espresso_contrib
     implementation Dependencies.android_material
     implementation Dependencies.danlew_android_joda
     implementation(Dependencies.androidx_fragment_testing) {

--- a/testshared/src/main/java/org/odk/collect/testshared/RecyclerViewMatcher.kt
+++ b/testshared/src/main/java/org/odk/collect/testshared/RecyclerViewMatcher.kt
@@ -3,6 +3,11 @@ package org.odk.collect.testshared
 import android.content.res.Resources
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
@@ -71,4 +76,12 @@ class RecyclerViewMatcher private constructor(private val recyclerViewId: Int) {
             }
         }
     }
+}
+
+fun recyclerView(): Matcher<View> {
+    return isAssignableFrom(RecyclerView::class.java)
+}
+
+fun clickOnItemWith(matcher: Matcher<View>): ViewAction {
+    return actionOnItem<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher), ViewActions.click())
 }

--- a/testshared/src/main/java/org/odk/collect/testshared/RecyclerViewMatcher.kt
+++ b/testshared/src/main/java/org/odk/collect/testshared/RecyclerViewMatcher.kt
@@ -3,10 +3,11 @@ package org.odk.collect.testshared
 import android.content.res.Resources
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.espresso.ViewAction
-import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
-import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -83,5 +84,5 @@ fun recyclerView(): Matcher<View> {
 }
 
 fun clickOnItemWith(matcher: Matcher<View>): ViewAction {
-    return actionOnItem<RecyclerView.ViewHolder>(ViewMatchers.hasDescendant(matcher), ViewActions.click())
+    return actionOnItem<ViewHolder>(hasDescendant(matcher), click())
 }

--- a/testshared/src/main/java/org/odk/collect/testshared/RecyclerViewMatcher.kt
+++ b/testshared/src/main/java/org/odk/collect/testshared/RecyclerViewMatcher.kt
@@ -3,12 +3,6 @@ package org.odk.collect.testshared
 import android.content.res.Resources
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
-import androidx.recyclerview.widget.RecyclerView.ViewHolder
-import androidx.test.espresso.ViewAction
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
-import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
-import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
@@ -77,12 +71,4 @@ class RecyclerViewMatcher private constructor(private val recyclerViewId: Int) {
             }
         }
     }
-}
-
-fun recyclerView(): Matcher<View> {
-    return isAssignableFrom(RecyclerView::class.java)
-}
-
-fun clickOnItemWith(matcher: Matcher<View>): ViewAction {
-    return actionOnItem<ViewHolder>(hasDescendant(matcher), click())
 }

--- a/testshared/src/main/java/org/odk/collect/testshared/ViewActions.kt
+++ b/testshared/src/main/java/org/odk/collect/testshared/ViewActions.kt
@@ -5,8 +5,13 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.StringRes
 import androidx.core.view.allViews
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import org.hamcrest.Matcher
 
 object ViewActions {
 
@@ -24,5 +29,10 @@ object ViewActions {
                 }
             }
         }
+    }
+
+    @JvmStatic
+    fun clickOnItemWith(matcher: Matcher<View>): ViewAction {
+        return actionOnItem<ViewHolder>(hasDescendant(matcher), click())
     }
 }

--- a/testshared/src/main/java/org/odk/collect/testshared/ViewMatchers.kt
+++ b/testshared/src/main/java/org/odk/collect/testshared/ViewMatchers.kt
@@ -1,0 +1,14 @@
+package org.odk.collect.testshared
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.matcher.ViewMatchers
+import org.hamcrest.Matcher
+
+object ViewMatchers {
+
+    @JvmStatic
+    fun recyclerView(): Matcher<View> {
+        return ViewMatchers.isAssignableFrom(RecyclerView::class.java)
+    }
+}


### PR DESCRIPTION
Closes #5594 

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

No other option here - the height for the list views was incorrectly set to fill the whole screen (rather than the available space).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

As I pointed out in the issue, this ended up being pretty hard to reproduce as you need the exact right number of forms so that the bottom one is cut off, but that there are not enough forms to actually scroll. I think just checking scrolling on the "Delete form" page (for Saved and Blank forms) is enough here.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
