### PR TITLE
Fixed layout direction in the ChoicesRecyclerView

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/ChoicesRecyclerView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ChoicesRecyclerView.java
@@ -45,6 +45,7 @@ public class ChoicesRecyclerView extends RecyclerView {
         }
         setAdapter(adapter);
         adjustRecyclerViewSize();
+        setLayoutDirection(LAYOUT_DIRECTION_LOCALE);
     }
 
     private void enableFlexboxLayout() {


### PR DESCRIPTION
Closes #5559 

#### What has been done to verify that this works as intended?
I've tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
Nothing important to discuss here. Looks like forcing the recycler view to use the direction of the currently used locale fixes the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test select_one/select_multiple questions to make sure there are no problems with displaying the choices in both LTR and RTL languages.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
