### PR TITLE
Allow editing finalized forms saved before October 1st 2023 UTC

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
@@ -27,6 +27,7 @@ import org.odk.collect.android.support.pages.FormEndPage;
 import org.odk.collect.android.support.pages.FormEntryPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.SaveOrDiscardFormDialog;
+import org.odk.collect.android.support.pages.SendFinalizedFormPage;
 import org.odk.collect.android.support.rules.CollectTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
@@ -181,6 +182,9 @@ public class BackgroundAudioRecordingTest {
                 .startBlankForm("One Question")
                 .fillOutAndFinalize(new FormEntryPage.QuestionAndAnswer("what is your age", "17"))
                 .clickSendFinalizedForm(1)
+                .clickSelectAll()
+                .clickSendSelected()
+                .clickOK(new SendFinalizedFormPage())
                 .clickOnForm("One Question");
 
         assertThat(stubAudioRecorderViewModel.isRecording(), is(false));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.odk.collect.android.instancemanagement.InstanceExtKt.OCTOBER_1st_2023_UTC;
 import static org.odk.collect.android.support.FileUtils.copyFileFromAssets;
 
 import android.Manifest;
@@ -27,7 +28,6 @@ import org.odk.collect.android.support.pages.FormEndPage;
 import org.odk.collect.android.support.pages.FormEntryPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.SaveOrDiscardFormDialog;
-import org.odk.collect.android.support.pages.SendFinalizedFormPage;
 import org.odk.collect.android.support.rules.CollectTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
@@ -41,6 +41,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 @RunWith(AndroidJUnit4.class)
 public class BackgroundAudioRecordingTest {
@@ -49,6 +50,8 @@ public class BackgroundAudioRecordingTest {
 
     private final RevokeableRecordAudioPermissionsChecker permissionsChecker = new RevokeableRecordAudioPermissionsChecker(ApplicationProvider.getApplicationContext());
     private final ControllableRecordAudioPermissionsProvider permissionsProvider = new ControllableRecordAudioPermissionsProvider(permissionsChecker);
+    private Long currentTimeMillis = System.currentTimeMillis();
+
     private final TestDependencies testDependencies = new TestDependencies() {
 
         @Override
@@ -76,6 +79,11 @@ public class BackgroundAudioRecordingTest {
         @Override
         public PermissionsProvider providesPermissionsProvider(PermissionsChecker permissionsChecker) {
             return permissionsProvider;
+        }
+
+        @Override
+        public Supplier<Long> providesClock() {
+            return () -> currentTimeMillis;
         }
     };
 
@@ -177,14 +185,13 @@ public class BackgroundAudioRecordingTest {
 
     @Test
     public void viewForm_doesNotRecordAudio() {
+        currentTimeMillis = OCTOBER_1st_2023_UTC + 1;
+
         rule.startAtMainMenu()
                 .copyForm("one-question-background-audio.xml")
                 .startBlankForm("One Question")
                 .fillOutAndFinalize(new FormEntryPage.QuestionAndAnswer("what is your age", "17"))
                 .clickSendFinalizedForm(1)
-                .clickSelectAll()
-                .clickSendSelected()
-                .clickOK(new SendFinalizedFormPage())
                 .clickOnForm("One Question");
 
         assertThat(stubAudioRecorderViewModel.isRecording(), is(false));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
@@ -44,9 +44,8 @@ class FormSavedSnackbarTest {
             .assertText(R.string.form_saved)
             .clickOnString(R.string.view_form)
             .assertText("25")
-            .assertTextDoesNotExist(R.string.jump_to_beginning)
-            .assertTextDoesNotExist(R.string.jump_to_end)
-            .assertText(R.string.exit)
+            .assertText(R.string.jump_to_beginning)
+            .assertText(R.string.jump_to_end)
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
@@ -4,15 +4,26 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.odk.collect.android.R
+import org.odk.collect.android.instancemanagement.OCTOBER_1st_2023_UTC
+import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain
+import java.util.function.Supplier
 
 class FormSavedSnackbarTest {
     private val rule = CollectTestRule()
 
+    private var currentTimeMillis: Long = System.currentTimeMillis()
+
+    private val testDependencies = object : TestDependencies() {
+        override fun providesClock(): Supplier<Long> {
+            return Supplier { currentTimeMillis }
+        }
+    }
+
     @get:Rule
-    val copyFormChain: RuleChain = TestRuleChain.chain().around(rule)
+    val copyFormChain: RuleChain = TestRuleChain.chain(testDependencies).around(rule)
 
     @Test
     fun whenBlankFormSavedAsDraft_displaySnackbarWithEditAction() {
@@ -30,7 +41,9 @@ class FormSavedSnackbarTest {
     }
 
     @Test
-    fun whenDraftFinalized_displaySnackbarWithViewAction() {
+    fun beforeOCTOBER_1st_2023_UTC_whenDraftFinalized_displaySnackbarWithViewActionThatOpensFormForEdit() {
+        currentTimeMillis = OCTOBER_1st_2023_UTC - 1
+
         rule.startAtMainMenu()
             .copyForm("one-question.xml")
             .startBlankForm("One Question")
@@ -46,6 +59,28 @@ class FormSavedSnackbarTest {
             .assertText("25")
             .assertText(R.string.jump_to_beginning)
             .assertText(R.string.jump_to_end)
+    }
+
+    @Test
+    fun afterOCTOBER_1st_2023_UTC_whenDraftFinalized_displaySnackbarWithViewActionThatOpensFormForViewOnly() {
+        currentTimeMillis = OCTOBER_1st_2023_UTC + 1
+
+        rule.startAtMainMenu()
+            .copyForm("one-question.xml")
+            .startBlankForm("One Question")
+            .answerQuestion(0, "25")
+            .swipeToEndScreen()
+            .clickSaveAsDraft()
+            .clickEditSavedForm()
+            .clickOnForm("One Question")
+            .clickGoToEnd()
+            .clickFinalize()
+            .assertText(R.string.form_saved)
+            .clickOnString(R.string.view_form)
+            .assertText("25")
+            .assertTextDoesNotExist(R.string.jump_to_beginning)
+            .assertTextDoesNotExist(R.string.jump_to_end)
+            .assertText(R.string.exit)
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.kt
@@ -36,7 +36,7 @@ class SendFinalizedFormTest {
             .startBlankForm("One Question")
             .fillOutAndFinalize(QuestionAndAnswer("what is your age", "52"))
             .clickSendFinalizedForm(1)
-            .clickOnForm("One Question")
+            .clickOnFormToEdit("One Question")
             .assertText("52")
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/SendFinalizedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/SendFinalizedFormPage.java
@@ -25,6 +25,11 @@ public class SendFinalizedFormPage extends Page<SendFinalizedFormPage> {
         return new ViewFormPage(formLabel).assertOnPage();
     }
 
+    public FormHierarchyPage clickOnFormToEdit(String formLabel) {
+        clickOnText(formLabel);
+        return new FormHierarchyPage(formLabel).assertOnPage();
+    }
+
     public OkDialog clickSendSelected() {
         clickOnText(getTranslatedString(R.string.send_selected_data));
         return new OkDialog();

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -11,7 +11,7 @@ import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.analytics.AnalyticsEvents
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.instancemanagement.InstanceDeleter
-import org.odk.collect.android.instancemanagement.canBeEdited
+import org.odk.collect.android.instancemanagement.canBeEditedWithGracePeriod
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.android.utilities.ContentUriHelper
@@ -206,7 +206,7 @@ class FormUriActivity : ComponentActivity() {
 
         val formEditingEnabled = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
             val instance = instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
-            instance!!.canBeEdited(settingsProvider)
+            instance!!.canBeEditedWithGracePeriod(settingsProvider)
         } else {
             true
         }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -146,6 +146,7 @@ import org.odk.collect.shared.strings.UUIDGenerator;
 import org.odk.collect.utilities.UserAgentProvider;
 
 import java.io.File;
+import java.util.function.Supplier;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -195,8 +196,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public FormDownloader providesFormDownloader(FormSourceProvider formSourceProvider, FormsRepositoryProvider formsRepositoryProvider, StoragePathProvider storagePathProvider) {
-        return new ServerFormDownloader(formSourceProvider.get(), formsRepositoryProvider.get(), new File(storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE)), storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS), new FormMetadataParser(), System::currentTimeMillis);
+    public FormDownloader providesFormDownloader(FormSourceProvider formSourceProvider, FormsRepositoryProvider formsRepositoryProvider, StoragePathProvider storagePathProvider, Supplier<Long> clock) {
+        return new ServerFormDownloader(formSourceProvider.get(), formsRepositoryProvider.get(), new File(storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE)), storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS), new FormMetadataParser(), clock);
     }
 
     @Provides
@@ -483,8 +484,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public InstancesRepositoryProvider providesInstancesRepositoryProvider(Context context, StoragePathProvider storagePathProvider) {
-        return new InstancesRepositoryProvider(context, storagePathProvider);
+    public InstancesRepositoryProvider providesInstancesRepositoryProvider(Context context, StoragePathProvider storagePathProvider, Supplier<Long> clock) {
+        return new InstancesRepositoryProvider(context, storagePathProvider, clock);
     }
 
     @Provides
@@ -513,8 +514,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public FormsUpdater providesFormsUpdater(Context context, Notifier notifier, SyncStatusAppState syncStatusAppState, ProjectDependencyProviderFactory projectDependencyProviderFactory) {
-        return new FormsUpdater(context, notifier, syncStatusAppState, projectDependencyProviderFactory, System::currentTimeMillis);
+    public FormsUpdater providesFormsUpdater(Context context, Notifier notifier, SyncStatusAppState syncStatusAppState, ProjectDependencyProviderFactory projectDependencyProviderFactory, Supplier<Long> clock) {
+        return new FormsUpdater(context, notifier, syncStatusAppState, projectDependencyProviderFactory, clock);
     }
 
     @Provides
@@ -647,5 +648,10 @@ public class AppDependencyModule {
     @Provides
     public SavedInstanceStateProvider providesSavedInstanceStateProvider() {
         return savedInstanceState -> savedInstanceState;
+    }
+
+    @Provides
+    public Supplier<Long> providesClock() {
+        return System::currentTimeMillis;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
@@ -7,6 +7,11 @@ import org.odk.collect.settings.keys.ProtectedProjectKeys
 const val OCTOBER_1st_2023_UTC = 1696118400000
 
 fun Instance.canBeEdited(settingsProvider: SettingsProvider): Boolean {
+    return this.status == Instance.STATUS_INCOMPLETE &&
+        settingsProvider.getProtectedSettings().getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
+}
+
+fun Instance.canBeEditedWithGracePeriod(settingsProvider: SettingsProvider): Boolean {
     return (this.status == Instance.STATUS_INCOMPLETE || (this.status == Instance.STATUS_COMPLETE && this.lastStatusChangeDate < OCTOBER_1st_2023_UTC)) &&
         settingsProvider.getProtectedSettings().getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
@@ -4,7 +4,9 @@ import org.odk.collect.forms.instances.Instance
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.ProtectedProjectKeys
 
+const val OCTOBER_1st_2023_UTC = 1696118400000
+
 fun Instance.canBeEdited(settingsProvider: SettingsProvider): Boolean {
-    return this.status == Instance.STATUS_INCOMPLETE &&
+    return (this.status == Instance.STATUS_INCOMPLETE || (this.status == Instance.STATUS_COMPLETE && this.lastStatusChangeDate < OCTOBER_1st_2023_UTC)) &&
         settingsProvider.getProtectedSettings().getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/InstancesRepositoryProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/InstancesRepositoryProvider.kt
@@ -5,10 +5,12 @@ import org.odk.collect.android.database.instances.DatabaseInstancesRepository
 import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.storage.StorageSubdirectory
 import org.odk.collect.forms.instances.InstancesRepository
+import java.util.function.Supplier
 
 class InstancesRepositoryProvider @JvmOverloads constructor(
     private val context: Context,
-    private val storagePathProvider: StoragePathProvider = StoragePathProvider()
+    private val storagePathProvider: StoragePathProvider = StoragePathProvider(),
+    private val clock: Supplier<Long> = Supplier { System.currentTimeMillis() }
 ) {
 
     @JvmOverloads
@@ -17,7 +19,7 @@ class InstancesRepositoryProvider @JvmOverloads constructor(
             context,
             storagePathProvider.getOdkDirPath(StorageSubdirectory.METADATA, projectId),
             storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, projectId),
-            System::currentTimeMillis
+            clock
         )
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpecTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpecTest.kt
@@ -18,6 +18,7 @@ import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.notifications.Notifier
 import org.odk.collect.android.projects.ProjectDependencyProviderFactory
 import org.odk.collect.android.support.CollectHelpers
+import java.util.function.Supplier
 
 @RunWith(AndroidJUnit4::class)
 class AutoUpdateTaskSpecTest {
@@ -29,10 +30,11 @@ class AutoUpdateTaskSpecTest {
     fun setup() {
         CollectHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
             override fun providesFormsUpdater(
-                context: Context,
-                notifier: Notifier,
-                syncStatusAppState: SyncStatusAppState,
-                projectDependencyProviderFactory: ProjectDependencyProviderFactory
+                context: Context?,
+                notifier: Notifier?,
+                syncStatusAppState: SyncStatusAppState?,
+                projectDependencyProviderFactory: ProjectDependencyProviderFactory?,
+                clock: Supplier<Long>?
             ): FormsUpdater {
                 return formUpdateChecker
             }

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpecTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpecTest.kt
@@ -17,6 +17,7 @@ import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.notifications.Notifier
 import org.odk.collect.android.projects.ProjectDependencyProviderFactory
 import org.odk.collect.android.support.CollectHelpers
+import java.util.function.Supplier
 
 @RunWith(AndroidJUnit4::class)
 class SyncFormsTaskSpecTest {
@@ -26,10 +27,11 @@ class SyncFormsTaskSpecTest {
     fun setup() {
         CollectHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
             override fun providesFormsUpdater(
-                context: Context,
-                notifier: Notifier,
-                syncStatusAppState: SyncStatusAppState,
-                projectDependencyProviderFactory: ProjectDependencyProviderFactory
+                context: Context?,
+                notifier: Notifier?,
+                syncStatusAppState: SyncStatusAppState?,
+                projectDependencyProviderFactory: ProjectDependencyProviderFactory?,
+                clock: Supplier<Long>?
             ): FormsUpdater {
                 return formsUpdater
             }

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -31,6 +31,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.odk.collect.android.R
 import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.instancemanagement.OCTOBER_1st_2023_UTC

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -56,6 +56,7 @@ import org.odk.collect.settings.keys.ProtectedProjectKeys
 import org.odk.collect.shared.TempFiles
 import org.odk.collect.shared.strings.UUIDGenerator
 import java.io.File
+import java.util.function.Supplier
 
 @RunWith(AndroidJUnit4::class)
 class FormUriActivityTest {
@@ -99,8 +100,9 @@ class FormUriActivityTest {
             }
 
             override fun providesInstancesRepositoryProvider(
-                context: Context,
-                storagePathProvider: StoragePathProvider
+                context: Context?,
+                storagePathProvider: StoragePathProvider?,
+                clock: Supplier<Long>?
             ): InstancesRepositoryProvider {
                 return mock<InstancesRepositoryProvider>().apply {
                     whenever(get()).thenReturn(instancesRepository)

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -31,9 +31,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.odk.collect.android.R
 import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.injection.config.AppDependencyModule
+import org.odk.collect.android.instancemanagement.OCTOBER_1st_2023_UTC
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.support.CollectHelpers
@@ -372,7 +372,7 @@ class FormUriActivityTest {
     }
 
     @Test
-    fun `When attempting to edit a finalized form then start form for view only`() {
+    fun `When attempting to edit a finalized form saved before October 1st 2023 UTC then start form filling`() {
         val project = Project.Saved("123", "First project", "A", "#cccccc")
         projectsRepository.save(project)
         whenever(currentProjectProvider.getCurrentProject()).thenReturn(project)
@@ -383,6 +383,32 @@ class FormUriActivityTest {
             Instance.Builder()
                 .formId("1")
                 .formVersion("1")
+                .lastStatusChangeDate(OCTOBER_1st_2023_UTC - 1)
+                .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
+                .status(Instance.STATUS_COMPLETE)
+                .build()
+        )
+
+        launcherRule.launchForResult<FormUriActivity>(getSavedIntent(project.uuid, instance.dbId))
+
+        assertStartSavedFormIntent(project.uuid, instance.dbId, true)
+    }
+
+    @Test
+    fun `When attempting to edit a finalized form saved after October 1st 2023 UTC then start form for view only`() {
+        val project = Project.Saved("123", "First project", "A", "#cccccc")
+        projectsRepository.save(project)
+        whenever(currentProjectProvider.getCurrentProject()).thenReturn(project)
+
+        formsRepository.save(
+            FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build()
+        )
+
+        val instance = instancesRepository.save(
+            Instance.Builder()
+                .formId("1")
+                .formVersion("1")
+                .lastStatusChangeDate(OCTOBER_1st_2023_UTC + 1)
                 .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
                 .status(Instance.STATUS_COMPLETE)
                 .build()


### PR DESCRIPTION
Closes #5669

#### What has been done to verify that this works as intended?
I've added automated tests and tested the changes manually.

#### Why is this the best possible solution? Were any other approaches considered?
There is nothing important to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Generally opening forms for edit/view only is at risk. To test the case described in the issue you need to change dates manually in the app (after October 1st 2023) but please also make sure here is no regression in other related cases.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
