### PR TITLE
Fixed the order of events when location tracking is enabled

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -115,4 +115,35 @@ class AuditTest {
         assertThat(auditLog[2].get("event"), equalTo("form save"))
         assertThat(auditLog[3].get("event"), equalTo("form exit"))
     }
+
+    @Test // https://github.com/getodk/collect/issues/5262
+    fun locationTrackingEventsShouldBeLoggedBeforeQuestionEventsWhenANewFormIsStartedOrAPreviouslySavedOneEdited() {
+        rule.startAtMainMenu()
+            .copyForm("location-audit.xml")
+            .startBlankForm("Audit with Location")
+            .pressBackAndSaveAsDraft()
+            .clickEditSavedForm()
+            .clickOnForm("Audit with Location")
+            .clickGoToStart()
+            .pressBackAndSaveAsDraft()
+
+        val auditLog = StorageUtils.getAuditLogForFirstInstance()
+        assertThat(auditLog.size, equalTo(15))
+
+        assertThat(auditLog[0].get("event"), equalTo("form start"))
+        assertThat(auditLog[1].get("event"), equalTo("location tracking enabled"))
+        assertThat(auditLog[2].get("event"), equalTo("location permissions granted"))
+        assertThat(auditLog[3].get("event"), equalTo("location providers enabled"))
+        assertThat(auditLog[4].get("event"), equalTo("question"))
+        assertThat(auditLog[5].get("event"), equalTo("form save"))
+        assertThat(auditLog[6].get("event"), equalTo("form exit"))
+        assertThat(auditLog[7].get("event"), equalTo("form resume"))
+        assertThat(auditLog[8].get("event"), equalTo("jump"))
+        assertThat(auditLog[9].get("event"), equalTo("location tracking enabled"))
+        assertThat(auditLog[10].get("event"), equalTo("location permissions granted"))
+        assertThat(auditLog[11].get("event"), equalTo("location providers enabled"))
+        assertThat(auditLog[12].get("event"), equalTo("question"))
+        assertThat(auditLog[13].get("event"), equalTo("form save"))
+        assertThat(auditLog[14].get("event"), equalTo("form exit"))
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -397,6 +397,12 @@ public class FormEntryPage extends Page<FormEntryPage> {
                 .clickDiscardChanges();
     }
 
+    public MainMenuPage pressBackAndSaveAsDraft() {
+        return closeSoftKeyboard()
+                .pressBack(new SaveOrDiscardFormDialog<>(new MainMenuPage()))
+                .clickSaveChanges();
+    }
+
     public MainMenuPage pressBackAndDiscardForm() {
         return closeSoftKeyboard()
                 .pressBack(new SaveOrDiscardFormDialog<>(new MainMenuPage()))

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -693,6 +693,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
 
                 if (formController != null) {
                     formControllerAvailable(formController);
+                    activityDisplayed();
                     formEntryViewModel.refresh();
                 } else {
                     Timber.w("Reloading form and restoring state.");
@@ -874,6 +875,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         // If we're coming back from the hierarchy view, the user has either tapped the back
         // button or another question to jump to so we need to rebuild the view.
         if (requestCode == RequestCodes.HIERARCHY_ACTIVITY || requestCode == RequestCodes.CHANGE_SETTINGS) {
+            activityDisplayed();
             formEntryViewModel.refresh();
             return;
         }


### PR DESCRIPTION
Closes #5262 

#### What has been done to verify that this works as intended?
I've tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
Enabling background recording takes place when we call `activityDisplayed()` when we navigate back from the hierarchy view we need to do that earlier than in `onResume()` because it's after refreshing the screen and logging the question event.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Apart from verifying that the issue has been fixed, it would be good to play a little bit with background location recording to make sure there is no regression.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
