### PR TITLE
Fixed memory leaks

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/data/AppState.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/data/AppState.kt
@@ -65,10 +65,6 @@ class AppState {
     fun clear(key: String) {
         map.remove(key)
     }
-
-    fun has(key: String): Boolean {
-        return map.containsKey(key)
-    }
 }
 
 interface StateStore {

--- a/androidshared/src/main/java/org/odk/collect/androidshared/data/AppState.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/data/AppState.kt
@@ -65,6 +65,10 @@ class AppState {
     fun clear(key: String) {
         map.remove(key)
     }
+
+    fun has(key: String): Boolean {
+        return map.containsKey(key)
+    }
 }
 
 interface StateStore {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
@@ -19,8 +19,6 @@ interface FormSessionRepository {
     }
 
     fun set(id: String, formController: FormController, form: Form, instance: Instance?)
-
-    fun has(id: String): Boolean
 }
 
 class AppStateFormSessionRepository(application: Application) : FormSessionRepository {
@@ -46,10 +44,6 @@ class AppStateFormSessionRepository(application: Application) : FormSessionRepos
     override fun clear(id: String) {
         getLiveData(id).value = null
         appState.clear(getKey(id))
-    }
-
-    override fun has(id: String): Boolean {
-        return appState.has(getKey(id))
     }
 
     private fun getLiveData(id: String) =

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
@@ -19,6 +19,8 @@ interface FormSessionRepository {
     }
 
     fun set(id: String, formController: FormController, form: Form, instance: Instance?)
+
+    fun has(id: String): Boolean
 }
 
 class AppStateFormSessionRepository(application: Application) : FormSessionRepository {
@@ -39,6 +41,10 @@ class AppStateFormSessionRepository(application: Application) : FormSessionRepos
 
     override fun clear(id: String) {
         appState.clear(getKey(id))
+    }
+
+    override fun has(id: String): Boolean {
+        return appState.has(getKey(id))
     }
 
     private fun getLiveData(id: String) =

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
@@ -38,7 +38,7 @@ class AppStateFormSessionRepository(application: Application) : FormSessionRepos
     }
 
     override fun clear(id: String) {
-        getLiveData(id).value = null
+        appState.clear(getKey(id))
     }
 
     private fun getLiveData(id: String) =

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
@@ -39,6 +39,10 @@ class AppStateFormSessionRepository(application: Application) : FormSessionRepos
         getLiveData(id).value = FormSession(formController, form, instance)
     }
 
+    /**
+     * Ensure the object gets completely removed. Simply nullifying it might cause memory leaks.
+     * See: https://github.com/getodk/collect/issues/5777
+     */
     override fun clear(id: String) {
         appState.clear(getKey(id))
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
@@ -44,6 +44,7 @@ class AppStateFormSessionRepository(application: Application) : FormSessionRepos
      * See: https://github.com/getodk/collect/issues/5777
      */
     override fun clear(id: String) {
+        getLiveData(id).value = null
         appState.clear(getKey(id))
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -34,6 +34,7 @@ import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.androidshared.data.AppState;
 import org.odk.collect.androidshared.livedata.LiveDataUtils;
+import org.odk.collect.async.Cancellable;
 import org.odk.collect.async.Scheduler;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.entities.EntitiesRepository;
@@ -89,6 +90,7 @@ public class FormSaveViewModel extends ViewModel implements MaterialProgressDial
     private final InstancesRepository instancesRepository;
     private Instance instance;
     private final AppState appState;
+    private final Cancellable formSessionObserver;
 
     public FormSaveViewModel(SavedStateHandle stateHandle, Supplier<Long> clock, FormSaver formSaver, MediaUtils mediaUtils, Scheduler scheduler, AudioRecorder audioRecorder, CurrentProjectProvider currentProjectProvider, LiveData<FormSession> formSession, EntitiesRepository entitiesRepository, InstancesRepository instancesRepository, AppState appState) {
         this.stateHandle = stateHandle;
@@ -109,10 +111,15 @@ public class FormSaveViewModel extends ViewModel implements MaterialProgressDial
             recentFiles = stateHandle.get(RECENT_FILES);
         }
 
-        LiveDataUtils.observe(formSession, it -> {
+        formSessionObserver = LiveDataUtils.observe(formSession, it -> {
             formController = it.getFormController();
             instance = it.getInstance();
         });
+    }
+
+    @Override
+    protected void onCleared() {
+        formSessionObserver.cancel();
     }
 
     public void saveForm(Uri instanceContentURI, boolean shouldFinalize, String updatedSaveName, boolean viewExiting) {

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormSessionRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormSessionRepositoryTest.kt
@@ -51,11 +51,12 @@ abstract class FormSessionRepositoryTest {
         val formController = mock<FormController>()
         val form = mock<Form>()
         formSessionRepository.set(id, formController, form)
-        assertThat(formSessionRepository.has(id), equalTo(true))
         val liveData = formSessionRepository.get(id)
 
         formSessionRepository.clear(id)
+        val newLiveData = formSessionRepository.get(id)
+
         assertThat(liveData.getOrAwaitValue(), equalTo(null))
-        assertThat(formSessionRepository.has(id), equalTo(false))
+        assertThat(liveData != newLiveData, equalTo(true))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormSessionRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormSessionRepositoryTest.kt
@@ -51,8 +51,9 @@ abstract class FormSessionRepositoryTest {
         val formController = mock<FormController>()
         val form = mock<Form>()
         formSessionRepository.set(id, formController, form)
+        assertThat(formSessionRepository.has(id), equalTo(true))
 
         formSessionRepository.clear(id)
-        assertThat(formSessionRepository.get(id).getOrAwaitValue(), equalTo(null))
+        assertThat(formSessionRepository.has(id), equalTo(false))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormSessionRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormSessionRepositoryTest.kt
@@ -52,8 +52,10 @@ abstract class FormSessionRepositoryTest {
         val form = mock<Form>()
         formSessionRepository.set(id, formController, form)
         assertThat(formSessionRepository.has(id), equalTo(true))
+        val liveData = formSessionRepository.get(id)
 
         formSessionRepository.clear(id)
+        assertThat(liveData.getOrAwaitValue(), equalTo(null))
         assertThat(formSessionRepository.has(id), equalTo(false))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
@@ -26,7 +26,11 @@ class InMemFormSessionRepository : FormSessionRepository {
     }
 
     override fun clear(id: String) {
-        getLiveData(id).value = null
+        map.remove(id)
+    }
+
+    override fun has(id: String): Boolean {
+        return map.containsKey(id)
     }
 
     private fun getLiveData(id: String): MutableLiveData<FormSession> {

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
@@ -30,10 +30,6 @@ class InMemFormSessionRepository : FormSessionRepository {
         map.remove(id)
     }
 
-    override fun has(id: String): Boolean {
-        return map.containsKey(id)
-    }
-
     private fun getLiveData(id: String): MutableLiveData<FormSession> {
         return map.getOrPut(id) { MutableLiveData<FormSession>(null) }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
@@ -26,6 +26,7 @@ class InMemFormSessionRepository : FormSessionRepository {
     }
 
     override fun clear(id: String) {
+        getLiveData(id).value = null
         map.remove(id)
     }
 


### PR DESCRIPTION
Closes #5777 

#### Why is this the best possible solution? Were any other approaches considered?
There was a problem with clearing form sessions. Nullifying objects was not enough and somehow garbage collector was not able to get rid of those objects. In the case of big forms (especially those with thousands of choices) the result was that every time we started a new form more and more memory was used:
![SelectOneFromFileMaster](https://github.com/getodk/collect/assets/3276264/a0a58e7c-5380-4364-b484-562d8fe0851f)
with the fix the chart is flat:
![Screenshot from 2023-10-16 21-25-59](https://github.com/getodk/collect/assets/3276264/f2aa9dee-e379-42fb-9767-090b1bf79414)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is rather a safe change so testing if the issue does not occur anymore should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
I've used 3 forms. Each with just one select one question with 50k items. The difference between the forms was just the source of choices:
- choices from form XML file [SelectOne.xlsx](https://github.com/getodk/collect/files/12921128/SelectOne.xlsx)
- choices from an external csv file using `select_one_from_file` question [SelectOneFromFile.zip](https://github.com/getodk/collect/files/12921133/SelectOneFromFile.zip)
- choices from an external csv file using `select_one` question with the search function [SelectOneSearch.zip](https://github.com/getodk/collect/files/12921126/SelectOneSearch.zip)

The two first forms caused memory leaks.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
