### PR TITLE
Add test to check date formats parse correctly

### DIFF
--- a/docs/CODE-GUIDELINES.md
+++ b/docs/CODE-GUIDELINES.md
@@ -60,6 +60,8 @@ When creating or refactoring views, keep in mind our vision of an "ideal" view:
 ## Strings
 Always use [string resources](https://developer.android.com/guide/topics/resources/string-resource.html) instead of literal strings. This ensures wording consistency across the project and also enables full translation of the app. Only make changes to the base `res/values/strings.xml` English file (in the `strings` module) and not to the other language files. The translated files are generated from [Transifex](https://www.transifex.com/getodk/collect/) where translations can be submitted by the community. Names of software packages or other untranslatable strings should be placed in `res/values/untranslated.xml`.
 
+If a new string is added that is used as a date format (with `SimpleDateFormat`), it should be added to `DateFormatsTest` to ensure that translations do not cause crashes.
+
 Strings that represent very rare failure cases or that are meant more for ODK developers to use for troubleshooting rather than directly for users may be written as literal strings. This reduces the burden on translators and makes it easier for developers to troubleshoot edge cases without having to look up translations.
 
 ## Dependency injection

--- a/strings/build.gradle
+++ b/strings/build.gradle
@@ -28,7 +28,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     namespace 'org.odk.collect.strings'
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -42,6 +49,8 @@ dependencies {
 
     testImplementation Dependencies.junit
     testImplementation Dependencies.hamcrest
+    testImplementation Dependencies.androidx_test_ext_junit
+    testImplementation Dependencies.robolectric
 }
 repositories {
     mavenCentral()

--- a/strings/src/main/java/org/odk/collect/strings/localization/LocalizedApplication.kt
+++ b/strings/src/main/java/org/odk/collect/strings/localization/LocalizedApplication.kt
@@ -2,6 +2,7 @@ package org.odk.collect.strings.localization
 
 import android.content.Context
 import android.content.res.Configuration
+import android.content.res.Resources
 import android.os.Build
 import android.view.View
 import java.util.Locale
@@ -20,13 +21,15 @@ fun Context.getLocalizedString(stringId: Int, vararg formatArgs: Any): String {
         else -> if (Build.VERSION.SDK_INT >= 24) resources.configuration.locales[0] else resources.configuration.locale
     }
 
+    return getLocalizedResources(locale).getString(stringId, *formatArgs)
+}
+
+fun Context.getLocalizedResources(locale: Locale): Resources {
     val newConfig = Configuration(resources.configuration).apply {
         setLocale(locale)
     }
 
-    return createConfigurationContext(newConfig)
-        .resources
-        .getString(stringId, *formatArgs)
+    return createConfigurationContext(newConfig).resources
 }
 
 fun Context.isLTR(): Boolean {

--- a/strings/src/main/res/values-cs/strings.xml
+++ b/strings/src/main/res/values-cs/strings.xml
@@ -18,7 +18,6 @@
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
   <string name="added_on_date_at_time">\'Přidáno\' EEE, dd MMM, yyyy \'v\' HH:mm</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
-  <string name="updated_on_date_at_time">\"Aktualizováno dne\" EEE, MMM dd, rrrr \"v\" HH:mm</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
   <string name="saved_on_date_at_time">\'Uloženo\' EEE, dd MMM, yyyy \'v\' HH:mm</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
@@ -139,10 +138,8 @@
   <string name="keep_editing">Pokračujte v úpravách</string>
   <string name="quit_form_title">Uložit formulář?</string>
   <string name="save_explanation">Tento formulář můžete uložit a kdykoli k němu přistupovat z návrhů.</string>
-  <string name="save_explanation_with_last_saved">\"Tento formulář byl naposledy uložen dne\" EEE, MMM dd, rrrr \"v\" HH:mm\". Uložit jako návrh pro zachování změn.</string>
   <string name="quit_form_continue_title">Pokračovat v úpravách?</string>
   <string name="discard_form_warning">Pokud formulář zahodíte, ztratíte všechny dosud provedené změny.</string>
-  <string name="discard_changes_warning">\"Tento formulář byl naposledy uložen dne\" EEE, MMM dd, rrrr \"v\" HH:mm\". Pokud změny zahodíte, ztratíte všechny změny, které jste od té doby provedli.</string>
   <string name="saving_form">Ukládám dotazník</string>
   <string name="survey_saving_validating_message">Ověřuji odpovědi…</string>
   <string name="survey_saving_collecting_message">Sbírám data…</string>

--- a/strings/src/main/res/values-it/strings.xml
+++ b/strings/src/main/res/values-it/strings.xml
@@ -138,10 +138,8 @@
   <string name="keep_editing">Continua a modificare</string>
   <string name="quit_form_title">Salvare il Modulo?</string>
   <string name="save_explanation">Puoi salvare questo modulo e accedervi dalle tue bozze in qualsiasi momento.</string>
-  <string name="save_explanation_with_last_saved">\'Questo modulo è stato salvato l\'ultima volta il\' EEE, MMM dd, yyyy \'alle\' HH:mm\'. Salva come bozza per conservare le modifiche.\'</string>
   <string name="quit_form_continue_title">Continua con le modifiche?</string>
   <string name="discard_form_warning">Se elimini il modulo, perderai tutte le modifiche apportate fino a quel momento.</string>
-  <string name="discard_changes_warning">\'Questo modulo è stato salvato l\'ultima volta il\' EEE, MMM dd, yyyy \'alle\' HH:mm\'. Se scarti le modifiche, perderai tutte le modifiche apportate da allora.\'</string>
   <string name="saving_form">Salvataggio Modulo</string>
   <string name="survey_saving_validating_message">Convalida risposte…</string>
   <string name="survey_saving_collecting_message">Raccolta dati in corso…</string>

--- a/strings/src/main/res/values-mr/strings.xml
+++ b/strings/src/main/res/values-mr/strings.xml
@@ -15,7 +15,6 @@
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
   <string name="finalized_on_date_at_time">\'इ.ई.ई., एमएमएम डीडी, य्यय\' एचएच: एमएम वर अंतिम रूप दिले</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
-  <string name="sent_on_date_at_time">\'सेंड ऑन\' ईईई, एमएमएम डीडी, य्य्य \'एचएच: एमएम</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
   <string name="sending_failed_on_date_at_time">\'ईईई, एमएमएम डीडी, येय एचएच: एमएम \'वर पाठविणे अयशस्वी झाले</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->

--- a/strings/src/main/res/values-nl/strings.xml
+++ b/strings/src/main/res/values-nl/strings.xml
@@ -123,7 +123,7 @@
   <string name="keep_changes">Wijzigingen opslaan</string>
   <string name="keep_editing">Doorgaan met invullen</string>
   <string name="quit_form_title">Bewaar formulier?</string>
-  <string name="save_explanation_with_last_saved">\'Dit formulier was voor het laatst bewaard op \' EEE dd MMM yyyy \'om\' HH:mm\'. Bewaar als concept om de wijzigingen te behouden.</string>
+  <string name="save_explanation_with_last_saved">\'Dit formulier was voor het laatst bewaard op \' EEE dd MMM yyyy \'om\' HH:mm\'. Bewaar als concept om de wijzigingen te behouden.\'</string>
   <string name="quit_form_continue_title">Doorgaan met wijzigen?</string>
   <string name="saving_form">Formulier opslaan</string>
   <string name="survey_saving_validating_message">Valideren antwoorden…</string>

--- a/strings/src/main/res/values-sw-rKE/strings.xml
+++ b/strings/src/main/res/values-sw-rKE/strings.xml
@@ -7,16 +7,16 @@
   <!--Text for an action button on the main screen.-->
   <!--Text for an action button on the main screen.-->
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
-  <string name="added_on_date_at_time">Imeongezwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
+  <string name="added_on_date_at_time">\'Imeongezwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
-  <string name="saved_on_date_at_time">Imehifadhiwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
+  <string name="saved_on_date_at_time">\'Imehifadhiwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
-  <string name="finalized_on_date_at_time">Imekamilishwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
+  <string name="finalized_on_date_at_time">\'Imekamilishwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
-  <string name="sent_on_date_at_time">Imetumwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
+  <string name="sent_on_date_at_time">\'Imetumwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
-  <string name="sending_failed_on_date_at_time">ilishindwa kutumwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
+  <string name="sending_failed_on_date_at_time">\'ilishindwa kutumwa \'EEE, MMM dd, yyyy \'at\' HH:mm</string>
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
   <!--Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
   <string name="sort_by_name_asc">Jina, A-Z</string>

--- a/strings/src/test/java/org/odk/collect/strings/format/DateFormatsTest.kt
+++ b/strings/src/test/java/org/odk/collect/strings/format/DateFormatsTest.kt
@@ -16,7 +16,7 @@ class DateFormatsTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
 
     @Test
-    fun checkAllDateFormatsParse() {
+    fun `all date formats parse in all available locales`() {
         formats.forEach { format ->
             application.resources.assets.locales.forEach { localeCode ->
                 val locale = Locale.forLanguageTag(localeCode)

--- a/strings/src/test/java/org/odk/collect/strings/format/DateFormatsTest.kt
+++ b/strings/src/test/java/org/odk/collect/strings/format/DateFormatsTest.kt
@@ -1,0 +1,42 @@
+package org.odk.collect.strings.format
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.strings.R
+import org.odk.collect.strings.localization.getLocalizedResources
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class DateFormatsTest {
+
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    @Test
+    fun checkAllDateFormatsParse() {
+        formats.forEach { format ->
+            application.resources.assets.locales.forEach { localeCode ->
+                val locale = Locale.forLanguageTag(localeCode)
+                val resources = application.getLocalizedResources(locale)
+                val string = resources.getString(format)
+                SimpleDateFormat(string, locale)
+            }
+        }
+    }
+}
+
+private val formats = setOf(
+    R.string.save_explanation_with_last_saved,
+    R.string.discard_changes_warning,
+    R.string.added_on_date_at_time,
+    R.string.updated_on_date_at_time,
+    R.string.saved_on_date_at_time,
+    R.string.finalized_on_date_at_time,
+    R.string.sent_on_date_at_time,
+    R.string.sending_failed_on_date_at_time,
+    R.string.deleted_on_date_at_time,
+    R.string.modified_on_date_at_time
+)

--- a/strings/src/test/java/org/odk/collect/strings/format/DateFormatsTest.kt
+++ b/strings/src/test/java/org/odk/collect/strings/format/DateFormatsTest.kt
@@ -22,7 +22,11 @@ class DateFormatsTest {
                 val locale = Locale.forLanguageTag(localeCode)
                 val resources = application.getLocalizedResources(locale)
                 val string = resources.getString(format)
-                SimpleDateFormat(string, locale)
+                try {
+                    SimpleDateFormat(string, locale)
+                } catch (e: Throwable) {
+                    throw IllegalArgumentException("Illegal format translation: $string", e)
+                }
             }
         }
     }


### PR DESCRIPTION
This adds a test to `strings` that checks all the strings used for date formats in every available locale to check that they won't cause parse errors (resulting in crashes).

I've additionally fixed any remaining broken strings.