### PR TITLE
Update bulk finalization strings

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormEndTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormEndTest.kt
@@ -42,8 +42,8 @@ class FormEndTest {
             .assertNumberOfFinalizedForms(0)
 
             .clickDrafts(1)
-            .assertText(string.complete)
-            .assertTextDoesNotExist(string.incomplete)
+            .assertText(string.draft_no_errors)
+            .assertTextDoesNotExist(string.draft_errors)
     }
 
     @Test
@@ -58,8 +58,8 @@ class FormEndTest {
             .assertNumberOfFinalizedForms(0)
 
             .clickDrafts(1)
-            .assertText(string.incomplete)
-            .assertTextDoesNotExist(string.complete)
+            .assertText(string.draft_errors)
+            .assertTextDoesNotExist(string.draft_no_errors)
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
@@ -87,8 +87,8 @@ class BulkFinalizationTest {
             .clickFinalize()
             .checkIsSnackbarWithQuantityDisplayed(plurals.bulk_finalize_failure, 1)
 
-            .clickOptionsIcon(string.finalize_all_forms)
-            .clickOnString(string.finalize_all_forms)
+            .clickOptionsIcon(string.finalize_all_drafts)
+            .clickOnString(string.finalize_all_drafts)
             .clickOnButtonInDialog(string.finalize, EditSavedFormPage(false))
             .checkIsSnackbarWithQuantityDisplayed(plurals.bulk_finalize_failure, 1)
     }
@@ -106,8 +106,8 @@ class BulkFinalizationTest {
             .killAndReopenApp(MainMenuPage())
 
             .clickDrafts(false)
-            .clickOptionsIcon(string.finalize_all_forms)
-            .clickOnString(string.finalize_all_forms)
+            .clickOptionsIcon(string.finalize_all_drafts)
+            .clickOnString(string.finalize_all_drafts)
             .checkIsSnackbarWithQuantityDisplayed(plurals.bulk_finalize_failure, 1)
             .assertText("One Question")
             .pressBack(MainMenuPage())
@@ -199,7 +199,7 @@ class BulkFinalizationTest {
             .clickSettings()
             .clickAccessControl()
             .clickFormEntrySettings()
-            .clickOnString(string.finalize_all_forms)
+            .clickOnString(string.finalize_all_drafts)
             .pressBack(AccessControlPage())
             .pressBack(ProjectSettingsPage())
             .pressBack(MainMenuPage())

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
@@ -53,7 +53,7 @@ public class EditSavedFormPage extends Page<EditSavedFormPage> {
 
     private void closeDraftsPillsEducationDialog() {
         if (firstOpen) {
-            assertText(org.odk.collect.strings.R.string.drafts_pills_education_title);
+            assertText(org.odk.collect.strings.R.string.new_feature);
             clickOKOnDialog();
         }
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
@@ -108,8 +108,8 @@ public class EditSavedFormPage extends Page<EditSavedFormPage> {
     }
 
     public BulkFinalizationConfirmationDialogPage clickFinalizeAll(int count) {
-        this.clickOptionsIcon(org.odk.collect.strings.R.string.finalize_all_forms)
-                .clickOnString(org.odk.collect.strings.R.string.finalize_all_forms);
+        this.clickOptionsIcon(org.odk.collect.strings.R.string.finalize_all_drafts)
+                .clickOnString(org.odk.collect.strings.R.string.finalize_all_drafts);
 
         return new BulkFinalizationConfirmationDialogPage(count).assertOnPage();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -123,7 +123,7 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
 
             if (!settingsProvider.getMetaSettings().getBoolean(MetaKeys.DRAFTS_PILLS_EDUCATION_SHOWN)) {
                 new MaterialAlertDialogBuilder(this)
-                        .setTitle(string.drafts_pills_education_title)
+                        .setTitle(string.new_feature)
                         .setMessage(string.drafts_pills_education_message)
                         .setPositiveButton(string.ok, null)
                         .show();

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -33,14 +33,14 @@ object InstanceListItemView {
             if (instance.status == Instance.STATUS_INVALID || instance.status == Instance.STATUS_INCOMPLETE) {
                 pill.visibility = View.VISIBLE
                 pill.setIcon(R.drawable.baseline_rule_24)
-                pill.setText(string.incomplete)
+                pill.setText(string.draft_errors)
                 pill.setPillBackgroundColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorErrorContainer))
                 pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
                 pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
             } else if (instance.status == Instance.STATUS_VALID) {
                 pill.visibility = View.VISIBLE
                 pill.setIcon(R.drawable.baseline_check_24)
-                pill.setText(string.complete)
+                pill.setText(string.draft_no_errors)
                 pill.setPillBackgroundColor(getThemeAttributeValue(context, R.attr.colorSurfaceContainerHighest))
                 pill.setTextColor(getThemeAttributeValue(context, R.attr.colorOnSurfaceContainerHighest))
                 pill.setIconTint(getThemeAttributeValue(context, R.attr.colorOnSurfaceContainerHighest))

--- a/collect_app/src/main/res/menu/drafts.xml
+++ b/collect_app/src/main/res/menu/drafts.xml
@@ -3,6 +3,6 @@
     <item
         android:id="@+id/bulk_finalize"
         android:showAsAction="never"
-        android:title="@string/finalize_all_forms">
+        android:title="@string/finalize_all_drafts">
     </item>
 </menu>

--- a/collect_app/src/main/res/xml/form_entry_access_preferences.xml
+++ b/collect_app/src/main/res/xml/form_entry_access_preferences.xml
@@ -54,7 +54,7 @@
         app:iconSpaceReserved="false">
         <CheckBoxPreference
             android:key="bulk_finalize"
-            android:title="@string/finalize_all_forms"
+            android:title="@string/finalize_all_drafts"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceListItemViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceListItemViewTest.kt
@@ -35,7 +35,7 @@ class InstanceListItemViewTest {
         InstanceListItemView.setInstance(binding.root, instance, false)
 
         assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
-        assertThat(binding.chip.text, equalTo(context.getString(string.incomplete)))
+        assertThat(binding.chip.text, equalTo(context.getString(string.draft_errors)))
     }
 
     @Test
@@ -46,7 +46,7 @@ class InstanceListItemViewTest {
         InstanceListItemView.setInstance(binding.root, instance, false)
 
         assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
-        assertThat(binding.chip.text, equalTo(context.getString(string.complete)))
+        assertThat(binding.chip.text, equalTo(context.getString(string.draft_no_errors)))
     }
 
     @Test
@@ -57,7 +57,7 @@ class InstanceListItemViewTest {
         InstanceListItemView.setInstance(binding.root, instance, false)
 
         assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
-        assertThat(binding.chip.text, equalTo(context.getString(string.incomplete)))
+        assertThat(binding.chip.text, equalTo(context.getString(string.draft_errors)))
     }
 
     @Test
@@ -77,12 +77,12 @@ class InstanceListItemViewTest {
         InstanceListItemView.setInstance(binding.root, valid, false)
 
         assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
-        assertThat(binding.chip.text, equalTo(context.getString(string.complete)))
+        assertThat(binding.chip.text, equalTo(context.getString(string.draft_no_errors)))
 
         val invalid = InstanceFixtures.instance(status = Instance.STATUS_INVALID)
         InstanceListItemView.setInstance(binding.root, invalid, false)
 
         assertThat(binding.chip.visibility, equalTo(View.VISIBLE))
-        assertThat(binding.chip.text, equalTo(context.getString(string.incomplete)))
+        assertThat(binding.chip.text, equalTo(context.getString(string.draft_errors)))
     }
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1238,11 +1238,11 @@
     <!-- Message shown when some drafts finalize successfully and others fail -->
     <string name="bulk_finalize_partial_success" oat:toReview="true">%d drafts finalized. %d drafts have errors. Address issues before finalizing all drafts.</string>
 
-    <!-- Message above a form draft that has not yet been completed -->
-    <string name="incomplete" oat:toReview="true">Incomplete</string>
+    <!-- Displayed above a draft that has constraints that aren't met or required questions that aren't answered or both. Should match the wording for the 'Check for errors' feature. -->
+    <string name="draft_errors">Errors</string>
 
-    <!-- Message above a form draft that has been completed -->
-    <string name="complete" oat:toReview="true">Complete</string>
+    <!-- Displayed above a draft that has no constraint violations and in which all required questions have been answered. Should match the wording for the 'Check for errors' feature. -->
+    <string name="draft_no_errors">No errors</string>
 
     <!-- Message shown when some forms finalize successfully but others need to be finalized manually -->
     <string name="bulk_finalize_unsupported" oat:toReview="true">%d drafts finalized. Some drafts need to be finalized manually.</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1223,23 +1223,32 @@
     <!-- Label for Drafts list option that attempts to finalize all the drafts the user is currently looking at. Finalizing a draft locks it so it can't be edited and makes it eligible for autosend -->
     <string name="finalize_all_drafts">Finalize all drafts</string>
 
+    <!-- Dialog title that asks if the user wants to finalize all drafts -->
+    <plurals name="bulk_finalize_confirmation">
+        <item quantity="one">Do you want to finalize %d draft?</item>
+        <item quantity="other">Do you want to finalize %d drafts?</item>
+    </plurals>
+
     <!-- Explanation for how bulk finalize works shown in a dialog before the user confirms if they want to proceed or cancel -->
     <string name="bulk_finalize_explanation">Once you finalize all drafts, they will be in "Ready to send" and you will not be able to make edits. Any drafts that have errors will not be finalized.\n\nYou will not be able to undo this action.</string>
 
-    <!-- Message shown when finalizing all drafts has succeeded -->
-    <plurals name="bulk_finalize_success" oat:toReview="true">
+    <!-- Message shown after bulk finalization when finalizing all drafts has succeeded -->
+    <plurals name="bulk_finalize_success">
         <item quantity="one">Success! %d draft finalized.</item>
         <item quantity="other">Success! %d drafts finalized.</item>
     </plurals>
 
-    <!-- Message shown when no drafts finalized successfully -->
-    <plurals name="bulk_finalize_failure" oat:toReview="true">
-        <item quantity="one">%d draft has an error. Address issues before finalizing all drafts.</item>
-        <item quantity="other">%d drafts have errors. Address issues before finalizing all drafts.</item>
+    <!-- Message shown after bulk finalization when no drafts finalized successfully -->
+    <plurals name="bulk_finalize_failure">
+        <item quantity="one">%d draft has an error that must be addressed before finalizing.</item>
+        <item quantity="other">%d drafts have errors that must be addressed before finalizing.</item>
     </plurals>
 
-    <!-- Message shown when some drafts finalize successfully and others fail -->
-    <string name="bulk_finalize_partial_success" oat:toReview="true">%d drafts finalized. %d drafts have errors. Address issues before finalizing all drafts.</string>
+    <!-- Message shown after bulk finalization when some drafts finalize successfully and others fail -->
+    <string name="bulk_finalize_partial_success">%d drafts finalized. %d drafts have errors that must be addressed before finalizing.</string>
+
+    <!-- Message shown when some drafts finalize successfully but others need to be finalized manually -->
+    <string name="bulk_finalize_unsupported">%d drafts finalized. Drafts that are left need to be finalized manually.</string>
 
     <!-- Displayed above a draft that has constraints that aren't met or required questions that aren't answered or both. Should match the wording for the 'Check for errors' feature. -->
     <string name="draft_errors">Errors</string>
@@ -1247,21 +1256,12 @@
     <!-- Displayed above a draft that has no constraint violations and in which all required questions have been answered. Should match the wording for the 'Check for errors' feature. -->
     <string name="draft_no_errors">No errors</string>
 
-    <!-- Message shown when some forms finalize successfully but others need to be finalized manually -->
-    <string name="bulk_finalize_unsupported" oat:toReview="true">%d drafts finalized. Some drafts need to be finalized manually.</string>
-
-    <!-- Dialog title that asks if the user wants to finalize all drafts -->
-    <plurals name="bulk_finalize_confirmation" oat:toReview="true">
-        <item quantity="one">Do you want to finalize %d draft?</item>
-        <item quantity="other">Do you want to finalize %d drafts?</item>
-    </plurals>
-
     <!-- Title of section of features that the user can uncheck to hide from the Drafts screen -->
     <string name="uncheck_to_hide_from_drafts">Uncheck to hide from Drafts</string>
 
     <!-- Title for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
-    <string name="drafts_pills_education_title" oat:toReview="true">Drafts have changed</string>
+    <string name="drafts_pills_education_title">Drafts now show errors</string>
 
     <!-- Message for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
-    <string name="drafts_pills_education_message" oat:toReview="true">The draft list now shows validation errors. Drafts marked with \"Errors\" are either missing required questions or have values that are not allowed. Each time you save a form as draft, its validation status is updated.</string>
+    <string name="drafts_pills_education_message">The draft list now shows validation errors. Drafts marked with \"Errors\" are either missing required questions or have values that are not allowed.\n\nEach time you save a form as draft, its validation status is updated.</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1220,23 +1220,23 @@
     <!-- Message showed on main menu to inform users that the ability to edit finalized forms is going away -->
     <string name="edit_finalized_form_deprecation_message">In later versions, finalized forms will no longer be editable.</string>
 
-    <!-- Label for option that finalizes all the forms the user is currently looking at -->
-    <string name="finalize_all_forms" oat:toReview="true">Finalize all forms</string>
+    <!-- Label for option that finalizes all the drafts the user is currently looking at -->
+    <string name="finalize_all_forms" oat:toReview="true">Finalize all drafts</string>
 
-    <!-- Message shown when finalizing all forms has succeeded and how many totally have been finalized -->
+    <!-- Message shown when finalizing all drafts has succeeded and how many totally have been finalized -->
     <plurals name="bulk_finalize_success" oat:toReview="true">
-        <item quantity="one">Success! %d form finalized.</item>
-        <item quantity="other">Success! %d forms finalized.</item>
+        <item quantity="one">Success! %d draft finalized.</item>
+        <item quantity="other">Success! %d drafts finalized.</item>
     </plurals>
 
-    <!-- Message shown when no forms finalized successfully -->
+    <!-- Message shown when no drafts finalized successfully -->
     <plurals name="bulk_finalize_failure" oat:toReview="true">
-        <item quantity="one">%d form has an error. Address issues before finalizing all forms.</item>
-        <item quantity="other">%d forms have errors. Address issues before finalizing all forms.</item>
+        <item quantity="one">%d draft has an error. Address issues before finalizing all drafts.</item>
+        <item quantity="other">%d drafts have errors. Address issues before finalizing all drafts.</item>
     </plurals>
 
-    <!-- Message shown when some forms finalize successfully and others fail -->
-    <string name="bulk_finalize_partial_success" oat:toReview="true">%d forms finalized. %d forms have errors. Address issues before finalizing all forms.</string>
+    <!-- Message shown when some drafts finalize successfully and others fail -->
+    <string name="bulk_finalize_partial_success" oat:toReview="true">%d drafts finalized. %d drafts have errors. Address issues before finalizing all drafts.</string>
 
     <!-- Message above a form draft that has not yet been completed -->
     <string name="incomplete" oat:toReview="true">Incomplete</string>
@@ -1245,21 +1245,23 @@
     <string name="complete" oat:toReview="true">Complete</string>
 
     <!-- Message shown when some forms finalize successfully but others need to be finalized manually -->
-    <string name="bulk_finalize_unsupported" oat:toReview="true">%d forms finalized. Some forms need to be finalized manually.</string>
+    <string name="bulk_finalize_unsupported" oat:toReview="true">%d drafts finalized. Some drafts need to be finalized manually.</string>
 
     <!-- Explanation for how bulk finalize works shown in a dialog before the user confirms if they want to proceed or cancel -->
-    <string name="bulk_finalize_explanation" oat:toReview="true">Once you finalize all forms, they will be in "Ready to send" and you will not be able to make edits. Any forms that have errors will not be finalized.\n\nYou will not be able to undo this action.</string>
+    <string name="bulk_finalize_explanation" oat:toReview="true">Once you finalize all drafts, they will be in "Ready to send" and you will not be able to make edits. Any drafts that have errors will not be finalized.\n\nYou will not be able to undo this action.</string>
 
     <!-- Dialog title that asks if the user wants to finalize all drafts -->
     <plurals name="bulk_finalize_confirmation" oat:toReview="true">
-        <item quantity="one">Do you want to finalize %d form?</item>
-        <item quantity="other">Do you want to finalize %d forms?</item>
+        <item quantity="one">Do you want to finalize %d draft?</item>
+        <item quantity="other">Do you want to finalize %d drafts?</item>
     </plurals>
 
     <!-- Title of section of features that the user can uncheck to hide from the Drafts screen -->
     <string name="uncheck_to_hide_from_drafts">Uncheck to hide from Drafts</string>
 
-    <!-- Title and message for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
+    <!-- Title for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
     <string name="drafts_pills_education_title" oat:toReview="true">Drafts have changed</string>
+
+    <!-- Message for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
     <string name="drafts_pills_education_message" oat:toReview="true">The draft list now shows validation errors. Drafts marked with \"Errors\" are either missing required questions or have values that are not allowed. Each time you save a form as draft, its validation status is updated.</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1220,10 +1220,13 @@
     <!-- Message showed on main menu to inform users that the ability to edit finalized forms is going away -->
     <string name="edit_finalized_form_deprecation_message">In later versions, finalized forms will no longer be editable.</string>
 
-    <!-- Label for option that finalizes all the drafts the user is currently looking at -->
-    <string name="finalize_all_forms" oat:toReview="true">Finalize all drafts</string>
+    <!-- Label for Drafts list option that attempts to finalize all the drafts the user is currently looking at. Finalizing a draft locks it so it can't be edited and makes it eligible for autosend -->
+    <string name="finalize_all_drafts">Finalize all drafts</string>
 
-    <!-- Message shown when finalizing all drafts has succeeded and how many totally have been finalized -->
+    <!-- Explanation for how bulk finalize works shown in a dialog before the user confirms if they want to proceed or cancel -->
+    <string name="bulk_finalize_explanation">Once you finalize all drafts, they will be in "Ready to send" and you will not be able to make edits. Any drafts that have errors will not be finalized.\n\nYou will not be able to undo this action.</string>
+
+    <!-- Message shown when finalizing all drafts has succeeded -->
     <plurals name="bulk_finalize_success" oat:toReview="true">
         <item quantity="one">Success! %d draft finalized.</item>
         <item quantity="other">Success! %d drafts finalized.</item>
@@ -1246,9 +1249,6 @@
 
     <!-- Message shown when some forms finalize successfully but others need to be finalized manually -->
     <string name="bulk_finalize_unsupported" oat:toReview="true">%d drafts finalized. Some drafts need to be finalized manually.</string>
-
-    <!-- Explanation for how bulk finalize works shown in a dialog before the user confirms if they want to proceed or cancel -->
-    <string name="bulk_finalize_explanation" oat:toReview="true">Once you finalize all drafts, they will be in "Ready to send" and you will not be able to make edits. Any drafts that have errors will not be finalized.\n\nYou will not be able to undo this action.</string>
 
     <!-- Dialog title that asks if the user wants to finalize all drafts -->
     <plurals name="bulk_finalize_confirmation" oat:toReview="true">

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1260,8 +1260,8 @@
     <string name="uncheck_to_hide_from_drafts">Uncheck to hide from Drafts</string>
 
     <!-- Title for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
-    <string name="drafts_pills_education_title">Drafts now show errors</string>
+    <string name="new_feature">New feature</string>
 
     <!-- Message for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
-    <string name="drafts_pills_education_message">The draft list now shows validation errors. Drafts marked with \"Errors\" are either missing required questions or have values that are not allowed.\n\nEach time you save a form as draft, its validation status is updated.</string>
+    <string name="drafts_pills_education_message">The draft list now shows validation errors. Each time you save a form as draft, its validation status is updated.\n\nDrafts marked with \"Errors\" are either missing required questions or have values that are not allowed.</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1240,7 +1240,7 @@
 
     <!-- Message shown after bulk finalization when no drafts finalized successfully -->
     <plurals name="bulk_finalize_failure">
-        <item quantity="one">%d draft has an error that must be addressed before finalizing.</item>
+        <item quantity="one">%d draft has errors that must be addressed before finalizing.</item>
         <item quantity="other">%d drafts have errors that must be addressed before finalizing.</item>
     </plurals>
 


### PR DESCRIPTION
Wordsmithing for the bulk finalization strings and their translation hints.

#### Why is this the best possible solution? Were any other approaches considered?
The main change I made was focusing on "drafts" rather than the more generic "forms."

I pulled in the strings from #5776 so we can look at all of the bulk finalization strings together. I'll rebase once that PR is merged.

One thing I'm not entirely sure of is whether the confirmation dialog makes it clear enough that drafts with errors will not be finalized. This is made particularly weird by the upgrade case where drafts without errors might be marked as having errors (but maybe as @seadowg said this is short-lived enough that we don't need to think about it).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risk because these are text-only changes to unreleased functionality.

#### Do we need any specific form for testing your changes? If so, please attach one.
Need a form with constraints or required questions.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
https://github.com/getodk/docs/issues/1673

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
