### PR TITLE
Prevent opening for review encrypted forms after finalizing

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
@@ -41,7 +41,6 @@ public class EncryptedFormTest {
     public void instanceOfEncryptedForm_cantBeViewedAfterFinalizing() {
         rule.startAtMainMenu()
                 .copyForm("encrypted.xml")
-                .setServer(testDependencies.server.getURL())
 
                 .startBlankForm("encrypted")
                 .assertQuestion("Question 1")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
@@ -38,6 +38,23 @@ public class EncryptedFormTest {
             .around(rule);
 
     @Test
+    public void instanceOfEncryptedForm_cantBeViewedAfterFinalizing() {
+        rule.startAtMainMenu()
+                .copyForm("encrypted.xml")
+                .setServer(testDependencies.server.getURL())
+
+                .startBlankForm("encrypted")
+                .assertQuestion("Question 1")
+                .swipeToEndScreen()
+                .clickFinalize()
+
+                .clickSendFinalizedForm(1)
+                .clickOnText("encrypted")
+                .checkIsToastWithMessageDisplayed(R.string.encrypted_form)
+                .assertOnPage();
+    }
+
+    @Test
     public void instanceOfEncryptedForm_cantBeViewedAfterSending() {
         rule.startAtMainMenu()
                 .copyForm("encrypted.xml")

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
@@ -388,9 +388,14 @@ public class InstanceUploaderListActivity extends LocalizedActivity implements
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long rowId) {
         Cursor c = (Cursor) listView.getAdapter().getItem(position);
-        long instanceId = c.getLong(c.getColumnIndex(DatabaseInstanceColumns._ID));
-        Intent intent = FormFillingIntentFactory.editInstanceIntent(this, currentProjectProvider.getCurrentProject().getUuid(), instanceId);
-        startActivity(intent);
+        boolean encryptedForm = !Boolean.parseBoolean(c.getString(c.getColumnIndex(DatabaseInstanceColumns.CAN_EDIT_WHEN_COMPLETE)));
+        if (encryptedForm) {
+            ToastUtils.showLongToast(this, R.string.encrypted_form);
+        } else {
+            long instanceId = c.getLong(c.getColumnIndex(DatabaseInstanceColumns._ID));
+            Intent intent = FormFillingIntentFactory.editInstanceIntent(this, currentProjectProvider.getCurrentProject().getUuid(), instanceId);
+            startActivity(intent);
+        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/database/instances/DatabaseInstanceColumns.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/instances/DatabaseInstanceColumns.kt
@@ -11,7 +11,7 @@ object DatabaseInstanceColumns : BaseColumns {
     const val JR_FORM_ID = "jrFormId"
     const val JR_VERSION = "jrVersion"
     const val STATUS = "status"
-    const val CAN_EDIT_WHEN_COMPLETE = "canEditWhenComplete"
+    const val CAN_EDIT_WHEN_COMPLETE = "canEditWhenComplete" // the only reason why a finalized form should not be opened for review is that it is encrypted
     const val LAST_STATUS_CHANGE_DATE = "date"
     const val DELETED_DATE = "deletedDate"
     const val GEOMETRY = "geometry"

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -61,6 +61,7 @@ class FormUriActivity : ComponentActivity() {
             !assertCurrentProjectUsed() -> Unit
             !assertValidUri() -> Unit
             !assertFormExists() -> Unit
+            !assertFormNotEncrypted() -> Unit
             !assertFormFillingNotAlreadyStarted(savedInstanceState) -> Unit
             else -> startForm()
         }
@@ -148,6 +149,23 @@ class FormUriActivity : ComponentActivity() {
         return if (!doesFormExist) {
             displayErrorDialog(getString(R.string.bad_uri))
             false
+        } else {
+            true
+        }
+    }
+
+    private fun assertFormNotEncrypted(): Boolean {
+        val uri = intent.data!!
+        val uriMimeType = contentResolver.getType(uri)
+
+        return if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
+            val instance = instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
+            if (instance!!.canEditWhenComplete()) {
+                true
+            } else {
+                displayErrorDialog(getString(R.string.encrypted_form))
+                false
+            }
         } else {
             true
         }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -329,12 +329,16 @@ class MainMenuActivity : LocalizedActivity() {
 
         val formSavedSnackbarDetails = mainMenuViewModel.getFormSavedSnackbarDetails(uri)
 
-        formSavedSnackbarDetails?.let { it ->
+        formSavedSnackbarDetails?.let {
             SnackbarUtils.showLongSnackbar(
                 binding.root,
                 getString(it.first),
-                action = SnackbarUtils.Action(getString(it.second)) {
-                    formLauncher.launch(FormFillingIntentFactory.editInstanceIntent(this, uri))
+                action = if (it.second == null) {
+                    null
+                } else {
+                    SnackbarUtils.Action(getString(it.second!!)) {
+                        formLauncher.launch(FormFillingIntentFactory.editInstanceIntent(this, uri))
+                    }
                 },
                 displayDismissButton = true
             )

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -333,10 +333,8 @@ class MainMenuActivity : LocalizedActivity() {
             SnackbarUtils.showLongSnackbar(
                 binding.root,
                 getString(it.first),
-                action = if (it.second == null) {
-                    null
-                } else {
-                    SnackbarUtils.Action(getString(it.second!!)) {
+                action = it.second?.let { action ->
+                    SnackbarUtils.Action(getString(action)) {
                         formLauncher.launch(FormFillingIntentFactory.editInstanceIntent(this, uri))
                     }
                 },

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
@@ -106,7 +106,7 @@ class MainMenuViewModel(
     val sentInstancesCount: LiveData<Int>
         get() = instancesAppState.sentCount
 
-    fun getFormSavedSnackbarDetails(uri: Uri): Pair<Int, Int>? {
+    fun getFormSavedSnackbarDetails(uri: Uri): Pair<Int, Int?>? {
         val instance = instancesRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
         return if (instance != null) {
             val message = if (instance.status == Instance.STATUS_INCOMPLETE) {
@@ -125,7 +125,11 @@ class MainMenuViewModel(
             val action = if (instance.canBeEdited(settingsProvider)) {
                 R.string.edit_form
             } else {
-                R.string.view_form
+                if (instance.status == Instance.STATUS_INCOMPLETE || instance.canEditWhenComplete()) {
+                    R.string.view_form
+                } else {
+                    null
+                }
             }
 
             return Pair(message, action)

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -310,6 +310,29 @@ class FormUriActivityTest {
     }
 
     @Test
+    fun `When attempting to edit an encrypted form then display alert dialog`() {
+        val project = Project.Saved("123", "First project", "A", "#cccccc")
+        projectsRepository.save(project)
+        whenever(currentProjectProvider.getCurrentProject()).thenReturn(project)
+
+        formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath, FormUtils.createXFormBody("1", "1", "Form 1")).build())
+
+        val instance = instancesRepository.save(
+            Instance.Builder()
+                .formId("1")
+                .formVersion("1")
+                .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
+                .status(Instance.STATUS_INCOMPLETE)
+                .canEditWhenComplete(false)
+                .build()
+        )
+
+        val scenario = launcherRule.launchForResult<FormUriActivity>(getSavedIntent(project.uuid, instance.dbId))
+
+        assertErrorDialog(scenario, context.getString(R.string.encrypted_form))
+    }
+
+    @Test
     fun `When attempting to edit an incomplete form with disabled editing then start form for view only`() {
         val project = Project.Saved("123", "First project", "A", "#cccccc")
         projectsRepository.save(project)

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuViewModelTest.kt
@@ -107,7 +107,6 @@ class MainMenuViewModelTest {
                 .formVersion("1")
                 .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
                 .status(Instance.STATUS_INCOMPLETE)
-                .canEditWhenComplete(true)
                 .build()
         )
 
@@ -151,7 +150,6 @@ class MainMenuViewModelTest {
                 .formVersion("1")
                 .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
                 .status(Instance.STATUS_INCOMPLETE)
-                .canEditWhenComplete(true)
                 .build()
         )
 
@@ -194,7 +192,6 @@ class MainMenuViewModelTest {
                 .formVersion("1")
                 .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
                 .status(Instance.STATUS_COMPLETE)
-                .canEditWhenComplete(true)
                 .build()
         )
         whenever(autoSendSettingsProvider.isAutoSendEnabledInSettings()).thenReturn(false)
@@ -238,7 +235,6 @@ class MainMenuViewModelTest {
                 .formVersion("1")
                 .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
                 .status(Instance.STATUS_COMPLETE)
-                .canEditWhenComplete(true)
                 .build()
         )
 

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuViewModelTest.kt
@@ -96,16 +96,18 @@ class MainMenuViewModelTest {
     }
 
     @Test
-    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is saved as draft and editing drafts is enabled`() {
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is saved as draft, editing drafts is enabled and encryption is disabled`() {
         val viewModel = createViewModelWithVersion("")
         settingsProvider.getProtectedSettings().save(ProtectedProjectKeys.KEY_EDIT_SAVED, true)
 
+        formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
         val instance = instancesRepository.save(
             Instance.Builder()
                 .formId("1")
                 .formVersion("1")
                 .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
                 .status(Instance.STATUS_INCOMPLETE)
+                .canEditWhenComplete(true)
                 .build()
         )
 
@@ -116,16 +118,40 @@ class MainMenuViewModelTest {
     }
 
     @Test
-    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is saved as draft and editing drafts is disabled`() {
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is saved as draft, editing drafts is enabled and encryption is enabled`() {
         val viewModel = createViewModelWithVersion("")
-        settingsProvider.getProtectedSettings().save(ProtectedProjectKeys.KEY_EDIT_SAVED, false)
+        settingsProvider.getProtectedSettings().save(ProtectedProjectKeys.KEY_EDIT_SAVED, true)
 
+        formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
         val instance = instancesRepository.save(
             Instance.Builder()
                 .formId("1")
                 .formVersion("1")
                 .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
                 .status(Instance.STATUS_INCOMPLETE)
+                .canEditWhenComplete(false)
+                .build()
+        )
+
+        val uri = InstancesContract.getUri(Project.DEMO_PROJECT_ID, instance.dbId)
+        val formSavedSnackbarType = viewModel.getFormSavedSnackbarDetails(uri)!!
+        assertThat(formSavedSnackbarType.first, equalTo(R.string.form_saved_as_draft))
+        assertThat(formSavedSnackbarType.second, equalTo(R.string.edit_form))
+    }
+
+    @Test
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is saved as draft, editing drafts is disabled and encryption is disabled`() {
+        val viewModel = createViewModelWithVersion("")
+        settingsProvider.getProtectedSettings().save(ProtectedProjectKeys.KEY_EDIT_SAVED, false)
+
+        formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
+        val instance = instancesRepository.save(
+            Instance.Builder()
+                .formId("1")
+                .formVersion("1")
+                .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
+                .status(Instance.STATUS_INCOMPLETE)
+                .canEditWhenComplete(true)
                 .build()
         )
 
@@ -136,7 +162,29 @@ class MainMenuViewModelTest {
     }
 
     @Test
-    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is finalized and auto send is disabled`() {
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is saved as draft, editing drafts is disabled and encryption is enabled`() {
+        val viewModel = createViewModelWithVersion("")
+        settingsProvider.getProtectedSettings().save(ProtectedProjectKeys.KEY_EDIT_SAVED, false)
+
+        formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
+        val instance = instancesRepository.save(
+            Instance.Builder()
+                .formId("1")
+                .formVersion("1")
+                .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
+                .status(Instance.STATUS_INCOMPLETE)
+                .canEditWhenComplete(false)
+                .build()
+        )
+
+        val uri = InstancesContract.getUri(Project.DEMO_PROJECT_ID, instance.dbId)
+        val formSavedSnackbarType = viewModel.getFormSavedSnackbarDetails(uri)!!
+        assertThat(formSavedSnackbarType.first, equalTo(R.string.form_saved_as_draft))
+        assertThat(formSavedSnackbarType.second, equalTo(R.string.view_form))
+    }
+
+    @Test
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is finalized, auto send is disabled and encryption is disabled`() {
         val viewModel = createViewModelWithVersion("")
 
         formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
@@ -146,6 +194,7 @@ class MainMenuViewModelTest {
                 .formVersion("1")
                 .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
                 .status(Instance.STATUS_COMPLETE)
+                .canEditWhenComplete(true)
                 .build()
         )
         whenever(autoSendSettingsProvider.isAutoSendEnabledInSettings()).thenReturn(false)
@@ -157,7 +206,7 @@ class MainMenuViewModelTest {
     }
 
     @Test
-    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is finalized and auto send is enabled`() {
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is finalized, auto send is disabled and encryption is enabled`() {
         val viewModel = createViewModelWithVersion("")
 
         formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
@@ -167,6 +216,29 @@ class MainMenuViewModelTest {
                 .formVersion("1")
                 .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
                 .status(Instance.STATUS_COMPLETE)
+                .canEditWhenComplete(false)
+                .build()
+        )
+        whenever(autoSendSettingsProvider.isAutoSendEnabledInSettings()).thenReturn(false)
+
+        val uri = InstancesContract.getUri(Project.DEMO_PROJECT_ID, instance.dbId)
+        val formSavedSnackbarDetails = viewModel.getFormSavedSnackbarDetails(uri)!!
+        assertThat(formSavedSnackbarDetails.first, equalTo(R.string.form_saved))
+        assertThat(formSavedSnackbarDetails.second, equalTo(null))
+    }
+
+    @Test
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is finalized, auto send is enabled and encryption is disabled`() {
+        val viewModel = createViewModelWithVersion("")
+
+        formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
+        val instance = instancesRepository.save(
+            Instance.Builder()
+                .formId("1")
+                .formVersion("1")
+                .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
+                .status(Instance.STATUS_COMPLETE)
+                .canEditWhenComplete(true)
                 .build()
         )
 
@@ -176,6 +248,29 @@ class MainMenuViewModelTest {
         val formSavedSnackbarDetails = viewModel.getFormSavedSnackbarDetails(uri)!!
         assertThat(formSavedSnackbarDetails.first, equalTo(R.string.form_sending))
         assertThat(formSavedSnackbarDetails.second, equalTo(R.string.view_form))
+    }
+
+    @Test
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance is finalized, auto send is enabled and encryption is enabled`() {
+        val viewModel = createViewModelWithVersion("")
+
+        formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
+        val instance = instancesRepository.save(
+            Instance.Builder()
+                .formId("1")
+                .formVersion("1")
+                .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
+                .status(Instance.STATUS_COMPLETE)
+                .canEditWhenComplete(false)
+                .build()
+        )
+
+        whenever(autoSendSettingsProvider.isAutoSendEnabledInSettings()).thenReturn(true)
+
+        val uri = InstancesContract.getUri(Project.DEMO_PROJECT_ID, instance.dbId)
+        val formSavedSnackbarDetails = viewModel.getFormSavedSnackbarDetails(uri)!!
+        assertThat(formSavedSnackbarDetails.first, equalTo(R.string.form_sending))
+        assertThat(formSavedSnackbarDetails.second, equalTo(null))
     }
 
     @Test

--- a/forms/src/main/java/org/odk/collect/forms/instances/Instance.java
+++ b/forms/src/main/java/org/odk/collect/forms/instances/Instance.java
@@ -63,7 +63,7 @@ public final class Instance {
     public static class Builder {
         private String displayName;
         private String submissionUri;
-        private boolean canEditWhenComplete;
+        private boolean canEditWhenComplete = true;
         private String instanceFilePath;
         private String formId;
         private String formVersion;


### PR DESCRIPTION
Closes #5642 

#### What has been done to verify that this works as intended?
I've tested the changes manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The only thing of note is how I determine if an instance is encrypted. I've decided to use the easiest solution and check the `CAN_EDIT_WHEN_COMPLETE` column from the `instances.db`. It turns out that the only way of having `false` in that column is when a form is encrypted. This column probably should be renamed to reflect its real purpose but that's something for the future, I don't want to introduce database upgrades now because it would be risky. 
Another option would be to check the `BASE64_RSA_PUBLIC_KEY` from the `forms.db` (if it's not null) but that would be more complex since I would need to browse the forms db instead of just checking the instance that is already available.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The case described in the issue was not the only way of opening an encrypted form. There were two more:
- opening the list of forms to send and clicking on a form
- using an external app (like the collect tester) and opening an encrypted form via that app

Please reproduce those two cases too and make sure they are handled properly.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
