### PR TITLE
Improve *quick* behaviour in SelectOneFromMapWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -315,8 +315,9 @@ public class WidgetFactory {
         } else if (appearance.contains(Appearances.IMAGE_MAP)) {
             questionWidget = new SelectOneImageMapWidget(activity, questionDetails, isQuick, formEntryViewModel);
         } else if (appearance.contains(Appearances.MAP)) {
-            questionWidget = new SelectOneFromMapWidget(activity, questionDetails);
+            questionWidget = new SelectOneFromMapWidget(activity, questionDetails, isQuick);
         } else {
+            // https://github.com/getodk/collect/issues/5540
             questionWidget = new SelectOneWidget(activity, questionDetails, isQuick, formController, formEntryViewModel);
         }
         return questionWidget;

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -22,7 +22,6 @@ import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.androidshared.ui.multiclicksafe.setMultiClickSafeOnClickListener
 import org.odk.collect.geo.GeoDependencyComponentProvider
-import org.odk.collect.geo.R
 import org.odk.collect.geo.ReferenceLayerSettingsNavigator
 import org.odk.collect.geo.databinding.SelectionMapLayoutBinding
 import org.odk.collect.maps.MapFragment
@@ -327,8 +326,12 @@ class SelectionMapFragment(
 
         updateFeatures(items)
 
-        val previouslySelectedItem =
+        // https://github.com/getodk/collect/issues/5540
+        val previouslySelectedItem = if (!skipSummary) {
             itemsByFeatureId.filter { it.value.selected }.map { it.key }.firstOrNull()
+        } else {
+            null
+        }
         val selectedItem = selectedItemViewModel.getSelectedItem()
 
         if (selectedItem != null) {


### PR DESCRIPTION
Fixes for #5540

#### What has been done to verify that this works as intended?
Tested manually using form [select-quick.xml](https://github.com/getodk/collect/files/12553727/select-quick.xml.txt) defined in [select-quick.xlsx](https://github.com/getodk/collect/files/12553733/select-quick.xlsx). 

Auto-advance now behaves exactly as for `SelectOneMinimalWidget` and widget can be re-opened.  

#### Why is this the best possible solution? Were any other approaches considered?
There are two independent aspects to this issue.  
>...and then skip to the next question... 

In `SelectOneFromMapWidget`, the `Context` as `AdvanceToNextListener` is now alerted  in `setData` on the lines of `SelectOneMinimalWidget`. `WidgetFactory` is adjusted to pass in `isQuick`.

(Aligning the behaviour exactly with `SelectOneMinimalWidget` was an interesting exercise in `null` safety, necessitated by a tiny detail in the internals of `Selection`.)

>...they should be able to change their selection...

`SelectionMapFragment` implements _quick_ by setting `skipSummary` so that `onFeatureClicked` jumps direct to `setFragmentResult` in `FragmentManager`; `onFragmentResult` in `SelectOneFromMapDialogFragment` then tidies up and calls `dismiss`. 

When the user tries to reopen the widget as described in the issue, `onFeatureClicked` is called again from `updateItems` to display (if `skipSummary` is _not_ set) the `previouslySelectedItem`, so (since `skipSummary` _is_ set) `SelectOneFromMapDialogFragment` quits immediately. 

Making `skipSummary` set `previouslySelectedItem` to `null` stops this happening. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No impact on tests; `SelectOneFromMapWidgetTest`, `SelectOneFromMapDialogFragmentTest` and `SelectionMapFragmentTest` all
pass unmodified (none of them currently tests for _quick_).

#### Do we need any specific form for testing your changes? If so, please attach one.
Form as above

#### Does this change require updates to documentation? If so, please file an issue [here](https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
