### PR TITLE
Use the same location providers in every map engine + some tweaks

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -53,6 +53,7 @@ import org.odk.collect.forms.Form;
 import org.odk.collect.geo.DaggerGeoDependencyComponent;
 import org.odk.collect.geo.GeoDependencyComponent;
 import org.odk.collect.geo.GeoDependencyComponentProvider;
+import org.odk.collect.location.LocationClient;
 import org.odk.collect.maps.layers.ReferenceLayerRepository;
 import org.odk.collect.osmdroid.DaggerOsmDroidDependencyComponent;
 import org.odk.collect.osmdroid.OsmDroidDependencyComponent;
@@ -190,6 +191,7 @@ public class Collect extends Application implements
         objectProvider.addSupplier(SettingsProvider.class, applicationComponent::settingsProvider);
         objectProvider.addSupplier(NetworkStateProvider.class, applicationComponent::networkStateProvider);
         objectProvider.addSupplier(ReferenceLayerRepository.class, applicationComponent::referenceLayerRepository);
+        objectProvider.addSupplier(LocationClient.class, applicationComponent::locationClient);
     }
 
     @NotNull

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -487,8 +487,6 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     @Override public void onClientStop() {
-        Timber.i("Stopping location updates (to %s)", this);
-        locationClient.stopLocationUpdates();
     }
 
     private static @NonNull MapPoint fromLatLng(@NonNull LatLng latLng) {

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -18,11 +18,9 @@ import static org.odk.collect.settings.keys.ProjectKeys.KEY_GOOGLE_MAP_STYLE;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.Intent;
 import android.location.Location;
 import android.os.Bundle;
 import android.os.Handler;
-import android.provider.Settings;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -47,7 +45,6 @@ import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
 import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.geo.GoogleMapConfigurator.GoogleMapTypeOption;
@@ -484,13 +481,9 @@ public class GoogleMapFragment extends SupportMapFragment implements
         lastLocationFix = fromLocation(locationClient.getLastLocation());
         Timber.i("Requesting location updates (to %s)", this);
         locationClient.requestLocationUpdates(this);
-        if (!locationClient.isLocationAvailable()) {
-            showGpsDisabledAlert();
-        }
     }
 
     @Override public void onClientStartFailure() {
-        showGpsDisabledAlert();
     }
 
     @Override public void onClientStop() {
@@ -694,19 +687,6 @@ public class GoogleMapFragment extends SupportMapFragment implements
 
     private static BitmapDescriptor getBitmapDescriptor(Context context, MarkerIconDescription markerIconDescription) {
         return BitmapDescriptorCache.getBitmapDescriptor(context, markerIconDescription);
-    }
-
-    private void showGpsDisabledAlert() {
-        new MaterialAlertDialogBuilder(getActivity())
-            .setMessage(getString(R.string.gps_enable_message))
-            .setCancelable(false)
-            .setPositiveButton(getString(R.string.enable_gps),
-                (dialog, id) -> startActivityForResult(
-                    new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS), 0))
-            .setNegativeButton(getString(R.string.cancel),
-                (dialog, id) -> dialog.cancel())
-            .create()
-            .show();
     }
 
     private void onConfigChanged(Bundle config) {

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
@@ -330,25 +330,22 @@ public class GeoPointMapActivity extends LocalizedActivity {
             placeMarkerButton.setEnabled(true);
         }
 
-        MapPoint previousLocation = this.location;
         this.location = point;
 
         if (point != null) {
-            if (previousLocation != null) {
-                enableZoomButton(true);
+            enableZoomButton(true);
 
-                if (!captureLocation && !setClear) {
-                    placeMarker(point);
-                    placeMarkerButton.setEnabled(true);
-                }
-
-                if (!foundFirstLocation) {
-                    map.zoomToPoint(map.getGpsLocation(), true);
-                    foundFirstLocation = true;
-                }
-
-                locationStatus.setText(formatLocationStatus(map.getLocationProvider(), point.accuracy));
+            if (!captureLocation && !setClear) {
+                placeMarker(point);
+                placeMarkerButton.setEnabled(true);
             }
+
+            if (!foundFirstLocation) {
+                map.zoomToPoint(map.getGpsLocation(), true);
+                foundFirstLocation = true;
+            }
+
+            locationStatus.setText(formatLocationStatus(map.getLocationProvider(), point.accuracy));
         }
     }
 

--- a/location/build.gradle
+++ b/location/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation project(':androidshared')
     implementation project(':icons')
     implementation project(':strings')
+    implementation project(':analytics')
     implementation Dependencies.kotlin_stdlib
     implementation Dependencies.androidx_core_ktx
     implementation Dependencies.play_services_location

--- a/location/src/main/java/org/odk/collect/location/GoogleFusedLocationClient.java
+++ b/location/src/main/java/org/odk/collect/location/GoogleFusedLocationClient.java
@@ -19,6 +19,8 @@ import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationServices;
 
+import org.odk.collect.analytics.Analytics;
+
 import timber.log.Timber;
 
 /**
@@ -196,6 +198,7 @@ public class GoogleFusedLocationClient
 
     @Override
     public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
+        Analytics.log("GoogleFusedLocationClient", "onConnectionFailed", connectionResult.toString());
         if (getListener() != null) {
             getListener().onClientStartFailure();
         }

--- a/location/src/main/java/org/odk/collect/location/GoogleFusedLocationClient.java
+++ b/location/src/main/java/org/odk/collect/location/GoogleFusedLocationClient.java
@@ -198,7 +198,7 @@ public class GoogleFusedLocationClient
 
     @Override
     public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
-        Analytics.log("GoogleFusedLocationClient", "onConnectionFailed", connectionResult.toString());
+        Analytics.log("GoogleFusedLocationClientConnectionFailed");
         if (getListener() != null) {
             getListener().onClientStartFailure();
         }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -12,8 +12,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.startup.AppInitializer
 import com.google.android.gms.location.LocationListener
-import com.mapbox.android.core.location.LocationEngineProvider
-import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.geojson.Point
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapView
@@ -50,6 +48,8 @@ import com.mapbox.maps.plugin.scalebar.scalebar
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.odk.collect.androidshared.utils.ScreenUtils
+import org.odk.collect.location.LocationClient
+import org.odk.collect.location.LocationClient.LocationClientListener
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragment.ErrorListener
 import org.odk.collect.maps.MapFragment.FeatureListener
@@ -74,7 +74,8 @@ class MapboxMapFragment :
     MapFragment,
     OnMapClickListener,
     OnMapLongClickListener,
-    LocationListener {
+    LocationListener,
+    LocationClientListener {
 
     private lateinit var mapView: MapView
     private lateinit var mapboxMap: MapboxMap
@@ -117,6 +118,10 @@ class MapboxMapFragment :
 
     private val referenceLayerRepository: ReferenceLayerRepository by lazy {
         (requireActivity().applicationContext as ObjectProviderHost).getObjectProvider().provide(ReferenceLayerRepository::class.java)
+    }
+
+    private val locationClient: LocationClient by lazy {
+        (requireActivity().applicationContext as ObjectProviderHost).getObjectProvider().provide(LocationClient::class.java)
     }
 
     override fun init(readyListener: ReadyListener?, errorListener: ErrorListener?) {
@@ -481,22 +486,16 @@ class MapboxMapFragment :
 
     @SuppressWarnings("MissingPermission") // permission checks for location services are handled in widgets
     private fun enableLocationUpdates(enabled: Boolean) {
-        val engine = LocationEngineProvider.getBestLocationEngine(requireContext())
+        locationClient.setListener(this)
+
         if (enabled) {
-            Timber.i("Requesting location updates from %s (to %s)", engine, this)
-            engine.requestLocationUpdates(
-                LocationEngineRequest.Builder(1000)
-                    .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
-                    .setMaxWaitTime(5000)
-                    .build(),
-                locationCallback,
-                null
-            )
-            engine.getLastLocation(locationCallback)
+            Timber.i("Starting LocationClient %s (for MapFragment %s)", locationClient, this)
+            locationClient.start()
         } else {
-            Timber.i("Stopping location updates from %s (to %s)", engine, this)
-            engine.removeLocationUpdates(locationCallback)
+            Timber.i("Stopping LocationClient %s (for MapFragment %s)", locationClient, this)
+            locationClient.stop()
         }
+
         mapView.location.enabled = enabled
     }
 
@@ -624,6 +623,17 @@ class MapboxMapFragment :
         if (mapboxMap.getStyle()?.getSource(source.sourceId) == null) {
             mapboxMap.getStyle()?.addSource(source)
         }
+    }
+
+    override fun onClientStart() {
+        Timber.i("Requesting location updates (to %s)", this)
+        locationClient.requestLocationUpdates(this)
+    }
+
+    override fun onClientStartFailure() {
+    }
+
+    override fun onClientStop() {
     }
 
     companion object {

--- a/osmdroid/build.gradle
+++ b/osmdroid/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     implementation Dependencies.osmdroid
     implementation Dependencies.androidx_fragment_ktx
     implementation Dependencies.androidx_preference_ktx
-    implementation Dependencies.android_material
     implementation Dependencies.timber
     implementation Dependencies.play_services_location
     implementation Dependencies.dagger

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -28,7 +28,6 @@ import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.os.Bundle;
 import android.os.Handler;
-import android.provider.Settings;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -40,7 +39,6 @@ import androidx.core.graphics.ColorUtils;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.gms.location.LocationListener;
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.androidshared.system.ContextUtils;
 import org.odk.collect.location.LocationClient;
@@ -470,7 +468,6 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
 
     @Override
     public void onClientStartFailure() {
-        showGpsDisabledAlert();
     }
 
     @Override
@@ -559,19 +556,6 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
             map.getOverlays().add(0, referenceOverlay);
         }
         map.invalidate();
-    }
-
-    private void showGpsDisabledAlert() {
-        new MaterialAlertDialogBuilder(getContext())
-                .setMessage(getString(R.string.gps_enable_message))
-                .setCancelable(false)
-                .setPositiveButton(getString(R.string.enable_gps),
-                        (dialog, id) -> startActivityForResult(
-                                new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS), 0))
-                .setNegativeButton(getString(R.string.cancel),
-                        (dialog, id) -> dialog.cancel())
-                .create()
-                .show();
     }
 
     /**


### PR DESCRIPTION
Closes #5633 

#### What has been done to verify that this works as intended?
I've tested manually the map engines we support.

#### Why is this the best possible solution? Were any other approaches considered?
The fix itself is in the first commit [Use the same location providers in all map engines
](https://github.com/getodk/collect/pull/5636/commits/092075aca098c1ea6a00768286bacc8a7fc92a34). As discussed on slack the problem was that mapbox used its own location engine but google and osm our own providers. As a result, the mapbox engine messed up somehow with our providers (internally). Now all map engines use the same mechanism to retrieve the location and thanks to that mapbox works well and the behavior is consistent.

Other commits are just some improvements that I've identified:
- [Removed duplicated GPS checking](https://github.com/getodk/collect/pull/5636/commits/afeece2b58ad5f21072353a8720c3ce013e39c48) this is something we check before starting maps so it's not needed in every map fragment too
- [Removed duplicated stopLocationUpdates call
](https://github.com/getodk/collect/pull/5636/commits/a2a57b04a6415bee698e11898936ef948d00f57c) `stopLocationUpdates` is already called in `GoogleFusedLocationClient`/`AndroidLocationClient`#stop() 
- [Do not ignore the first received location
](https://github.com/getodk/collect/pull/5636/commits/d6a63e42b76909c7f886d5ee8839f822a59c3fc1) I don't know why the first location was ignored. As a result, zooming to the current location in `GeoPointMapActivity` was slower compared to `GeoPolyActivity` it was an old fragment of code so I believe it is something we do not need anymore.
- [Track if GPS connection fails and why
](https://github.com/getodk/collect/pull/5636/commits/92f036c99d4ceacc11f96561d02bb7c41bdaa3fb) just wanted to check if there are problems with connections and why. Maybe we need to display something ins such a case? We will see. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should solve the problem with switching map engines and also make the behavior across different engines consistent. There is no one particular area of risk but it ould be more about recording locations than drawing lines/shapes/points for example.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
