### PR TITLE
Determine in what way the test is failing

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
@@ -17,12 +17,14 @@ class FormMediaDownloader(
     private val formSource: FormSource
 ) {
 
+    @JvmOverloads
     @Throws(IOException::class, FormSourceException::class, InterruptedException::class)
     fun download(
         formToDownload: ServerFormDetails,
         tempMediaPath: String,
         tempDir: File,
-        stateListener: OngoingWorkListener
+        stateListener: OngoingWorkListener,
+        test: Boolean = false
     ): Boolean {
         var atLeastOneNewMediaFileDetected = false
         val tempMediaDir = File(tempMediaPath).also { it.mkdir() }
@@ -43,10 +45,16 @@ class FormMediaDownloader(
                         interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
 
                         if (!getMd5Hash(tempMediaFile).contentEquals(existingFileHash)) {
+                            if (test) {
+                                throw Exception("Content does not equal")
+                            }
                             atLeastOneNewMediaFileDetected = true
                         }
                     }
                 } else {
+                    if (test) {
+                        throw Exception("File does not exist")
+                    }
                     val file = formSource.fetchMediaFile(mediaFile.downloadUrl)
                     interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
                     atLeastOneNewMediaFileDetected = true

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMediaDownloaderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMediaDownloaderTest.kt
@@ -50,7 +50,8 @@ class FormMediaDownloaderTest {
             serverFormDetails,
             File(TempFiles.createTempDir(), "temp").absolutePath,
             TempFiles.createTempDir(),
-            mock()
+            mock(),
+            true
         )
 
         assertThat(result, equalTo(false))


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
I've spent some time investigating `returns false when there is an existing copy of a media file and an older one` test that randomly fails on CircleCI and here are my thoughts:
- I wasn't able to reproduce the issue locally what was expected because we had tried earlier to no avail too
- in FormMediaDownloaderTest we have two tests that are almost identical but somehow only `returns false when there is an existing copy of a media file and an older one` is the one that fails
- reviewing the test and the code that this test verifies I wasn't able to spot any bug/mistake
- My gut says that somehow [file.exists()](https://github.com/getodk/collect/pull/5608/files#diff-0a05b9f66563367bc25db2a9f96f05525f14d66d4b464a5e70322108e8295eafR78) might return false and that's the reason
- In order to check if what I said above is right I've added some changes so that next time the test fails we know in what way

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
