### PR TITLE
Preserve range widget values in field list when minimizing app

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
@@ -90,6 +90,8 @@ public class RangeWidgetUtils {
             slider.setEnabled(false);
         }
 
+        slider.setId(View.generateViewId());
+
         return new RangeWidgetLayoutElements(answerView, slider, currentValue);
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeDecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeDecimalWidgetTest.java
@@ -189,6 +189,14 @@ public class RangeDecimalWidgetTest {
         verify(listener, never()).onLongClick(widget.slider);
     }
 
+    @Test // https://github.com/getodk/collect/issues/5530
+    public void everyTriggerWidgetShouldHaveCheckboxWithUniqueID() {
+        RangeDecimalWidget widget1 = createWidget(promptWithQuestionDefAndAnswer(rangeQuestion, null));
+        RangeDecimalWidget widget2 = createWidget(promptWithQuestionDefAndAnswer(rangeQuestion, null));
+
+        assertThat(widget1.slider.getId(), not(equalTo(widget2.slider.getId())));
+    }
+
     private RangeDecimalWidget createWidget(FormEntryPrompt prompt) {
         return new RangeDecimalWidget(widgetTestActivity(), new QuestionDetails(prompt));
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeIntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeIntegerWidgetTest.java
@@ -192,6 +192,14 @@ public class RangeIntegerWidgetTest {
         verify(listener, never()).onLongClick(widget.slider);
     }
 
+    @Test // https://github.com/getodk/collect/issues/5530
+    public void everyTriggerWidgetShouldHaveCheckboxWithUniqueID() {
+        RangeIntegerWidget widget1 = createWidget(promptWithQuestionDefAndAnswer(rangeQuestion, null));
+        RangeIntegerWidget widget2 = createWidget(promptWithQuestionDefAndAnswer(rangeQuestion, null));
+
+        assertThat(widget1.slider.getId(), not(equalTo(widget2.slider.getId())));
+    }
+
     private RangeIntegerWidget createWidget(FormEntryPrompt prompt) {
         return new RangeIntegerWidget(widgetTestActivity(), new QuestionDetails(prompt));
     }


### PR DESCRIPTION
Closes #5530 

#### What has been done to verify that this works as intended?
I've tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
`Sliders` need to have their own unique ids (just like `EditTexts` and `Checkboxes`) otherwise because of android internal mechanism of restoring their state bugs like this one might occur.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just verify that the issue is solved but it's the second issue like that (after https://github.com/getodk/collect/issues/5523) where there are problems when we have two the same widgets on one page so please play with other widgets in the same way more in the future.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
