### PR TITLE
Block closing the notification permission dialog by tapping outside the bounds

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -158,13 +158,6 @@ object AnalyticsEvents {
     const val TEXT_NUMBER_WIDGET_WITH_THOUSANDS_SEPARATOR = "TextNumberWidgetWithThousandsSeparator"
 
     /**
-     * Tracks how many users cancel the permission dialog vs how many go through the permissions
-     * request flow.
-     */
-    const val PERMISSIONS_DIALOG_CANCEL = "PermissionsDialogCancel"
-    const val PERMISSIONS_DIALOG_OK = "PermissionsDialogOK"
-
-    /**
      * Tracks how often a form is finalized using a `ref` attribute on the `submission` element
      */
     const val PARTIAL_FORM_FINALIZED = "PartialFormFinalized"

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -1,7 +1,6 @@
 package org.odk.collect.android.mainmenu
 
 import android.app.Dialog
-import android.content.DialogInterface
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.RequiresApi
@@ -9,7 +8,6 @@ import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
-import org.odk.collect.android.analytics.AnalyticsEvents.PERMISSIONS_DIALOG_CANCEL
 import org.odk.collect.android.analytics.AnalyticsEvents.PERMISSIONS_DIALOG_OK
 import org.odk.collect.permissions.PermissionListener
 import org.odk.collect.permissions.PermissionsProvider
@@ -39,10 +37,5 @@ class PermissionsDialogFragment(
                 )
             }
             .create()
-    }
-
-    override fun onCancel(dialog: DialogInterface) {
-        Analytics.log(PERMISSIONS_DIALOG_CANCEL)
-        requestPermissionsViewModel.permissionsRequested()
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -21,6 +21,8 @@ class PermissionsDialogFragment(
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        isCancelable = false
+
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(org.odk.collect.strings.R.string.permission_dialog_title)
             .setView(R.layout.permissions_dialog_layout)

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -6,9 +6,7 @@ import android.os.Bundle
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
-import org.odk.collect.android.analytics.AnalyticsEvents.PERMISSIONS_DIALOG_OK
 import org.odk.collect.permissions.PermissionListener
 import org.odk.collect.permissions.PermissionsProvider
 
@@ -25,8 +23,6 @@ class PermissionsDialogFragment(
             .setTitle(org.odk.collect.strings.R.string.permission_dialog_title)
             .setView(R.layout.permissions_dialog_layout)
             .setPositiveButton(org.odk.collect.strings.R.string.ok) { _, _ ->
-                Analytics.log(PERMISSIONS_DIALOG_OK)
-
                 requestPermissionsViewModel.permissionsRequested()
                 permissionsProvider.requestPermissions(
                     requireActivity(),

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.android.mainmenu
 
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -54,14 +53,6 @@ class PermissionsDialogFragmentTest {
         launcherRule.launch(PermissionsDialogFragment::class.java)
 
         onView(withText(org.odk.collect.strings.R.string.ok)).inRoot(isDialog()).perform(click())
-        verify(requestPermissionsViewModel).permissionsRequested()
-    }
-
-    @Test
-    fun dismissing_callsPermissionRequested() {
-        launcherRule.launch(PermissionsDialogFragment::class.java)
-
-        Espresso.pressBack()
         verify(requestPermissionsViewModel).permissionsRequested()
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
@@ -70,4 +70,12 @@ class PermissionsDialogFragmentTest {
         launcherRule.launch(PermissionsDialogFragment::class.java).recreate()
         verify(requestPermissionsViewModel, never()).permissionsRequested()
     }
+
+    @Test
+    fun `The dialog should not be dismissed after clicking out of its area or on device back button`() {
+        val scenario = launcherRule.launch(PermissionsDialogFragment::class.java)
+        scenario.onFragment {
+            assertThat(it.isCancelable, equalTo(false))
+        }
+    }
 }


### PR DESCRIPTION
Closes #5758

#### Why is this the best possible solution? Were any other approaches considered?
I think one way of closing the dialog (by clicking the ok button) is enough and we should block closing it by tapping outside the bounds. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing the dialog should be enough. Other parts of the app should not be affected. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
