### PR TITLE
Upgrade to JavaRosa 4.3.0-SNAPSHOT

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -40,7 +40,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.0.1"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.7.1"
-    const val javarosa = "org.getodk:javarosa:4.2.0"
+    const val javarosa = "org.getodk:javarosa:4.3.0-SNAPSHOT"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val karumi_dexter = "com.karumi:dexter:6.2.3"
     const val zxing_android_embedded = "com.journeyapps:zxing-android-embedded:4.3.0"

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AddRepeatTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AddRepeatTest.java
@@ -11,11 +11,10 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
-import org.odk.collect.android.support.pages.ErrorDialog;
-import org.odk.collect.android.support.rules.CollectTestRule;
-import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.android.support.pages.EndOfFormPage;
 import org.odk.collect.android.support.pages.FormEntryPage;
+import org.odk.collect.android.support.rules.CollectTestRule;
+import org.odk.collect.android.support.rules.TestRuleChain;
 
 @RunWith(AndroidJUnit4.class)
 public class AddRepeatTest {
@@ -117,25 +116,5 @@ public class AddRepeatTest {
                 .clickGoUpIcon()
                 .addGroup()
                 .assertText("Person > 3");
-    }
-
-    @Test // This test might be not needed anymore once we fix https://github.com/getodk/javarosa/issues/686
-    public void whenRepeatCountIsNotAnInteger_swipingForward_displaysErrorDialog() {
-        rule.startAtMainMenu()
-                .copyForm("RepeatCount.xml")
-                .startBlankForm("RepeatCount")
-                .answerQuestion("Number", "2.1")
-                .swipeToNextQuestionWithError();
-    }
-
-    @Test // This test might be not needed anymore once we fix https://github.com/getodk/javarosa/issues/686
-    public void whenRepeatCountIsNotAnInteger_checkingForErrors_displaysErrorDialog() {
-        rule.startAtMainMenu()
-                .copyForm("RepeatCount.xml")
-                .startBlankForm("RepeatCount")
-                .answerQuestion("Number", "2.1")
-                .clickOptionsIcon()
-                .clickOnString(org.odk.collect.strings.R.string.validate)
-                .assertOnPage(new ErrorDialog());
     }
 }


### PR DESCRIPTION
This upgrade breaks a few tests (that we no longer need as they were testing a now fixed issue).