### PR TITLE
Prompt before discarding changes when exiting geopoint with map

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
@@ -32,6 +32,8 @@ import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder;
 import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.externalapp.ExternalAppUtils;
@@ -93,6 +95,7 @@ public class GeoPointMapActivity extends LocalizedActivity {
     private TextView locationInfo;
 
     private MapPoint location;
+    private MapPoint savedLocation;
     private ImageButton placeMarkerButton;
 
     private boolean isDragged;
@@ -189,6 +192,7 @@ public class GeoPointMapActivity extends LocalizedActivity {
 
     public void returnLocation() {
         String result = null;
+        savedLocation = location;
 
         if (setClear || (intentReadOnly && featureId == -1)) {
             result = "";
@@ -323,6 +327,22 @@ public class GeoPointMapActivity extends LocalizedActivity {
 
         locationInfo.setVisibility(state.getInt(LOCATION_INFO_VISIBILITY_KEY, View.GONE));
         locationStatus.setVisibility(state.getInt(LOCATION_STATUS_VISIBILITY_KEY, View.GONE));
+    }
+
+    // https://github.com/getodk/collect/issues/5293
+    @Override
+    public void onBackPressed() {
+        if (location != null
+                && !location.equals(savedLocation)) {
+            new MaterialAlertDialogBuilder(this)
+                    .setMessage(getString(org.odk.collect.strings.R.string.geo_exit_warning_single))
+                    .setPositiveButton(org.odk.collect.strings.R.string.discard, (dialog, id) -> finish())
+                    .setNegativeButton(org.odk.collect.strings.R.string.cancel, null)
+                    .show();
+
+        } else {
+            finish();
+        }
     }
 
     public void onLocationChanged(MapPoint point) {

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
@@ -27,6 +27,7 @@ import android.view.Window;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
@@ -156,6 +157,26 @@ public class GeoPointMapActivity extends LocalizedActivity {
 
         MapFragment mapFragment = ((FragmentContainerView) findViewById(R.id.map_container)).getFragment();
         mapFragment.init(this::initMap, this::finish);
+
+        // https://github.com/getodk/collect/issues/5293
+        getOnBackPressedDispatcher().addCallback(
+                new OnBackPressedCallback(true) {
+                    @Override
+                    public void handleOnBackPressed() {
+                        if (location != null
+                                && !location.equals(savedLocation)) {
+                            new MaterialAlertDialogBuilder(GeoPointMapActivity.this)
+                                    .setMessage(getString(org.odk.collect.strings.R.string.geo_exit_warning_single))
+                                    .setPositiveButton(org.odk.collect.strings.R.string.discard, (dialog, id) -> finish())
+                                    .setNegativeButton(org.odk.collect.strings.R.string.cancel, null)
+                                    .show();
+
+                        } else {
+                            finish();
+                        }
+                    }
+                }
+        );
     }
 
     @Override protected void onSaveInstanceState(Bundle state) {
@@ -327,22 +348,6 @@ public class GeoPointMapActivity extends LocalizedActivity {
 
         locationInfo.setVisibility(state.getInt(LOCATION_INFO_VISIBILITY_KEY, View.GONE));
         locationStatus.setVisibility(state.getInt(LOCATION_STATUS_VISIBILITY_KEY, View.GONE));
-    }
-
-    // https://github.com/getodk/collect/issues/5293
-    @Override
-    public void onBackPressed() {
-        if (location != null
-                && !location.equals(savedLocation)) {
-            new MaterialAlertDialogBuilder(this)
-                    .setMessage(getString(org.odk.collect.strings.R.string.geo_exit_warning_single))
-                    .setPositiveButton(org.odk.collect.strings.R.string.discard, (dialog, id) -> finish())
-                    .setNegativeButton(org.odk.collect.strings.R.string.cancel, null)
-                    .show();
-
-        } else {
-            finish();
-        }
     }
 
     public void onLocationChanged(MapPoint point) {

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -546,6 +546,7 @@
     <string name="gps_enable_message">GPS is disabled on your device. Would you like to enable it?</string>
     <string name="geo_clear_warning">Feature already created. Would you like to clear the feature?</string>
     <string name="geo_exit_warning">Discard changes and return to ODK?</string>
+    <string name="geo_exit_warning_single">Discard change and return to ODK?</string>
     <string name="polygon_validator">Must have at least 3 points to create Polygon</string>
     <string name="polyline_validator">Must have at least 2 points to create Polyline</string>
     <string name="clear">Clear</string>


### PR DESCRIPTION
Fixes #5293

#### What has been done to verify that this works as intended?
Tested manually. Couldn't see any tests in `GeoPolyActivityTest` suitable for reworking in `GeoPointMapActivityTest`.

#### Why is this the best possible solution? Were any other approaches considered?
New override of `onBackPressed` in `GeoPointMapActivity` by analogy with `GeoPolyActivity`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Behaviour is now as desired. No impact on tests.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.
#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)