### PR TITLE
Disable reconfiguring in GD projects

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/GoogleDriveDeprecationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/GoogleDriveDeprecationTest.kt
@@ -95,4 +95,26 @@ class GoogleDriveDeprecationTest {
             .clickOnDeleteProject()
             .assertText(org.odk.collect.strings.R.string.delete_google_drive_project_confirm_message)
     }
+
+    @Test
+    fun reconfiguringShouldBeVisibleInNonGoogleDriveProjects() {
+        rule.startAtMainMenu()
+            .openProjectSettingsDialog()
+            .clickSettings()
+            .clickProjectManagement()
+            .assertText(org.odk.collect.strings.R.string.reconfigure_with_qr_code_settings_title)
+    }
+
+    @Test
+    fun reconfiguringShouldBeHiddenInGoogleDriveProjects() {
+        CollectHelpers.addGDProject(gdProject1, "steph@curry.basket", testDependencies)
+
+        rule.startAtMainMenu()
+            .openProjectSettingsDialog()
+            .selectProject(gdProject1.name)
+            .openProjectSettingsDialog()
+            .clickSettings()
+            .clickProjectManagement()
+            .assertTextDoesNotExist(org.odk.collect.strings.R.string.reconfigure_with_qr_code_settings_title)
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
@@ -39,6 +39,12 @@ class ProjectManagementPreferencesFragment :
         super.onCreatePreferences(savedInstanceState, rootKey)
         setPreferencesFromResource(R.xml.project_management_preferences, rootKey)
 
+        val unprotectedSettings = settingsProvider.getUnprotectedSettings()
+        val protocol = unprotectedSettings.getString(ProjectKeys.KEY_PROTOCOL)
+        if (protocol == ProjectKeys.PROTOCOL_GOOGLE_SHEETS) {
+            findPreference<Preference>(IMPORT_SETTINGS_KEY)!!.isVisible = false
+        }
+
         findPreference<Preference>(IMPORT_SETTINGS_KEY)!!.onPreferenceClickListener = this
         findPreference<Preference>(DELETE_PROJECT_KEY)!!.onPreferenceClickListener = this
     }


### PR DESCRIPTION
Closes #5704 

#### What has been done to verify that this works as intended?
I've tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
We decided that disabling reconfiguring for GD projects would be a good solution for GD projects that still exist to avoid loosing data.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Reconfiguring projects should be disabled (not visible) for GD projects. It's a safe change so verifying that the option is visible for non-GD projects nd hidden for GD projects would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
