### PR TITLE
Allow local JavaRosa to be used with one change

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ JavaRosa is the form engine that powers Collect. If you want to debug or change 
 ./gradlew installLocal
 ```
 
-1. Change `implementation(Dependencies.javarosa)` in Collect's `build.gradle` to `implementation(Dependencies.javarosa_local)`
+1. Change `const val javarosa = javarosa_online` in `Dependencies.kt` to `const val javarosa = javarosa_local`
 
 ## Troubleshooting
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ allprojects {
         // Needs to go first to get specialty libraries https://stackoverflow.com/a/48438866/137744
         google()
 
+        mavenLocal() // Only used for javarosa_local dependency
         mavenCentral()
 
         maven { url 'https://oss.sonatype.org/content/groups/public' }

--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -40,8 +40,9 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.0.1"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.7.1"
-    const val javarosa = "org.getodk:javarosa:4.3.0-SNAPSHOT"
+    const val javarosa_online = "org.getodk:javarosa:4.3.0-SNAPSHOT"
     const val javarosa_local = "org.getodk:javarosa:local"
+    const val javarosa = javarosa_online
     const val karumi_dexter = "com.karumi:dexter:6.2.3"
     const val zxing_android_embedded = "com.journeyapps:zxing-android-embedded:4.3.0"
     const val dagger = "com.google.dagger:dagger:${Versions.dagger}"

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -226,10 +226,6 @@ configurations.all {
 }
 
 dependencies {
-    repositories {
-        mavenLocal() // Only used for javarosa_local dependency
-    }
-
     coreLibraryDesugaring Dependencies.desugar
 
     implementation project(':shared')


### PR DESCRIPTION
Allows JavaRosa to be debugged again now that we have multiple modules relying on it.