### PR TITLE
Fix date format in translation

### DIFF
--- a/strings/src/main/res/values-in/strings.xml
+++ b/strings/src/main/res/values-in/strings.xml
@@ -139,7 +139,7 @@
   <string name="keep_editing">Terus mengubah</string>
   <string name="quit_form_title">Simpan formulir?</string>
   <string name="save_explanation">Anda dapat menyimpan formulir ini dan mengaksesnya dari draf anda kapan saja.</string>
-  <string name="save_explanation_with_last_saved">\'Formulir ini terakhir disimpan pada\' EEE, dd MMM yyyy\', pukul\' HH:mm\'\'. Simpan sebagai draf untuk menyimpan perubahan.\'</string>
+  <string name="save_explanation_with_last_saved">\'Formulir ini terakhir disimpan pada\' EEE, dd MMM yyyy\', pukul\' HH:mm\'. Simpan sebagai draf untuk menyimpan perubahan.\'</string>
   <string name="quit_form_continue_title">Lanjutkan pengubahan?</string>
   <string name="discard_form_warning">Jika anda membuang formulir, anda akan kehilangan perubahan yang telah anda buat sejauh ini.</string>
   <string name="discard_changes_warning">\'Formulir ini terakhir disimpan pada\' EEE, dd MMM yyyy\', pukul\' HH:mm\'. Jika anda membuang perubahan, anda akan kehilangan perubahan yang telah anda buat sejak saat itu.\'</string>


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/dcc0857c75ce5837d437257c8ff9b02a?time=last-seven-days&versions=v2023.2.1%20(4675)&types=crash&sessionEventKey=64AC164E027E00013E338329F3768D08_1832658475027750783)

#### What has been done to verify that this works as intended?

Verified manually

#### Why is this the best possible solution? Were any other approaches considered?

Not really any other option here!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue - can be reproduced by trying to quit form entry while in a Draft with the language set to Indonesian.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
