### PR TITLE
Add finalized form edit warning string for translation

### DIFF
--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1206,4 +1206,7 @@
     <string name="edit_form">Edit</string>
     <string name="view_form">View</string>
     <string name="close_snackbar">Close snackbar</string>
+
+    <!-- This warning will be shown when a user edits a form that is ready to send. The next version will also provide a link to learn more -->
+    <string name="edit_finalized_form_warning" tools:ignore="UnusedResources">In later releases, you will not be able to edit finalized forms. Save forms as draft to edit them later.\n\nYou can check for errors in a draft form by tapping the three dots (⋮) and then Check for errors.</string>
 </resources>


### PR DESCRIPTION
https://github.com/getodk/collect/pull/5717 will be released in a 2023.2 point release. We'd like to warn users in their language as much as possible. Our current Transifex workflow requires having the string on `master`.