### PR TITLE
Fixed FormMediaDownloaderTest

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMediaDownloaderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMediaDownloaderTest.kt
@@ -18,18 +18,20 @@ class FormMediaDownloaderTest {
 
     @Test
     fun `returns false when there is an existing copy of a media file and an older one`() {
+        var date: Long = 0
         // Save forms
-        val formsRepository = InMemFormsRepository()
+        val formsRepository = InMemFormsRepository {
+            date += 1
+            date
+        }
         val form1 = FormFixtures.form(
             version = "1",
-            date = 1,
             mediaFiles = listOf(Pair("file", "old"))
         )
         formsRepository.save(form1)
 
         val form2 = FormFixtures.form(
             version = "2",
-            date = 2,
             mediaFiles = listOf(Pair("file", "existing"))
         )
         formsRepository.save(form2)
@@ -60,17 +62,19 @@ class FormMediaDownloaderTest {
     @Test
     fun `returns false when there is an existing copy of a media file and an older one and media file list hash doesn't match existing copy`() {
         // Save forms
-        val formsRepository = InMemFormsRepository()
+        var date: Long = 0
+        val formsRepository = InMemFormsRepository {
+            date += 1
+            date
+        }
         val form1 = FormFixtures.form(
             version = "1",
-            date = 1,
             mediaFiles = listOf(Pair("file", "old"))
         )
         formsRepository.save(form1)
 
         val form2 = FormFixtures.form(
             version = "2",
-            date = 2,
             mediaFiles = listOf(Pair("file", "existing"))
         )
         formsRepository.save(form2)

--- a/formstest/src/main/java/org/odk/collect/formstest/FormFixtures.kt
+++ b/formstest/src/main/java/org/odk/collect/formstest/FormFixtures.kt
@@ -5,10 +5,10 @@ import org.odk.collect.shared.TempFiles
 import java.io.File
 
 object FormFixtures {
+    // If you set the date here, it might be overridden with the current date during saving to the database if dbId is not set too
     fun form(
         formId: String = "formId",
         version: String = "1",
-        date: Long = 1,
         mediaFiles: List<Pair<String, String>> = emptyList(),
         autoSend: String? = null
     ): Form {
@@ -25,7 +25,6 @@ object FormFixtures {
             .version(version)
             .formFilePath(FormUtils.createFormFixtureFile(formId, version, formFilesPath))
             .formMediaPath(mediaFilePath)
-            .date(date)
             .autoSend(autoSend)
             .build()
     }


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've reviewed implemented changes and ran tests.

#### Why is this the best possible solution? Were any other approaches considered?
I finally was able to track the issue down. We can't set dates creating forms if `dbId` is not set too because then it is overridden during saving such a form to the database with the current date. That's what we experienced in this case. It worked well in 90% of cases because between saving the two forms used in the test there was a small difference of at least 1 millisecond. In the cases when the test was failing the time was equal and then sorting by dates didn't work as expected in https://github.com/getodk/collect/blob/be9ad728cbb6e5e7ed88061a5826ee0424935a6a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt#L65.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
