### PR TITLE
Do not allow to attach gifs in AnnotateWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -35,6 +35,7 @@ import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+import org.odk.collect.androidshared.ui.ToastUtils;
 
 import java.io.File;
 import java.util.Locale;
@@ -187,8 +188,14 @@ public class AnnotateWidget extends BaseImageWidget implements ButtonClickListen
 
     @Override
     public void setData(Object newImageObj) {
-        super.setData(newImageObj);
-
-        annotateButton.setEnabled(binaryName != null);
+        if (newImageObj instanceof File) {
+            String mimeType = FileUtils.getMimeType((File) newImageObj);
+            if ("image/gif".equals(mimeType)) {
+                ToastUtils.showLongToast(getContext(), org.odk.collect.strings.R.string.gif_not_supported);
+            } else {
+                super.setData(newImageObj);
+                annotateButton.setEnabled(binaryName != null);
+            }
+        }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -11,13 +11,10 @@ import android.widget.ImageView;
 import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
 
-import net.bytebuddy.utility.RandomString;
-
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.reference.ReferenceManager;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.draw.DrawActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
@@ -55,8 +52,7 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
     private File currentFile;
     private FakeQuestionMediaManager questionMediaManager;
 
-    @Mock
-    File file;
+    private final File file = TempFiles.createTempFile("sample", ".jpg");
 
     @NonNull
     @Override
@@ -81,14 +77,11 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
     @NonNull
     @Override
     public StringData getNextAnswer() {
-        return new StringData(RandomString.make());
+        return new StringData(file.getName());
     }
 
     @Override
     public Object createBinaryData(@NotNull StringData answerData) {
-        when(file.exists()).thenReturn(true);
-        when(file.getName()).thenReturn(answerData.getDisplayText());
-
         return file;
     }
 

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -257,6 +257,7 @@
     <string name="camera_error">There was an error taking picture</string>
     <string name="camera_failed_to_initialize">Couldn\'t initialize camera!</string>
     <string name="annotate_image">Annotate Image</string>
+    <string name="gif_not_supported">Gif files are not supported</string>
     <string name="invalid_file_type">Application returned an invalid file type</string>
     <!-- Dialog heading for saving annotated image -->
     <string name="save_and_close">Save and Close</string>


### PR DESCRIPTION
Closes #5485

#### What has been done to verify that this works as intended?
I've tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
In the issue, I said that a good solution would be to just update the intent that opens the file picker and filter available files excluding gifs so that only other types of images are visible to select. This would be a nice solution but error-prone because when we build such an intent it's not possible to exclude gifs, instead we would have to pass a list of supported mime types and easily miss something. A better solution in this case would be to still allow selecting gifs in the file picker but blocking attaching them in the widget.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think focusing on the fix should be enough. It shouldn't affect any other functionalities.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
