### PR TITLE
Don't start background recording when viewing forms

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
@@ -174,6 +174,18 @@ public class BackgroundAudioRecordingTest {
         new MainMenuPage().assertOnPage();
     }
 
+    @Test
+    public void viewForm_doesNotRecordAudio() {
+        rule.startAtMainMenu()
+                .copyForm("one-question-background-audio.xml")
+                .startBlankForm("One Question")
+                .fillOutAndFinalize(new FormEntryPage.QuestionAndAnswer("what is your age", "17"))
+                .clickSendFinalizedForm(1)
+                .clickOnForm("One Question");
+
+        assertThat(stubAudioRecorderViewModel.isRecording(), is(false));
+    }
+
     private static class RevokeableRecordAudioPermissionsChecker extends ContextCompatPermissionChecker {
 
         private boolean revoked;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -413,7 +413,22 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
             sessionId = savedInstanceState.getString(KEY_SESSION_ID);
         }
 
-        viewModelFactory = new FormEntryViewModelFactory(this, sessionId, scheduler, formSessionRepository, mediaUtils, audioRecorder, currentProjectProvider, entitiesRepositoryProvider, settingsProvider, permissionsChecker, fusedLocatonClient, permissionsProvider, autoSendSettingsProvider, instancesRepositoryProvider);
+        viewModelFactory = new FormEntryViewModelFactory(this,
+                getIntent().getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE),
+                sessionId,
+                scheduler,
+                formSessionRepository,
+                mediaUtils,
+                audioRecorder,
+                currentProjectProvider,
+                entitiesRepositoryProvider,
+                settingsProvider,
+                permissionsChecker,
+                fusedLocatonClient,
+                permissionsProvider,
+                autoSendSettingsProvider,
+                instancesRepositoryProvider
+        );
 
         this.getSupportFragmentManager().setFragmentFactory(new FragmentFactoryBuilder()
                 .forClass(AudioRecordingControllerFragment.class, () -> new AudioRecordingControllerFragment(viewModelFactory))

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -57,6 +57,7 @@ import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.javarosawrapper.JavaRosaFormController;
 import org.odk.collect.android.logic.HierarchyElement;
 import org.odk.collect.android.projects.CurrentProjectProvider;
+import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.HtmlUtils;
 import org.odk.collect.android.utilities.InstancesRepositoryProvider;
@@ -181,7 +182,22 @@ public class FormHierarchyActivity extends LocalizedActivity implements DeleteRe
         DaggerUtils.getComponent(this).inject(this);
 
         String sessionId = getIntent().getStringExtra(EXTRA_SESSION_ID);
-        FormEntryViewModelFactory viewModelFactory = new FormEntryViewModelFactory(this, sessionId, scheduler, formSessionRepository, mediaUtils, audioRecorder, currentProjectProvider, entitiesRepositoryProvider, settingsProvider, permissionsChecker, fusedLocationClient, permissionsProvider, autoSendSettingsProvider, instancesRepositoryProvider);
+        FormEntryViewModelFactory viewModelFactory = new FormEntryViewModelFactory(this,
+                ApplicationConstants.FormModes.EDIT_SAVED,
+                sessionId,
+                scheduler,
+                formSessionRepository,
+                mediaUtils,
+                audioRecorder,
+                currentProjectProvider,
+                entitiesRepositoryProvider,
+                settingsProvider,
+                permissionsChecker,
+                fusedLocationClient,
+                permissionsProvider,
+                autoSendSettingsProvider,
+                instancesRepositoryProvider
+        );
 
         this.getSupportFragmentManager().setFragmentFactory(new FragmentFactoryBuilder()
                 .forClass(DeleteRepeatDialogFragment.class, () -> new DeleteRepeatDialogFragment(viewModelFactory))


### PR DESCRIPTION
Closes #5643 

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I actually think the better solution would be to rework `FormFillingActivity` so that the form entry, hierarchy and view only hierarchy views are all separate fragments that get navigated to after form load (depending on form state etc). This is work we've already planned (#5420), and it'd be a major effort that doesn't feel worth it to fix this one bug in isolation.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

As well as verifying the issue is fixed, checking editing and filling forms with background recordings in general would be good.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
