### PR TITLE
Fix translation test

### DIFF
--- a/strings/src/main/res/values-sv-rSE/strings.xml
+++ b/strings/src/main/res/values-sv-rSE/strings.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources xmlns:tools="http://schemas.android.com/tools">
   <!--Text for an action button on the main screen.-->
+  <string name="enter_data">Fyll i tomt formulär</string>
   <!--Text for an action button on the main screen.-->
   <!--Text for an action button on the main screen.-->
   <!--Text for an action button on the main screen.-->


### PR DESCRIPTION
This readds the old translation for "Fill Blank Form" (which will be used for the "Start new form" button). This is the simplest way to get the test passing without needing to restructure it. 

I'm making an assumption here that it is not problematic to have the translated "Fill Blank Form" in there instead of the new English text and that this will eventually be replaced with a more accurate translation (which will again mean updating the test).