### PR TITLE
Renamed the 'Save Form' setting

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormFinalizingTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormFinalizingTest.kt
@@ -64,7 +64,7 @@ class FormFinalizingTest {
             .clickSettings()
             .clickAccessControl()
             .clickFormEntrySettings()
-            .clickOnString(R.string.save_as_draft)
+            .clickOnSaveAsDraftInFormEnd()
             .pressBack(AccessControlPage())
             .pressBack(ProjectSettingsPage())
             .pressBack(MainMenuPage())

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormEntrySettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormEntrySettingsTest.java
@@ -41,7 +41,7 @@ public class FormEntrySettingsTest {
                 .assertText(R.string.yes)
                 .assertText(R.string.no)
                 .clickOnString(R.string.yes)
-                .checkIfSaveFormOptionIsDisabled()
+                .checkIfSaveAsDraftInFormEntryOptionIsDisabled()
                 .pressBack(new AccessControlPage())
                 .pressBack(new ProjectSettingsPage())
                 .pressBack(new MainMenuPage())

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AccessControlPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AccessControlPage.kt
@@ -1,11 +1,13 @@
 package org.odk.collect.android.support.pages
 
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.Matchers.not
 import org.odk.collect.android.R
+import org.odk.collect.android.support.matchers.CustomMatchers.withIndex
 
 class AccessControlPage : Page<AccessControlPage>() {
 
@@ -29,8 +31,13 @@ class AccessControlPage : Page<AccessControlPage>() {
         return this
     }
 
-    fun checkIfSaveFormOptionIsDisabled(): AccessControlPage {
-        onView(withText(getTranslatedString(R.string.save_all_answers))).check(matches(not(isEnabled())))
+    fun checkIfSaveAsDraftInFormEntryOptionIsDisabled(): AccessControlPage {
+        onView(withIndex(withText(getTranslatedString(R.string.save_mid)), 0)).check(matches(not(isEnabled())))
+        return this
+    }
+
+    fun clickOnSaveAsDraftInFormEnd(): AccessControlPage {
+        onView(withIndex(withText(getTranslatedString(R.string.save_mid)), 1)).perform(click())
         return this
     }
 

--- a/collect_app/src/main/res/xml/form_entry_access_preferences.xml
+++ b/collect_app/src/main/res/xml/form_entry_access_preferences.xml
@@ -27,7 +27,14 @@
         <CheckBoxPreference
             android:key="save_mid"
             android:title="@string/save_mid"
+            android:summary="@string/save_mid_summary"
             app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/form_end"
+        app:allowDividerAbove="false"
+        app:allowDividerBelow="false"
+        app:iconSpaceReserved="false" >
         <CheckBoxPreference
             android:key="save_as_draft"
             android:title="@string/save_as_draft"

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -922,6 +922,7 @@
     <string name="found_in_main">Uncheck to hide from Main Menu</string>
     <string name="found_in_settings">Uncheck to hide from Unprotected Settings</string>
     <string name="form_entry">Uncheck to hide from Form Entry</string>
+    <string name="form_end">Uncheck to hide from Form End</string>
 
     <string name="reset_project_settings_title">Reset</string>
     <string name="reset_project_settings_subtext">Choose from settings, forms, data</string>
@@ -961,7 +962,8 @@
     <string name="moving_backwards_enabled_message">You may wish to review the following settings:\n\n\u2022 Edit Draft\n\u2022 Save Form\n\u2022 Go To Prompt\n\u2022 Constraint processing</string>
 
     <!-- Protected setting. When enabled, users are allowed to save forms while filling them. When disabled, users are only allowed to save forms when they reach their end -->
-    <string name="save_mid">Save Form</string>
+    <string name="save_mid">Save as draft</string>
+    <string name="save_mid_summary">Save icon in top bar and \"Save as draft\" button when exiting form</string>
 
     <!--
      ##############################################

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -105,7 +105,7 @@
     <!-- Text for button displayed in the form filling menu to see the form's table of contents -->
     <string name="view_hierarchy">Go To Prompt</string>
     <!-- Text for button displayed in the form filling menu to save the form -->
-    <string name="save_all_answers">Save Form</string>
+    <string name="save_all_answers">Save as draft</string>
 
     <!-- Text of button from the form's table of contents to jump to the beginning of the form -->
     <string name="jump_to_beginning">Go To Start</string>
@@ -955,11 +955,11 @@
     <!-- Name of a setting that determines whether users can navigate backwards in a form -->
     <string name="moving_backwards_title">Moving backwards</string>
     <string name="moving_backwards_disabled_title">Moving backwards disabled</string>
-    <string name="moving_backwards_disabled_message">Configure the device to prevent users from bypassing this setting?\n\nThe changes are:\n\u2022 Disable Edit Draft\n\u2022 Disable Save Form\n\u2022 Disable Go To Prompt\n\u2022 Set Constraint processing to Validate upon forward swipe</string>
+    <string name="moving_backwards_disabled_message">Configure the device to prevent users from bypassing this setting?\n\nThe changes are:\n\u2022 Disable Edit Draft\n\u2022 Disable Save as draft\n\u2022 Disable Go To Prompt\n\u2022 Set Constraint processing to Validate upon forward swipe</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="moving_backwards_enabled_title">Moving backwards enabled</string>
-    <string name="moving_backwards_enabled_message">You may wish to review the following settings:\n\n\u2022 Edit Draft\n\u2022 Save Form\n\u2022 Go To Prompt\n\u2022 Constraint processing</string>
+    <string name="moving_backwards_enabled_message">You may wish to review the following settings:\n\n\u2022 Edit Draft\n\u2022 Save as draft\n\u2022 Go To Prompt\n\u2022 Constraint processing</string>
 
     <!-- Protected setting. When enabled, users are allowed to save forms while filling them. When disabled, users are only allowed to save forms when they reach their end -->
     <string name="save_mid">Save as draft</string>


### PR DESCRIPTION
Closes #5580

#### What has been done to verify that this works as intended?
I've tested the changes manually and updated automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
There is nothing to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that strings are updated according to what is described in the issue. It's rather a safe change and I don't see any area of risk to explore more carefully.
Please keep in mind that I've implemented:
> 1) Rename "Save Form" to "Save as draft" and add subtext "Save icon in top bar and "Save as draft" button when exiting form"
> 2) Add a section header below it called "Uncheck to hide from Form End". That will contain "Save as draft" and "Finalize"

but not:

> A further change we could consider is separating the two concepts that are currently linked: we could have "Save icon" and "Save as draft" with subtext "In dialog when exiting form". We could migrate the existing "Save Form" setting to uncheck both settings if it's unchecked.

The second part is something we are not sure about yet and will consider in the future. 
#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
