### PR TITLE
Revert 'Do not mark forms as failed to send before sending' in v2023.3

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
@@ -88,6 +88,8 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
     @Override
     public String uploadOneSubmission(Instance instance, String spreadsheetUrl) throws FormUploadException {
+        markSubmissionFailed(instance);
+
         File instanceFile = new File(instance.getInstanceFilePath());
         if (!instanceFile.exists()) {
             throw new FormUploadException(FAIL + "instance XML file does not exist!");
@@ -103,7 +105,6 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
             Form form = forms.get(0);
             if (form.getBASE64RSAPublicKey() != null) {
-                markSubmissionFailed(instance);
                 throw new FormUploadException(getLocalizedString(Collect.getInstance(), org.odk.collect.strings.R.string.google_sheets_encrypted_message));
             }
 
@@ -121,7 +122,6 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             }
             insertRows(instance, instanceElement, null, key, instanceFile, spreadsheet.getSheets().get(0).getProperties().getTitle());
         } catch (GoogleJsonResponseException e) {
-            markSubmissionFailed(instance);
             throw new FormUploadException(getErrorMessageFromGoogleJsonResponseException(e));
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
@@ -111,7 +111,7 @@ class MainMenuViewModel(
         return if (instance != null) {
             val message = if (instance.isDraft()) {
                 org.odk.collect.strings.R.string.form_saved_as_draft
-            } else if (instance.status == Instance.STATUS_COMPLETE) {
+            } else if (instance.status == Instance.STATUS_COMPLETE || instance.status == Instance.STATUS_SUBMISSION_FAILED) {
                 val form = formsRepositoryProvider.get().getAllByFormIdAndVersion(instance.formId, instance.formVersion).first()
                 if (form.shouldFormBeSentAutomatically(autoSendSettingsProvider.isAutoSendEnabledInSettings())) {
                     org.odk.collect.strings.R.string.form_sending

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuViewModelTest.kt
@@ -291,7 +291,7 @@ class MainMenuViewModelTest {
     }
 
     @Test
-    fun `getFormSavedSnackbarDetails should return null when the corresponding instance failed to sent`() {
+    fun `getFormSavedSnackbarDetails should return proper message and action when the corresponding instance failed to sent`() {
         val viewModel = createViewModelWithVersion("")
 
         formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
@@ -307,8 +307,9 @@ class MainMenuViewModelTest {
         whenever(autoSendSettingsProvider.isAutoSendEnabledInSettings()).thenReturn(true)
 
         val uri = InstancesContract.getUri(Project.DEMO_PROJECT_ID, instance.dbId)
-        val formSavedSnackbarDetails = viewModel.getFormSavedSnackbarDetails(uri)
-        assertThat(formSavedSnackbarDetails, equalTo(null))
+        val formSavedSnackbarDetails = viewModel.getFormSavedSnackbarDetails(uri)!!
+        assertThat(formSavedSnackbarDetails.first, equalTo(org.odk.collect.strings.R.string.form_sending))
+        assertThat(formSavedSnackbarDetails.second, equalTo(org.odk.collect.strings.R.string.view_form))
     }
 
     private fun createViewModelWithVersion(version: String): MainMenuViewModel {


### PR DESCRIPTION
Closes #5790 

#### Why is this the best possible solution? Were any other approaches considered?
In https://github.com/getodk/collect/pull/5609 we removed marking forms as failed before sending them to avoid editing (this was a workaround) because we blocked editing finalized forms. Recently we have introduced the grace period and because of that wee need the workaround again.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test the scenario described in the issue in the same way https://github.com/getodk/collect/pull/5688 has been tested.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
