### PR TITLE
Use recommended OSM tile URL

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapConfiguratorProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapConfiguratorProvider.java
@@ -81,9 +81,7 @@ public class MapConfiguratorProvider {
                 new OsmDroidMapConfigurator(
                         new WebMapService(
                                 "Mapnik", 0, 19, 256, OSM_COPYRIGHT,
-                                "http://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-                                "http://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-                                "http://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                                "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
                         )
                 )
         ));


### PR DESCRIPTION
Supports HTTP/2 and HTTP/3 so aliases are no longer required to support connection concurrency

#### Why is this the best possible solution? Were any other approaches considered?
This is what https://github.com/openstreetmap/operations/issues/737 recommends. I verified I could launch a map with OSM tiles.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Worst case is that OSM tiles stop working.

#### Do we need any specific form for testing your changes? If so, please attach one.
No. Can use the filled form map.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
