### PR TITLE
Increase select checkbox touch target size in Ready to send

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.CursorAdapter;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -65,9 +66,7 @@ public class InstanceUploaderAdapter extends CursorAdapter {
 
         long dbId = cursor.getLong(cursor.getColumnIndex(DatabaseInstanceColumns._ID));
         viewHolder.checkbox.setChecked(selected.contains(dbId));
-        viewHolder.checkbox.setOnClickListener(v -> {
-            onItemCheckboxClickListener.accept(dbId);
-        });
+        viewHolder.selectView.setOnClickListener(v -> onItemCheckboxClickListener.accept(dbId));
     }
 
     public void setSelected(Set<Long> ids) {
@@ -81,6 +80,7 @@ public class InstanceUploaderAdapter extends CursorAdapter {
         CheckBox checkbox;
         ImageView statusIcon;
         ImageView closeButton;
+        FrameLayout selectView;
 
         ViewHolder(View view) {
             formTitle = view.findViewById(R.id.form_title);
@@ -88,6 +88,7 @@ public class InstanceUploaderAdapter extends CursorAdapter {
             checkbox = view.findViewById(R.id.checkbox);
             statusIcon = view.findViewById(R.id.image);
             closeButton = view.findViewById(R.id.close_box);
+            selectView = view.findViewById(R.id.selectView);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/views/TwoItemMultipleChoiceView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/TwoItemMultipleChoiceView.java
@@ -18,11 +18,12 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.CheckBox;
 import android.widget.Checkable;
-import android.widget.RelativeLayout;
+
+import androidx.constraintlayout.widget.ConstraintLayout;
 
 import org.odk.collect.android.R;
 
-public class TwoItemMultipleChoiceView extends RelativeLayout implements Checkable {
+public class TwoItemMultipleChoiceView extends ConstraintLayout implements Checkable {
 
     public TwoItemMultipleChoiceView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);

--- a/collect_app/src/main/res/layout/form_chooser_list_item_multiple_choice.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item_multiple_choice.xml
@@ -9,8 +9,7 @@ the specific language governing permissions and limitations under the License. -
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:layout_height="wrap_content">
 
     <!-- Material Design reference: https://material.io/design/components/lists.html#specs -->
 
@@ -18,20 +17,24 @@ the specific language governing permissions and limitations under the License. -
         android:id="@+id/imageView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true">
+        android:layout_alignParentTop="true"
+        android:paddingVertical="@dimen/margin_standard"
+        android:paddingHorizontal="@dimen/margin_standard"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <include layout="@layout/form_chooser_list_item_icon" />
 
     </FrameLayout>
 
     <FrameLayout
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_alignTop="@id/imageView"
-        android:layout_marginStart="@dimen/margin_standard"
-        android:layout_marginEnd="16dp"
-        android:layout_toStartOf="@id/selectView"
-        android:layout_toEndOf="@id/imageView">
+        android:paddingVertical="@dimen/margin_standard"
+        app:layout_constraintStart_toEndOf="@id/imageView"
+        app:layout_constraintEnd_toStartOf="@id/selectView"
+        app:layout_constraintTop_toTopOf="@id/imageView">
 
         <include layout="@layout/form_chooser_list_item_text" />
 
@@ -40,9 +43,12 @@ the specific language governing permissions and limitations under the License. -
     <FrameLayout
         android:id="@+id/selectView"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentEnd="true">
+        android:layout_height="0dp"
+        android:paddingVertical="@dimen/margin_standard"
+        android:paddingHorizontal="@dimen/margin_standard"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/imageView">
 
         <CheckBox
             android:id="@+id/checkbox"
@@ -61,5 +67,4 @@ the specific language governing permissions and limitations under the License. -
             tools:visibility="visible" />
 
     </FrameLayout>
-
 </org.odk.collect.android.views.TwoItemMultipleChoiceView>


### PR DESCRIPTION
Closes #5648

#### What has been done to verify that this works as intended?
I've tested the changes manually.

#### Why is this the best possible solution? Were any other approaches considered?
The clickable area is now much bigger (the grey area):

| Before  | Now |
| ------------- | ------------- |
| ![Screenshot_1688077391](https://github.com/getodk/collect/assets/3276264/43e9513a-178f-4244-a232-fe3f458caa56) | ![Screenshot_1688077298](https://github.com/getodk/collect/assets/3276264/8e258345-6915-4110-abe1-5f8f5cb347b1) |

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just make the clickable area bigger.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
