### PR TITLE
Show dialog when the user sees the drafts screen for the first time

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
@@ -33,7 +33,7 @@ class InstancePickActionTest {
 
         val intent = Intent(Intent.ACTION_PICK)
         intent.type = InstancesContract.CONTENT_TYPE
-        val result = rule.launchForResult(intent, EditSavedFormPage()) {
+        val result = rule.launchForResult(intent, EditSavedFormPage(true)) {
             it.clickOnFormClosingApp("One Question")
         }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuickSaveTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuickSaveTest.java
@@ -69,7 +69,7 @@ public class QuickSaveTest {
                 .clickSave()
                 .pressBackAndDiscardChanges()
 
-                .clickDrafts(1)
+                .clickDrafts(1, false)
                 .clickOnForm("Two Question Required")
                 .assertText("Another Reuben");
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
@@ -104,7 +104,7 @@ public class QuittingFormTest {
                 .pressBack(new SaveOrDiscardFormDialog<>(new MainMenuPage()))
                 .clickSaveChanges()
 
-                .clickDrafts(1)
+                .clickDrafts(1, false)
                 .clickOnForm("Two Question Required")
                 .assertText("Another Reuben");
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
@@ -97,7 +97,7 @@ class BulkFinalizationTest {
             .clickOnForm("One Question")
             .killAndReopenApp(MainMenuPage())
 
-            .clickDrafts()
+            .clickDrafts(false)
             .clickOptionsIcon(string.finalize_all_forms)
             .clickOnString(string.finalize_all_forms)
             .checkIsSnackbarWithQuantityDisplayed(plurals.bulk_finalize_failure, 1)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/SwitchProjectTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/SwitchProjectTest.kt
@@ -110,7 +110,7 @@ class SwitchProjectTest {
             .pressBack(MainMenuPage())
 
             // Check instances
-            .clickDrafts(1)
+            .clickDrafts(1, false)
             .assertText("Two Question")
             .pressBack(MainMenuPage())
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
@@ -62,7 +62,7 @@ public class ResetApplicationTest {
                 .clickFillBlankForm()
                 .assertTextDoesNotExist("All widgets")
                 .pressBack(new MainMenuPage())
-                .clickDrafts()
+                .clickDrafts(false)
                 .assertTextDoesNotExist("All widgets");
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
@@ -38,9 +38,17 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
 public class EditSavedFormPage extends Page<EditSavedFormPage> {
+    private final boolean firstOpen;
+
+    public EditSavedFormPage(boolean first) {
+        this.firstOpen = first;
+    }
 
     @Override
     public EditSavedFormPage assertOnPage() {
+        if (firstOpen) {
+            clickOKOnDialog();
+        }
         assertText(org.odk.collect.strings.R.string.review_data);
         return this;
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
@@ -46,11 +46,16 @@ public class EditSavedFormPage extends Page<EditSavedFormPage> {
 
     @Override
     public EditSavedFormPage assertOnPage() {
-        if (firstOpen) {
-            clickOKOnDialog();
-        }
+        closeDraftsPillsEducationDialog();
         assertText(org.odk.collect.strings.R.string.review_data);
         return this;
+    }
+
+    private void closeDraftsPillsEducationDialog() {
+        if (firstOpen) {
+            assertText(org.odk.collect.strings.R.string.drafts_pills_education_title);
+            clickOKOnDialog();
+        }
     }
 
     public EditSavedFormPage checkInstanceState(String instanceName, String desiredStatus) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -67,13 +67,21 @@ public class MainMenuPage extends Page<MainMenuPage> {
     }
 
     public EditSavedFormPage clickDrafts() {
+        return clickDrafts(true);
+    }
+
+    public EditSavedFormPage clickDrafts(boolean firstOpen) {
         onView(withId(R.id.review_data)).perform(click());
-        return new EditSavedFormPage().assertOnPage();
+        return new EditSavedFormPage(firstOpen).assertOnPage();
     }
 
     public EditSavedFormPage clickDrafts(int formCount) {
+        return clickDrafts(formCount, true);
+    }
+
+    public EditSavedFormPage clickDrafts(int formCount, boolean firstOpen) {
         assertNumberOfEditableForms(formCount);
-        return clickDrafts();
+        return clickDrafts(firstOpen);
     }
 
     public MainMenuPage assertNumberOfFinalizedForms(int number) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -38,6 +38,7 @@ import androidx.loader.content.Loader;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.InstanceListCursorAdapter;
 import org.odk.collect.android.analytics.AnalyticsEvents;
@@ -63,6 +64,7 @@ import org.odk.collect.forms.Form;
 import org.odk.collect.forms.instances.Instance;
 import org.odk.collect.material.MaterialProgressDialogFragment;
 import org.odk.collect.settings.SettingsProvider;
+import org.odk.collect.settings.keys.MetaKeys;
 import org.odk.collect.strings.R.plurals;
 import org.odk.collect.strings.R.string;
 
@@ -193,6 +195,16 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
                 finalizedForms.consume();
             }
         });
+
+        if (!settingsProvider.getMetaSettings().getBoolean(MetaKeys.DRAFTS_PILLS_EDUCATION_SHOWN) && !BuildConfig.DEBUG) {
+            new MaterialAlertDialogBuilder(this)
+                    .setTitle(string.drafts_pills_education_title)
+                    .setMessage(string.drafts_pills_education_message)
+                    .setPositiveButton(string.ok, null)
+                    .show();
+
+            settingsProvider.getMetaSettings().save(MetaKeys.DRAFTS_PILLS_EDUCATION_SHOWN, true);
+        }
     }
 
     private void init() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -124,6 +124,16 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
         if (formMode == null || ApplicationConstants.FormModes.EDIT_SAVED.equalsIgnoreCase(formMode)) {
             setTitle(getString(org.odk.collect.strings.R.string.review_data));
             editMode = true;
+
+            if (!settingsProvider.getMetaSettings().getBoolean(MetaKeys.DRAFTS_PILLS_EDUCATION_SHOWN)) {
+                new MaterialAlertDialogBuilder(this)
+                        .setTitle(string.drafts_pills_education_title)
+                        .setMessage(string.drafts_pills_education_message)
+                        .setPositiveButton(string.ok, null)
+                        .show();
+
+                settingsProvider.getMetaSettings().save(MetaKeys.DRAFTS_PILLS_EDUCATION_SHOWN, true);
+            }
         } else {
             setTitle(getString(org.odk.collect.strings.R.string.view_sent_forms));
             ((TextView) findViewById(android.R.id.empty)).setText(org.odk.collect.strings.R.string.no_items_display_sent_forms);
@@ -195,16 +205,6 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
                 finalizedForms.consume();
             }
         });
-
-        if (!settingsProvider.getMetaSettings().getBoolean(MetaKeys.DRAFTS_PILLS_EDUCATION_SHOWN)) {
-            new MaterialAlertDialogBuilder(this)
-                    .setTitle(string.drafts_pills_education_title)
-                    .setMessage(string.drafts_pills_education_message)
-                    .setPositiveButton(string.ok, null)
-                    .show();
-
-            settingsProvider.getMetaSettings().save(MetaKeys.DRAFTS_PILLS_EDUCATION_SHOWN, true);
-        }
     }
 
     private void init() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -38,7 +38,6 @@ import androidx.loader.content.Loader;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
-import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.InstanceListCursorAdapter;
 import org.odk.collect.android.analytics.AnalyticsEvents;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -196,7 +196,7 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
             }
         });
 
-        if (!settingsProvider.getMetaSettings().getBoolean(MetaKeys.DRAFTS_PILLS_EDUCATION_SHOWN) && !BuildConfig.DEBUG) {
+        if (!settingsProvider.getMetaSettings().getBoolean(MetaKeys.DRAFTS_PILLS_EDUCATION_SHOWN)) {
             new MaterialAlertDialogBuilder(this)
                     .setTitle(string.drafts_pills_education_title)
                     .setMessage(string.drafts_pills_education_message)

--- a/settings/src/main/java/org/odk/collect/settings/keys/MetaKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/MetaKeys.kt
@@ -11,4 +11,5 @@ object MetaKeys {
     const val LAST_LAUNCHED = "last_launched"
     const val LAST_USED_PEN_COLOR = "last_used_pen_color"
     const val PERMISSIONS_REQUESTED = "permissions_requested"
+    const val DRAFTS_PILLS_EDUCATION_SHOWN = "drafts_pills_education_shown"
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1243,4 +1243,8 @@
 
     <!-- Message above a form draft that has been completed -->
     <string name="complete" oat:toReview="true">Complete</string>
+
+    <!-- Title and message for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
+    <string name="drafts_pills_education_title">Drafts have changed</string>
+    <string name="drafts_pills_education_message">The draft list now shows validation errors. Drafts marked with \"Errors\" are either missing required questions or have values that are not allowed. Each time you save a form as draft, its validation status is updated.</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1245,6 +1245,6 @@
     <string name="complete" oat:toReview="true">Complete</string>
 
     <!-- Title and message for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
-    <string name="drafts_pills_education_title">Drafts have changed</string>
-    <string name="drafts_pills_education_message">The draft list now shows validation errors. Drafts marked with \"Errors\" are either missing required questions or have values that are not allowed. Each time you save a form as draft, its validation status is updated.</string>
+    <string name="drafts_pills_education_title" oat:toReview="true">Drafts have changed</string>
+    <string name="drafts_pills_education_message" oat:toReview="true">The draft list now shows validation errors. Drafts marked with \"Errors\" are either missing required questions or have values that are not allowed. Each time you save a form as draft, its validation status is updated.</string>
 </resources>


### PR DESCRIPTION
The dialog currently only shows in non debug builds to avoid needing to build test infrastructure to deal with it.