### PR TITLE
Track partial form submissions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -163,4 +163,9 @@ object AnalyticsEvents {
      */
     const val PERMISSIONS_DIALOG_CANCEL = "PermissionsDialogCancel"
     const val PERMISSIONS_DIALOG_OK = "PermissionsDialogOK"
+
+    /**
+     * Tracks how often a form is finalized using a `ref` attribute on the `submission` element
+     */
+    const val PARTIAL_FORM_FINALIZED = "PartialFormFinalized"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -39,6 +39,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.odk.collect.analytics.Analytics;
+import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.instances.DatabaseInstanceColumns;
 import org.odk.collect.android.exception.EncryptionException;
@@ -361,6 +362,10 @@ public class SaveFormToDisk {
             // now see if the packaging of the data for the server would make it
             // non-reopenable (e.g., encryption or other fraction of the form).
             boolean canEditAfterCompleted = formController.isSubmissionEntireForm();
+            if (!canEditAfterCompleted) {
+                Analytics.log(AnalyticsEvents.PARTIAL_FORM_FINALIZED, "form");
+            }
+
             boolean isEncrypted = false;
 
             // build a submission.xml to hold the data being submitted


### PR DESCRIPTION
This adds an event that will allow us to track how often forms that use a `ref` attribute on their `submission` element are finalized in the wild.