### PR TITLE
Fix multi select widget with no-buttons appearance

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
@@ -137,6 +137,10 @@ public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
             }
             playAudio(selection.choice);
         }
+
+        if (listener != null) {
+            listener.onItemClicked();
+        }
     }
 
     public void addItem(Selection item) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneWidgetTest.java
@@ -43,6 +43,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.QuestionTextSizeHelper;
 import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.listeners.AdvanceToNextListener;
+import org.odk.collect.android.listeners.WidgetValueChangedListener;
 import org.odk.collect.android.support.CollectHelpers;
 import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.utilities.Appearances;
@@ -285,6 +286,45 @@ public class SelectOneWidgetTest extends GeneralSelectOneWidgetTest<SelectOneWid
 
         FrameLayout view = (FrameLayout) getSpyWidget().binding.choicesRecyclerView.getLayoutManager().getChildAt(0);
         assertThat(view.isEnabled(), is(Boolean.FALSE));
+    }
+
+    @Test
+    public void clickingItem_callsValueChangedListener() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withIndex("i am index")
+                .withSelectChoices(asList(
+                        new SelectChoice("1", "1"),
+                        new SelectChoice("2", "2")
+                ))
+                .build();
+
+        SelectOneWidget widget = getWidget();
+        WidgetValueChangedListener valueChangedListener = mock();
+        widget.setValueChangedListener(valueChangedListener);
+        populateRecyclerView(widget);
+
+        ((AudioVideoImageTextLabel) getWidget().binding.choicesRecyclerView.getChildAt(0)).getLabelTextView().performClick();
+        verify(valueChangedListener).widgetValueChanged(widget);
+    }
+
+    @Test
+    public void whenPromptHasNoButtonsAppearance_clickingItem_callsValueChangedListener() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withIndex("i am index")
+                .withAppearance("no-buttons")
+                .withSelectChoices(asList(
+                        new SelectChoice("1", "1"),
+                        new SelectChoice("2", "2")
+                ))
+                .build();
+
+        SelectOneWidget widget = getWidget();
+        WidgetValueChangedListener valueChangedListener = mock();
+        widget.setValueChangedListener(valueChangedListener);
+        populateRecyclerView(widget);
+
+        getWidget().binding.choicesRecyclerView.getChildAt(0).performClick();
+        verify(valueChangedListener).widgetValueChanged(widget);
     }
 
     private void overrideDependencyModule() throws Exception {


### PR DESCRIPTION
Closes #5821

#### Why is this the best possible solution? Were any other approaches considered?

All widget implementations need to call `widgetValueChanged()` whenever their state changes for things like field list calculations to work and the call was simply missing in this case.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't change anything other than fixing the issue! It'd be good to have a quick poke around with other appearance combos for widgets in general to see if we can find any other problematic ones.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
