### PR TITLE
Catch runtime exceptions that might occur during form validation

### DIFF
--- a/collect_app/src/androidTest/assets/forms/RepeatCount.xml
+++ b/collect_app/src/androidTest/assets/forms/RepeatCount.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>RepeatCount</h:title>
+        <model odk:xforms-version="1.0.0">
+            <itext>
+                <translation lang="English">
+                    <text id="/data/number:label">
+                        <value>Number</value>
+                    </text>
+                    <text id="/data/group/thing:label">
+                        <value>Thing</value>
+                    </text>
+                </translation>
+            </itext>
+            <instance>
+                <data id="RepeatCount">
+                    <number />
+                    <group_count />
+                    <group jr:template="">
+                        <thing />
+                    </group>
+                    <group>
+                        <thing />
+                    </group>
+                    <meta>
+                        <instanceID />
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/number" type="decimal" />
+            <bind calculate=" /data/number " nodeset="/data/group_count" readonly="true()" type="string" />
+            <bind nodeset="/data/group/thing" type="string" />
+            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/number">
+            <label ref="jr:itext('/data/number:label')" />
+        </input>
+        <group ref="/data/group">
+            <label />
+            <repeat jr:count=" /data/group_count " nodeset="/data/group">
+                <input ref="/data/group/thing">
+                    <label ref="jr:itext('/data/group/thing:label')" />
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AddRepeatTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AddRepeatTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
+import org.odk.collect.android.support.pages.ErrorDialog;
 import org.odk.collect.android.support.rules.CollectTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.android.support.pages.EndOfFormPage;
@@ -116,5 +117,25 @@ public class AddRepeatTest {
                 .clickGoUpIcon()
                 .addGroup()
                 .assertText("Person > 3");
+    }
+
+    @Test // This test might be not needed anymore once we fix https://github.com/getodk/javarosa/issues/686
+    public void whenRepeatCountIsNotAnInteger_swipingForward_displaysErrorDialog() {
+        rule.startAtMainMenu()
+                .copyForm("RepeatCount.xml")
+                .startBlankForm("RepeatCount")
+                .answerQuestion("Number", "2.1")
+                .swipeToNextQuestionWithError();
+    }
+
+    @Test // This test might be not needed anymore once we fix https://github.com/getodk/javarosa/issues/686
+    public void whenRepeatCountIsNotAnInteger_checkingForErrors_displaysErrorDialog() {
+        rule.startAtMainMenu()
+                .copyForm("RepeatCount.xml")
+                .startBlankForm("RepeatCount")
+                .answerQuestion("Number", "2.1")
+                .clickOptionsIcon()
+                .clickOnString(R.string.validate)
+                .assertOnPage(new ErrorDialog());
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -299,7 +299,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                     try {
                         result = formController.validateAnswers(true);
                     } catch (JavaRosaException e) {
-                        error.setValue(new NonFatal(e.getMessage()));
+                        error.postValue(new NonFatal(e.getMessage()));
                     }
 
                     return result;

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
@@ -396,15 +396,19 @@ public class JavaRosaFormController implements FormController {
     }
 
     public ValidationResult validateAnswers(boolean markCompleted) throws JavaRosaException {
-        ValidateOutcome validateOutcome = getFormDef().validate(markCompleted);
-        if (validateOutcome != null) {
-            this.jumpToIndex(validateOutcome.failedPrompt);
-            if (indexIsInFieldList()) {
-                stepToPreviousScreenEvent();
+        try {
+            ValidateOutcome validateOutcome = getFormDef().validate(markCompleted);
+            if (validateOutcome != null) {
+                this.jumpToIndex(validateOutcome.failedPrompt);
+                if (indexIsInFieldList()) {
+                    stepToPreviousScreenEvent();
+                }
+                return new FailedValidationResult(validateOutcome.failedPrompt, validateOutcome.outcome);
             }
-            return new FailedValidationResult(validateOutcome.failedPrompt, validateOutcome.outcome);
+            return SuccessValidationResult.INSTANCE;
+        } catch (RuntimeException e) {
+            throw new JavaRosaException(e);
         }
-        return SuccessValidationResult.INSTANCE;
     }
 
     public boolean saveAnswer(FormIndex index, IAnswerData data) throws JavaRosaException {


### PR DESCRIPTION
Closes #5671 

#### What has been done to verify that this works as intended?
I've tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
As discussed on slack the root issue is https://github.com/getodk/javarosa/issues/686 and there is even a pull request that addresses that issue but for now (for a point release) I don't think we should implement changes in javarosa. It's enough to make sure that when the problem occurs during form validation the app does not crash but an error dialog is displayed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think that focusing on the issue and verifying that it doesn't exist anymore would be enough here. I don't see any risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
