### PR TITLE
Add logging when showing crash report screen

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -42,6 +42,7 @@ import org.odk.collect.projects.Project.Saved
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.strings.localization.LocalizedActivity
+import timber.log.Timber
 import javax.inject.Inject
 
 class MainMenuActivity : LocalizedActivity() {
@@ -69,6 +70,8 @@ class MainMenuActivity : LocalizedActivity() {
 
         CrashHandler.getInstance(this)?.also {
             if (it.hasCrashed(this)) {
+                Timber.w("Showing previous crash report")
+
                 super.onCreate(null)
                 ActivityUtils.startActivityAndCloseAllOthers(this, CrashHandlerActivity::class.java)
                 return


### PR DESCRIPTION
This adds logging when showing the crash reporting screen to verify whether it's the culprit for [this crash](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/47715f939f7fb01d63834a14e6d88cf6?time=last-seven-days&sessionEventKey=64C3E096003300012D48945A99E83A45_1839339571413297162) or not.