### PR TITLE
Prevent "Check for errors" result snackbar from reappearing on rotation

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -65,6 +65,8 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -140,6 +142,7 @@ import org.odk.collect.android.javarosawrapper.FailedValidationResult;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.javarosawrapper.RepeatsInFieldListException;
 import org.odk.collect.android.javarosawrapper.SuccessValidationResult;
+import org.odk.collect.android.javarosawrapper.ValidationResult;
 import org.odk.collect.android.listeners.AdvanceToNextListener;
 import org.odk.collect.android.listeners.FormLoaderListener;
 import org.odk.collect.android.listeners.SavePointListener;
@@ -547,7 +550,8 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
             }
         });
 
-        formEntryViewModel.getValidationResult().observe(this, validationResult -> {
+        LiveData<ValidationResult> validation = formEntryViewModel.getValidationResult();
+        validation.observe(this, validationResult -> {
             if (validationResult instanceof FailedValidationResult) {
                 FailedValidationResult failedValidationResult = (FailedValidationResult) validationResult;
                 try {
@@ -562,6 +566,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 swipeHandler.setBeenSwiped(false);
             } else if (validationResult instanceof SuccessValidationResult) {
                 SnackbarUtils.showLongSnackbar(findViewById(R.id.llParent), getString(org.odk.collect.strings.R.string.success_form_validation), findViewById(R.id.buttonholder));
+                ((MutableLiveData) validation).setValue(null);
             }
         });
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -25,6 +25,7 @@ import org.odk.collect.android.javarosawrapper.FailedValidationResult;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.javarosawrapper.ValidationResult;
 import org.odk.collect.android.widgets.interfaces.SelectChoiceLoader;
+import org.odk.collect.androidshared.data.Consumable;
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData;
 import org.odk.collect.androidshared.livedata.NonNullLiveData;
 import org.odk.collect.async.Cancellable;
@@ -44,7 +45,8 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
     private final MutableNonNullLiveData<Boolean> hasBackgroundRecording = new MutableNonNullLiveData<>(false);
     private final MutableLiveData<FormIndex> currentIndex = new MutableLiveData<>(null);
     private final MutableNonNullLiveData<Boolean> isLoading = new MutableNonNullLiveData<>(false);
-    private final MutableLiveData<ValidationResult> validationResult = new MutableLiveData<>(null);
+    private final MutableLiveData<Consumable<ValidationResult>>
+            validationResult = new MutableLiveData<>(new Consumable<>(null));
     @NonNull
     private final FormSessionRepository formSessionRepository;
     private final String sessionId;
@@ -95,7 +97,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         return error;
     }
 
-    public LiveData<ValidationResult> getValidationResult() {
+    public LiveData<Consumable<ValidationResult>> getValidationResult() {
         return validationResult;
     }
 
@@ -237,7 +239,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         try {
             ValidationResult result = formController.saveAllScreenAnswers(answers, evaluateConstraints);
             if (result instanceof FailedValidationResult) {
-                validationResult.postValue(result);
+                validationResult.postValue(new Consumable<>(result));
                 return false;
             }
         } catch (JavaRosaException e) {
@@ -298,7 +300,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                     try {
                         result = formController.validateAnswers(true);
                     } catch (JavaRosaException e) {
-                        error.setValue(new FormError.NonFatal(e.getMessage()));
+                        error.postValue(new FormError.NonFatal(e.getMessage()));
                     }
 
                     return result;
@@ -308,7 +310,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                     if (result instanceof FailedValidationResult) {
                         refresh();
                     }
-                    validationResult.setValue(result);
+                    validationResult.setValue(new Consumable<>(result));
                 }
         );
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -35,6 +35,7 @@ import org.odk.collect.android.formentry.support.InMemFormSessionRepository;
 import org.odk.collect.android.javarosawrapper.FailedValidationResult;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.support.MockFormEntryPromptBuilder;
+import org.odk.collect.androidshared.data.Consumable;
 import org.odk.collect.testshared.FakeScheduler;
 
 import java.io.IOException;
@@ -227,8 +228,9 @@ public class FormEntryViewModelTest {
 
     @Test
     public void moveForward_whenThereIsAFailedConstraint_setsFailedConstraint() throws Exception {
-        FailedValidationResult failedValidationResult = new FailedValidationResult(startingIndex, 0);
-        when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenReturn(failedValidationResult);
+        Consumable<FailedValidationResult> failedValidationResult =
+                new Consumable<>(new FailedValidationResult(startingIndex, 0));
+        when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenReturn(failedValidationResult.getValue());
 
         viewModel.moveForward(new HashMap<>());
         scheduler.runBackground();


### PR DESCRIPTION
Closes #5678?

#### What has been done to verify that this works as intended?

Tested manually.

#### Why is this the best possible solution? Were any other approaches considered?

Seems to be "the simplest thing that could possibly work". More elegant alternatives could be to change the signature of `FormEntryViewModel.getValidationResult` to reflect the actual class; or completely encapsulate with something like `resetValidationResult`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Behaviour is now as expected. Doesn't break any tests.

#### Do we need any specific form for testing your changes? If so, please attach one.
No?

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
* [x]  run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
* [x]  verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
* [x]  verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)

