### PR TITLE
Fix for #5634 Crash after zooming map

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -263,9 +263,10 @@ public class GoogleMapFragment extends SupportMapFragment implements
                 new Handler().postDelayed(() -> {
                     try {
                         moveOrAnimateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), animate);
-                        // https://github.com/getodk/collect/issues/5379
-                        // https://github.com/getodk/collect/issues/5634
-                    } catch (RuntimeException e) {
+                    } catch (IllegalArgumentException
+                             //https://github.com/getodk/collect/issues/5379
+                             |
+                             IllegalStateException e) { // https://github.com/getodk/collect/issues/5634
                         LatLng boxCenter = bounds.getCenter();
                         zoomToPoint(new MapPoint(boxCenter.latitude, boxCenter.longitude), map.getMinZoomLevel(), false);
                     }

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -263,7 +263,9 @@ public class GoogleMapFragment extends SupportMapFragment implements
                 new Handler().postDelayed(() -> {
                     try {
                         moveOrAnimateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), animate);
-                    } catch (IllegalArgumentException e) { // https://github.com/getodk/collect/issues/5379
+                        // https://github.com/getodk/collect/issues/5379
+                        // https://github.com/getodk/collect/issues/5634
+                    } catch (RuntimeException e) {
                         LatLng boxCenter = bounds.getCenter();
                         zoomToPoint(new MapPoint(boxCenter.latitude, boxCenter.longitude), map.getMinZoomLevel(), false);
                     }


### PR DESCRIPTION
Fixes #5634

#### What has been done to verify that this works as intended?
Tested manually using issue form.

#### Why is this the best possible solution? Were any other approaches considered?
The issue seems analogous (even identical) to #5379, with Google's `CameraUpdate` again choking on `LatLng` data. Rather than simply updating to handle the `IllegalStateException` thrown by this issue, I've generalised to `RuntimeException`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Behaviour is now as in #5393.  No impact on tests.

#### Do we need any specific form for testing your changes? If so, please attach one.
Form provided in #5634.

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)