### PR TITLE
Migrate old finalize key correctly

### DIFF
--- a/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsMigrator.java
+++ b/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsMigrator.java
@@ -155,17 +155,17 @@ public class ODKAppSettingsMigrator implements SettingsMigrator {
                         .withValues(false, false)
                         .toPairs(
                                 ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, true,
-                                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, false
+                                "finalize", false
                         )
                         .withValues(false, true)
                         .toPairs(
                                 ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, false,
-                                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, true
+                                "finalize", true
                         )
                         .withValues(false, null)
                         .toPairs(
                                 ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, false,
-                                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, true
+                                "finalize", true
                         ),
                 removeKey("mark_as_finalized"),
                 removeKey("default_completed"),
@@ -173,12 +173,17 @@ public class ODKAppSettingsMigrator implements SettingsMigrator {
                         .withValues(false)
                         .toPairs(
                                 ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, false,
-                                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, true
+                                "finalize", true
                         ),
                 updateKeys("finalize").withValues(false)
                         .toPairs(
                                 ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, false,
                                 ProtectedProjectKeys.KEY_BULK_FINALIZE, false
+                        )
+                        .withValues(true)
+                        .toPairs(
+                                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, true,
+                                ProtectedProjectKeys.KEY_BULK_FINALIZE, true
                         ),
                 removeKey("finalize")
         );

--- a/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsMigratorTest.java
+++ b/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsMigratorTest.java
@@ -260,7 +260,11 @@ public class ODKAppSettingsMigratorTest {
 
         runMigrations();
 
-        assertSettings(protectedSettings, ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, true, ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, false);
+        assertSettings(protectedSettings,
+                ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, true,
+                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, false,
+                ProtectedProjectKeys.KEY_BULK_FINALIZE, false
+        );
 
         assertThat(protectedSettings.contains("mark_as_finalized"), equalTo(false));
         assertThat(protectedSettings.contains("default_completed"), equalTo(false));
@@ -273,7 +277,11 @@ public class ODKAppSettingsMigratorTest {
 
         runMigrations();
 
-        assertSettings(protectedSettings, ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, false, ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, true);
+        assertSettings(protectedSettings,
+                ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, false,
+                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, true,
+                ProtectedProjectKeys.KEY_BULK_FINALIZE, true
+        );
 
         assertThat(protectedSettings.contains("mark_as_finalized"), equalTo(false));
         assertThat(protectedSettings.contains("default_completed"), equalTo(false));
@@ -285,7 +293,11 @@ public class ODKAppSettingsMigratorTest {
 
         runMigrations();
 
-        assertSettings(protectedSettings, ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, false, ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, true);
+        assertSettings(protectedSettings,
+                ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, false,
+                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, true,
+                ProtectedProjectKeys.KEY_BULK_FINALIZE, true
+        );
 
         assertThat(protectedSettings.contains("mark_as_finalized"), equalTo(false));
         assertThat(protectedSettings.contains("default_completed"), equalTo(false));
@@ -322,7 +334,7 @@ public class ODKAppSettingsMigratorTest {
         initSettings(protectedSettings,
                 ProtectedProjectKeys.ALLOW_OTHER_WAYS_OF_EDITING_FORM, false,
                 ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, true,
-                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, false
+                "finalize", false
         );
 
         runMigrations();
@@ -338,7 +350,7 @@ public class ODKAppSettingsMigratorTest {
         initSettings(protectedSettings,
                 ProtectedProjectKeys.ALLOW_OTHER_WAYS_OF_EDITING_FORM, true,
                 ProtectedProjectKeys.KEY_SAVE_AS_DRAFT, true,
-                ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY, false
+                "finalize", false
         );
 
         runMigrations();
@@ -365,6 +377,20 @@ public class ODKAppSettingsMigratorTest {
         initSettings(protectedSettings, "finalize", false);
 
         runMigrations();
+
+        assertThat(protectedSettings.contains(ProtectedProjectKeys.KEY_BULK_FINALIZE), equalTo(true));
+        assertThat(protectedSettings.getBoolean(ProtectedProjectKeys.KEY_BULK_FINALIZE), equalTo(false));
+    }
+
+    @Test
+    public void whenMarkAsFinalizeAndDefaultCompletedWereDisabled_disablesWaysToFinalize() {
+        initSettings(protectedSettings, "mark_as_finalized", false);
+        initSettings(unprotectedSettings, "default_completed", false);
+
+        runMigrations();
+
+        assertThat(protectedSettings.contains(ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY), equalTo(true));
+        assertThat(protectedSettings.getBoolean(ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY), equalTo(false));
 
         assertThat(protectedSettings.contains(ProtectedProjectKeys.KEY_BULK_FINALIZE), equalTo(true));
         assertThat(protectedSettings.getBoolean(ProtectedProjectKeys.KEY_BULK_FINALIZE), equalTo(false));

--- a/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsMigratorTest.java
+++ b/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsMigratorTest.java
@@ -382,20 +382,6 @@ public class ODKAppSettingsMigratorTest {
         assertThat(protectedSettings.getBoolean(ProtectedProjectKeys.KEY_BULK_FINALIZE), equalTo(false));
     }
 
-    @Test
-    public void whenMarkAsFinalizeAndDefaultCompletedWereDisabled_disablesWaysToFinalize() {
-        initSettings(protectedSettings, "mark_as_finalized", false);
-        initSettings(unprotectedSettings, "default_completed", false);
-
-        runMigrations();
-
-        assertThat(protectedSettings.contains(ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY), equalTo(true));
-        assertThat(protectedSettings.getBoolean(ProtectedProjectKeys.KEY_FINALIZE_IN_FORM_ENTRY), equalTo(false));
-
-        assertThat(protectedSettings.contains(ProtectedProjectKeys.KEY_BULK_FINALIZE), equalTo(true));
-        assertThat(protectedSettings.getBoolean(ProtectedProjectKeys.KEY_BULK_FINALIZE), equalTo(false));
-    }
-
     private void runMigrations() {
         new ODKAppSettingsMigrator(metaSettings).migrate(unprotectedSettings, protectedSettings);
     }


### PR DESCRIPTION
Closes #5788

#### Why is this the best possible solution? Were any other approaches considered?

The problem was just that older migrations were migration straight to the new "finalize in form entry" setting rather than to the old "finalize" (which would then have the newer migrations run on it).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I've only made changes to settings migrations here, so focusing on that will be fine.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
