### PR TITLE
Re-introduce app bar elevation

### DIFF
--- a/androidshared/src/main/res/layout/app_bar_layout.xml
+++ b/androidshared/src/main/res/layout/app_bar_layout.xml
@@ -3,8 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/appBarLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:elevation="4dp">
+    android:layout_height="wrap_content">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
@@ -12,4 +11,5 @@
         android:layout_height="?attr/actionBarSize"
         tools:title="Title" />
 
+    <include layout="@layout/app_bar_shadow"/>
 </com.google.android.material.appbar.AppBarLayout>

--- a/androidshared/src/main/res/layout/app_bar_shadow.xml
+++ b/androidshared/src/main/res/layout/app_bar_shadow.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    We had to build this custom gradient because using colors with a given transparency level in Android gradients is not possible.
+    We can't specify alpha directly, and using color selector doesn't seem to work too:
+    see more at https://stackoverflow.com/questions/62982873/gradient-with-color-selector-attribute.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:alpha="0.10"
+        android:background="?colorOnSurface" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:alpha="0.07"
+        android:background="?colorOnSurface" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:alpha="0.04"
+        android:background="?colorOnSurface" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:alpha="0.01"
+        android:background="?colorOnSurface" />
+</LinearLayout>

--- a/collect_app/src/main/res/layout/changes_reason_dialog.xml
+++ b/collect_app/src/main/res/layout/changes_reason_dialog.xml
@@ -9,8 +9,7 @@
     <com.google.android.material.appbar.AppBarLayout xmlns:tools="http://schemas.android.com/tools"
         style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:elevation="4dp">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
@@ -19,6 +18,7 @@
             android:layout_height="?attr/actionBarSize"
             tools:title="Title" />
 
+        <include layout="@layout/app_bar_shadow"/>
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView

--- a/collect_app/src/main/res/layout/form_entry.xml
+++ b/collect_app/src/main/res/layout/form_entry.xml
@@ -22,13 +22,14 @@ the License.
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:elevation="4dp">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <include layout="@layout/app_bar_shadow"/>
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/audio_recording_controller"

--- a/collect_app/src/main/res/layout/identify_user_dialog.xml
+++ b/collect_app/src/main/res/layout/identify_user_dialog.xml
@@ -9,8 +9,7 @@
     <com.google.android.material.appbar.AppBarLayout xmlns:tools="http://schemas.android.com/tools"
         style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:elevation="4dp">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
@@ -19,6 +18,7 @@
             android:layout_height="?attr/actionBarSize"
             tools:title="Title" />
 
+        <include layout="@layout/app_bar_shadow"/>
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView

--- a/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
@@ -11,7 +11,6 @@
         style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:elevation="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -22,6 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize" />
 
+        <include layout="@layout/app_bar_shadow"/>
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView

--- a/collect_app/src/main/res/layout/qr_code_project_creator_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/qr_code_project_creator_dialog_layout.xml
@@ -10,7 +10,6 @@
         style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:elevation="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -23,6 +22,7 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize" />
 
+        <include layout="@layout/app_bar_shadow"/>
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView

--- a/collect_app/src/main/res/layout/select_minimal_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/select_minimal_dialog_layout.xml
@@ -8,8 +8,7 @@
     <com.google.android.material.appbar.AppBarLayout xmlns:tools="http://schemas.android.com/tools"
         style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:elevation="4dp">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
@@ -18,6 +17,7 @@
             android:layout_height="?attr/actionBarSize"
             tools:title="Title" />
 
+        <include layout="@layout/app_bar_shadow"/>
     </com.google.android.material.appbar.AppBarLayout>
 
     <org.odk.collect.android.views.ChoicesRecyclerView


### PR DESCRIPTION
Closes #5750 

#### What has been done to verify that this works as intended?
I've tested the changes manually.

#### Why is this the best possible solution? Were any other approaches considered?
It looks like there is no easy way to enable elevation in material 3 because it has been removed. There is also a bug that makes using gradients impossible (see: https://github.com/getodk/collect/pull/5761/files#diff-7d12231ce75168eb1a5759984db076573126bdb318d87c98dcb4059be8ba2c87R3) so I had to build my own gradient/shadow.

It would be like:

| Light mode | Dark mode |
| ------------- | ------------- |
| ![Screenshot_1699453557](https://github.com/getodk/collect/assets/3276264/803344cf-8b25-40fd-b484-384c1cdfadd8)| ![Screenshot_1699453579](https://github.com/getodk/collect/assets/3276264/828d9a14-29af-4887-b6eb-fffc9a83c5a4) |

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Just review different screens in the app to make sure there is a shadow below the app bar. It's of course important to check both themes (light/dark).

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
