### PR TITLE
Protect against `onResume` running in `MainMenuActivity` during crash flow

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -123,6 +123,10 @@ class MainMenuActivity : LocalizedActivity() {
 
     override fun onResume() {
         super.onResume()
+        if (isFinishing) {
+            return // Guard against onResume calls after we've finished in onCreate
+        }
+
         currentProjectViewModel.refresh()
         mainMenuViewModel.refreshInstances()
         setButtonsVisibility()

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -14,6 +15,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,10 +43,13 @@ import org.odk.collect.android.version.VersionInformation
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.async.Scheduler
+import org.odk.collect.crashhandler.CrashHandler
 import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.permissions.PermissionsProvider
 import org.odk.collect.projects.Project
 import org.odk.collect.settings.SettingsProvider
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(AndroidJUnit4::class)
 class MainMenuActivityTest {
@@ -67,6 +72,8 @@ class MainMenuActivityTest {
     }
 
     private val permissionsProvider = FakePermissionsProvider()
+
+    private val application = ApplicationProvider.getApplicationContext<Application>()
 
     @get:Rule
     val launcherRule = ActivityScenarioLauncherRule()
@@ -115,6 +122,13 @@ class MainMenuActivityTest {
                 return permissionsProvider
             }
         })
+
+        CrashHandler.install(application)
+    }
+
+    @After
+    fun teardown() {
+        CrashHandler.uninstall(application)
     }
 
     @Test
@@ -429,5 +443,14 @@ class MainMenuActivityTest {
                 it.supportFragmentManager.findFragmentByTag(PermissionsDialogFragment::class.java.name)
             assertThat(dialog, equalTo(null))
         }
+    }
+
+    @Test
+    fun `when there has been a crash, opens CrashHandlerActivity and finishes`() {
+        CrashHandler.getInstance(application)!!.registerCrash(application, IllegalStateException())
+
+        val activity = Robolectric.setupActivity(MainMenuActivity::class.java)
+        assertThat(shadowOf(activity).nextStartedActivity, notNullValue())
+        assertThat(activity.isFinishing, equalTo(true))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -24,6 +24,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.odk.collect.android.R
+import org.odk.collect.android.activities.CrashHandlerActivity
 import org.odk.collect.android.activities.DeleteSavedFormActivity
 import org.odk.collect.android.activities.FormDownloadListActivity
 import org.odk.collect.android.activities.InstanceChooserList
@@ -450,7 +451,8 @@ class MainMenuActivityTest {
         CrashHandler.getInstance(application)!!.registerCrash(application, IllegalStateException())
 
         val activity = Robolectric.setupActivity(MainMenuActivity::class.java)
-        assertThat(shadowOf(activity).nextStartedActivity, notNullValue())
+        val intent = shadowOf(activity).nextStartedActivity
+        assertThat(intent.component?.className, equalTo(CrashHandlerActivity::class.qualifiedName))
         assertThat(activity.isFinishing, equalTo(true))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -450,9 +450,12 @@ class MainMenuActivityTest {
     fun `when there has been a crash, opens CrashHandlerActivity and finishes`() {
         CrashHandler.getInstance(application)!!.registerCrash(application, IllegalStateException())
 
-        val activity = Robolectric.setupActivity(MainMenuActivity::class.java)
-        val intent = shadowOf(activity).nextStartedActivity
-        assertThat(intent.component?.className, equalTo(CrashHandlerActivity::class.qualifiedName))
-        assertThat(activity.isFinishing, equalTo(true))
+        Robolectric.buildActivity(MainMenuActivity::class.java).use {
+            it.setup()
+
+            val startedActivityName = shadowOf(it.get()).nextStartedActivity.component?.className
+            assertThat(startedActivityName, equalTo(CrashHandlerActivity::class.qualifiedName))
+            assertThat(it.get().isFinishing, equalTo(true))
+        }
     }
 }

--- a/crash-handler/src/main/java/org/odk/collect/crashhandler/CrashHandler.kt
+++ b/crash-handler/src/main/java/org/odk/collect/crashhandler/CrashHandler.kt
@@ -95,8 +95,8 @@ class CrashHandler(private val processKiller: Runnable = Runnable { exitProcess(
 
         @JvmStatic
         fun uninstall(context: Context) {
-            Thread.setDefaultUncaughtExceptionHandler(originalHandler)
             context.getState().set("crash_handler", null)
+            unwrapUncaughtExceptionHandler()
         }
 
         @JvmStatic
@@ -120,6 +120,11 @@ class CrashHandler(private val processKiller: Runnable = Runnable { exitProcess(
                 crashHandler.registerCrash(context, e)
                 defaultUncaughtExceptionHandler?.uncaughtException(t, e)
             }
+        }
+
+        private fun unwrapUncaughtExceptionHandler() {
+            Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+            originalHandler = null
         }
     }
 }


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/47715f939f7fb01d63834a14e6d88cf6?time=last-seven-days&versions=v2023.2.2%20(4677)&types=crash&sessionEventKey=64B56953038600010890080ECD34D909_1835267793951965635).

The crash is fairly rare, but I ended up fixing it while investigating.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I didn't think we'd need to do this, but it seems like some devices might call `onResume` after an `onCreate` that calls `finish` and the fact that this is reproducible in Robolectric definitely backs that up.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only thing affected is the flow when reopening the app after a crash, so that would be good to play with.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
