### PR TITLE
Remove lifecycle logging from FormFillingActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -193,7 +193,6 @@ import org.odk.collect.permissions.PermissionsChecker;
 import org.odk.collect.permissions.PermissionsProvider;
 import org.odk.collect.settings.SettingsProvider;
 import org.odk.collect.settings.keys.ProjectKeys;
-import org.odk.collect.shared.strings.Md5;
 import org.odk.collect.strings.localization.LocalizedActivity;
 
 import java.io.File;
@@ -393,8 +392,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
      */
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Timber.w("onCreate %s", Md5.getMd5Hash(getIntent().getData().toString()));
-
         // Workaround for https://issuetracker.google.com/issues/37124582. Some widgets trigger
         // this issue by including WebViews
         if (Build.VERSION.SDK_INT >= 24) {
@@ -780,8 +777,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
-        Timber.w("onSaveInstanceState %s", Md5.getMd5Hash(getIntent().getData().toString()));
-
         super.onSaveInstanceState(outState);
 
         outState.putString(KEY_SESSION_ID, sessionId);
@@ -1843,8 +1838,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
 
     @Override
     protected void onStart() {
-        Timber.w("onStart %s", Md5.getMd5Hash(getIntent().getData().toString()));
-
         super.onStart();
         FormController formController = getFormController();
 
@@ -1863,8 +1856,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
 
     @Override
     protected void onPause() {
-        Timber.w("onPause %s", Md5.getMd5Hash(getIntent().getData().toString()));
-
         backgroundLocationViewModel.activityHidden();
 
         super.onPause();
@@ -1872,8 +1863,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
 
     @Override
     protected void onResume() {
-        Timber.w("onResume %s", Md5.getMd5Hash(getIntent().getData().toString()));
-
         super.onResume();
 
         activityDisplayed();
@@ -1976,8 +1965,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
 
     @Override
     protected void onDestroy() {
-        Timber.w("onDestroy %s", Md5.getMd5Hash(getIntent().getData().toString()));
-
         if (formLoaderTask != null) {
             formLoaderTask.setFormLoaderListener(null);
             // We have to call cancel to terminate the thread, otherwise it


### PR DESCRIPTION
These were added as part of investigating #5241 which we've now closed. It looks like one of the logs was actually causing [a crash](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/8422878c9ce85c9670e545a4a210bc4d?time=last-thirty-days&versions=v2023.2-beta.2%20(4658)&types=crash&sessionEventKey=648555AF02DF00011374DAB8BC611771_1821736509047329068), so I though it would make sense to just remove them.

If others feel we should keep them in, we could pull out a helper method that can safely create a hash if the data portion of the `Intent` is `null` as an alternative to removing them.