### PR TITLE
Fixed killing app in tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -454,6 +454,10 @@ abstract class Page<T : Page<T>> {
 
         // kill
         device.pressRecentApps()
+        device.findObject(UiSelector().textContains("Select text and images to copy"))?.apply {
+            wait250ms()
+            device.pressBack() // the first time we open the list of recent apps, a tooltip might be displayed and we need to close it
+        }
         device
             .findObject(UiSelector().descriptionContains("Collect"))
             .swipeUp(10).also {


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?
It turns out that the first time we open the list of apps an additional tooltip is displayed that we need to close:
![Screenshot_1697114329](https://github.com/getodk/collect/assets/3276264/8348b409-91ed-4288-a198-05d01ba3d1c2)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
