### PR TITLE
Fallback to Material 2 OutlinedButton on API 22

### DIFF
--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -90,7 +90,7 @@ the specific language governing permissions and limitations under the License.
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/save_as_draft"
-                style="@style/Widget.Material3.Button.OutlinedButton"
+                style="@style/Widget.Collect.Material3.Button.OutlinedButton"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@string/save_as_draft"

--- a/collect_app/src/main/res/layout/quit_form_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/quit_form_dialog_layout.xml
@@ -21,7 +21,7 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/discard_changes"
-            style="@style/Widget.Material3.Button.OutlinedButton.Icon"
+            style="@style/Widget.Collect.Material3.Button.OutlinedButton.Icon"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_marginTop="@dimen/margin"
@@ -35,7 +35,7 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/keep_editing_outlined"
-            style="@style/Widget.Material3.Button.OutlinedButton.Icon"
+            style="@style/Widget.Collect.Material3.Button.OutlinedButton.Icon"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_marginTop="@dimen/margin_small"

--- a/collect_app/src/main/res/values-v23/outlined_button.xml
+++ b/collect_app/src/main/res/values-v23/outlined_button.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Widget.Collect.Material3.Button.OutlinedButton" parent="Widget.Material3.Button.OutlinedButton"></style>
+
+    <style name="Widget.Collect.Material3.Button.OutlinedButton.Icon" parent="Widget.Material3.Button.OutlinedButton.Icon"></style>
+</resources>

--- a/collect_app/src/main/res/values/outlined_button.xml
+++ b/collect_app/src/main/res/values/outlined_button.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Material3.Button.OutlinedButton` doesn't work properly on older API levels (22 and under) without a Material 3 theme so we fall back to Material 2 -->
+    <style name="Widget.Collect.Material3.Button.OutlinedButton" parent="Widget.MaterialComponents.Button.OutlinedButton"></style>
+
+    <style name="Widget.Collect.Material3.Button.OutlinedButton.Icon" parent="Widget.MaterialComponents.Button.OutlinedButton"></style>
+</resources>


### PR DESCRIPTION
Closes #5582

The problem was also now visible for the buttons shown in the quit form dialog so we wanted to see if there was anything quick we could do to fix it.

#### Why is this the best possible solution? Were any other approaches considered?

I've checked the problem on `master` and, as I hoped, the problem is fixed there (most likely because we're using a Material 3 theme and the latest Material Components version). We don't want to make that level of change for v2023.3 though -  I've made it so that the buttons fallback to using the Material 2 `OutlinedButton` style for API < 22. This doesn't look amazing, but it's far better than not being able to read the text in the button. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue. It'd be good to have a quick hunt for any other unreadable buttons/controls.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
