### PR TITLE
Implement Material 3 "pill" component

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -32,14 +32,14 @@ object InstanceListItemView {
         if (pill != null) {
             if (instance.status == Instance.STATUS_INVALID || instance.status == Instance.STATUS_INCOMPLETE) {
                 pill.visibility = View.VISIBLE
-                pill.setIcon(R.drawable.baseline_error_24)
+                pill.setIcon(R.drawable.baseline_rule_24)
                 pill.setText(string.incomplete)
                 pill.setPillBackgroundColor(getThemeAttributeValue(context, R.attr.colorSurfaceContainer))
                 pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
                 pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
             } else if (instance.status == Instance.STATUS_VALID) {
                 pill.visibility = View.VISIBLE
-                pill.setIcon(R.drawable.ic_check_circle_24)
+                pill.setIcon(R.drawable.baseline_check_24)
                 pill.setText(string.complete)
                 pill.setPillBackgroundColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorPrimary))
                 pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnPrimary))

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -34,9 +34,9 @@ object InstanceListItemView {
                 pill.visibility = View.VISIBLE
                 pill.setIcon(R.drawable.baseline_rule_24)
                 pill.setText(string.incomplete)
-                pill.setPillBackgroundColor(getThemeAttributeValue(context, R.attr.colorSurfaceContainerLow))
-                pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
-                pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
+                pill.setPillBackgroundColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorErrorContainer))
+                pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
+                pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
             } else if (instance.status == Instance.STATUS_VALID) {
                 pill.visibility = View.VISIBLE
                 pill.setIcon(R.drawable.baseline_check_24)

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -7,6 +7,7 @@ import android.widget.TextView
 import org.odk.collect.android.R
 import org.odk.collect.android.utilities.FormsRepositoryProvider
 import org.odk.collect.forms.instances.Instance
+import org.odk.collect.material.MaterialPill
 import org.odk.collect.strings.R.string
 import timber.log.Timber
 import java.text.SimpleDateFormat
@@ -26,14 +27,16 @@ object InstanceListItemView {
         setImageFromStatus(imageView, instance)
         setUpSubtext(view, instance, context)
 
-        val chip = view.findViewById<TextView>(R.id.chip)
-        if (chip != null) {
+        val pill = view.findViewById<MaterialPill>(R.id.chip)
+        if (pill != null) {
+            pill.setIcon(R.drawable.baseline_error_24)
+
             if (instance.status == Instance.STATUS_INVALID || instance.status == Instance.STATUS_INCOMPLETE) {
-                chip.visibility = View.VISIBLE
-                chip.setText(string.incomplete)
+                pill.visibility = View.VISIBLE
+                pill.setText(string.incomplete)
             } else if (instance.status == Instance.STATUS_VALID) {
-                chip.visibility = View.VISIBLE
-                chip.setText(string.complete)
+                pill.visibility = View.VISIBLE
+                pill.setText(string.complete)
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -41,9 +41,11 @@ object InstanceListItemView {
                 pill.visibility = View.VISIBLE
                 pill.setIcon(R.drawable.baseline_check_24)
                 pill.setText(string.complete)
-                pill.setPillBackgroundColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorPrimary))
-                pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnPrimary))
-                pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnPrimary))
+                pill.setPillBackgroundColor(getThemeAttributeValue(context, R.attr.colorSurfaceContainerHighest))
+                pill.setTextColor(getThemeAttributeValue(context, R.attr.colorOnSurfaceContainerHighest))
+                pill.setIconTint(getThemeAttributeValue(context, R.attr.colorOnSurfaceContainerHighest))
+            } else {
+                pill.visibility = View.GONE
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -29,14 +29,16 @@ object InstanceListItemView {
 
         val pill = view.findViewById<MaterialPill>(R.id.chip)
         if (pill != null) {
-            pill.setIcon(R.drawable.baseline_error_24)
-
             if (instance.status == Instance.STATUS_INVALID || instance.status == Instance.STATUS_INCOMPLETE) {
                 pill.visibility = View.VISIBLE
+                pill.setIcon(R.drawable.baseline_error_24)
                 pill.setText(string.incomplete)
+                pill.setPillBackgroundColor(view.context.resources.getColor(R.color.colorError))
             } else if (instance.status == Instance.STATUS_VALID) {
                 pill.visibility = View.VISIBLE
+                pill.setIcon(R.drawable.ic_check_circle_24)
                 pill.setText(string.complete)
+                pill.setPillBackgroundColor(view.context.resources.getColor(R.color.colorPrimary))
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -34,7 +34,7 @@ object InstanceListItemView {
                 pill.visibility = View.VISIBLE
                 pill.setIcon(R.drawable.baseline_rule_24)
                 pill.setText(string.incomplete)
-                pill.setPillBackgroundColor(getThemeAttributeValue(context, R.attr.colorSurfaceContainer))
+                pill.setPillBackgroundColor(getThemeAttributeValue(context, R.attr.colorSurfaceContainerLow))
                 pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
                 pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
             } else if (instance.status == Instance.STATUS_VALID) {

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -6,6 +6,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import org.odk.collect.android.R
 import org.odk.collect.android.utilities.FormsRepositoryProvider
+import org.odk.collect.androidshared.system.ContextUtils.getThemeAttributeValue
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.material.MaterialPill
 import org.odk.collect.strings.R.string
@@ -33,12 +34,16 @@ object InstanceListItemView {
                 pill.visibility = View.VISIBLE
                 pill.setIcon(R.drawable.baseline_error_24)
                 pill.setText(string.incomplete)
-                pill.setPillBackgroundColor(view.context.resources.getColor(R.color.colorError))
+                pill.setPillBackgroundColor(getThemeAttributeValue(context, R.attr.colorSurfaceContainer))
+                pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
+                pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
             } else if (instance.status == Instance.STATUS_VALID) {
                 pill.visibility = View.VISIBLE
                 pill.setIcon(R.drawable.ic_check_circle_24)
                 pill.setText(string.complete)
-                pill.setPillBackgroundColor(view.context.resources.getColor(R.color.colorPrimary))
+                pill.setPillBackgroundColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorPrimary))
+                pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnPrimary))
+                pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnPrimary))
             }
         }
 

--- a/collect_app/src/main/res/drawable/baseline_check_24.xml
+++ b/collect_app/src/main/res/drawable/baseline_check_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/collect_app/src/main/res/drawable/baseline_check_24.xml
+++ b/collect_app/src/main/res/drawable/baseline_check_24.xml
@@ -2,10 +2,10 @@
     android:width="24dp"
     android:height="24dp"
     android:autoMirrored="true"
-    android:tint="#000000"
+    android:tint="?colorOnSurface"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/white"
+        android:fillColor="?colorOnSurface"
         android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z" />
 </vector>

--- a/collect_app/src/main/res/drawable/baseline_check_24.xml
+++ b/collect_app/src/main/res/drawable/baseline_check_24.xml
@@ -1,5 +1,11 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z" />
 </vector>

--- a/collect_app/src/main/res/drawable/baseline_error_24.xml
+++ b/collect_app/src/main/res/drawable/baseline_error_24.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="?colorOnSurface"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="?colorSurface" android:fillAlpha="1.0" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2L11,7h2v6z"/>
-</vector>

--- a/collect_app/src/main/res/drawable/baseline_rule_24.xml
+++ b/collect_app/src/main/res/drawable/baseline_rule_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M16.54,11L13,7.46l1.41,-1.41l2.12,2.12l4.24,-4.24l1.41,1.41L16.54,11zM11,7H2v2h9V7zM21,13.41L19.59,12L17,14.59L14.41,12L13,13.41L15.59,16L13,18.59L14.41,20L17,17.41L19.59,20L21,18.59L18.41,16L21,13.41zM11,15H2v2h9V15z"/>
+</vector>

--- a/collect_app/src/main/res/drawable/baseline_rule_24.xml
+++ b/collect_app/src/main/res/drawable/baseline_rule_24.xml
@@ -1,5 +1,11 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:tint="#000000" android:viewportHeight="24"
-    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M16.54,11L13,7.46l1.41,-1.41l2.12,2.12l4.24,-4.24l1.41,1.41L16.54,11zM11,7H2v2h9V7zM21,13.41L19.59,12L17,14.59L14.41,12L13,13.41L15.59,16L13,18.59L14.41,20L17,17.41L19.59,20L21,18.59L18.41,16L21,13.41zM11,15H2v2h9V15z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16.54,11L13,7.46l1.41,-1.41l2.12,2.12l4.24,-4.24l1.41,1.41L16.54,11zM11,7H2v2h9V7zM21,13.41L19.59,12L17,14.59L14.41,12L13,13.41L15.59,16L13,18.59L14.41,20L17,17.41L19.59,20L21,18.59L18.41,16L21,13.41zM11,15H2v2h9V15z" />
 </vector>

--- a/collect_app/src/main/res/drawable/baseline_rule_24.xml
+++ b/collect_app/src/main/res/drawable/baseline_rule_24.xml
@@ -2,10 +2,10 @@
     android:width="24dp"
     android:height="24dp"
     android:autoMirrored="true"
-    android:tint="#000000"
+    android:tint="?colorOnSurface"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/white"
+        android:fillColor="?colorOnSurface"
         android:pathData="M16.54,11L13,7.46l1.41,-1.41l2.12,2.12l4.24,-4.24l1.41,1.41L16.54,11zM11,7H2v2h9V7zM21,13.41L19.59,12L17,14.59L14.41,12L13,13.41L15.59,16L13,18.59L14.41,20L17,17.41L19.59,20L21,18.59L18.41,16L21,13.41zM11,15H2v2h9V15z" />
 </vector>

--- a/collect_app/src/main/res/drawable/list_item_divider.xml
+++ b/collect_app/src/main/res/drawable/list_item_divider.xml
@@ -3,14 +3,11 @@
 
     <!-- Material Design reference: https://material.io/design/components/dividers.html#specs -->
 
-    <item android:left="72dp"
-          android:right="0dp">
-
+    <item>
         <shape android:shape="rectangle">
             <size android:height="1dp" />
             <solid android:color="@color/color_on_surface_low_emphasis"/>
         </shape>
-
     </item>
 
 </layer-list>

--- a/collect_app/src/main/res/layout/deprecation_banner.xml
+++ b/collect_app/src/main/res/layout/deprecation_banner.xml
@@ -30,6 +30,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_standard"
             android:textAppearance="?textAppearanceBody2"
+            android:textColor="?colorOnSurfaceContainerHighest"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/deprecation_icon"
             app:layout_constraintTop_toTopOf="@id/deprecation_icon"

--- a/collect_app/src/main/res/layout/form_chooser_list_item.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item.xml
@@ -8,21 +8,13 @@
 
     <!-- Material Design reference: https://material.io/design/components/lists.html#specs -->
 
-    <com.google.android.material.textview.MaterialTextView
+    <org.odk.collect.material.MaterialPill
         android:id="@+id/chip"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_alignParentTop="true"
         android:layout_marginBottom="@dimen/margin_extra_small"
-        android:background="?colorSurfaceContainerLow"
-        android:drawablePadding="@dimen/margin_small"
-        android:gravity="center"
-        android:padding="@dimen/margin_small"
-        android:textAppearance="?textAppearanceLabelLarge"
-        android:visibility="gone"
-        app:drawableStartCompat="@drawable/baseline_error_24"
-        tools:text="@string/incomplete"
         tools:visibility="visible" />
 
     <FrameLayout

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -69,10 +69,11 @@ the specific language governing permissions and limitations under the License.
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin"
                     android:textAppearance="?textAppearanceBodyLarge"
+                    android:textColor="?colorOnSurfaceContainerHighest"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/deprecation_icon"
                     app:layout_constraintTop_toTopOf="@id/deprecation_icon"
-                    tools:text="@string/form_edits_warning_save_as_draft_and_finalize_enabled"/>
+                    tools:text="@string/form_edits_warning_save_as_draft_and_finalize_enabled" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/collect_app/src/main/res/values-night/colors.xml
+++ b/collect_app/src/main/res/values-night/colors.xml
@@ -6,6 +6,8 @@
     <color name="colorSurfaceContainerLow">#1D1B20</color>
     <color name="colorSurfaceContainerHighest">#EAF3F8</color>
     <color name="colorOnSurfaceContainerHighest">#000000</color>
+    <color name="colorErrorContainer">#ffdad6</color>
+    <color name="colorOnErrorContainer">#410002</color>
 
     <bool name="lightStatusBar">false</bool>
 

--- a/collect_app/src/main/res/values-night/colors.xml
+++ b/collect_app/src/main/res/values-night/colors.xml
@@ -4,7 +4,6 @@
     <color name="colorSurfaceVariant">#41484d</color>
     <color name="colorOnSurface">#FFFFFF</color>
     <color name="colorSurfaceContainerLow">#1D1B20</color>
-    <color name="colorSurfaceContainer">#41484d</color>
     <color name="colorSurfaceContainerHighest">#EAF3F8</color>
     <color name="colorOnSurfaceContainerHighest">#000000</color>
 

--- a/collect_app/src/main/res/values-night/colors.xml
+++ b/collect_app/src/main/res/values-night/colors.xml
@@ -4,6 +4,7 @@
     <color name="colorSurfaceVariant">#41484d</color>
     <color name="colorOnSurface">#FFFFFF</color>
     <color name="colorSurfaceContainerLow">#1D1B20</color>
+    <color name="colorSurfaceContainer">#41484d</color>
 
     <bool name="lightStatusBar">false</bool>
 

--- a/collect_app/src/main/res/values-night/colors.xml
+++ b/collect_app/src/main/res/values-night/colors.xml
@@ -5,6 +5,8 @@
     <color name="colorOnSurface">#FFFFFF</color>
     <color name="colorSurfaceContainerLow">#1D1B20</color>
     <color name="colorSurfaceContainer">#41484d</color>
+    <color name="colorSurfaceContainerHighest">#EAF3F8</color>
+    <color name="colorOnSurfaceContainerHighest">#000000</color>
 
     <bool name="lightStatusBar">false</bool>
 

--- a/collect_app/src/main/res/values/attrs.xml
+++ b/collect_app/src/main/res/values/attrs.xml
@@ -18,7 +18,6 @@
     <!--  Should be removed when these attributes are added to Material Components  -->
     <declare-styleable name="Material3PolyFill">
         <attr name="colorSurfaceContainerLow" format="color" />
-        <attr name="colorSurfaceContainer" format="color" />
         <attr name="colorSurfaceContainerHighest" format="color" />
 
         <!-- Needed because the colorOnSurface is incorrect for this in dark theme. Hopefully fixed in Material 3 -->

--- a/collect_app/src/main/res/values/attrs.xml
+++ b/collect_app/src/main/res/values/attrs.xml
@@ -20,6 +20,9 @@
         <attr name="colorSurfaceContainerLow" format="color" />
         <attr name="colorSurfaceContainer" format="color" />
         <attr name="colorSurfaceContainerHighest" format="color" />
+
+        <!-- Needed because the colorOnSurface is incorrect for this in dark theme. Hopefully fixed in Material 3 -->
+        <attr name="colorOnSurfaceContainerHighest" format="color" />
     </declare-styleable>
 
     <!--  These attributes are extensions to Material 3  -->

--- a/collect_app/src/main/res/values/attrs.xml
+++ b/collect_app/src/main/res/values/attrs.xml
@@ -18,6 +18,7 @@
     <!--  Should be removed when these attributes are added to Material Components  -->
     <declare-styleable name="Material3PolyFill">
         <attr name="colorSurfaceContainerLow" format="color" />
+        <attr name="colorSurfaceContainer" format="color" />
         <attr name="colorSurfaceContainerHighest" format="color" />
     </declare-styleable>
 

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -6,6 +6,8 @@
 
     <color name="colorError">#D42C2C</color>
     <color name="colorOnError">#ffffff</color>
+    <color name="colorErrorContainer">#F9DEDC</color>
+    <color name="colorOnErrorContainer">#410002</color>
 
     <color name="colorSurface">#FFFFFF</color>
     <color name="colorSurfaceVariant">#dce3e9</color>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -11,7 +11,6 @@
     <color name="colorSurfaceVariant">#dce3e9</color>
     <color name="colorOnSurface">#000000</color>
     <color name="colorSurfaceContainerLow">#F7F7FA</color>
-    <color name="colorSurfaceContainer">#E6E1E5</color>
     <color name="colorSurfaceContainerHighest">#EAF3F8</color>
     <color name="colorOnSurfaceContainerHighest">#000000</color>
 

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -11,6 +11,7 @@
     <color name="colorSurfaceVariant">#dce3e9</color>
     <color name="colorOnSurface">#000000</color>
     <color name="colorSurfaceContainerLow">#F7F7FA</color>
+    <color name="colorSurfaceContainer">#E6E1E5</color>
 
     <bool name="lightStatusBar">true</bool>
 

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -12,6 +12,8 @@
     <color name="colorOnSurface">#000000</color>
     <color name="colorSurfaceContainerLow">#F7F7FA</color>
     <color name="colorSurfaceContainer">#E6E1E5</color>
+    <color name="colorSurfaceContainerHighest">#EAF3F8</color>
+    <color name="colorOnSurfaceContainerHighest">#000000</color>
 
     <bool name="lightStatusBar">true</bool>
 

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -18,7 +18,8 @@
         <item name="colorOnSurface">@color/colorOnSurface</item>
         <item name="colorSurfaceContainerLow">@color/colorSurfaceContainerLow</item>
         <item name="colorSurfaceContainer">@color/colorSurfaceContainer</item>
-        <item name="colorSurfaceContainerHighest">@color/color_primary_low_emphasis</item>
+        <item name="colorSurfaceContainerHighest">@color/colorSurfaceContainerHighest</item>
+        <item name="colorOnSurfaceContainerHighest">@color/colorOnSurfaceContainerHighest</item>
         <item name="colorOutline">@color/color_on_surface_medium_emphasis</item>
 
         <item name="textAppearanceHeadline1">@style/TextAppearance.MaterialComponents.Headline1

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -17,7 +17,6 @@
         <item name="colorOnError">@color/colorOnError</item>
         <item name="colorOnSurface">@color/colorOnSurface</item>
         <item name="colorSurfaceContainerLow">@color/colorSurfaceContainerLow</item>
-        <item name="colorSurfaceContainer">@color/colorSurfaceContainer</item>
         <item name="colorSurfaceContainerHighest">@color/colorSurfaceContainerHighest</item>
         <item name="colorOnSurfaceContainerHighest">@color/colorOnSurfaceContainerHighest</item>
         <item name="colorOutline">@color/color_on_surface_medium_emphasis</item>

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -17,6 +17,7 @@
         <item name="colorOnError">@color/colorOnError</item>
         <item name="colorOnSurface">@color/colorOnSurface</item>
         <item name="colorSurfaceContainerLow">@color/colorSurfaceContainerLow</item>
+        <item name="colorSurfaceContainer">@color/colorSurfaceContainer</item>
         <item name="colorSurfaceContainerHighest">@color/color_primary_low_emphasis</item>
         <item name="colorOutline">@color/color_on_surface_medium_emphasis</item>
 

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -64,6 +64,7 @@
         <item name="textAppearanceLabelExtraLarge">@style/TextAppearance.Collect.LabelExtraLarge</item>
         <item name="textAppearanceTitleLarge">@style/TextAppearance.Material3.TitleLarge</item>
 
+        <item name="shapeAppearanceCornerSmall">@style/ShapeAppearance.Material3.Corner.Small</item>
         <item name="shapeAppearanceCornerMedium">@style/ShapeAppearance.Material3.Corner.Medium</item>
         <!--/Material3 attributes-->
 

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -58,6 +58,8 @@
         <item name="colorPrimaryContainer">?colorPrimary</item>
 
         <item name="colorOnPrimaryContainer">?colorOnPrimary</item>
+        <item name="colorErrorContainer">@color/colorErrorContainer</item>
+        <item name="colorOnErrorContainer">@color/colorOnErrorContainer</item>
 
         <item name="textAppearanceBodyMedium">@style/TextAppearance.Material3.BodyMedium</item>
         <item name="textAppearanceBodyLarge">?textAppearanceBody1</item>

--- a/material/build.gradle
+++ b/material/build.gradle
@@ -36,6 +36,11 @@ android {
             includeAndroidResources = true
         }
     }
+
+    buildFeatures {
+        viewBinding true
+    }
+
     namespace 'org.odk.collect.material'
 }
 

--- a/material/src/main/java/org/odk/collect/material/MaterialPill.kt
+++ b/material/src/main/java/org/odk/collect/material/MaterialPill.kt
@@ -3,9 +3,8 @@ package org.odk.collect.material
 import android.content.Context
 import android.content.res.ColorStateList
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.widget.FrameLayout
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
@@ -13,6 +12,7 @@ import androidx.core.content.res.ResourcesCompat
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
 import org.odk.collect.androidshared.system.ContextUtils.getThemeAttributeValue
+import org.odk.collect.material.databinding.PillBinding
 
 /**
  * Implementation of "pills" present on the Material 3 website and its examples, but not
@@ -25,14 +25,15 @@ class MaterialPill(context: Context, attrs: AttributeSet?) :
     var text: String? = null
         set(value) {
             field = value
-            findViewById<TextView>(R.id.text).text = text
+            binding.text.text = text
         }
 
     private val shapeAppearanceModel =
         ShapeAppearanceModel.builder(context, getShapeAppearance(context), -1).build()
 
+    val binding = PillBinding.inflate(LayoutInflater.from(context), this, true)
+
     init {
-        inflate(context, R.layout.pill, this)
         background = createMaterialShapeDrawable(getDefaultBackgroundColor(context))
     }
 
@@ -42,11 +43,11 @@ class MaterialPill(context: Context, attrs: AttributeSet?) :
 
     fun setIcon(@DrawableRes id: Int) {
         val drawable = ResourcesCompat.getDrawable(resources, id, context.theme)
-        findViewById<ImageView>(R.id.icon).setImageDrawable(drawable)
+        binding.icon.setImageDrawable(drawable)
     }
 
     fun setIconTint(@ColorInt color: Int) {
-        findViewById<ImageView>(R.id.icon).setColorFilter(color)
+        binding.icon.setColorFilter(color)
     }
 
     fun setPillBackgroundColor(@ColorInt color: Int) {
@@ -54,7 +55,7 @@ class MaterialPill(context: Context, attrs: AttributeSet?) :
     }
 
     fun setTextColor(@ColorInt color: Int) {
-        findViewById<TextView>(R.id.text).setTextColor(color)
+        binding.text.setTextColor(color)
     }
 
     private fun getShapeAppearance(context: Context) = getThemeAttributeValue(

--- a/material/src/main/java/org/odk/collect/material/MaterialPill.kt
+++ b/material/src/main/java/org/odk/collect/material/MaterialPill.kt
@@ -39,8 +39,16 @@ class MaterialPill(context: Context, attrs: AttributeSet?) :
         findViewById<ImageView>(R.id.icon).setImageDrawable(drawable)
     }
 
+    fun setIconTint(@ColorInt color: Int) {
+        findViewById<ImageView>(R.id.icon).setColorFilter(color)
+    }
+
     fun setPillBackgroundColor(@ColorInt color: Int) {
         background = createMaterialShapeDrawable(color)
+    }
+
+    fun setTextColor(@ColorInt color: Int) {
+        findViewById<TextView>(R.id.text).setTextColor(color)
     }
 
     private fun getShapeAppearance(context: Context) = getThemeAttributeValue(

--- a/material/src/main/java/org/odk/collect/material/MaterialPill.kt
+++ b/material/src/main/java/org/odk/collect/material/MaterialPill.kt
@@ -22,6 +22,12 @@ import org.odk.collect.androidshared.system.ContextUtils.getThemeAttributeValue
 class MaterialPill(context: Context, attrs: AttributeSet?) :
     FrameLayout(context, attrs) {
 
+    var text: String? = null
+        set(value) {
+            field = value
+            findViewById<TextView>(R.id.text).text = text
+        }
+
     private val shapeAppearanceModel =
         ShapeAppearanceModel.builder(context, getShapeAppearance(context), -1).build()
 
@@ -31,7 +37,7 @@ class MaterialPill(context: Context, attrs: AttributeSet?) :
     }
 
     fun setText(@StringRes id: Int) {
-        findViewById<TextView>(R.id.text).setText(id)
+        text = context.getString(id)
     }
 
     fun setIcon(@DrawableRes id: Int) {

--- a/material/src/main/java/org/odk/collect/material/MaterialPill.kt
+++ b/material/src/main/java/org/odk/collect/material/MaterialPill.kt
@@ -1,18 +1,33 @@
 package org.odk.collect.material
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.content.res.ResourcesCompat
+import com.google.android.material.shape.MaterialShapeDrawable
+import com.google.android.material.shape.ShapeAppearanceModel
+import org.odk.collect.androidshared.system.ContextUtils.getThemeAttributeValue
 
-class MaterialPill(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs) {
+/**
+ * Implementation of "pills" present on the Material 3 website and its examples, but not
+ * included in the spec or in Android's MaterialComponents. The pill will use the
+ * `?shapeAppearanceCornerSmall` shape appearance for the current theme.
+ */
+class MaterialPill(context: Context, attrs: AttributeSet?) :
+    FrameLayout(context, attrs) {
+
+    private val shapeAppearanceModel =
+        ShapeAppearanceModel.builder(context, getShapeAppearance(context), -1).build()
 
     init {
         inflate(context, R.layout.pill, this)
+        background = createMaterialShapeDrawable(getDefaultBackgroundColor(context))
     }
 
     fun setText(@StringRes id: Int) {
@@ -22,5 +37,25 @@ class MaterialPill(context: Context, attrs: AttributeSet?) : FrameLayout(context
     fun setIcon(@DrawableRes id: Int) {
         val drawable = ResourcesCompat.getDrawable(resources, id, context.theme)
         findViewById<ImageView>(R.id.icon).setImageDrawable(drawable)
+    }
+
+    fun setPillBackgroundColor(@ColorInt color: Int) {
+        background = createMaterialShapeDrawable(color)
+    }
+
+    private fun getShapeAppearance(context: Context) = getThemeAttributeValue(
+        context,
+        com.google.android.material.R.attr.shapeAppearanceCornerSmall
+    )
+
+    private fun getDefaultBackgroundColor(context: Context) = getThemeAttributeValue(
+        context,
+        com.google.android.material.R.attr.colorPrimary
+    )
+
+    private fun createMaterialShapeDrawable(@ColorInt color: Int): MaterialShapeDrawable {
+        return MaterialShapeDrawable(shapeAppearanceModel).also {
+            it.fillColor = ColorStateList.valueOf(color)
+        }
     }
 }

--- a/material/src/main/java/org/odk/collect/material/MaterialPill.kt
+++ b/material/src/main/java/org/odk/collect/material/MaterialPill.kt
@@ -1,0 +1,26 @@
+package org.odk.collect.material
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.core.content.res.ResourcesCompat
+
+class MaterialPill(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs) {
+
+    init {
+        inflate(context, R.layout.pill, this)
+    }
+
+    fun setText(@StringRes id: Int) {
+        findViewById<TextView>(R.id.text).setText(id)
+    }
+
+    fun setIcon(@DrawableRes id: Int) {
+        val drawable = ResourcesCompat.getDrawable(resources, id, context.theme)
+        findViewById<ImageView>(R.id.icon).setImageDrawable(drawable)
+    }
+}

--- a/material/src/main/res/layout/pill.xml
+++ b/material/src/main/res/layout/pill.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="?colorPrimary"
+    android:padding="@dimen/margin_small">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?colorOnPrimary"
+        tools:src="@drawable/ic_baseline_warning_24" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_small"
+        android:textAppearance="?textAppearanceLabelLarge"
+        android:textColor="?colorOnPrimary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Text" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/material/src/main/res/layout/pill.xml
+++ b/material/src/main/res/layout/pill.xml
@@ -9,8 +9,8 @@
 
     <ImageView
         android:id="@+id/icon"
-        android:layout_width="16dp"
-        android:layout_height="16dp"
+        android:layout_width="@dimen/margin_standard"
+        android:layout_height="@dimen/margin_standard"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/material/src/main/res/layout/pill.xml
+++ b/material/src/main/res/layout/pill.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_small">
+    android:paddingHorizontal="@dimen/margin_small"
+    android:paddingVertical="@dimen/margin_extra_small">
 
     <ImageView
         android:id="@+id/icon"

--- a/material/src/main/res/layout/pill.xml
+++ b/material/src/main/res/layout/pill.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:background="?colorPrimary"
     android:padding="@dimen/margin_small">
 
     <ImageView


### PR DESCRIPTION
~~Blocked by #5760~~

The "pill" component appears to exist in several places in Material 3's own spec ([this table](https://m3.material.io/components/chips/overview#5e30d365-636f-4638-97f4-4fd25222b843) for instance), but doesn't seem to have been explicitly called out or implemented. It also appears in Google Maps.

This PR provides an implementation of the component that should adapt appropriately to shape, typography and color theming. 

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

For code reviewers: the shape theming was the most complex here and involved some reverse engineering of the implementation of several Material components. In short, I ended up building a `ShapeAppearanceModel` with the theme's `shapeAppearanceCornerSmall` attribute and then used that to create a `MaterialShapeDrawable` that I could change the color on and set as the component's background. I'm not 100% sure this is correct™️, so it'd be worth doing some quick research to see if you agree with me. There are some docs on this ([here](https://github.com/material-components/material-components-android/blob/master/docs/theming/Shape.md)), but they seemed to be more aimed at customising the shapes at a theme level and I didn't personally get much from them.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is just a visual change to the "complete" and "incomplete" pill on drafts, so verifying that they look correct is all that's needed really.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
