### PR TITLE
Fixed: Crash when logging background location

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -2268,6 +2268,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
     }
 
     private void exit() {
+        backgroundLocationViewModel.activityHidden();
         formEntryViewModel.exit();
         finish();
     }


### PR DESCRIPTION
Closes #5726 

#### What has been done to verify that this works as intended?
I've tested implemented changes by providing new locations programmatically. 

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that new locations could be received after starting exiting a form (when the form controller is cleared) in `FormFillingActivity#exit()` and before stopping handling those new locations `FormFillingActivity#onPause()`.
I wasn't able to reproduce the issue in normal circumstances but I did it programmatically.
What we need is to stop handling those locations earlier if we are about to exit a form.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As I said I don't think this is easy to reproduce so probably we can skip testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
