### PR TITLE
Remove +/- buttons from OSMDroidMap

### DIFF
--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -62,6 +62,7 @@ import org.osmdroid.events.ZoomEvent;
 import org.osmdroid.tileprovider.IRegisterReceiver;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.MapEventsOverlay;
 import org.osmdroid.views.overlay.Marker;
@@ -195,7 +196,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
             map.setTileSource(webMapService.asOnlineTileSource());
         }
         map.setMultiTouchControls(true);
-        map.setBuiltInZoomControls(true);
+        map.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.NEVER);
         map.setMinZoomLevel(2.0);
         map.setMaxZoomLevel(22.0);
         map.getController().setCenter(toGeoPoint(INITIAL_CENTER));


### PR DESCRIPTION
Closes #5522 

#### What has been done to verify that this works as intended?
I've tested the changes manually.

#### Why is this the best possible solution? Were any other approaches considered?
As we discussed in the issue removing the buttons to make it consistent across the three engines seems like the best solution here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just verify that the buttons are no longer visible in OSM.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
