### PR TITLE
Improved handing fast clicking on different elements in the main menu

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
@@ -35,4 +35,8 @@ object MultiClickGuard {
         }
         return allowClick
     }
+
+    enum class ScreenName {
+        MAIN_MENU
+    }
 }

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
@@ -36,6 +36,12 @@ object MultiClickGuard {
         return allowClick
     }
 
+    /*
+    Utilizing screen names instead of class names offers a more robust approach, as elements placed
+    on the same user interface screen may potentially belong to distinct classes (such as fragments or custom views).
+    Consequently, employing screen names for identification ensures that these elements are recognized
+    as components of the same screen, disabling rapid clicking.
+     */
     enum class ScreenName {
         MAIN_MENU
     }

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
@@ -14,15 +14,22 @@ object MultiClickGuard {
         return allowClick(className, 500)
     }
 
-    // Debounce multiple clicks within the same screen
+    /**
+     * Debounce multiple clicks within the same screen
+     *
+     * @param screenName The name of the screen. If not provided, the Java class name of the element
+     * is used. However, this approach is imperfect, as elements on the same screen might belong to
+     * different classes. Consequently, clicks on these elements are treated as interactions occurring
+     * on two distinct screens, not protecting from rapid clicking.
+     */
     @JvmStatic
     @JvmOverloads
-    fun allowClick(className: String = javaClass.name, clickDebounceMs: Long = 1000): Boolean {
+    fun allowClick(screenName: String = javaClass.name, clickDebounceMs: Long = 1000): Boolean {
         if (test) {
             return true
         }
         val elapsedRealtime = SystemClock.elapsedRealtime()
-        val isSameClass = className == lastClickName
+        val isSameClass = screenName == lastClickName
         val isBeyondThreshold = elapsedRealtime - lastClickTime > clickDebounceMs
         val isBeyondTestThreshold =
             lastClickTime == 0L || lastClickTime == elapsedRealtime // just for tests
@@ -31,18 +38,8 @@ object MultiClickGuard {
 
         if (allowClick) {
             lastClickTime = elapsedRealtime
-            lastClickName = className
+            lastClickName = screenName
         }
         return allowClick
-    }
-
-    /*
-    Utilizing screen names instead of class names offers a more robust approach, as elements placed
-    on the same user interface screen may potentially belong to distinct classes (such as fragments or custom views).
-    Consequently, employing screen names for identification ensures that these elements are recognized
-    as components of the same screen, disabling rapid clicking.
-     */
-    enum class ScreenName {
-        MAIN_MENU
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -34,6 +34,7 @@ import org.odk.collect.android.utilities.ThemeUtils
 import org.odk.collect.androidshared.ui.DialogFragmentUtils.showIfNotShowing
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.SnackbarUtils
+import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard.allowClick
 import org.odk.collect.crashhandler.CrashHandler
 import org.odk.collect.permissions.PermissionsProvider
@@ -161,7 +162,7 @@ class MainMenuActivity : LocalizedActivity() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (!allowClick(javaClass.name)) {
+        if (!allowClick(MultiClickGuard.ScreenName.MAIN_MENU.name)) {
             return true
         }
         if (item.itemId == R.id.projects) {

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -34,7 +34,6 @@ import org.odk.collect.android.utilities.ThemeUtils
 import org.odk.collect.androidshared.ui.DialogFragmentUtils.showIfNotShowing
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.SnackbarUtils
-import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard.allowClick
 import org.odk.collect.crashhandler.CrashHandler
 import org.odk.collect.permissions.PermissionsProvider
@@ -162,7 +161,7 @@ class MainMenuActivity : LocalizedActivity() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (!allowClick(MultiClickGuard.ScreenName.MAIN_MENU.name)) {
+        if (!allowClick(ApplicationConstants.ScreenName.MAIN_MENU.name)) {
             return true
         }
         if (item.itemId == R.id.projects) {

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
@@ -10,6 +10,7 @@ import com.google.android.material.badge.BadgeUtils
 import com.google.android.material.badge.ExperimentalBadgeUtils
 import org.odk.collect.android.R
 import org.odk.collect.android.databinding.MainMenuButtonBinding
+import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.androidshared.system.ContextUtils.getThemeAttributeValue
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
 
@@ -50,7 +51,7 @@ class MainMenuButton(context: Context, attrs: AttributeSet?) : FrameLayout(conte
         get() = binding.name.text.toString()
 
     override fun performClick(): Boolean {
-        return MultiClickGuard.allowClick(MultiClickGuard.ScreenName.MAIN_MENU.name) && super.performClick()
+        return MultiClickGuard.allowClick(ApplicationConstants.ScreenName.MAIN_MENU.name) && super.performClick()
     }
 
     fun setNumberOfForms(number: Int) {

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuButton.kt
@@ -50,7 +50,7 @@ class MainMenuButton(context: Context, attrs: AttributeSet?) : FrameLayout(conte
         get() = binding.name.text.toString()
 
     override fun performClick(): Boolean {
-        return MultiClickGuard.allowClick() && super.performClick()
+        return MultiClickGuard.allowClick(MultiClickGuard.ScreenName.MAIN_MENU.name) && super.performClick()
     }
 
     fun setNumberOfForms(number: Int) {

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/StartNewFormButton.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/StartNewFormButton.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.widget.FrameLayout
 import android.widget.TextView
 import org.odk.collect.android.R
+import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
 
 class StartNewFormButton(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs) {
@@ -19,6 +20,6 @@ class StartNewFormButton(context: Context, attrs: AttributeSet?) : FrameLayout(c
         get() = findViewById<TextView>(R.id.name).text.toString()
 
     override fun performClick(): Boolean {
-        return MultiClickGuard.allowClick(MultiClickGuard.ScreenName.MAIN_MENU.name) && super.performClick()
+        return MultiClickGuard.allowClick(ApplicationConstants.ScreenName.MAIN_MENU.name) && super.performClick()
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/StartNewFormButton.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/StartNewFormButton.kt
@@ -19,6 +19,6 @@ class StartNewFormButton(context: Context, attrs: AttributeSet?) : FrameLayout(c
         get() = findViewById<TextView>(R.id.name).text.toString()
 
     override fun performClick(): Boolean {
-        return MultiClickGuard.allowClick() && super.performClick()
+        return MultiClickGuard.allowClick(MultiClickGuard.ScreenName.MAIN_MENU.name) && super.performClick()
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -88,4 +88,8 @@ public class ApplicationConstants {
         public static final String XML_OPENROSA_NAMESPACE = "http://openrosa.org/xforms";
         public static final String XML_OPENDATAKIT_NAMESPACE = "http://www.opendatakit.org/xforms";
     }
+
+    public enum ScreenName {
+        MAIN_MENU
+    }
 }


### PR DESCRIPTION
Closes #5307 

#### What has been done to verify that this works as intended?
I've tested the changes manually.

#### Why is this the best possible solution? Were any other approaches considered?
As I said in the comment:
```
   /*
    Utilizing screen names instead of class names offers a more robust approach, as elements placed
    on the same user interface screen may potentially belong to distinct classes (such as fragments or custom views).
    Consequently, employing screen names for identification ensures that these elements are recognized
    as components of the same screen, disabling rapid clicking.
     */
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test fast clicking on main menu elements (buttons and the project icon). It's an isolated change so we can focus on the main menu only.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
