### PR TITLE
Return user to main menu when tapping outside of summary dialog in "Download form"

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/FormsDownloadResultDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/FormsDownloadResultDialog.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import org.odk.collect.android.R
 import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.android.injection.DaggerUtils
@@ -28,7 +27,9 @@ class FormsDownloadResultDialog : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        result = arguments?.getSerializable(ARG_RESULT) as Map<ServerFormDetails, FormDownloadException?>
+        isCancelable = false
+        result =
+            arguments?.getSerializable(ARG_RESULT) as Map<ServerFormDetails, FormDownloadException?>
 
         val builder = MaterialAlertDialogBuilder(requireContext())
             .setMessage(getMessage())

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/FormsDownloadResultDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/FormsDownloadResultDialogTest.kt
@@ -18,7 +18,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.odk.collect.android.R
 import org.odk.collect.android.application.Collect
 import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
@@ -35,7 +34,7 @@ class FormsDownloadResultDialogTest {
     val launcherRule = FragmentScenarioLauncherRule()
 
     @Test
-    fun `The dialog should be dismissed after clicking out of it's area or on device back button`() {
+    fun `The dialog should not be dismissed after clicking out of its area or on device back button`() {
         val args = Bundle()
         args.putSerializable(
             FormsDownloadResultDialog.ARG_RESULT,
@@ -45,7 +44,7 @@ class FormsDownloadResultDialogTest {
         val scenario =
             launcherRule.launch(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
-            assertThat(it.isCancelable, `is`(true))
+            assertThat(it.isCancelable, `is`(false))
         }
     }
 


### PR DESCRIPTION
Addresses #5358

#### What has been done to verify that this works as intended?

Tested manually including simulation of failed download, and by adjustment of `FormsDownloadResultDialogTest`. 

#### Why is this the best possible solution? Were any other approaches considered?
In effect this approach forces the updated expected behaviour 
>The user should be returned to the Main Menu (as they are when tapping OK).

in that the only available action is to tap OK and thus be returned to the Main Menu.

A model for this was the Ready to Send screen, which behaves similarly (though visually in a less user-friendly way). 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Behaviour is now effectively as proposed. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
