### PR TITLE
Fixed missing „form resume” in audit log events when moving backward in not allowed in Collect settings

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -90,6 +90,8 @@ class AuditTest {
             .fillOut(FormEntryPage.QuestionAndAnswer("what is your age", "31"))
             .killAndReopenApp(MainMenuPage())
             .startBlankForm("One Question Audit")
+            .swipeToEndScreen()
+            .clickFinalize()
 
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
         assertThat(auditLog[1].get("event"), equalTo("form resume"))

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -7,7 +7,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.StorageUtils
 import org.odk.collect.android.support.pages.AccessControlPage
 import org.odk.collect.android.support.pages.FormEntryPage

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -65,9 +65,7 @@ class AuditTest {
         rule.startAtMainMenu()
             .copyForm("one-question-audit-track-changes.xml")
             .startBlankForm("One Question Audit Track Changes")
-            .fillOut(
-                FormEntryPage.QuestionAndAnswer("What is your age", "31")
-            )
+            .fillOut(FormEntryPage.QuestionAndAnswer("What is your age", "31"))
             .clickOptionsIcon()
             .clickGeneralSettings()
 
@@ -90,14 +88,9 @@ class AuditTest {
             .pressBack(ProjectSettingsPage())
             .pressBack(MainMenuPage())
             .startBlankForm("One Question Audit")
-            .fillOut(
-                FormEntryPage.QuestionAndAnswer("what is your age", "31")
-            )
-            .let {
-                CollectHelpers.killAndReopenApp()
-            }
-
-        MainMenuPage().startBlankForm("One Question Audit")
+            .fillOut(FormEntryPage.QuestionAndAnswer("what is your age", "31"))
+            .killAndReopenApp(MainMenuPage())
+            .startBlankForm("One Question Audit")
 
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
         assertThat(auditLog[1].get("event"), equalTo("form resume"))

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectHelpers.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectHelpers.kt
@@ -2,9 +2,6 @@ package org.odk.collect.android.support
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import org.odk.collect.android.application.Collect
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.injection.config.AppDependencyComponent
@@ -59,21 +56,5 @@ object CollectHelpers {
                 it.save(ProjectKeys.KEY_PROTOCOL, ProjectKeys.PROTOCOL_GOOGLE_SHEETS)
                 it.save(ProjectKeys.KEY_SELECTED_GOOGLE_ACCOUNT, accountName)
             }
-    }
-
-    fun killAndReopenApp() {
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
-        // kill
-        device.pressRecentApps()
-        device
-            .findObject(UiSelector().descriptionContains("Collect"))
-            .swipeUp(10)
-
-        // reopen
-        InstrumentationRegistry.getInstrumentation().targetContext.apply {
-            val intent = packageManager.getLaunchIntentForPackage("org.odk.collect.android")!!
-            startActivity(intent)
-        }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectHelpers.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectHelpers.kt
@@ -2,6 +2,9 @@ package org.odk.collect.android.support
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import org.odk.collect.android.application.Collect
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.injection.config.AppDependencyComponent
@@ -56,5 +59,21 @@ object CollectHelpers {
                 it.save(ProjectKeys.KEY_PROTOCOL, ProjectKeys.PROTOCOL_GOOGLE_SHEETS)
                 it.save(ProjectKeys.KEY_SELECTED_GOOGLE_ACCOUNT, accountName)
             }
+    }
+
+    fun killAndReopenApp() {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        // kill
+        device.pressRecentApps()
+        device
+            .findObject(UiSelector().descriptionContains("Collect"))
+            .swipeUp(10)
+
+        // reopen
+        InstrumentationRegistry.getInstrumentation().targetContext.apply {
+            val intent = packageManager.getLaunchIntentForPackage("org.odk.collect.android")!!
+            startActivity(intent)
+        }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -37,10 +37,12 @@ import org.hamcrest.Matchers.allOf
 import org.hamcrest.core.StringContains.containsString
 import org.hamcrest.core.StringEndsWith.endsWith
 import org.junit.Assert
+import org.odk.collect.android.BuildConfig
 import org.odk.collect.android.R
 import org.odk.collect.android.application.Collect
 import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.support.ActivityHelpers
+import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.WaitFor.wait250ms
 import org.odk.collect.android.support.WaitFor.waitFor
 import org.odk.collect.android.support.actions.RotateAction
@@ -51,8 +53,6 @@ import org.odk.collect.testshared.EspressoHelpers
 import org.odk.collect.testshared.RecyclerViewMatcher
 import timber.log.Timber
 import java.io.File
-import org.odk.collect.android.BuildConfig
-import org.odk.collect.android.support.CollectHelpers
 
 /**
  * Base class for Page Objects used in Espresso tests. Provides shared helpers/setup.

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -51,6 +51,7 @@ import org.odk.collect.testshared.EspressoHelpers
 import org.odk.collect.testshared.RecyclerViewMatcher
 import timber.log.Timber
 import java.io.File
+import org.odk.collect.android.BuildConfig
 
 /**
  * Base class for Page Objects used in Espresso tests. Provides shared helpers/setup.
@@ -448,7 +449,7 @@ abstract class Page<T : Page<T>> {
 
         // reopen
         InstrumentationRegistry.getInstrumentation().targetContext.apply {
-            val intent = packageManager.getLaunchIntentForPackage("org.odk.collect.android")!!
+            val intent = packageManager.getLaunchIntentForPackage(BuildConfig.APPLICATION_ID)!!
             startActivity(intent)
         }
         return destination!!.assertOnPage()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -29,6 +29,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withHint
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.core.StringContains.containsString
@@ -432,6 +435,23 @@ abstract class Page<T : Page<T>> {
         })
 
         return this as T
+    }
+
+    fun <D : Page<D>?> killAndReopenApp(destination: D): D {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        // kill
+        device.pressRecentApps()
+        device
+            .findObject(UiSelector().descriptionContains("Collect"))
+            .swipeUp(10)
+
+        // reopen
+        InstrumentationRegistry.getInstrumentation().targetContext.apply {
+            val intent = packageManager.getLaunchIntentForPackage("org.odk.collect.android")!!
+            startActivity(intent)
+        }
+        return destination!!.assertOnPage()
     }
 
     companion object {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -52,6 +52,7 @@ import org.odk.collect.testshared.RecyclerViewMatcher
 import timber.log.Timber
 import java.io.File
 import org.odk.collect.android.BuildConfig
+import org.odk.collect.android.support.CollectHelpers
 
 /**
  * Base class for Page Objects used in Espresso tests. Provides shared helpers/setup.
@@ -445,7 +446,9 @@ abstract class Page<T : Page<T>> {
         device.pressRecentApps()
         device
             .findObject(UiSelector().descriptionContains("Collect"))
-            .swipeUp(10)
+            .swipeUp(10).also {
+                CollectHelpers.simulateProcessRestart() // the process is not restarted automatically (probably to keep the test running) so we have simulate it
+            }
 
         // reopen
         InstrumentationRegistry.getInstrumentation().targetContext.apply {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -2158,6 +2158,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                     identityPromptViewModel.formLoaded(formController);
                     identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                         if (!requiresIdentity) {
+                            formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_RESUME, true, System.currentTimeMillis());
                             if (!allowMovingBackwards) {
                                 // we aren't allowed to jump around the form so attempt to
                                 // go directly to the question we were on last time the
@@ -2179,7 +2180,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                                 formEntryViewModel.refresh();
                                 onActivityResult(task.getRequestCode(), task.getResultCode(), task.getIntent());
                             } else {
-                                formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_RESUME, true, System.currentTimeMillis());
                                 formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.HIERARCHY, true, System.currentTimeMillis());
                                 formControllerAvailable(formController);
                                 Intent intent = new Intent(this, FormHierarchyActivity.class);


### PR DESCRIPTION
Closes #5253 

#### What has been done to verify that this works as intended?
I've added automated tests and verified the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
There is nothing to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue. I don't think it can affect anything else.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
