### PR TITLE
Fix for #5547 in FormMetadataPreferencesFragment

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
@@ -6,6 +6,8 @@ import static org.odk.collect.settings.keys.ProjectKeys.KEY_METADATA_PHONENUMBER
 
 import android.content.Context;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.Selection;
 import android.text.TextUtils;
 import android.view.inputmethod.EditorInfo;
 
@@ -64,7 +66,12 @@ public class FormMetadataPreferencesFragment extends BaseProjectPreferencesFragm
             return true;
         });
 
-        phonePreference.setOnBindEditTextListener(editText -> editText.setInputType(EditorInfo.TYPE_CLASS_PHONE));
+        phonePreference.setOnBindEditTextListener(editText -> {
+            editText.setInputType(EditorInfo.TYPE_CLASS_PHONE);
+            Editable text = editText.getText();
+            Selection.setSelection(text, text.length());
+        });
+
         deviceIDPreference.setSummaryProvider(new PropertyManagerPropertySummaryProvider(propertyManager, PROPMGR_DEVICE_ID));
     }
 


### PR DESCRIPTION
Closes #5547

#### What has been done to verify that this works as intended?

Tested manually. (In any case not possible  to simulate in test?)

#### Why is this the best possible solution? Were any other approaches considered?

Aligns behaviour of `phonePreference` in `FormMetadataPreferencesFragment` with `StringWidget`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Behaviour is now as desired. Doesn't break any tests.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
* [x]  run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
* [x]  verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
* [x]  verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)