### PR TITLE
Revert "Do not mark forms as failed to send before sending"

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
@@ -89,6 +89,8 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
     @Override
     public String uploadOneSubmission(Instance instance, String spreadsheetUrl) throws FormUploadException {
+        markSubmissionFailed(instance);
+
         File instanceFile = new File(instance.getInstanceFilePath());
         if (!instanceFile.exists()) {
             throw new FormUploadException(FAIL + "instance XML file does not exist!");
@@ -104,7 +106,6 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
             Form form = forms.get(0);
             if (form.getBASE64RSAPublicKey() != null) {
-                markSubmissionFailed(instance);
                 throw new FormUploadException(getLocalizedString(Collect.getInstance(), R.string.google_sheets_encrypted_message));
             }
 
@@ -122,7 +123,6 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             }
             insertRows(instance, instanceElement, null, key, instanceFile, spreadsheet.getSheets().get(0).getProperties().getTitle());
         } catch (GoogleJsonResponseException e) {
-            markSubmissionFailed(instance);
             throw new FormUploadException(getErrorMessageFromGoogleJsonResponseException(e));
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
@@ -111,7 +111,7 @@ class MainMenuViewModel(
         return if (instance != null) {
             val message = if (instance.status == Instance.STATUS_INCOMPLETE) {
                 R.string.form_saved_as_draft
-            } else if (instance.status == Instance.STATUS_COMPLETE) {
+            } else if (instance.status == Instance.STATUS_COMPLETE || instance.status == Instance.STATUS_SUBMISSION_FAILED) {
                 val form = formsRepositoryProvider.get().getAllByFormIdAndVersion(instance.formId, instance.formVersion).first()
                 if (form.shouldFormBeSentAutomatically(autoSendSettingsProvider.isAutoSendEnabledInSettings())) {
                     R.string.form_sending

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -71,6 +71,8 @@ public class InstanceServerUploader extends InstanceUploader {
      */
     @Override
     public String uploadOneSubmission(Instance instance, String urlString) throws FormUploadException {
+        markSubmissionFailed(instance);
+
         Uri submissionUri = Uri.parse(urlString);
 
         long contentLength = 10000000L;
@@ -84,7 +86,6 @@ public class InstanceServerUploader extends InstanceUploader {
                     submissionUri.toString());
         } else {
             if (submissionUri.getHost() == null) {
-                markSubmissionFailed(instance);
                 throw new FormUploadException(FAIL + "Host name may not be null");
             }
 
@@ -92,7 +93,6 @@ public class InstanceServerUploader extends InstanceUploader {
             try {
                 uri = URI.create(submissionUri.toString());
             } catch (IllegalArgumentException e) {
-                markSubmissionFailed(instance);
                 Timber.d(e.getMessage() != null ? e.getMessage() : e.toString());
                 throw new FormUploadException(getLocalizedString(Collect.getInstance(), R.string.url_error));
             }
@@ -113,13 +113,11 @@ public class InstanceServerUploader extends InstanceUploader {
                 }
 
             } catch (Exception e) {
-                markSubmissionFailed(instance);
                 throw new FormUploadException(FAIL
                         + (e.getMessage() != null ? e.getMessage() : e.toString()));
             }
 
             if (headResult.getStatusCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
-                markSubmissionFailed(instance);
                 throw new FormUploadAuthRequestedException(getLocalizedString(Collect.getInstance(), R.string.server_auth_credentials, submissionUri.getHost()),
                         submissionUri);
             } else if (headResult.getStatusCode() == HttpsURLConnection.HTTP_NO_CONTENT) {
@@ -140,20 +138,17 @@ public class InstanceServerUploader extends InstanceUploader {
                         } else {
                             // Don't follow a redirection attempt to a different host.
                             // We can't tell if this is a spoof or not.
-                            markSubmissionFailed(instance);
                             throw new FormUploadException(FAIL
                                     + "Unexpected redirection attempt to a different host: "
                                     + newURI.toString());
                         }
                     } catch (Exception e) {
-                        markSubmissionFailed(instance);
                         throw new FormUploadException(FAIL + urlString + " " + e.toString());
                     }
                 }
             } else {
                 if (headResult.getStatusCode() >= HttpsURLConnection.HTTP_OK
                         && headResult.getStatusCode() < HttpsURLConnection.HTTP_MULT_CHOICE) {
-                    markSubmissionFailed(instance);
                     throw new FormUploadException("Failed to send to " + uri + ". Is this an OpenRosa " +
                             "submission endpoint? If you have a web proxy you may need to log in to " +
                             "your network.\n\nHEAD request result status code: " + headResult.getStatusCode());
@@ -175,7 +170,6 @@ public class InstanceServerUploader extends InstanceUploader {
         }
 
         if (!instanceFile.exists() && !submissionFile.exists()) {
-            markSubmissionFailed(instance);
             throw new FormUploadException(FAIL + "instance XML file does not exist!");
         }
 
@@ -216,12 +210,10 @@ public class InstanceServerUploader extends InstanceUploader {
                     }
 
                 }
-                markSubmissionFailed(instance);
                 throw exception;
             }
 
         } catch (Exception e) {
-            markSubmissionFailed(instance);
             throw new FormUploadException(FAIL + "Generic Exception: "
                     + (e.getMessage() != null ? e.getMessage() : e.toString()));
         }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuViewModelTest.kt
@@ -291,7 +291,7 @@ class MainMenuViewModelTest {
     }
 
     @Test
-    fun `getFormSavedSnackbarDetails should return null when the corresponding instance failed to sent`() {
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance failed to sent`() {
         val viewModel = createViewModelWithVersion("")
 
         formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
@@ -307,8 +307,9 @@ class MainMenuViewModelTest {
         whenever(autoSendSettingsProvider.isAutoSendEnabledInSettings()).thenReturn(true)
 
         val uri = InstancesContract.getUri(Project.DEMO_PROJECT_ID, instance.dbId)
-        val formSavedSnackbarDetails = viewModel.getFormSavedSnackbarDetails(uri)
-        assertThat(formSavedSnackbarDetails, equalTo(null))
+        val formSavedSnackbarDetails = viewModel.getFormSavedSnackbarDetails(uri)!!
+        assertThat(formSavedSnackbarDetails.first, equalTo(R.string.form_sending))
+        assertThat(formSavedSnackbarDetails.second, equalTo(R.string.view_form))
     }
 
     private fun createViewModelWithVersion(version: String): MainMenuViewModel {


### PR DESCRIPTION
Closes #5687 

#### What has been done to verify that this works as intended?
I've tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
In https://github.com/getodk/collect/pull/5609 we removed marking forms as failed before sending them to avoid editing (this was a workaround) because we blocked editing finalized forms. Recently we have introduced the grace period and because of that wee need the workaround again.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test the scenario described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
