### PR TITLE
Validate drafts when saved from end screen

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
@@ -85,7 +85,7 @@ public class EncryptedFormTest {
                 .swipeToEndScreen()
                 .clickFinalize()
                 .checkIsToastWithMessageDisplayed("This form does not specify an instanceID. You must specify one to enable encryption. Form has not been saved as finalized.")
-                .clickEditSavedForm()
+                .clickDrafts()
                 .checkInstanceState("encrypted-no-instanceID", Instance.STATUS_INCOMPLETE);
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormEndTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormEndTest.kt
@@ -5,17 +5,15 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.odk.collect.android.R
 import org.odk.collect.android.support.pages.AccessControlPage
 import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.ProjectSettingsPage
-import org.odk.collect.android.support.pages.SaveOrDiscardFormDialog
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 
 @RunWith(AndroidJUnit4::class)
-class FormFinalizingTest {
+class FormEndTest {
     private val rule = CollectTestRule()
 
     @get:Rule
@@ -40,19 +38,6 @@ class FormFinalizingTest {
             .startBlankForm("One Question")
             .swipeToEndScreen()
             .clickSaveAsDraft()
-            .assertNumberOfEditableForms(1)
-            .assertNumberOfFinalizedForms(0)
-    }
-
-    @Test
-    fun fillingForm_andPressingBack_andPressingSave_doesNotFinalizesForm() {
-        rule.startAtMainMenu()
-            .copyForm(FORM)
-            .assertNumberOfFinalizedForms(0)
-            .startBlankForm("One Question")
-            .closeSoftKeyboard()
-            .pressBack(SaveOrDiscardFormDialog(MainMenuPage()))
-            .clickSaveChanges()
             .assertNumberOfEditableForms(1)
             .assertNumberOfFinalizedForms(0)
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormEndTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormEndTest.kt
@@ -11,6 +11,7 @@ import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.ProjectSettingsPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
+import org.odk.collect.strings.R.string
 
 @RunWith(AndroidJUnit4::class)
 class FormEndTest {
@@ -31,15 +32,34 @@ class FormEndTest {
     }
 
     @Test
-    fun fillingForm_andPressingSaveAsDraft_doesNotFinalizesForm() {
+    fun fillingForm_andPressingSaveAsDraft_savesACompleteDraft() {
         rule.startAtMainMenu()
             .copyForm(FORM)
             .assertNumberOfFinalizedForms(0)
             .startBlankForm("One Question")
             .swipeToEndScreen()
             .clickSaveAsDraft()
-            .assertNumberOfEditableForms(1)
             .assertNumberOfFinalizedForms(0)
+
+            .clickDrafts(1)
+            .assertText(string.complete)
+            .assertTextDoesNotExist(string.incomplete)
+    }
+
+    @Test
+    fun fillingForm_andPressingSaveAsDraft_whenThereAreViolatedConstraints_savesAIncompleteDraft() {
+        rule.startAtMainMenu()
+            .copyForm("two-question-required.xml")
+            .assertNumberOfFinalizedForms(0)
+            .startBlankForm("Two Question Required")
+            .clickGoToArrow()
+            .clickGoToEnd()
+            .clickSaveAsDraft()
+            .assertNumberOfFinalizedForms(0)
+
+            .clickDrafts(1)
+            .assertText(string.incomplete)
+            .assertTextDoesNotExist(string.complete)
     }
 
     @Test
@@ -56,7 +76,7 @@ class FormEndTest {
             .copyForm(FORM)
             .startBlankForm("One Question")
             .swipeToEndScreen()
-            .assertTextDoesNotExist(org.odk.collect.strings.R.string.save_as_draft)
+            .assertTextDoesNotExist(string.save_as_draft)
     }
 
     @Test
@@ -66,14 +86,14 @@ class FormEndTest {
             .clickSettings()
             .clickAccessControl()
             .clickFormEntrySettings()
-            .clickOnString(org.odk.collect.strings.R.string.finalize)
+            .clickOnString(string.finalize)
             .pressBack(AccessControlPage())
             .pressBack(ProjectSettingsPage())
             .pressBack(MainMenuPage())
             .copyForm(FORM)
             .startBlankForm("One Question")
             .swipeToEndScreen()
-            .assertTextDoesNotExist(org.odk.collect.strings.R.string.finalize)
+            .assertTextDoesNotExist(string.finalize)
     }
 
     companion object {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
@@ -36,7 +36,7 @@ class FormSavedSnackbarTest {
             .answerQuestion(0, "25")
             .swipeToEndScreen()
             .clickSaveAsDraft()
-            .clickEditSavedForm()
+            .clickDrafts()
             .clickOnForm("One Question")
             .clickGoToEnd()
             .clickFinalize()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuickSaveTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuickSaveTest.java
@@ -31,7 +31,7 @@ public class QuickSaveTest {
                 .clickSave()
                 .pressBackAndDiscardChanges()
 
-                .clickEditSavedForm(1)
+                .clickDrafts(1)
                 .clickOnForm("Two Question")
                 .assertText("Reuben")
                 .assertText("32");
@@ -47,7 +47,7 @@ public class QuickSaveTest {
                 .clickSave()
                 .pressBackAndDiscardChanges()
 
-                .clickEditSavedForm(1)
+                .clickDrafts(1)
                 .clickOnForm("Two Question Required")
                 .assertText("Reuben");
     }
@@ -61,7 +61,7 @@ public class QuickSaveTest {
                 .clickSave()
                 .pressBackAndDiscardChanges()
 
-                .clickEditSavedForm(1)
+                .clickDrafts(1)
                 .clickOnForm("Two Question Required")
                 .clickGoToStart()
                 .answerQuestion("What is your name?", "Another Reuben")
@@ -69,7 +69,7 @@ public class QuickSaveTest {
                 .clickSave()
                 .pressBackAndDiscardChanges()
 
-                .clickEditSavedForm(1)
+                .clickDrafts(1)
                 .clickOnForm("Two Question Required")
                 .assertText("Another Reuben");
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
@@ -34,6 +34,7 @@ public class QuittingFormTest {
                 .pressBack(new SaveOrDiscardFormDialog<>(new MainMenuPage()))
                 .clickSaveChanges()
 
+                .assertNumberOfFinalizedForms(0)
                 .clickEditSavedForm(1)
                 .clickOnForm("Two Question")
                 .assertText("Reuben")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
@@ -35,7 +35,7 @@ public class QuittingFormTest {
                 .clickSaveChanges()
 
                 .assertNumberOfFinalizedForms(0)
-                .clickEditSavedForm(1)
+                .clickDrafts(1)
                 .clickOnForm("Two Question")
                 .assertText("Reuben")
                 .assertText("10");
@@ -64,7 +64,7 @@ public class QuittingFormTest {
                 .answerQuestion("What is your age?", "10")
                 .pressBackAndDiscardChanges()
 
-                .clickEditSavedForm(1)
+                .clickDrafts(1)
                 .clickOnForm("Two Question")
                 .assertText("Reuben")
                 .assertTextDoesNotExist("10");
@@ -81,7 +81,7 @@ public class QuittingFormTest {
                 .pressBack(new SaveOrDiscardFormDialog<>(new MainMenuPage()))
                 .clickSaveChanges()
 
-                .clickEditSavedForm(1)
+                .clickDrafts(1)
                 .clickOnForm("Two Question Required")
                 .assertText("Reuben");
     }
@@ -95,7 +95,7 @@ public class QuittingFormTest {
                 .pressBack(new SaveOrDiscardFormDialog<>(new MainMenuPage()))
                 .clickSaveChanges()
 
-                .clickEditSavedForm(1)
+                .clickDrafts(1)
                 .clickOnForm("Two Question Required")
                 .clickGoToStart()
                 .answerQuestion("What is your name?", "Another Reuben")
@@ -104,7 +104,7 @@ public class QuittingFormTest {
                 .pressBack(new SaveOrDiscardFormDialog<>(new MainMenuPage()))
                 .clickSaveChanges()
 
-                .clickEditSavedForm(1)
+                .clickDrafts(1)
                 .clickOnForm("Two Question Required")
                 .assertText("Another Reuben");
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SaveIncompleteTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SaveIncompleteTest.kt
@@ -26,7 +26,7 @@ class SaveIncompleteTest {
             .swipeToNextQuestion("[saveIncomplete] What is your age?")
             .pressBackAndDiscardChanges()
 
-            .clickEditSavedForm(1)
+            .clickDrafts(1)
             .clickOnForm("Two Question Save Incomplete")
             .assertText("Dez")
     }
@@ -40,7 +40,7 @@ class SaveIncompleteTest {
             .swipeToNextQuestion("[saveIncomplete] What is your age?", true)
             .pressBackAndDiscardChanges()
 
-            .clickEditSavedForm(1)
+            .clickDrafts(1)
             .clickOnForm("Two Question Save Incomplete Required")
             .assertText("Dez")
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -31,7 +31,7 @@ class AuditTest {
             )
             .swipeToEndScreen()
             .clickSaveAsDraft()
-            .clickEditSavedForm(1)
+            .clickDrafts(1)
             .clickOnForm("One Question Audit")
             .clickGoToStart()
             .fillOutAndFinalize(

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/IdentifyUserTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/IdentifyUserTest.java
@@ -61,7 +61,7 @@ public class IdentifyUserTest {
                 .swipeToEndScreen()
                 .clickSaveAsDraft()
 
-                .clickEditSavedForm()
+                .clickDrafts()
                 .clickOnFormWithIdentityPrompt("Identify User")
                 .enterIdentity("Jack")
                 .clickKeyboardEnter(new FormHierarchyPage("Identify User"))

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.kt
@@ -33,7 +33,7 @@ class TrackChangesReasonTest {
             .swipeToEndScreen()
             .clickSaveAsDraft()
 
-            .clickEditSavedForm()
+            .clickDrafts()
             .clickOnForm("Track Changes Reason")
             .clickGoToEnd()
             .clickSaveAndExitWithChangesReasonPrompt()
@@ -56,7 +56,7 @@ class TrackChangesReasonTest {
             .inputText("Nothing much...")
             .swipeToEndScreen()
             .clickSaveAsDraft()
-            .clickEditSavedForm()
+            .clickDrafts()
 
             .clickOnForm("Track Changes Reason")
             .clickGoToEnd()
@@ -74,7 +74,7 @@ class TrackChangesReasonTest {
             .swipeToEndScreen()
             .clickSaveAsDraft()
 
-            .clickEditSavedForm()
+            .clickDrafts()
             .clickOnForm("Track Changes Reason")
             .clickGoToEnd()
             .clickSaveAndExitWithChangesReasonPrompt()
@@ -91,7 +91,7 @@ class TrackChangesReasonTest {
             .swipeToEndScreen()
             .clickSaveAsDraft()
 
-            .clickEditSavedForm()
+            .clickDrafts()
             .clickOnForm("Track Changes Reason")
             .clickGoToEnd()
             .clickSaveAndExitWithChangesReasonPrompt()
@@ -111,7 +111,7 @@ class TrackChangesReasonTest {
             .swipeToEndScreen()
             .clickSaveAsDraft()
 
-            .clickEditSavedForm()
+            .clickDrafts()
             .clickOnForm("Track Changes Reason")
             .clickGoToStart()
             .closeSoftKeyboard()
@@ -132,7 +132,7 @@ class TrackChangesReasonTest {
             .swipeToEndScreen()
             .clickSaveAsDraft()
 
-            .clickEditSavedForm()
+            .clickDrafts()
             .clickOnForm("Track Changes Reason")
             .clickGoToStart()
             .closeSoftKeyboard()
@@ -149,7 +149,7 @@ class TrackChangesReasonTest {
             .swipeToEndScreen()
             .clickSaveAsDraft()
 
-            .clickEditSavedForm()
+            .clickDrafts()
             .clickOnForm("Track Changes Reason")
             .clickGoToStart()
             .clickSaveWithChangesReasonPrompt()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
@@ -30,7 +30,7 @@ class BulkFinalizationTest {
             .startBlankForm("One Question")
             .fillOutAndSave(QuestionAndAnswer("what is your age", "98"))
 
-            .clickEditSavedForm(2)
+            .clickDrafts(2)
             .clickOptionsIcon(string.finalize_all_forms)
             .clickOnString(string.finalize_all_forms)
             .checkIsSnackbarWithQuantityDisplayed(plurals.bulk_finalize_success, 2)
@@ -55,7 +55,7 @@ class BulkFinalizationTest {
                 QuestionAndAnswer("What is your age?", "45", true)
             )
 
-            .clickEditSavedForm(2)
+            .clickDrafts(2)
             .clickOptionsIcon(string.finalize_all_forms)
             .clickOnString(string.finalize_all_forms)
             .checkIsSnackbarWithMessageDisplayed(string.bulk_finalize_partial_success, 1, 1)
@@ -75,7 +75,7 @@ class BulkFinalizationTest {
             .pressBack(SaveOrDiscardFormDialog(MainMenuPage()))
             .clickSaveChanges()
 
-            .clickEditSavedForm(1)
+            .clickDrafts(1)
             .clickOptionsIcon(string.finalize_all_forms)
             .clickOnString(string.finalize_all_forms)
             .checkIsSnackbarWithQuantityDisplayed(plurals.bulk_finalize_failure, 1)
@@ -94,7 +94,7 @@ class BulkFinalizationTest {
             .startBlankForm("One Question")
             .fillOutAndFinalize(QuestionAndAnswer("what is your age", "98"))
 
-            .clickEditSavedForm(1)
+            .clickDrafts(1)
             .clickOptionsIcon(string.finalize_all_forms)
             .clickOnString(string.finalize_all_forms)
             .checkIsSnackbarWithQuantityDisplayed(plurals.bulk_finalize_success, 1)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
@@ -55,7 +55,7 @@ public class DeleteBlankFormTest {
                 .assertNoForms()
                 .pressBack(new MainMenuPage())
 
-                .clickEditSavedForm()
+                .clickDrafts()
                 .clickOnForm("One Question")
                 .clickOnQuestion("what is your age")
                 .answerQuestion("what is your age", "30")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/EditSavedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/EditSavedFormTest.java
@@ -40,7 +40,7 @@ public class EditSavedFormTest {
                 .pressBack(new MainMenuPage())
 
                 .assertNumberOfEditableForms(0)
-                .clickEditSavedForm()
+                .clickDrafts()
                 .assertTextDoesNotExist("One Question")
 
                 // Tests that search doesn't change visibility. Move down to lower testing level.
@@ -68,7 +68,7 @@ public class EditSavedFormTest {
                 .pressBack(new MainMenuPage())
 
                 .assertNumberOfEditableForms(0)
-                .clickEditSavedForm()
+                .clickDrafts()
                 .assertTextDoesNotExist("One Question")
 
                 // Tests that search doesn't change visibility. Move down to lower testing level

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/InstancesAdbTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/InstancesAdbTest.kt
@@ -6,7 +6,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.odk.collect.android.R
 import org.odk.collect.android.storage.StorageSubdirectory
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.MainMenuPage
@@ -48,7 +47,7 @@ class InstancesAdbTest {
         Assert.assertTrue(instanceDeleted)
 
         mainMenuPage
-            .clickEditSavedForm(1)
+            .clickDrafts(1)
             .clickOnFormWithDialog("One Question")
             .assertText(org.odk.collect.strings.R.string.instance_deleted_message)
             .clickOK(MainMenuPage())

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.kt
@@ -66,7 +66,7 @@ class SendFinalizedFormTest {
             .clickSaveAsDraft()
             .checkIsSnackbarWithMessageDisplayed(org.odk.collect.strings.R.string.form_saved_as_draft)
 
-            .clickEditSavedForm(1)
+            .clickDrafts(1)
             .clickOnForm("One Question")
             .assertText("53")
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/SwitchProjectTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/SwitchProjectTest.kt
@@ -5,7 +5,6 @@ import androidx.test.rule.GrantPermissionRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
-import org.odk.collect.android.R
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.EntitiesPage
 import org.odk.collect.android.support.pages.ExperimentalPage
@@ -57,7 +56,7 @@ class SwitchProjectTest {
             .swipeToNextQuestion("What is your age?")
             .swipeToEndScreen()
             .clickSaveAsDraft()
-            .clickEditSavedForm(1)
+            .clickDrafts(1)
             .assertText("Two Question")
             .pressBack(MainMenuPage())
 
@@ -111,7 +110,7 @@ class SwitchProjectTest {
             .pressBack(MainMenuPage())
 
             // Check instances
-            .clickEditSavedForm(1)
+            .clickDrafts(1)
             .assertText("Two Question")
             .pressBack(MainMenuPage())
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
@@ -46,7 +46,7 @@ public class ResetApplicationTest {
                 .clickGoToArrow()
                 .clickJumpEndButton()
                 .clickSaveAsDraft()
-                .clickEditSavedForm()
+                .clickDrafts()
                 .assertText("All widgets")
                 .pressBack(new MainMenuPage())
                 .openProjectSettingsDialog()
@@ -62,7 +62,7 @@ public class ResetApplicationTest {
                 .clickFillBlankForm()
                 .assertTextDoesNotExist("All widgets")
                 .pressBack(new MainMenuPage())
-                .clickEditSavedForm()
+                .clickDrafts()
                 .assertTextDoesNotExist("All widgets");
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -66,14 +66,14 @@ public class MainMenuPage extends Page<MainMenuPage> {
         clickFillBlankForm().clickOnForm(formName);
     }
 
-    public EditSavedFormPage clickEditSavedForm() {
+    public EditSavedFormPage clickDrafts() {
         onView(withId(R.id.review_data)).perform(click());
         return new EditSavedFormPage().assertOnPage();
     }
 
-    public EditSavedFormPage clickEditSavedForm(int formCount) {
+    public EditSavedFormPage clickDrafts(int formCount) {
         assertNumberOfEditableForms(formCount);
-        return clickEditSavedForm();
+        return clickDrafts();
     }
 
     public MainMenuPage assertNumberOfFinalizedForms(int number) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -46,8 +46,8 @@ public class CursorLoaderFactory {
     public CursorLoader createEditableInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
         CursorLoader cursorLoader;
         if (charSequence.length() == 0) {
-            String selection = DatabaseInstanceColumns.STATUS + "=? or " + DatabaseInstanceColumns.STATUS + "=?";
-            String[] selectionArgs = {Instance.STATUS_INCOMPLETE, Instance.STATUS_INVALID};
+            String selection = DatabaseInstanceColumns.STATUS + "=? or " + DatabaseInstanceColumns.STATUS + "=? or " + DatabaseInstanceColumns.STATUS + "=?";
+            String[] selectionArgs = {Instance.STATUS_INCOMPLETE, Instance.STATUS_INVALID, Instance.STATUS_VALID};
 
             cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -267,6 +267,7 @@ class FormUriActivity : LocalizedActivity() {
 private val editableStatuses = arrayOf(
     Instance.STATUS_INCOMPLETE,
     Instance.STATUS_INVALID,
+    Instance.STATUS_VALID,
     Instance.STATUS_COMPLETE
 )
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/InstancesDataService.kt
@@ -36,7 +36,8 @@ class InstancesDataService(
         )
         val editableInstances = instancesRepository.getCountByStatus(
             Instance.STATUS_INCOMPLETE,
-            Instance.STATUS_INVALID
+            Instance.STATUS_INVALID,
+            Instance.STATUS_VALID
         )
 
         appState.setLive(EDITABLE_COUNT_KEY, editableInstances)
@@ -52,8 +53,11 @@ class InstancesDataService(
         val entitiesRepository = entitiesRepositoryProvider.get()
         val projectRootDir = File(storagePathProvider.getProjectRootDirPath())
 
-        val instances =
-            instancesRepository.getAllByStatus(Instance.STATUS_INCOMPLETE, Instance.STATUS_INVALID)
+        val instances = instancesRepository.getAllByStatus(
+            Instance.STATUS_INCOMPLETE,
+            Instance.STATUS_INVALID,
+            Instance.STATUS_VALID
+        )
 
         val totalFailed = instances.fold(0) { failCount, instance ->
             val form = formsRepository.getAllByFormId(instance.formId)[0]

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
@@ -149,11 +149,12 @@ class FormMapViewModel(
                 info
             )
         } else {
-            val action = if (instance.status == Instance.STATUS_INCOMPLETE) {
-                createEditAction()
-            } else {
-                createViewAction()
-            }
+            val action =
+                if (instance.status == Instance.STATUS_INCOMPLETE || instance.status == Instance.STATUS_VALID) {
+                    createEditAction()
+                } else {
+                    createViewAction()
+                }
 
             MappableSelectItem.WithAction(
                 instance.dbId,

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
@@ -8,6 +8,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import org.odk.collect.android.R
 import org.odk.collect.android.instancemanagement.getStatusDescription
+import org.odk.collect.android.instancemanagement.isDraft
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidshared.livedata.NonNullLiveData
 import org.odk.collect.async.Scheduler
@@ -150,7 +151,7 @@ class FormMapViewModel(
             )
         } else {
             val action =
-                if (instance.status == Instance.STATUS_INCOMPLETE || instance.status == Instance.STATUS_VALID) {
+                if (instance.isDraft(settingsProvider)) {
                     createEditAction()
                 } else {
                     createViewAction()

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
@@ -8,7 +8,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import org.odk.collect.android.R
 import org.odk.collect.android.instancemanagement.getStatusDescription
-import org.odk.collect.android.instancemanagement.isDraft
+import org.odk.collect.android.instancemanagement.showAsEditable
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidshared.livedata.NonNullLiveData
 import org.odk.collect.async.Scheduler
@@ -151,7 +151,7 @@ class FormMapViewModel(
             )
         } else {
             val action =
-                if (instance.isDraft(settingsProvider)) {
+                if (instance.showAsEditable(settingsProvider)) {
                     createEditAction()
                 } else {
                     createViewAction()

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
@@ -19,8 +19,12 @@ fun getStatusDescription(context: Context, state: String?, date: Date): String {
     return getStatusDescription(context.resources, state, date)
 }
 
-fun Instance.isDraft(settingsProvider: SettingsProvider): Boolean {
-    return draftStatuses.contains(status) && settingsProvider.getProtectedSettings()
+fun Instance.isDraft(): Boolean {
+    return draftStatuses.contains(status)
+}
+
+fun Instance.showAsEditable(settingsProvider: SettingsProvider): Boolean {
+    return isDraft() && settingsProvider.getProtectedSettings()
         .getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
@@ -30,12 +30,7 @@ fun Instance.showAsEditable(settingsProvider: SettingsProvider): Boolean {
 
 private fun getStatusDescription(resources: Resources, state: String?, date: Date): String {
     return try {
-        if (state == null) {
-            SimpleDateFormat(
-                resources.getString(R.string.added_on_date_at_time),
-                Locale.getDefault()
-            ).format(date)
-        } else if (Instance.STATUS_INCOMPLETE.equals(state, ignoreCase = true)) {
+        if (Instance.STATUS_INCOMPLETE.equals(state, ignoreCase = true)) {
             SimpleDateFormat(
                 resources.getString(R.string.saved_on_date_at_time),
                 Locale.getDefault()
@@ -56,6 +51,11 @@ private fun getStatusDescription(resources: Resources, state: String?, date: Dat
                 Locale.getDefault()
             ).format(date)
         } else if (Instance.STATUS_INVALID.equals(state, ignoreCase = true)) {
+            SimpleDateFormat(
+                resources.getString(R.string.saved_on_date_at_time),
+                Locale.getDefault()
+            ).format(date)
+        } else if (Instance.STATUS_VALID.equals(state, ignoreCase = true)) {
             SimpleDateFormat(
                 resources.getString(R.string.saved_on_date_at_time),
                 Locale.getDefault()

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceExt.kt
@@ -3,6 +3,8 @@ package org.odk.collect.android.instancemanagement
 import android.content.Context
 import android.content.res.Resources
 import org.odk.collect.forms.instances.Instance
+import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.keys.ProtectedProjectKeys
 import org.odk.collect.strings.R
 import timber.log.Timber
 import java.text.SimpleDateFormat
@@ -15,6 +17,11 @@ fun Instance.getStatusDescription(resources: Resources): String {
 
 fun getStatusDescription(context: Context, state: String?, date: Date): String {
     return getStatusDescription(context.resources, state, date)
+}
+
+fun Instance.isDraft(settingsProvider: SettingsProvider): Boolean {
+    return draftStatuses.contains(status) && settingsProvider.getProtectedSettings()
+        .getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
 }
 
 private fun getStatusDescription(resources: Resources, state: String?, date: Date): String {
@@ -60,3 +67,9 @@ private fun getStatusDescription(resources: Resources, state: String?, date: Dat
         ""
     }
 }
+
+private val draftStatuses = arrayOf(
+    Instance.STATUS_INCOMPLETE,
+    Instance.STATUS_INVALID,
+    Instance.STATUS_VALID
+)

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -30,6 +30,9 @@ object InstanceListItemView {
         if (chip != null) {
             if (instance.status == Instance.STATUS_INVALID || instance.status == Instance.STATUS_INCOMPLETE) {
                 chip.visibility = View.VISIBLE
+            } else if (instance.status == Instance.STATUS_VALID) {
+                chip.visibility = View.VISIBLE
+                chip.setText(string.complete)
             }
         }
 
@@ -114,7 +117,7 @@ object InstanceListItemView {
 
     private fun getFormStateImageResourceIdForStatus(formStatus: String?): Int {
         when (formStatus) {
-            Instance.STATUS_INCOMPLETE, Instance.STATUS_INVALID -> return R.drawable.ic_form_state_saved
+            Instance.STATUS_INCOMPLETE, Instance.STATUS_INVALID, Instance.STATUS_VALID -> return R.drawable.ic_form_state_saved
             Instance.STATUS_COMPLETE -> return R.drawable.ic_form_state_finalized
             Instance.STATUS_SUBMITTED -> return R.drawable.ic_form_state_submitted
             Instance.STATUS_SUBMISSION_FAILED -> return R.drawable.ic_form_state_submission_failed

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -30,6 +30,7 @@ object InstanceListItemView {
         if (chip != null) {
             if (instance.status == Instance.STATUS_INVALID || instance.status == Instance.STATUS_INCOMPLETE) {
                 chip.visibility = View.VISIBLE
+                chip.setText(string.incomplete)
             } else if (instance.status == Instance.STATUS_VALID) {
                 chip.visibility = View.VISIBLE
                 chip.setText(string.complete)

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
@@ -9,6 +9,7 @@ import org.odk.collect.android.instancemanagement.InstanceDiskSynchronizer
 import org.odk.collect.android.instancemanagement.autosend.AutoSendSettingsProvider
 import org.odk.collect.android.instancemanagement.autosend.shouldFormBeSentAutomatically
 import org.odk.collect.android.instancemanagement.isDraft
+import org.odk.collect.android.instancemanagement.showAsEditable
 import org.odk.collect.android.preferences.utilities.FormUpdateMode
 import org.odk.collect.android.preferences.utilities.SettingsUtils
 import org.odk.collect.android.utilities.ContentUriHelper
@@ -108,9 +109,7 @@ class MainMenuViewModel(
     fun getFormSavedSnackbarDetails(uri: Uri): Pair<Int, Int?>? {
         val instance = instancesRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
         return if (instance != null) {
-            val isDraft = instance.isDraft(settingsProvider)
-
-            val message = if (isDraft) {
+            val message = if (instance.isDraft()) {
                 org.odk.collect.strings.R.string.form_saved_as_draft
             } else if (instance.status == Instance.STATUS_COMPLETE) {
                 val form = formsRepositoryProvider.get().getAllByFormIdAndVersion(instance.formId, instance.formVersion).first()
@@ -123,14 +122,10 @@ class MainMenuViewModel(
                 return null
             }
 
-            val action = if (
-                isDraft &&
-                settingsProvider.getProtectedSettings()
-                    .getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
-            ) {
+            val action = if (instance.showAsEditable(settingsProvider)) {
                 org.odk.collect.strings.R.string.edit_form
             } else {
-                if (isDraft || instance.canEditWhenComplete()) {
+                if (instance.isDraft() || instance.canEditWhenComplete()) {
                     org.odk.collect.strings.R.string.view_form
                 } else {
                     null

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
@@ -107,7 +107,10 @@ class MainMenuViewModel(
     fun getFormSavedSnackbarDetails(uri: Uri): Pair<Int, Int?>? {
         val instance = instancesRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
         return if (instance != null) {
-            val message = if (instance.status == Instance.STATUS_INCOMPLETE) {
+            val isDraft =
+                instance.status == Instance.STATUS_INCOMPLETE || instance.status == Instance.STATUS_VALID
+
+            val message = if (isDraft) {
                 org.odk.collect.strings.R.string.form_saved_as_draft
             } else if (instance.status == Instance.STATUS_COMPLETE) {
                 val form = formsRepositoryProvider.get().getAllByFormIdAndVersion(instance.formId, instance.formVersion).first()
@@ -121,13 +124,13 @@ class MainMenuViewModel(
             }
 
             val action = if (
-                instance.status == Instance.STATUS_INCOMPLETE &&
+                isDraft &&
                 settingsProvider.getProtectedSettings()
                     .getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
             ) {
                 org.odk.collect.strings.R.string.edit_form
             } else {
-                if (instance.status == Instance.STATUS_INCOMPLETE || instance.canEditWhenComplete()) {
+                if (isDraft || instance.canEditWhenComplete()) {
                     org.odk.collect.strings.R.string.view_form
                 } else {
                     null

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
@@ -8,6 +8,7 @@ import org.odk.collect.android.formmanagement.InstancesDataService
 import org.odk.collect.android.instancemanagement.InstanceDiskSynchronizer
 import org.odk.collect.android.instancemanagement.autosend.AutoSendSettingsProvider
 import org.odk.collect.android.instancemanagement.autosend.shouldFormBeSentAutomatically
+import org.odk.collect.android.instancemanagement.isDraft
 import org.odk.collect.android.preferences.utilities.FormUpdateMode
 import org.odk.collect.android.preferences.utilities.SettingsUtils
 import org.odk.collect.android.utilities.ContentUriHelper
@@ -107,8 +108,7 @@ class MainMenuViewModel(
     fun getFormSavedSnackbarDetails(uri: Uri): Pair<Int, Int?>? {
         val instance = instancesRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
         return if (instance != null) {
-            val isDraft =
-                instance.status == Instance.STATUS_INCOMPLETE || instance.status == Instance.STATUS_VALID
+            val isDraft = instance.isDraft(settingsProvider)
 
             val message = if (isDraft) {
                 org.odk.collect.strings.R.string.form_saved_as_draft

--- a/collect_app/src/main/res/layout/form_chooser_list_item.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item.xml
@@ -16,13 +16,13 @@
         android:layout_alignParentTop="true"
         android:layout_marginBottom="@dimen/margin_extra_small"
         android:background="?colorSurfaceContainerLow"
+        android:drawablePadding="@dimen/margin_small"
         android:gravity="center"
         android:padding="@dimen/margin_small"
-        android:text="@string/incomplete"
         android:textAppearance="?textAppearanceLabelLarge"
         android:visibility="gone"
         app:drawableStartCompat="@drawable/baseline_error_24"
-        android:drawablePadding="@dimen/margin_small"
+        tools:text="@string/incomplete"
         tools:visibility="visible" />
 
     <FrameLayout

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceExtKtTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceExtKtTest.kt
@@ -32,6 +32,12 @@ class InstanceExtKtTest {
             R.string.saved_on_date_at_time
         )
 
+        val valid = InstanceFixtures.instance(status = Instance.STATUS_VALID)
+        assertDateFormat(
+            valid.getStatusDescription(resources),
+            R.string.saved_on_date_at_time
+        )
+
         val complete = InstanceFixtures.instance(status = Instance.STATUS_COMPLETE)
         assertDateFormat(
             complete.getStatusDescription(resources),

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceListItemViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceListItemViewTest.kt
@@ -69,4 +69,20 @@ class InstanceListItemViewTest {
 
         assertThat(binding.chip.visibility, equalTo(View.GONE))
     }
+
+    @Test
+    fun chipCanBeRecycled() {
+        val binding = FormChooserListItemBinding.inflate(layoutInflater)
+        val valid = InstanceFixtures.instance(status = Instance.STATUS_VALID)
+        InstanceListItemView.setInstance(binding.root, valid, false)
+
+        assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
+        assertThat(binding.chip.text, equalTo(context.getString(string.complete)))
+
+        val invalid = InstanceFixtures.instance(status = Instance.STATUS_INVALID)
+        InstanceListItemView.setInstance(binding.root, invalid, false)
+
+        assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
+        assertThat(binding.chip.text, equalTo(context.getString(string.incomplete)))
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceListItemViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceListItemViewTest.kt
@@ -14,6 +14,7 @@ import org.odk.collect.android.R
 import org.odk.collect.android.databinding.FormChooserListItemBinding
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.formstest.InstanceFixtures
+import org.odk.collect.strings.R.string
 
 @RunWith(AndroidJUnit4::class)
 class InstanceListItemViewTest {
@@ -34,6 +35,18 @@ class InstanceListItemViewTest {
         InstanceListItemView.setInstance(binding.root, instance, false)
 
         assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
+        assertThat(binding.chip.text, equalTo(context.getString(string.incomplete)))
+    }
+
+    @Test
+    fun whenInstanceIsValid_showsCompleteChip() {
+        val binding = FormChooserListItemBinding.inflate(layoutInflater)
+        val instance = InstanceFixtures.instance(status = Instance.STATUS_VALID)
+
+        InstanceListItemView.setInstance(binding.root, instance, false)
+
+        assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
+        assertThat(binding.chip.text, equalTo(context.getString(string.complete)))
     }
 
     @Test
@@ -44,6 +57,7 @@ class InstanceListItemViewTest {
         InstanceListItemView.setInstance(binding.root, instance, false)
 
         assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
+        assertThat(binding.chip.text, equalTo(context.getString(string.incomplete)))
     }
 
     @Test

--- a/forms/src/main/java/org/odk/collect/forms/instances/Instance.java
+++ b/forms/src/main/java/org/odk/collect/forms/instances/Instance.java
@@ -27,6 +27,7 @@ public final class Instance {
     // status for instances
     public static final String STATUS_INCOMPLETE = "incomplete";
     public static final String STATUS_INVALID = "invalid";
+    public static final String STATUS_VALID = "valid";
     public static final String STATUS_COMPLETE = "complete";
     public static final String STATUS_SUBMITTED = "submitted";
     public static final String STATUS_SUBMISSION_FAILED = "submissionFailed";

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1237,4 +1237,7 @@
 
     <!-- Message above a form draft that has not yet been completed -->
     <string name="incomplete" oat:toReview="true">Incomplete</string>
+
+    <!-- Message above a form draft that has been completed -->
+    <string name="complete" oat:toReview="true">Complete</string>
 </resources>


### PR DESCRIPTION
Closes #5718

#### What has been done to verify that this works as intended?

New and existing tests.

#### Why is this the best possible solution? Were any other approaches considered?

I'd really wanted to implement this using only new code to make merging easier later, but couldn't get that to happen here. Because the existing save process marks the draft "incomplete" I had to update that, or rewrite the whole "Save as draft" flow.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We skipped QA for #5734, but I think it makes sense to test that and #5718 here now that we don't end up with all drafts being marked as "incomplete". In this PR, I've made changes to the core save code so testing all the different ways to save a form (both a new one and a draft being edited) would be good.

In terms of testing the new functionality: it'd definitely be good to check bulk finalization with as many different kinds of forms as you can think of! The kinds of scenarios that I expect not work are listed in #5740 and #5739.

It's important to note that the pill surfacing the "Complete"/"Incomplete" status is still really basic and the color/icon are fixed. @alyblenkin and I will pair on making a proper component for this later on.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
