### PR TITLE
Add custom attribute to flag strings to review

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
 
       - run:
           name: Run code quality checks
-          command: ./gradlew pmd ktlintCheck checkstyle lintDebug -PlintStrings
+          command: ./gradlew pmd ktlintCheck checkstyle lintDebug
 
   test_modules:
     <<: *android_config

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -216,10 +216,6 @@ android {
         htmlReport true
         lintConfig file("$rootDir/config/lint.xml")
         xmlReport true
-
-        if (!project.hasProperty("lintStrings")) {
-            disable += ["HardcodedText"]
-        }
     }
     namespace 'org.odk.collect.android'
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     the specific language governing permissions and limitations under the
     License.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation" tools:locale="en">
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:oat="http://schema.getodk.org/odkAndroidTools" tools:ignore="MissingTranslation" tools:locale="en">
     <!-- Text for the topmost button on the main screen. It should be short and action-oriented. -->
     <string name="enter_data">Start new form</string>
     <!-- Text for an action button on the main screen. -->
@@ -1218,23 +1218,23 @@
     <string name="edit_finalized_form_warning">In later releases, you will not be able to edit finalized forms. Save forms as draft to edit them later.\n\nYou can check for errors in a draft form by tapping the three dots (⋮) and then Check for errors.</string>
 
     <!-- Label for option that finalizes all the forms the user is currently looking at -->
-    <string name="finalize_all_forms" toReview="true">Finalize all forms</string>
+    <string name="finalize_all_forms" oat:toReview="true">Finalize all forms</string>
 
     <!-- Message shown when finalizing all forms has succeeded and how many totally have been finalized -->
-    <plurals name="bulk_finalize_success" toReview="true">
+    <plurals name="bulk_finalize_success" oat:toReview="true">
         <item quantity="one">Success! %d form finalized.</item>
         <item quantity="other">Success! %d forms finalized.</item>
     </plurals>
 
     <!-- Message shown when no forms finalized successfully -->
-    <plurals name="bulk_finalize_failure" toReview="true">
+    <plurals name="bulk_finalize_failure" oat:toReview="true">
         <item quantity="one">%d form has an error. Address issues before finalizing all forms.</item>
         <item quantity="other">%d forms have errors. Address issues before finalizing all forms.</item>
     </plurals>
 
     <!-- Message shown when some forms finalize successfully and others fail -->
-    <string name="bulk_finalize_partial_success" toReview="true">%d forms finalized. %d forms have errors. Address issues before finalizing all forms.</string>
+    <string name="bulk_finalize_partial_success" oat:toReview="true">%d forms finalized. %d forms have errors. Address issues before finalizing all forms.</string>
 
     <!-- Message above a form draft that has not yet been completed -->
-    <string name="incomplete" toReview="true">Incomplete</string>
+    <string name="incomplete" oat:toReview="true">Incomplete</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1218,23 +1218,23 @@
     <string name="edit_finalized_form_warning">In later releases, you will not be able to edit finalized forms. Save forms as draft to edit them later.\n\nYou can check for errors in a draft form by tapping the three dots (⋮) and then Check for errors.</string>
 
     <!-- Label for option that finalizes all the forms the user is currently looking at -->
-    <string name="finalize_all_forms">Finalize all forms</string>
+    <string name="finalize_all_forms" toReview="true">Finalize all forms</string>
 
     <!-- Message shown when finalizing all forms has succeeded and how many totally have been finalized -->
-    <plurals name="bulk_finalize_success">
+    <plurals name="bulk_finalize_success" toReview="true">
         <item quantity="one">Success! %d form finalized.</item>
         <item quantity="other">Success! %d forms finalized.</item>
     </plurals>
 
     <!-- Message shown when no forms finalized successfully -->
-    <plurals name="bulk_finalize_failure">
+    <plurals name="bulk_finalize_failure" toReview="true">
         <item quantity="one">%d form has an error. Address issues before finalizing all forms.</item>
         <item quantity="other">%d forms have errors. Address issues before finalizing all forms.</item>
     </plurals>
 
     <!-- Message shown when some forms finalize successfully and others fail -->
-    <string name="bulk_finalize_partial_success">%d forms finalized. %d forms have errors. Address issues before finalizing all forms.</string>
+    <string name="bulk_finalize_partial_success" toReview="true">%d forms finalized. %d forms have errors. Address issues before finalizing all forms.</string>
 
     <!-- Message above a form draft that has not yet been completed -->
-    <string name="incomplete">Incomplete</string>
+    <string name="incomplete" toReview="true">Incomplete</string>
 </resources>


### PR DESCRIPTION
This adds a new `toReview` attribute to strings that we want to review. The idea here is to allow copy discussions to happen separately from PR review: the strings can be reviewed later and then the flag can be removed when we're happy with them.

We're going to experiment with this process on the `v2023.3.x` and then decide if we want to continue it when merging everything back in to `master`.