### PR TITLE
Fixed detecting if a form can be edited

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -187,16 +187,14 @@ class FormUriActivity : ComponentActivity() {
         val uri = intent.data!!
         val uriMimeType = contentResolver.getType(uri)
 
-        val formBlankOrUnsent = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
+        val formEditingEnabled = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
             val instance = instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
-            instance!!.status == Instance.STATUS_INCOMPLETE
+            instance!!.status == Instance.STATUS_INCOMPLETE && settingsProvider.getProtectedSettings().getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
         } else {
             true
         }
 
-        val formEditingEnabled = settingsProvider.getProtectedSettings().getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
-
-        return formBlankOrUnsent && formEditingEnabled
+        return formEditingEnabled
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -334,6 +334,21 @@ class FormUriActivityTest {
     }
 
     @Test
+    fun `When attempting to start a new form then there should be no form mode passed with the intent even if editing saved forms is disabled`() {
+        val project = Project.Saved("123", "First project", "A", "#cccccc")
+        projectsRepository.save(project)
+        whenever(currentProjectProvider.getCurrentProject()).thenReturn(project)
+
+        settingsProvider.getProtectedSettings().save(ProtectedProjectKeys.KEY_EDIT_SAVED, false)
+
+        val form = formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
+
+        launcherRule.launchForResult<FormUriActivity>(getBlankFormIntent(project.uuid, form.dbId))
+
+        assertStartBlankFormIntent(project.uuid, form.dbId)
+    }
+
+    @Test
     fun `When attempting to edit a finalized form then start form for view only`() {
         val project = Project.Saved("123", "First project", "A", "#cccccc")
         projectsRepository.save(project)
@@ -538,6 +553,7 @@ class FormUriActivityTest {
         } else {
             Intents.intended(hasData(FormsContract.getUri(projectId, dbId)))
         }
+        Intents.intended(not(hasExtraWithKey(ApplicationConstants.BundleKeys.FORM_MODE)))
         Intents.intended(hasExtra("KEY_1", "Text"))
     }
 


### PR DESCRIPTION
Closes #5628 

#### What has been done to verify that this works as intended?
I've verified the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's a bug fix so there is nothing important to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing the scenario described in the issue should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
