### PR TITLE
Fixed: Doubled event in the audit log after saving a draft in Audit Test Location Background Audio form

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -96,4 +96,23 @@ class AuditTest {
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
         assertThat(auditLog[1].get("event"), equalTo("form resume"))
     }
+
+    @Test // https://github.com/getodk/collect/issues/5659
+    fun savingFormWithBackgroundRecording_doesNotDuplicateAnyEvent() {
+        rule.startAtMainMenu()
+            .copyForm("one-question-background-audio-audit.xml")
+            .startBlankForm("One Question Background Audio And Audit")
+            .fillOutAndSave(
+                MainMenuPage(),
+                FormEntryPage.QuestionAndAnswer("what is your age", "31")
+            )
+
+        val auditLog = StorageUtils.getAuditLogForFirstInstance()
+        assertThat(auditLog.size, equalTo(4))
+
+        assertThat(auditLog[0].get("event"), equalTo("form start"))
+        assertThat(auditLog[1].get("event"), equalTo("question"))
+        assertThat(auditLog[2].get("event"), equalTo("form save"))
+        assertThat(auditLog[3].get("event"), equalTo("form exit"))
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -618,7 +618,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
             if (session != null && session.getFile() != null) {
                 recordingHandler.handle(getFormController(), session, success -> {
                     if (success) {
-                        onScreenRefresh();
                         formSaveViewModel.resumeSave();
                     } else {
                         String path = session.getFile().getAbsolutePath();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/RecordingHandler.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/RecordingHandler.java
@@ -39,8 +39,6 @@ public class RecordingHandler {
     public void handle(FormController formController, RecordingSession session, Consumer<Boolean> onRecordingHandled) {
         questionMediaManager.createAnswerFile(session.getFile()).observe(lifecycleOwner, result -> {
             if (result != null && result.isSuccess()) {
-                audioRecorder.cleanUp();
-
                 try {
                     if (session.getId() instanceof FormIndex) {
                         handleForegroundRecording(formController, session, result);
@@ -53,6 +51,7 @@ public class RecordingHandler {
                     Timber.e(e);
                     onRecordingHandled.accept(false);
                 }
+                audioRecorder.cleanUp();
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -95,7 +95,9 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
                 binding.audioPlayer.waveform.addAmplitude(session.second);
             } else {
                 recordingInProgress = false;
+                binaryName = questionDetails.getPrompt().getAnswerText();
                 updateVisibilities();
+                updatePlayerMedia();
             }
         });
     }

--- a/test-forms/src/main/resources/forms/one-question-background-audio-audit.xml
+++ b/test-forms/src/main/resources/forms/one-question-background-audio-audit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:odk="http://www.opendatakit.org/xforms">
+    <h:head>
+        <h:title>One Question Background Audio And Audit</h:title>
+        <model>
+            <instance>
+                <data id="one_question" orx:version="1">
+                    <recording/>
+                    <age/>
+                    <meta>
+                        <audit/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="age" type="int"/>
+            <bind nodeset="/data/meta/audit" type="binary"/>
+            <odk:recordaudio event="odk-instance-load" ref="/data/recording"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/age">
+            <label>what is your age</label>
+        </input>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #5659 
Closes #5752 

#### What has been done to verify that this works as intended?
I've tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that when background recording was being finished then audit logs were flushed but after that, we called `onScreenRefresh` which caused logging events from the current screen again. I could write a method that would compare those already logged events with new ones (maybe this is something we will need at some point either way but hopefully not because this would be cumbersome) but in this case, avoiding that `onScreenRefresh` is a better solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Apart from the issue itself please test [Background audio recording](https://docs.getodk.org/form-question-types/#background-audio-recording) and the [Audio widget](https://docs.getodk.org/form-question-types/#audio-widgets) to make sure there is no regression.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
