### PR TITLE
Fixed annotate widget tests

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -221,7 +221,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
             Intent i = new Intent(getContext(), DrawActivity.class);
             i.putExtra(DrawActivity.OPTION, drawOption);
             File file = getFile();
-            if (file != null) {
+            if (file != null && file.exists()) {
                 i.putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(file));
             }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -285,8 +285,17 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
     }
 
     @Test
-    @Ignore("https://github.com/getodk/collect/issues/5753")
-    public void whenPromptHasDefaultAnswerThatDoesNotExist_doNotPassUriToDrawActivity() {
+    public void whenPromptHasDefaultAnswerThatDoesNotExist_doNotPassUriToDrawActivity() throws Exception {
+        ReferenceManager referenceManager = setupFakeReferenceManager(singletonList(
+                new Pair<>(DrawWidgetTest.DEFAULT_IMAGE_ANSWER, "/something")
+        ));
+        CollectHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public ReferenceManager providesReferenceManager() {
+                return referenceManager;
+            }
+        });
+
         formEntryPrompt = new MockFormEntryPromptBuilder()
                 .withAnswerDisplayText(DrawWidgetTest.DEFAULT_IMAGE_ANSWER)
                 .build();

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -14,7 +14,6 @@ import androidx.core.util.Pair;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.reference.ReferenceManager;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.draw.DrawActivity;

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
@@ -220,8 +220,17 @@ public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
     }
 
     @Test
-    @Ignore("https://github.com/getodk/collect/issues/5753")
-    public void whenPromptHasDefaultAnswerThatDoesNotExist_doNotPassUriToDrawActivity() {
+    public void whenPromptHasDefaultAnswerThatDoesNotExist_doNotPassUriToDrawActivity() throws Exception {
+        ReferenceManager referenceManager = setupFakeReferenceManager(singletonList(
+                new Pair<>(DrawWidgetTest.DEFAULT_IMAGE_ANSWER, "/something")
+        ));
+        CollectHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public ReferenceManager providesReferenceManager() {
+                return referenceManager;
+            }
+        });
+
         formEntryPrompt = new MockFormEntryPromptBuilder()
                 .withAnswerDisplayText(DrawWidgetTest.DEFAULT_IMAGE_ANSWER)
                 .build();

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
@@ -14,7 +14,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import net.bytebuddy.utility.RandomString;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.reference.ReferenceManager;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
@@ -14,7 +14,6 @@ import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.reference.ReferenceManager;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.draw.DrawActivity;

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
@@ -214,8 +214,17 @@ public class SignatureWidgetTest extends FileWidgetTest<SignatureWidget> {
     }
 
     @Test
-    @Ignore("https://github.com/getodk/collect/issues/5753")
-    public void whenPromptHasDefaultAnswerThatDoesNotExist_doNotPassUriToDrawActivity() {
+    public void whenPromptHasDefaultAnswerThatDoesNotExist_doNotPassUriToDrawActivity() throws Exception {
+        ReferenceManager referenceManager = setupFakeReferenceManager(singletonList(
+                new Pair<>(DrawWidgetTest.DEFAULT_IMAGE_ANSWER, "/something")
+        ));
+        CollectHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public ReferenceManager providesReferenceManager() {
+                return referenceManager;
+            }
+        });
+
         formEntryPrompt = new MockFormEntryPromptBuilder()
                 .withAnswerDisplayText(DrawWidgetTest.DEFAULT_IMAGE_ANSWER)
                 .build();


### PR DESCRIPTION
Closes #5753 

#### What has been done to verify that this works as intended?
I was able to reproduce the issue locally and verified that with this fix the issue does not exist anymore.

#### Why is this the best possible solution? Were any other approaches considered?
We had two bugs in the code:
1. The tests didn't work in the same way as the real (production) code. If the default image is set but it doesn't exist physically the it's not null but it doesn't exist https://github.com/getodk/collect/pull/5756/files#diff-17f2760db9afd9042769752c16db6039529e87db4691461d501f4980a4cf3621R224 but our tests assumed it's null.
2. The tests used the real `ReferenceManager` that is a singleton and depending on the order of tests it made tests work in a different way.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
