### PR TITLE
Fixed TriggerWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TriggerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TriggerWidget.java
@@ -51,6 +51,7 @@ public class TriggerWidget extends QuestionWidget {
         triggerButton.setEnabled(!prompt.isReadOnly());
         triggerButton.setChecked(OK_TEXT.equals(prompt.getAnswerText()));
         triggerButton.setOnCheckedChangeListener((buttonView, isChecked) -> widgetValueChanged());
+        triggerButton.setId(View.generateViewId());
 
         return answerView;
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/TriggerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/TriggerWidgetTest.java
@@ -14,6 +14,7 @@ import org.odk.collect.android.listeners.WidgetValueChangedListener;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.verify;
 import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.mockValueChangedListener;
@@ -82,6 +83,14 @@ public class TriggerWidgetTest {
 
         triggerButton.setChecked(true);
         verify(valueChangedListener).widgetValueChanged(widget);
+    }
+
+    @Test // https://github.com/getodk/collect/issues/5523
+    public void everyTriggerWidgetShouldHaveCheckboxWithUniqueID() {
+        TriggerWidget widget1 = createWidget(promptWithAnswer(new StringData("OK")));
+        TriggerWidget widget2 = createWidget(promptWithAnswer(new StringData("OK")));
+
+        assertThat(widget1.getCheckBox().getId(), not(equalTo(widget2.getCheckBox().getId())));
     }
 
     private TriggerWidget createWidget(FormEntryPrompt prompt) {


### PR DESCRIPTION
Closes #5523 

#### What has been done to verify that this works as intended?
I've tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
`Checkboxes` need to have their own unique ids (just like `EditTexts`) otherwise because of android internal mechanism of restoring their state bugs like this one might occur.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
For now, we can focus on testing the scenario described in the issue but it would be good if we don't have similar problems with other widgets.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
