### PR TITLE
Improvements around new statuses used by drafts in v2023.3

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -19,7 +19,6 @@ import static org.odk.collect.android.utilities.ApplicationConstants.SortingOrde
 import static org.odk.collect.android.utilities.ApplicationConstants.SortingOrder.BY_NAME_ASC;
 import static org.odk.collect.android.utilities.ApplicationConstants.SortingOrder.BY_NAME_DESC;
 
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -32,7 +31,6 @@ import android.widget.Toast;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
@@ -79,8 +77,6 @@ import javax.inject.Inject;
 public class InstanceChooserList extends AppListActivity implements AdapterView.OnItemClickListener, LoaderManager.LoaderCallbacks<Cursor> {
     private static final String INSTANCE_LIST_ACTIVITY_SORTING_ORDER = "instanceListActivitySortingOrder";
     private static final String VIEW_SENT_FORM_SORTING_ORDER = "ViewSentFormSortingOrder";
-
-    private static final boolean DO_NOT_EXIT = false;
 
     private boolean editMode;
 
@@ -205,22 +201,6 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
                     setResult(RESULT_OK, new Intent().setData(instanceUri));
                     finish();
                 } else {
-                    // the form can be edited if it is incomplete or if, when it was
-                    // marked as complete, it was determined that it could be edited
-                    // later.
-                    String status = c.getString(c.getColumnIndex(DatabaseInstanceColumns.STATUS));
-                    String strCanEditWhenComplete =
-                            c.getString(c.getColumnIndex(DatabaseInstanceColumns.CAN_EDIT_WHEN_COMPLETE));
-
-                    boolean canEdit = status.equals(Instance.STATUS_INCOMPLETE)
-                            || status.equals(Instance.STATUS_INVALID)
-                            || status.equals(Instance.STATUS_VALID)
-                            || Boolean.parseBoolean(strCanEditWhenComplete);
-                    if (!canEdit) {
-                        createErrorDialog(getString(org.odk.collect.strings.R.string.cannot_edit_completed_form),
-                                DO_NOT_EXIT);
-                        return;
-                    }
                     // caller wants to view/edit a form, so launch FormFillingActivity
                     Intent parentIntent = this.getIntent();
                     Intent intent = new Intent(this, FormUriActivity.class);
@@ -297,26 +277,6 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
     @Override
     public void onLoaderReset(@NonNull Loader loader) {
         listAdapter.swapCursor(null);
-    }
-
-    private void createErrorDialog(String errorMsg, final boolean shouldExit) {
-        AlertDialog alertDialog = new MaterialAlertDialogBuilder(this).create();
-        alertDialog.setMessage(errorMsg);
-        DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int i) {
-                switch (i) {
-                    case DialogInterface.BUTTON_POSITIVE:
-                        if (shouldExit) {
-                            finish();
-                        }
-                        break;
-                }
-            }
-        };
-        alertDialog.setCancelable(false);
-        alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(org.odk.collect.strings.R.string.ok), errorListener);
-        alertDialog.show();
     }
 
     protected String getSortingOrder() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -213,6 +213,8 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
                             c.getString(c.getColumnIndex(DatabaseInstanceColumns.CAN_EDIT_WHEN_COMPLETE));
 
                     boolean canEdit = status.equals(Instance.STATUS_INCOMPLETE)
+                            || status.equals(Instance.STATUS_INVALID)
+                            || status.equals(Instance.STATUS_VALID)
                             || Boolean.parseBoolean(strCanEditWhenComplete);
                     if (!canEdit) {
                         createErrorDialog(getString(org.odk.collect.strings.R.string.cannot_edit_completed_form),

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -252,7 +252,7 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
         Form form = formsRepositoryProvider.get().getLatestByFormIdAndVersion(formId, version);
         String formTitle = form != null ? form.getDisplayName() : "";
 
-        if (status.equals(Instance.STATUS_INCOMPLETE)) {
+        if (status.equals(Instance.STATUS_INCOMPLETE) || status.equals(Instance.STATUS_INVALID) || status.equals(Instance.STATUS_VALID)) {
             AnalyticsUtils.logFormEvent(AnalyticsEvents.EDIT_NON_FINALIZED_FORM, formId, formTitle);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -30,22 +30,26 @@ object InstanceListItemView {
 
         val pill = view.findViewById<MaterialPill>(R.id.chip)
         if (pill != null) {
-            if (instance.status == Instance.STATUS_INVALID || instance.status == Instance.STATUS_INCOMPLETE) {
-                pill.visibility = View.VISIBLE
-                pill.setIcon(R.drawable.baseline_rule_24)
-                pill.setText(string.draft_errors)
-                pill.setPillBackgroundColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorErrorContainer))
-                pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
-                pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
-            } else if (instance.status == Instance.STATUS_VALID) {
-                pill.visibility = View.VISIBLE
-                pill.setIcon(R.drawable.baseline_check_24)
-                pill.setText(string.draft_no_errors)
-                pill.setPillBackgroundColor(getThemeAttributeValue(context, R.attr.colorSurfaceContainerHighest))
-                pill.setTextColor(getThemeAttributeValue(context, R.attr.colorOnSurfaceContainerHighest))
-                pill.setIconTint(getThemeAttributeValue(context, R.attr.colorOnSurfaceContainerHighest))
-            } else {
-                pill.visibility = View.GONE
+            when (instance.status) {
+                Instance.STATUS_INVALID, Instance.STATUS_INCOMPLETE -> {
+                    pill.visibility = View.VISIBLE
+                    pill.setIcon(R.drawable.baseline_rule_24)
+                    pill.setText(string.draft_errors)
+                    pill.setPillBackgroundColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorErrorContainer))
+                    pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
+                    pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
+                }
+                Instance.STATUS_VALID -> {
+                    pill.visibility = View.VISIBLE
+                    pill.setIcon(R.drawable.baseline_check_24)
+                    pill.setText(string.draft_no_errors)
+                    pill.setPillBackgroundColor(getThemeAttributeValue(context, R.attr.colorSurfaceContainerHighest))
+                    pill.setTextColor(getThemeAttributeValue(context, R.attr.colorOnSurfaceContainerHighest))
+                    pill.setIconTint(getThemeAttributeValue(context, R.attr.colorOnSurfaceContainerHighest))
+                }
+                else -> {
+                    pill.visibility = View.GONE
+                }
             }
         }
 


### PR DESCRIPTION
This pr does not fix anything important but adds some improvements that should be included in v2023.3. I've investigated the places in the app where draft statuses are used and did not discover anything apart from: https://github.com/getodk/collect/issues/5798 so this pr with improvements should be the last fix

#### Why is this the best possible solution? Were any other approaches considered?
The only thing of note is the fix for opening editable instances: https://github.com/getodk/collect/commit/43071e0140e4ad266d1fca398d6b058713e4d817
It worked well but only because of the fact that `strCanEditWhenComplete` is always true for drafts. In the future, if we remove it we could introduce regression easily.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
