### PR TITLE
Only load dynamic preload data when needed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/DynamicPreloadXFormParserFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/DynamicPreloadXFormParserFactory.kt
@@ -1,11 +1,13 @@
 package org.odk.collect.android.dynamicpreload
 
 import org.javarosa.core.model.FormDef
+import org.javarosa.core.model.QuestionDef
 import org.javarosa.core.util.externalizable.ExtUtil
 import org.javarosa.core.util.externalizable.Externalizable
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.xform.parse.IXFormParserFactory
 import org.javarosa.xform.parse.XFormParser
+import org.javarosa.xpath.expr.XPathExpression
 import java.io.DataInputStream
 import java.io.DataOutputStream
 
@@ -19,10 +21,28 @@ class DynamicPreloadXFormParserFactory(base: IXFormParserFactory) :
     }
 }
 
-class DynamicPreloadParseProcessor : XFormParser.FormDefProcessor {
+class DynamicPreloadParseProcessor :
+    XFormParser.XPathProcessor,
+    XFormParser.QuestionProcessor,
+    XFormParser.FormDefProcessor {
+
+    private var containsPullData = false
+    private var containsSearch = false
+
+    override fun processXPath(xPathExpression: XPathExpression) {
+        if (xPathExpression.containsFunc("pulldata")) {
+            containsPullData = true
+        }
+    }
+
+    override fun processQuestion(question: QuestionDef) {
+        if (ExternalDataUtil.getSearchXPathExpression(question.appearanceAttr) != null) {
+            containsSearch = true
+        }
+    }
 
     override fun processFormDef(formDef: FormDef) {
-        formDef.extras.put(DynamicPreloadExtra(true))
+        formDef.extras.put(DynamicPreloadExtra(containsPullData || containsSearch))
     }
 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/DynamicPreloadXFormParserFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/DynamicPreloadXFormParserFactory.kt
@@ -30,12 +30,20 @@ class DynamicPreloadParseProcessor :
     private var containsSearch = false
 
     override fun processXPath(xPathExpression: XPathExpression) {
+        if (containsPullData) {
+            return // No need to search if we already found pulldata
+        }
+
         if (xPathExpression.containsFunc("pulldata")) {
             containsPullData = true
         }
     }
 
     override fun processQuestion(question: QuestionDef) {
+        if (containsSearch) {
+            return // No need to search if we already found search
+        }
+
         if (ExternalDataUtil.getSearchXPathExpression(question.appearanceAttr) != null) {
             containsSearch = true
         }

--- a/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/DynamicPreloadParseProcessorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/DynamicPreloadParseProcessorTest.kt
@@ -3,24 +3,75 @@ package org.odk.collect.android.dynamicpreload
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.javarosa.core.model.FormDef
+import org.javarosa.core.model.QuestionDef
+import org.javarosa.xpath.expr.XPathExpression
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 class DynamicPreloadParseProcessorTest {
 
     private val processor = DynamicPreloadParseProcessor()
 
-    /**
-     * This is currently a "stub" implementation until we have a good way of determining whether
-     * a form contains search/pulldata.
-     */
     @Test
-    fun `usesDynamicPreload is true`() {
+    fun `usesDynamicPreload is false when xpath does not contain pulldata`() {
         val formDef = FormDef()
 
+        processor.processXPath(createNonPullDataExpression())
+        processor.processFormDef(formDef)
+        assertThat(
+            formDef.extras.get(DynamicPreloadExtra::class.java).usesDynamicPreload,
+            equalTo(false)
+        )
+    }
+
+    @Test
+    fun `usesDynamicPreload is true when xpath does contain pulldata`() {
+        val formDef = FormDef()
+
+        processor.processXPath(createPullDataExpression())
         processor.processFormDef(formDef)
         assertThat(
             formDef.extras.get(DynamicPreloadExtra::class.java).usesDynamicPreload,
             equalTo(true)
         )
+    }
+
+    @Test
+    fun `usesDynamicPreload is false when question appearance does not contain search`() {
+        val formDef = FormDef()
+
+        processor.processQuestion(createQuestion(appearance = "minimal"))
+        processor.processFormDef(formDef)
+        assertThat(
+            formDef.extras.get(DynamicPreloadExtra::class.java).usesDynamicPreload,
+            equalTo(false)
+        )
+    }
+
+    @Test
+    fun `usesDynamicPreload is true when question appearance does contain search`() {
+        val formDef = FormDef()
+
+        processor.processQuestion(createQuestion(appearance = "search('fruits')"))
+        processor.processFormDef(formDef)
+        assertThat(
+            formDef.extras.get(DynamicPreloadExtra::class.java).usesDynamicPreload,
+            equalTo(true)
+        )
+    }
+
+    private fun createNonPullDataExpression() = mock<XPathExpression> {
+        on { containsFunc("pulldata") } doReturn false
+    }
+
+    private fun createPullDataExpression() = mock<XPathExpression> {
+        on { containsFunc("pulldata") } doReturn true
+    }
+
+    private fun createQuestion(appearance: String): QuestionDef {
+        return mock() {
+            on { appearanceAttr } doReturn appearance
+        }
     }
 }


### PR DESCRIPTION
Closes #5620
~~Blocked by #5665~~
~~Blocked by getodk/javarosa#733~~

Uses the newly added `XFormParser.XPathProcessor` to detect `pulldata` or `search` in forms and only if they are present create the database needed for them.

#### Why is this the best possible solution? Were any other approaches considered?

This is a direct follow on from #5665 where most of the structure was defined - all I've done here is integrate `XFormParser.XPathProcessor` to properly implement `DynamicPreloadParseProcessor`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users should no longer see the "Pre-loading data from" loading state when opening a form with a secondary instance for the first time **unless** it contains a `pulldata` or `search` function. It'd be good to test forms with and without these functions to check that everything works as expected, and that the first load is now faster for forms that don't include `search`/`pulldata`.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
