### PR TITLE
Protect GeoJSONFeature from ProGuard alterations

### DIFF
--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -14,6 +14,8 @@
 -keep class org.odk.collect.android.logic.actions.**
 -keep class android.support.v7.widget.** { *; }
 -keep class org.mp4parser.boxes.** { *; }
+-keep class org.javarosa.core.model.instance.geojson.GeojsonFeature { *; }
+-keep class org.javarosa.core.model.instance.geojson.GeojsonGeometry { *; }
 -keepclassmembers class * {
   @com.google.api.client.util.Key <fields>;
 }


### PR DESCRIPTION
Closes #5812 

#### Why is this the best possible solution? Were any other approaches considered?
We use `com.fasterxml.jackson` in javarosa to map geojson files into java classes. One of those classes is `GeoJSONFeature` class with its `private Map<String, String> properties`  field. So properties are pairs where both keys and values should be strings. When it comes to keys it's not a problem because in geojson they are always just strings but values could be integers for example:
`"properties": { "_uid_": 1,...`
`com.fasterxml.jackson` takes care of that and automatically converts those values into strings because that's what we expect `private Map<String, String> properties`. However, if minification is enabled ProGuard messes up with that class disabling that conversion. 
The fix is to let ProGuard know that this class should be intact.

Another solution would be to change `private Map<String, String> properties` to `private Map<String, Object> properties` and always programmatically convert those object values to strings. However, if `com.fasterxml.jackson` does that for us (if ProGuard does not break it) we should still take advantage of it I guess.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing the form shared on the forum (see the issue) should be enough. I can't be sure that we don't have other issues like this one caused by proguard but the fix itself is safe so we can focus on testing the described scenario.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
