### PR TITLE
Make the 'Ready to send' button highlightable

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
@@ -1,11 +1,16 @@
 package org.odk.collect.android.mainmenu
 
 import android.content.Context
+import android.graphics.Typeface
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import com.google.android.material.badge.BadgeDrawable
+import com.google.android.material.badge.BadgeUtils
+import com.google.android.material.badge.ExperimentalBadgeUtils
 import org.odk.collect.android.R
 import org.odk.collect.android.databinding.MainMenuButtonBinding
+import org.odk.collect.androidshared.system.ContextUtils.getThemeAttributeValue
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
 
 class MainMenuButton(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs) {
@@ -13,6 +18,8 @@ class MainMenuButton(context: Context, attrs: AttributeSet?) : FrameLayout(conte
     constructor(context: Context) : this(context, null)
 
     private val binding = MainMenuButtonBinding.inflate(LayoutInflater.from(context), this, true)
+    private val badge: BadgeDrawable
+    private val highlightable: Boolean
 
     init {
         context.theme.obtainStyledAttributes(
@@ -24,12 +31,18 @@ class MainMenuButton(context: Context, attrs: AttributeSet?) : FrameLayout(conte
             try {
                 val buttonIcon = this.getResourceId(R.styleable.MainMenuButton_icon, 0)
                 val buttonName = this.getString(R.styleable.MainMenuButton_name)
+                highlightable = this.getBoolean(R.styleable.MainMenuButton_highlightable, false)
 
                 binding.icon.setImageResource(buttonIcon)
                 binding.name.text = buttonName
             } finally {
                 recycle()
             }
+        }
+
+        badge = BadgeDrawable.create(context).apply {
+            backgroundColor = getThemeAttributeValue(context, R.attr.colorPrimary)
+            badgeGravity = BadgeDrawable.BOTTOM_END
         }
     }
 
@@ -45,6 +58,19 @@ class MainMenuButton(context: Context, attrs: AttributeSet?) : FrameLayout(conte
             ""
         } else {
             number.toString()
+        }
+
+        @ExperimentalBadgeUtils
+        if (highlightable) {
+            if (number > 0) {
+                BadgeUtils.attachBadgeDrawable(badge, binding.icon)
+                binding.name.typeface = Typeface.DEFAULT_BOLD
+                binding.number.typeface = Typeface.DEFAULT_BOLD
+            } else {
+                BadgeUtils.detachBadgeDrawable(badge, binding.icon)
+                binding.name.typeface = Typeface.DEFAULT
+                binding.number.typeface = Typeface.DEFAULT
+            }
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
@@ -63,7 +63,9 @@ class MainMenuButton(context: Context, attrs: AttributeSet?) : FrameLayout(conte
         @ExperimentalBadgeUtils
         if (highlightable) {
             if (number > 0) {
-                BadgeUtils.attachBadgeDrawable(badge, binding.icon)
+                binding.icon.viewTreeObserver.addOnGlobalLayoutListener {
+                    BadgeUtils.attachBadgeDrawable(badge, binding.icon)
+                }
                 binding.name.setTypeface(binding.name.typeface, Typeface.BOLD)
                 binding.number.setTypeface(binding.name.typeface, Typeface.BOLD)
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
@@ -64,8 +64,8 @@ class MainMenuButton(context: Context, attrs: AttributeSet?) : FrameLayout(conte
         if (highlightable) {
             if (number > 0) {
                 BadgeUtils.attachBadgeDrawable(badge, binding.icon)
-                binding.name.typeface = Typeface.DEFAULT_BOLD
-                binding.number.typeface = Typeface.DEFAULT_BOLD
+                binding.name.setTypeface(binding.name.typeface, Typeface.BOLD)
+                binding.number.setTypeface(binding.name.typeface, Typeface.BOLD)
             } else {
                 BadgeUtils.detachBadgeDrawable(badge, binding.icon)
                 binding.name.typeface = Typeface.DEFAULT

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -60,7 +60,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:icon="@drawable/ic_send_24"
-                    app:name="@string/send_data"/>
+                    app:name="@string/send_data"
+                    app:highlightable="true"/>
 
                 <org.odk.collect.android.mainmenu.MainMenuButton
                     android:id="@+id/view_sent_forms"

--- a/collect_app/src/main/res/values/attrs.xml
+++ b/collect_app/src/main/res/values/attrs.xml
@@ -12,6 +12,7 @@
     <declare-styleable name="MainMenuButton">
         <attr name="icon" format="reference" />
         <attr name="name" format="string" />
+        <attr name="highlightable" format="boolean" />
     </declare-styleable>
 
     <!--  Should be removed when these attributes are added to Material Components  -->

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuButtonTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuButtonTest.kt
@@ -1,7 +1,11 @@
 package org.odk.collect.android.mainmenu
 
 import android.app.Application
+import android.graphics.Typeface
+import android.graphics.drawable.VectorDrawable
+import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.graphics.drawable.toBitmap
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
@@ -9,6 +13,7 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.odk.collect.android.R
+import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
 class MainMenuButtonTest {
@@ -17,19 +22,100 @@ class MainMenuButtonTest {
             it.setTheme(R.style.Theme_Material3_Light)
         }
 
-    private val mainMenuButton = MainMenuButton(context)
+    @Test
+    fun `when icon attribute is not used then it is null`() {
+        val mainMenuButton = MainMenuButton(context)
+
+        assertThat(mainMenuButton.findViewById<ImageView>(R.id.icon).drawable, equalTo(null))
+    }
 
     @Test
-    fun `setNumberOfForms sets the number correctly`() {
+    fun `when icon attribute is used then it is set correctly`() {
+        val attrs = Robolectric.buildAttributeSet().addAttribute(R.attr.icon, "@drawable/ic_edit_24").build()
+        val mainMenuButton = MainMenuButton(context, attrs)
+
+        assertThat(
+            (mainMenuButton.findViewById<ImageView>(R.id.icon).drawable as VectorDrawable).toBitmap().sameAs((context.getDrawable(R.drawable.ic_edit_24) as VectorDrawable).toBitmap()),
+            equalTo(true)
+        )
+    }
+
+    @Test
+    fun `when name attribute is not used then it is empty`() {
+        val mainMenuButton = MainMenuButton(context)
+
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.name).text, equalTo(""))
+    }
+
+    @Test
+    fun `when name attribute is used then it is set correctly`() {
+        val attrs = Robolectric.buildAttributeSet().addAttribute(R.attr.name, "blah").build()
+        val mainMenuButton = MainMenuButton(context, attrs)
+
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.name).text, equalTo("blah"))
+    }
+
+    @Test
+    fun `setNumberOfForms sets number correctly`() {
+        val mainMenuButton = MainMenuButton(context)
+
         mainMenuButton.setNumberOfForms(10)
 
         assertThat(mainMenuButton.findViewById<TextView>(R.id.number).text, equalTo("10"))
     }
 
     @Test
+    fun `setNumberOfForms makes 'name' and 'number' bold if highlightable attr is true`() {
+        val attrs = Robolectric.buildAttributeSet().addAttribute(R.attr.highlightable, "true").build()
+        val mainMenuButton = MainMenuButton(context, attrs)
+
+        mainMenuButton.setNumberOfForms(10)
+
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.name).typeface.style, equalTo(Typeface.BOLD))
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.number).typeface.style, equalTo(Typeface.BOLD))
+    }
+
+    @Test
+    fun `setNumberOfForms does not 'make' name and 'number' bold if highlightable attr is false`() {
+        val attrs = Robolectric.buildAttributeSet().addAttribute(R.attr.highlightable, "false").build()
+        val mainMenuButton = MainMenuButton(context, attrs)
+
+        mainMenuButton.setNumberOfForms(10)
+
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.name).typeface, equalTo(null))
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.number).typeface, equalTo(null))
+    }
+
+    @Test
+    fun `setNumberOfForms does not make 'name' and 'number' bold if highlightable attr is not set`() {
+        val mainMenuButton = MainMenuButton(context)
+
+        mainMenuButton.setNumberOfForms(10)
+
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.name).typeface, equalTo(null))
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.number).typeface, equalTo(null))
+    }
+
+    @Test
     fun `setNumberOfForms sets an empty string when number is less than 1`() {
+        val mainMenuButton = MainMenuButton(context)
+
         mainMenuButton.setNumberOfForms(0)
 
         assertThat(mainMenuButton.findViewById<TextView>(R.id.number).text, equalTo(""))
+    }
+
+    @Test
+    fun `setNumberOfForms removes bold typeface form 'name' and 'number' when number is less than 1`() {
+        val attrs = Robolectric.buildAttributeSet().addAttribute(R.attr.highlightable, "true").build()
+        val mainMenuButton = MainMenuButton(context, attrs)
+
+        mainMenuButton.setNumberOfForms(10)
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.name).typeface.style, equalTo(Typeface.BOLD))
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.number).typeface.style, equalTo(Typeface.BOLD))
+
+        mainMenuButton.setNumberOfForms(0)
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.name).typeface.style, equalTo(Typeface.NORMAL))
+        assertThat(mainMenuButton.findViewById<TextView>(R.id.number).typeface.style, equalTo(Typeface.NORMAL))
     }
 }


### PR DESCRIPTION
Closes #5600

#### What has been done to verify that this works as intended?
I've tested the changes manually. 

#### Why is this the best possible solution? Were any other approaches considered?
I could have extended `MainMenuButton` and created a special class for that one single button but I think solving this problem with a custom attribute is better in this case.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test the buttons used in the main menu to make sure that only the 'Ready to send' button is highlightable.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
