### PR TITLE
Fixed displaying valid and invalid drafts on a map

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
@@ -194,7 +194,7 @@ class FormMapViewModel(
 
     private fun getDrawableIdForStatus(status: String, enlarged: Boolean): Int {
         return when (status) {
-            Instance.STATUS_INCOMPLETE -> if (enlarged) R.drawable.ic_room_form_state_incomplete_48dp else R.drawable.ic_room_form_state_incomplete_24dp
+            Instance.STATUS_INCOMPLETE, Instance.STATUS_VALID, Instance.STATUS_INVALID -> if (enlarged) R.drawable.ic_room_form_state_incomplete_48dp else R.drawable.ic_room_form_state_incomplete_24dp
             Instance.STATUS_COMPLETE -> if (enlarged) R.drawable.ic_room_form_state_complete_48dp else R.drawable.ic_room_form_state_complete_24dp
             Instance.STATUS_SUBMITTED -> if (enlarged) R.drawable.ic_room_form_state_submitted_48dp else R.drawable.ic_room_form_state_submitted_24dp
             Instance.STATUS_SUBMISSION_FAILED -> if (enlarged) R.drawable.ic_room_form_state_submission_failed_48dp else R.drawable.ic_room_form_state_submission_failed_24dp

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
@@ -127,6 +127,94 @@ class FormMapViewModelTest {
     }
 
     @Test
+    fun `valid drafts with geometry have proper icons, actions and no info`() {
+        val form = formsRepository.save(
+            FormUtils.buildForm("id", "version", TempFiles.createTempDir().absolutePath)
+                .build()
+        )
+        val instance = instancesRepository.save(
+            InstanceUtils.buildInstance(
+                form.formId,
+                form.version,
+                TempFiles.createTempDir().absolutePath
+            )
+                .geometry("{ \"coordinates\": [1.0, 2.0] }")
+                .geometryType("Point")
+                .canEditWhenComplete(true)
+                .status(Instance.STATUS_VALID)
+                .build()
+        )
+
+        val viewModel = createAndLoadViewModel(form)
+        val expectedItem = MappableSelectItem.WithAction(
+            instance.dbId,
+            2.0,
+            1.0,
+            R.drawable.ic_room_form_state_incomplete_24dp,
+            R.drawable.ic_room_form_state_incomplete_48dp,
+            instance.displayName,
+            listOf(
+                MappableSelectItem.IconifiedText(
+                    R.drawable.ic_form_state_saved,
+                    formatDate(
+                        org.odk.collect.strings.R.string.saved_on_date_at_time,
+                        instance.lastStatusChangeDate
+                    )
+                )
+            ),
+            action = MappableSelectItem.IconifiedText(
+                R.drawable.ic_edit,
+                application.getString(org.odk.collect.strings.R.string.edit_data)
+            )
+        )
+        assertThat(viewModel.getMappableItems().value!![0], equalTo(expectedItem))
+    }
+
+    @Test
+    fun `invalid drafts with geometry have proper icons, actions and no info`() {
+        val form = formsRepository.save(
+            FormUtils.buildForm("id", "version", TempFiles.createTempDir().absolutePath)
+                .build()
+        )
+        val instance = instancesRepository.save(
+            InstanceUtils.buildInstance(
+                form.formId,
+                form.version,
+                TempFiles.createTempDir().absolutePath
+            )
+                .geometry("{ \"coordinates\": [1.0, 2.0] }")
+                .geometryType("Point")
+                .canEditWhenComplete(true)
+                .status(Instance.STATUS_INVALID)
+                .build()
+        )
+
+        val viewModel = createAndLoadViewModel(form)
+        val expectedItem = MappableSelectItem.WithAction(
+            instance.dbId,
+            2.0,
+            1.0,
+            R.drawable.ic_room_form_state_incomplete_24dp,
+            R.drawable.ic_room_form_state_incomplete_48dp,
+            instance.displayName,
+            listOf(
+                MappableSelectItem.IconifiedText(
+                    R.drawable.ic_form_state_saved,
+                    formatDate(
+                        org.odk.collect.strings.R.string.saved_on_date_at_time,
+                        instance.lastStatusChangeDate
+                    )
+                )
+            ),
+            action = MappableSelectItem.IconifiedText(
+                R.drawable.ic_edit,
+                application.getString(org.odk.collect.strings.R.string.edit_data)
+            )
+        )
+        assertThat(viewModel.getMappableItems().value!![0], equalTo(expectedItem))
+    }
+
+    @Test
     fun `finalized instances with geometry have view action and no info`() {
         val form = formsRepository.save(
             FormUtils.buildForm("id", "version", TempFiles.createTempDir().absolutePath)


### PR DESCRIPTION
Closes #5783

#### Why is this the best possible solution? Were any other approaches considered?
I've updated the method responsible for returning map icons based on the status. Both `valid` and `invalid` drafts are displayed in the same way like `incomplete` ones before (with a blue icon).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is a small change so testing the scenario described in the issue should be enough. However, there might be also other similar issues caused by introducing new instance statuses (`valid` and `invalid`) so be careful.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
