### PR TITLE
Fixed missing audit events after navigating to settings

### DIFF
--- a/collect_app/src/androidTest/assets/forms/one-question-audit-track-changes.xml
+++ b/collect_app/src/androidTest/assets/forms/one-question-audit-track-changes.xml
@@ -4,7 +4,7 @@
     xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns="http://www.w3.org/2002/xforms">
     <h:head>
-        <h:title>One Question Audit Constraint</h:title>
+        <h:title>One Question Audit Track Changes</h:title>
         <model>
             <instance>
                 <data id="one_question_audit" orx:version="1">
@@ -14,7 +14,6 @@
                     </meta>
                 </data>
             </instance>
-            <bind constraint=". &lt; 120" nodeset="age" type="int" jr:constraintMsg="Too old!" />
             <bind nodeset="/data/meta/audit" type="binary" odk:track-changes="true" />
         </model>
     </h:head>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -55,4 +55,20 @@ class AuditTest {
         assertThat(auditLog[10].get("event"), equalTo("form exit"))
         assertThat(auditLog[11].get("event"), equalTo("form finalize"))
     }
+
+    @Test // https://github.com/getodk/collect/issues/5551
+    fun navigatingToSettings_savesAnswersFormCurrentScreenToAuditLog() {
+        rule.startAtMainMenu()
+            .copyForm("one-question-audit-track-changes.xml")
+            .startBlankForm("One Question Audit Track Changes")
+            .fillOut(
+                FormEntryPage.QuestionAndAnswer("What is your age", "31")
+            )
+            .clickOptionsIcon()
+            .clickGeneralSettings()
+
+        val auditLog = StorageUtils.getAuditLogForFirstInstance()
+        assertThat(auditLog[1].get("event"), equalTo("question"))
+        assertThat(auditLog[1].get("new-value"), equalTo("31"))
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -111,6 +111,7 @@ public class FormEntryMenuDelegate implements MenuDelegate {
             if (audioRecorder.isRecording()) {
                 DialogFragmentUtils.showIfNotShowing(RecordingWarningDialogFragment.class, activity.getSupportFragmentManager());
             } else {
+                formEntryViewModel.updateAnswersForScreen(answersProvider.getAnswers(), false);
                 Intent pref = new Intent(activity, ProjectPreferencesActivity.class);
                 activity.startActivityForResult(pref, ApplicationConstants.RequestCodes.CHANGE_SETTINGS);
             }


### PR DESCRIPTION
Closes #5551 

#### What has been done to verify that this works as intended?
I've added automated tests and tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that after going to settings (which is a separate activity) answers from the current screen weren't saved and audit events related to those answers weren't saved as well. I think we should just do that before navigating to settings.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Generally, the fix should be safe and it should only address the issue but you know how complicated logging events is... 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
