### PR TITLE
Allow custom camera app to be specified in a question

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/media/PromptAutoplayer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/media/PromptAutoplayer.java
@@ -6,6 +6,7 @@ import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.audio.AudioHelper;
 import org.odk.collect.android.utilities.Appearances;
+import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.audioclips.Clip;
 
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ public class PromptAutoplayer {
     }
 
     public Boolean autoplayIfNeeded(FormEntryPrompt prompt) {
-        String autoplayOption = prompt.getFormElement().getAdditionalAttribute(null, AUTOPLAY_ATTRIBUTE);
+        String autoplayOption = FormEntryPromptUtils.getBodyAttribute(prompt, AUTOPLAY_ATTRIBUTE);
 
         if (hasAudioAutoplay(autoplayOption)) {
             List<Clip> clipsToPlay = new ArrayList<>();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/media/PromptAutoplayer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/media/PromptAutoplayer.java
@@ -31,7 +31,7 @@ public class PromptAutoplayer {
     }
 
     public Boolean autoplayIfNeeded(FormEntryPrompt prompt) {
-        String autoplayOption = FormEntryPromptUtils.getBodyAttribute(prompt, AUTOPLAY_ATTRIBUTE);
+        String autoplayOption = FormEntryPromptUtils.getAdditionalAttribute(prompt, AUTOPLAY_ATTRIBUTE);
 
         if (hasAudioAutoplay(autoplayOption)) {
             List<Clip> clipsToPlay = new ArrayList<>();

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -144,7 +144,7 @@ public final class FormEntryPromptUtils {
     }
 
     @Nullable
-    public static String getBodyAttribute(FormEntryPrompt formEntryPrompt, String attributeName) {
+    public static String getAdditionalAttribute(FormEntryPrompt formEntryPrompt, String attributeName) {
         String value = formEntryPrompt.getQuestion().getAdditionalAttribute(null, attributeName);
         return value != null && !value.isEmpty() ? value : null;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -37,6 +37,7 @@ import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtils;
+import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
@@ -163,6 +164,10 @@ public class AnnotateWidget extends BaseImageWidget implements ButtonClickListen
 
     private void captureImage() {
         Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
+        String packageName = FormEntryPromptUtils.getBindAttribute(getFormEntryPrompt(), "intent");
+        if (packageName != null) {
+            intent.setPackage(packageName);
+        }
         // We give the camera an absolute filename/path where to put the
         // picture because of bug:
         // http://code.google.com/p/android/issues/detail?id=1480

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -158,7 +158,7 @@ public class AnnotateWidget extends BaseImageWidget implements ButtonClickListen
     }
 
     private void captureImage() {
-        Intent intent = ImageCaptureIntentCreator.INSTANCE.imageCaptureIntent(getFormEntryPrompt(), getContext(), tmpImageFilePath);
+        Intent intent = ImageCaptureIntentCreator.imageCaptureIntent(getFormEntryPrompt(), getContext(), tmpImageFilePath);
         imageCaptureHandler.captureImage(intent, RequestCodes.IMAGE_CAPTURE, org.odk.collect.strings.R.string.annotate_image);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -25,28 +25,23 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
-import android.net.Uri;
 import android.view.View;
 import android.widget.Button;
 
-import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.draw.DrawActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.utilities.Appearances;
-import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtils;
-import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
+import org.odk.collect.android.widgets.utilities.ImageCaptureIntentCreator;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 import org.odk.collect.androidshared.ui.ToastUtils;
 
 import java.io.File;
 import java.util.Locale;
-
-import timber.log.Timber;
 
 /**
  * Image widget that supports annotations on the image.
@@ -163,27 +158,7 @@ public class AnnotateWidget extends BaseImageWidget implements ButtonClickListen
     }
 
     private void captureImage() {
-        Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
-        String packageName = FormEntryPromptUtils.getBindAttribute(getFormEntryPrompt(), "intent");
-        if (packageName != null) {
-            intent.setPackage(packageName);
-        }
-
-        // The Android Camera application saves a full-size photo if you give it a file to save into.
-        // You must provide a fully qualified file name where the camera app should save the photo.
-        // https://developer.android.com/training/camera-deprecated/photobasics
-        try {
-            Uri uri = new ContentUriProvider().getUriForFile(getContext(),
-                    BuildConfig.APPLICATION_ID + ".provider",
-                    new File(tmpImageFilePath));
-            // if this gets modified, the onActivityResult in
-            // FormEntyActivity will also need to be updated.
-            intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
-            FileUtils.grantFilePermissions(intent, uri, getContext());
-        } catch (IllegalArgumentException e) {
-            Timber.e(e);
-        }
-
+        Intent intent = ImageCaptureIntentCreator.INSTANCE.imageCaptureIntent(getFormEntryPrompt(), getContext(), tmpImageFilePath);
         imageCaptureHandler.captureImage(intent, RequestCodes.IMAGE_CAPTURE, org.odk.collect.strings.R.string.annotate_image);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -168,14 +168,10 @@ public class AnnotateWidget extends BaseImageWidget implements ButtonClickListen
         if (packageName != null) {
             intent.setPackage(packageName);
         }
-        // We give the camera an absolute filename/path where to put the
-        // picture because of bug:
-        // http://code.google.com/p/android/issues/detail?id=1480
-        // The bug appears to be fixed in Android 2.0+, but as of feb 2,
-        // 2010, G1 phones only run 1.6. Without specifying the path the
-        // images returned by the camera in 1.6 (and earlier) are ~1/4
-        // the size. boo.
 
+        // The Android Camera application saves a full-size photo if you give it a file to save into.
+        // You must provide a fully qualified file name where the camera app should save the photo.
+        // https://developer.android.com/training/camera-deprecated/photobasics
         try {
             Uri uri = new ContentUriProvider().getUriForFile(getContext(),
                     BuildConfig.APPLICATION_ID + ".provider",

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -21,30 +21,23 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.net.Uri;
 import android.view.View;
 import android.widget.Button;
 
-import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.utilities.Appearances;
-import org.odk.collect.android.utilities.ContentUriProvider;
-import org.odk.collect.android.utilities.FileUtils;
-import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
+import org.odk.collect.android.widgets.utilities.ImageCaptureIntentCreator;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 import org.odk.collect.androidshared.system.CameraUtils;
 import org.odk.collect.selfiecamera.CaptureSelfieActivity;
 
-import java.io.File;
 import java.util.Locale;
-
-import timber.log.Timber;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the form.
@@ -144,27 +137,7 @@ public class ImageWidget extends BaseImageWidget implements ButtonClickListener 
             intent.putExtra(CaptureSelfieActivity.EXTRA_TMP_PATH, new StoragePathProvider().getOdkDirPath(StorageSubdirectory.CACHE));
             imageCaptureHandler.captureImage(intent, RequestCodes.MEDIA_FILE_PATH, org.odk.collect.strings.R.string.capture_image);
         } else {
-            Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
-            String packageName = FormEntryPromptUtils.getBindAttribute(getFormEntryPrompt(), "intent");
-            if (packageName != null) {
-                intent.setPackage(packageName);
-            }
-
-            // The Android Camera application saves a full-size photo if you give it a file to save into.
-            // You must provide a fully qualified file name where the camera app should save the photo.
-            // https://developer.android.com/training/camera-deprecated/photobasics
-            try {
-                Uri uri = new ContentUriProvider().getUriForFile(getContext(),
-                        BuildConfig.APPLICATION_ID + ".provider",
-                        new File(tmpImageFilePath));
-                // if this gets modified, the onActivityResult in
-                // FormEntyActivity will also need to be updated.
-                intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
-                FileUtils.grantFilePermissions(intent, uri, getContext());
-            } catch (IllegalArgumentException e) {
-                Timber.e(e);
-            }
-
+            Intent intent = ImageCaptureIntentCreator.INSTANCE.imageCaptureIntent(getFormEntryPrompt(), getContext(), tmpImageFilePath);
             imageCaptureHandler.captureImage(intent, RequestCodes.IMAGE_CAPTURE, org.odk.collect.strings.R.string.capture_image);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -137,7 +137,7 @@ public class ImageWidget extends BaseImageWidget implements ButtonClickListener 
             intent.putExtra(CaptureSelfieActivity.EXTRA_TMP_PATH, new StoragePathProvider().getOdkDirPath(StorageSubdirectory.CACHE));
             imageCaptureHandler.captureImage(intent, RequestCodes.MEDIA_FILE_PATH, org.odk.collect.strings.R.string.capture_image);
         } else {
-            Intent intent = ImageCaptureIntentCreator.INSTANCE.imageCaptureIntent(getFormEntryPrompt(), getContext(), tmpImageFilePath);
+            Intent intent = ImageCaptureIntentCreator.imageCaptureIntent(getFormEntryPrompt(), getContext(), tmpImageFilePath);
             imageCaptureHandler.captureImage(intent, RequestCodes.IMAGE_CAPTURE, org.odk.collect.strings.R.string.capture_image);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -34,6 +34,7 @@ import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtils;
+import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
@@ -144,6 +145,10 @@ public class ImageWidget extends BaseImageWidget implements ButtonClickListener 
             imageCaptureHandler.captureImage(intent, RequestCodes.MEDIA_FILE_PATH, org.odk.collect.strings.R.string.capture_image);
         } else {
             Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
+            String packageName = FormEntryPromptUtils.getBindAttribute(getFormEntryPrompt(), "intent");
+            if (packageName != null) {
+                intent.setPackage(packageName);
+            }
             // We give the camera an absolute filename/path where to put the
             // picture because of bug:
             // http://code.google.com/p/android/issues/detail?id=1480

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -149,14 +149,10 @@ public class ImageWidget extends BaseImageWidget implements ButtonClickListener 
             if (packageName != null) {
                 intent.setPackage(packageName);
             }
-            // We give the camera an absolute filename/path where to put the
-            // picture because of bug:
-            // http://code.google.com/p/android/issues/detail?id=1480
-            // The bug appears to be fixed in Android 2.0+, but as of feb 2,
-            // 2010, G1 phones only run 1.6. Without specifying the path the
-            // images returned by the camera in 1.6 (and earlier) are ~1/4
-            // the size. boo.
 
+            // The Android Camera application saves a full-size photo if you give it a file to save into.
+            // You must provide a fully qualified file name where the camera app should save the photo.
+            // https://developer.android.com/training/camera-deprecated/photobasics
             try {
                 Uri uri = new ContentUriProvider().getUriForFile(getContext(),
                         BuildConfig.APPLICATION_ID + ".provider",

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequester.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequester.kt
@@ -44,9 +44,9 @@ class ActivityGeoDataRequester(
                         }
 
                         val accuracyThreshold =
-                            FormEntryPromptUtils.getBodyAttribute(prompt, "accuracyThreshold")
+                            FormEntryPromptUtils.getAdditionalAttribute(prompt, "accuracyThreshold")
                         val unacceptableAccuracyThreshold =
-                            FormEntryPromptUtils.getBodyAttribute(
+                            FormEntryPromptUtils.getAdditionalAttribute(
                                 prompt,
                                 "unacceptableAccuracyThreshold"
                             )

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ImageCaptureIntentCreator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ImageCaptureIntentCreator.kt
@@ -15,7 +15,7 @@ object ImageCaptureIntentCreator {
     @JvmStatic
     fun imageCaptureIntent(prompt: FormEntryPrompt, context: Context, tmpImageFilePath: String): Intent {
         val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        val packageName = FormEntryPromptUtils.getBodyAttribute(prompt, "intent")
+        val packageName = FormEntryPromptUtils.getAdditionalAttribute(prompt, "intent")
         if (packageName != null) {
             intent.setPackage(packageName)
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ImageCaptureIntentCreator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ImageCaptureIntentCreator.kt
@@ -12,6 +12,7 @@ import timber.log.Timber
 import java.io.File
 
 object ImageCaptureIntentCreator {
+    @JvmStatic
     fun imageCaptureIntent(prompt: FormEntryPrompt, context: Context, tmpImageFilePath: String): Intent {
         val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
         val packageName = FormEntryPromptUtils.getBodyAttribute(prompt, "intent")

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ImageCaptureIntentCreator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ImageCaptureIntentCreator.kt
@@ -1,0 +1,41 @@
+package org.odk.collect.android.widgets.utilities
+
+import android.content.Context
+import android.content.Intent
+import android.provider.MediaStore
+import org.javarosa.form.api.FormEntryPrompt
+import org.odk.collect.android.BuildConfig
+import org.odk.collect.android.utilities.ContentUriProvider
+import org.odk.collect.android.utilities.FileUtils
+import org.odk.collect.android.utilities.FormEntryPromptUtils
+import timber.log.Timber
+import java.io.File
+
+object ImageCaptureIntentCreator {
+    fun imageCaptureIntent(prompt: FormEntryPrompt, context: Context, tmpImageFilePath: String): Intent {
+        val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        val packageName = FormEntryPromptUtils.getBindAttribute(prompt, "intent")
+        if (packageName != null) {
+            intent.setPackage(packageName)
+        }
+
+        // The Android Camera application saves a full-size photo if you give it a file to save into.
+        // You must provide a fully qualified file name where the camera app should save the photo.
+        // https://developer.android.com/training/camera-deprecated/photobasics
+        try {
+            val uri = ContentUriProvider().getUriForFile(
+                context,
+                BuildConfig.APPLICATION_ID + ".provider",
+                File(tmpImageFilePath)
+            )
+            // if this gets modified, the onActivityResult in
+            // FormEntyActivity will also need to be updated.
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
+            FileUtils.grantFilePermissions(intent, uri, context)
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e)
+        }
+
+        return intent
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ImageCaptureIntentCreator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ImageCaptureIntentCreator.kt
@@ -14,7 +14,7 @@ import java.io.File
 object ImageCaptureIntentCreator {
     fun imageCaptureIntent(prompt: FormEntryPrompt, context: Context, tmpImageFilePath: String): Intent {
         val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        val packageName = FormEntryPromptUtils.getBindAttribute(prompt, "intent")
+        val packageName = FormEntryPromptUtils.getBodyAttribute(prompt, "intent")
         if (packageName != null) {
             intent.setPackage(packageName)
         }

--- a/collect_app/src/test/java/org/odk/collect/android/support/MockFormEntryPromptBuilder.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/MockFormEntryPromptBuilder.java
@@ -65,7 +65,7 @@ public class MockFormEntryPromptBuilder {
     }
 
     public MockFormEntryPromptBuilder withAdditionalAttribute(String name, String value) {
-        when(prompt.getFormElement().getAdditionalAttribute(null, name)).thenReturn(value);
+        when(prompt.getQuestion().getAdditionalAttribute(null, name)).thenReturn(value);
         return this;
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -86,11 +86,12 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
     }
 
     @Test
-    public void buttonsShouldLaunchCorrectIntents() {
+    public void buttonsShouldLaunchCorrectIntentsWhenThereIsNoCustomPackage() {
         stubAllRuntimePermissionsGranted(true);
 
         Intent intent = getIntentLaunchedByClick(R.id.capture_image);
         assertActionEquals(MediaStore.ACTION_IMAGE_CAPTURE, intent);
+        assertThat(intent.getPackage(), equalTo(null));
 
         intent = getIntentLaunchedByClick(R.id.choose_image);
         assertActionEquals(Intent.ACTION_GET_CONTENT, intent);
@@ -98,6 +99,23 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
         intent = getIntentLaunchedByClick(R.id.markup_image);
         assertComponentEquals(activity, DrawActivity.class, intent);
         assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE, intent);
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntentsWhenCustomPackageIsSet() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withBindAttribute("odk", "intent", "com.customcameraapp")
+                .build();
+
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.capture_image);
+        assertActionEquals(MediaStore.ACTION_IMAGE_CAPTURE, intent);
+        assertThat(intent.getPackage(), equalTo("com.customcameraapp"));
+
+        intent = getIntentLaunchedByClick(R.id.choose_image);
+        assertActionEquals(Intent.ACTION_GET_CONTENT, intent);
+        assertTypeEquals("image/*", intent);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -104,7 +104,7 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
     @Test
     public void buttonsShouldLaunchCorrectIntentsWhenCustomPackageIsSet() {
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withBindAttribute("odk", "intent", "com.customcameraapp")
+                .withAdditionalAttribute("intent", "com.customcameraapp")
                 .build();
 
         stubAllRuntimePermissionsGranted(true);

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
@@ -75,11 +75,29 @@ public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
     }
 
     @Test
-    public void buttonsShouldLaunchCorrectIntents() {
+    public void buttonsShouldLaunchCorrectIntentsWhenThereIsNoCustomPackage() {
         stubAllRuntimePermissionsGranted(true);
 
         Intent intent = getIntentLaunchedByClick(R.id.capture_image);
         assertActionEquals(MediaStore.ACTION_IMAGE_CAPTURE, intent);
+        assertThat(intent.getPackage(), equalTo(null));
+
+        intent = getIntentLaunchedByClick(R.id.choose_image);
+        assertActionEquals(Intent.ACTION_GET_CONTENT, intent);
+        assertTypeEquals("image/*", intent);
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntentsWhenCustomPackageIsSet() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withBindAttribute("odk", "intent", "com.customcameraapp")
+                .build();
+
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.capture_image);
+        assertActionEquals(MediaStore.ACTION_IMAGE_CAPTURE, intent);
+        assertThat(intent.getPackage(), equalTo("com.customcameraapp"));
 
         intent = getIntentLaunchedByClick(R.id.choose_image);
         assertActionEquals(Intent.ACTION_GET_CONTENT, intent);

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
@@ -90,7 +90,7 @@ public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
     @Test
     public void buttonsShouldLaunchCorrectIntentsWhenCustomPackageIsSet() {
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withBindAttribute("odk", "intent", "com.customcameraapp")
+                .withAdditionalAttribute("intent", "com.customcameraapp")
                 .build();
 
         stubAllRuntimePermissionsGranted(true);

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/WidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/WidgetTest.java
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.IFormElement;
+import org.javarosa.core.model.QuestionDef;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Rule;
@@ -47,6 +48,7 @@ public abstract class WidgetTest {
         when(formEntryPrompt.getIndex()).thenReturn(mock(FormIndex.class));
         when(formEntryPrompt.getIndex().toString()).thenReturn("0, 0");
         when(formEntryPrompt.getFormElement()).thenReturn(formElement);
+        when(formEntryPrompt.getQuestion()).thenReturn(mock(QuestionDef.class));
     }
 
     @Test


### PR DESCRIPTION
Closes #5621 

#### What has been done to verify that this works as intended?
I've tested the changes manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
We have discussed other options (see in the issue) but decided that the issue should be fixed in this particular way.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As described in the issue this should allow specifying custom camera apps in image/annotate widgets. We need to test carefully those two widgets and verify edge cases like:
- what happens if a widget has a custom camera app specified but it's not installed 
- what if the package name is wrong
- what if the package name is correct but points to an app tat is not a camera app

#### Do we need any specific form for testing your changes? If so, please attach one.
I've used:
[image_questions.xlsx](https://github.com/getodk/collect/files/13249701/image_questions.xlsx)
[image_questions.xml.txt](https://github.com/getodk/collect/files/13249712/image_questions.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Yes https://github.com/getodk/docs/issues/1652

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
