### PR TITLE
Updated messages displayed in empty lists

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
@@ -120,7 +120,7 @@ public class FillBlankFormPage extends Page<FillBlankFormPage> {
     }
 
     public FillBlankFormPage assertNoForms() {
-        assertText(org.odk.collect.strings.R.string.empty_list_title);
+        assertText(org.odk.collect.strings.R.string.empty_list_of_blank_forms_title);
         return this;
     }
 }

--- a/collect_app/src/main/res/layout/activity_blank_form_list.xml
+++ b/collect_app/src/main/res/layout/activity_blank_form_list.xml
@@ -17,5 +17,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:icon="@drawable/ic_baseline_note_72"
-        app:title="@string/empty_list_title"/>
+        app:title="@string/empty_list_of_blank_forms_title"
+        app:subtitle="@string/empty_list_of_blank_forms_subtitle"/>
 </LinearLayout>

--- a/collect_app/src/main/res/layout/delete_blank_form_layout.xml
+++ b/collect_app/src/main/res/layout/delete_blank_form_layout.xml
@@ -16,7 +16,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:icon="@drawable/ic_baseline_delete_72"
-        app:title="@string/empty_list_title"/>
+        app:title="@string/empty_list_of_forms_to_delete_title"
+        app:subtitle="@string/empty_list_of_forms_to_delete_subtitle"/>
 
     <LinearLayout
         android:id="@+id/buttons"

--- a/collect_app/src/main/res/layout/delete_blank_form_layout.xml
+++ b/collect_app/src/main/res/layout/delete_blank_form_layout.xml
@@ -17,7 +17,7 @@
         android:layout_height="match_parent"
         app:icon="@drawable/ic_baseline_delete_72"
         app:title="@string/empty_list_of_forms_to_delete_title"
-        app:subtitle="@string/empty_list_of_forms_to_delete_subtitle"/>
+        app:subtitle="@string/empty_list_of_blank_forms_to_delete_subtitle"/>
 
     <LinearLayout
         android:id="@+id/buttons"

--- a/collect_app/src/main/res/layout/file_manager_list.xml
+++ b/collect_app/src/main/res/layout/file_manager_list.xml
@@ -32,7 +32,7 @@ the License.
         android:layout_height="match_parent"
         app:icon="@drawable/ic_baseline_delete_72"
         app:title="@string/empty_list_of_forms_to_delete_title"
-        app:subtitle="@string/empty_list_of_forms_to_delete_subtitle"/>
+        app:subtitle="@string/empty_list_of_saved_forms_to_delete_subtitle"/>
 
     <LinearLayout
         android:id="@+id/buttons"

--- a/collect_app/src/main/res/layout/file_manager_list.xml
+++ b/collect_app/src/main/res/layout/file_manager_list.xml
@@ -31,7 +31,8 @@ the License.
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:icon="@drawable/ic_baseline_delete_72"
-        app:title="@string/empty_list_title"/>
+        app:title="@string/empty_list_of_forms_to_delete_title"
+        app:subtitle="@string/empty_list_of_forms_to_delete_subtitle"/>
 
     <LinearLayout
         android:id="@+id/buttons"

--- a/collect_app/src/main/res/layout/form_download_list.xml
+++ b/collect_app/src/main/res/layout/form_download_list.xml
@@ -49,7 +49,8 @@ the License.
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:icon="@drawable/ic_baseline_download_72"
-                app:title="@string/empty_list_title"/>
+                app:title="@string/empty_list_of_forms_to_download_title"
+                app:subtitle="@string/empty_list_of_forms_to_download_subtitle"/>
 
         </LinearLayout>
 

--- a/collect_app/src/main/res/layout/hierarchy_layout.xml
+++ b/collect_app/src/main/res/layout/hierarchy_layout.xml
@@ -82,5 +82,5 @@ the License.
         android:id="@android:id/empty"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:title="@string/empty_list_title"/>
+        app:title="@string/empty_list_of_questions"/>
 </RelativeLayout>

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/DeleteBlankFormFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/DeleteBlankFormFragmentTest.kt
@@ -250,11 +250,11 @@ class DeleteBlankFormFragmentTest {
     fun `empty message shows when there are no forms`() {
         fragmentScenarioLauncherRule.launchInContainer(DeleteBlankFormFragment::class.java)
 
-        onView(withText(org.odk.collect.strings.R.string.empty_list_title)).check(matches(isDisplayed()))
+        onView(withText(org.odk.collect.strings.R.string.empty_list_of_forms_to_delete_title)).check(matches(isDisplayed()))
 
         formsToDisplay.value = listOf(blankFormListItem(databaseId = 1, formName = "Form 1"))
 
-        onView(withText(org.odk.collect.strings.R.string.empty_list_title)).check(matches(not(isDisplayed())))
+        onView(withText(org.odk.collect.strings.R.string.empty_list_of_forms_to_delete_title)).check(matches(not(isDisplayed())))
     }
 
     @Test

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1280,6 +1280,10 @@
     <!-- General message displayed when the list of forms -->
     <string name="empty_list_title">Nothing available to display</string>
 
+    <!-- Message displayed when the list of blank forms is empty -->
+    <string name="empty_list_of_blank_forms_title">No blank forms</string>
+    <string name="empty_list_of_blank_forms_subtitle">Download form to get started</string>
+
     <!-- Message displayed when the list of drafts is empty -->
     <string name="empty_list_of_drafts_title">Nothing in drafts</string>
     <string name="empty_list_of_drafts_subtitle">When you save as draft, forms will appear here</string>
@@ -1291,4 +1295,12 @@
     <!-- Message displayed when the list of sent forms is empty -->
     <string name="empty_list_of_sent_forms_title">Nothing in sent</string>
     <string name="empty_list_of_sent_forms_subtitle">When you send finalized forms, they will appear here</string>
+
+    <!-- Message displayed when the list of forms to download is empty -->
+    <string name="empty_list_of_forms_to_download_title">No forms to download</string>
+    <string name="empty_list_of_forms_to_download_subtitle">Download form to get started</string>
+
+    <!-- Message displayed when the list of forms to delete is empty -->
+    <string name="empty_list_of_forms_to_delete_title">No forms to delete</string>
+    <string name="empty_list_of_forms_to_delete_subtitle">Once you have saved forms they will appear here</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1277,8 +1277,8 @@
     <!-- Message for dialog explaining the drafts marked with "Error" shown to the user the first time they view the Drafts screen -->
     <string name="drafts_pills_education_message">The draft list now shows validation errors. Each time you save a form as draft, its validation status is updated.\n\nDrafts marked with \"Errors\" are either missing required questions or have values that are not allowed.</string>
 
-    <!-- General message displayed when the list of forms -->
-    <string name="empty_list_title">Nothing available to display</string>
+    <!-- Message displayed when the list of questions is empty -->
+    <string name="empty_list_of_questions">Nothing available to display</string>
 
     <!-- Message displayed when the list of blank forms is empty -->
     <string name="empty_list_of_blank_forms_title">No blank forms</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1302,5 +1302,6 @@
 
     <!-- Message displayed when the list of forms to delete is empty -->
     <string name="empty_list_of_forms_to_delete_title">No forms to delete</string>
-    <string name="empty_list_of_forms_to_delete_subtitle">Once you have saved forms they will appear here</string>
+    <string name="empty_list_of_blank_forms_to_delete_subtitle">When you have downloaded blank forms they will appear here</string>
+    <string name="empty_list_of_saved_forms_to_delete_subtitle">Once you have saved forms they will appear here</string>
 </resources>


### PR DESCRIPTION
Closes #5820 

#### Why is this the best possible solution? Were any other approaches considered?
Nothing to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please review the messages displayed when the list of forms is empty:
- the list of blank forms
- the list of forms to download
- the list of forms to delete 

other lists should be intact.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
