### PR TITLE
Show warning when editing finalized form

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
@@ -56,6 +56,7 @@ class FormSavedSnackbarTest {
             .clickFinalize()
             .assertText(R.string.form_saved)
             .clickOnString(R.string.view_form)
+            .clickOKOnDialog()
             .assertText("25")
             .assertText(R.string.jump_to_beginning)
             .assertText(R.string.jump_to_end)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/SendFinalizedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/SendFinalizedFormPage.java
@@ -27,6 +27,7 @@ public class SendFinalizedFormPage extends Page<SendFinalizedFormPage> {
 
     public FormHierarchyPage clickOnFormToEdit(String formLabel) {
         clickOnText(formLabel);
+        clickOKOnDialog();
         return new FormHierarchyPage(formLabel).assertOnPage();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -163,4 +163,9 @@ object AnalyticsEvents {
      */
     const val PERMISSIONS_DIALOG_CANCEL = "PermissionsDialogCancel"
     const val PERMISSIONS_DIALOG_OK = "PermissionsDialogOK"
+
+    /**
+     * Tracks how often forms are validated
+     */
+    const val CHECK_FOR_ERRORS = "CheckForErrors"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -2,7 +2,6 @@ package org.odk.collect.android.external
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.analytics.Analytics
@@ -21,6 +20,7 @@ import org.odk.collect.forms.Form
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.strings.localization.LocalizedActivity
 import java.io.File
 import javax.inject.Inject
 
@@ -28,7 +28,7 @@ import javax.inject.Inject
  * This class serves as a firewall for starting form filling. It should be used to do that
  * rather than [FormFillingActivity] directly as it ensures that the required data is valid.
  */
-class FormUriActivity : ComponentActivity() {
+class FormUriActivity : LocalizedActivity() {
 
     @Inject
     lateinit var currentProjectProvider: CurrentProjectProvider

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -11,8 +11,10 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormHierarchyActivity;
+import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationViewModel;
 import org.odk.collect.android.formentry.questions.AnswersProvider;
 import org.odk.collect.android.javarosawrapper.FormController;
@@ -154,6 +156,8 @@ public class FormEntryMenuDelegate implements MenuDelegate {
 
             return true;
         } else if (item.getItemId() == R.id.menu_validate) {
+            Analytics.log(AnalyticsEvents.CHECK_FOR_ERRORS, "form");
+
             formEntryViewModel.saveScreenAnswersToFormController(answersProvider.getAnswers(), false);
             formEntryViewModel.validate();
             return true;

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -375,7 +375,7 @@ class FormUriActivityTest {
     }
 
     @Test
-    fun `When attempting to edit a finalized form saved before October 1st 2023 UTC then start form filling`() {
+    fun `When attempting to edit a finalized form saved before October 1st 2023 UTC then display a warning and start form filling`() {
         val project = Project.Saved("123", "First project", "A", "#cccccc")
         projectsRepository.save(project)
         whenever(currentProjectProvider.getCurrentProject()).thenReturn(project)
@@ -393,6 +393,9 @@ class FormUriActivityTest {
         )
 
         launcherRule.launchForResult<FormUriActivity>(getSavedIntent(project.uuid, instance.dbId))
+
+        onView(withText(R.string.edit_finalized_form_warning)).inRoot(isDialog()).check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
 
         assertStartSavedFormIntent(project.uuid, instance.dbId, true)
     }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1215,5 +1215,5 @@
     <string name="view_form">View</string>
     <string name="close_snackbar">Close snackbar</string>
 
-    <string name="edit_finalized_form_warning">After September 30th, you will not be able to edit finalized forms.\n\nSave forms as draft to edit them. You can check a draft form to see if it is complete and valid by using ⋮ > Check for errors.</string>
+    <string name="edit_finalized_form_warning">After September 30th, you will not be able to edit finalized forms.\n\nSave forms as draft to edit them. You can check for errors in a draft form by using ⋮ > Check for errors.</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1215,5 +1215,5 @@
     <string name="view_form">View</string>
     <string name="close_snackbar">Close snackbar</string>
 
-    <string name="edit_finalized_form_warning">After September 30th, you will not be able to edit finalized forms.\n\nSave forms as draft to edit them. You can check for errors in a draft form by using ⋮ > Check for errors.</string>
+    <string name="edit_finalized_form_warning">After September 30th, you will not be able to edit finalized forms. Save forms as draft to edit them later.\n\nYou can check for errors in a draft form by tapping the three dots (⋮) and then Check for errors.</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1214,4 +1214,6 @@
     <string name="edit_form">Edit</string>
     <string name="view_form">View</string>
     <string name="close_snackbar">Close snackbar</string>
+
+    <string name="edit_finalized_form_warning">After September 30th, you will not be able to edit finalized forms.\n\nSave forms as draft to edit them. You can check a draft form to see if it is complete and valid by using ⋮ > Check for errors.</string>
 </resources>


### PR DESCRIPTION
Closes #5680 

#### What has been done to verify that this works as intended?
I've tested the changes manually and updated automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
Displaying the warning in `FormUriActivity` ensures that it will be displayed no matter how the form editing is started (from any place in ODK Collect or an external app).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think that testing editing forms (drafts too) would be enough and there is not a big risk here. Please keep in mind that the warning should not be displayed after October 1st.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
