### PR TITLE
Refresh the list adapter to solve the problem with selecting items

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
@@ -106,6 +106,8 @@ public class SavedFormListFragment extends FileManagerFragment implements Delete
 
     @Override
     public void onResume() {
+        listAdapter.notifyDataSetChanged();
+
         // hook up to receive completion events
         if (deleteInstancesTask != null) {
             deleteInstancesTask.setDeleteListener(this);


### PR DESCRIPTION
Closes #5552 

#### What has been done to verify that this works as intended?
I've tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
We have two lists there represented by two tabs (`ViewPager2`):
- saved forms - the list is built with the old `SimpleCursorAdapter`
- blank forms - the list is built with `RecyclerView`

it looks like there is something wrong when we combine `ViewPager2` with `SimpleCursorAdapter`. I was thinking about refactoring that list what we will need to do at some point either way but I was able to come up with a smaller fix for now which is refreshing the adapter when it became visible.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change is small so we can focus only on that view with two tabs (for blank and saved forms). Please make sure there is no regression there and that should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
