### PR TITLE
Revise notification flows

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
@@ -157,7 +157,7 @@ class BulkFinalizationTest {
     @Test
     fun whenAutoSendIsEnabled_draftsAreSentAfterFinalizing() {
         val mainMenuPage = rule.withProject(testDependencies.server.url)
-            .enableAutoSend()
+            .enableAutoSend(testDependencies.scheduler)
 
             .copyForm("one-question.xml", testDependencies.server.hostName)
             .startBlankForm("One Question")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.kt
@@ -54,7 +54,7 @@ class MatchExactlyTest {
     }
 
     @Test
-    fun whenMatchExactlyEnabled_clickingFillBlankForm_andClickingRefresh_whenThereIsAnError_showsNotification_andClickingNotification_returnsToFillBlankForms() {
+    fun whenMatchExactlyEnabled_clickingFillBlankForm_andClickingRefresh_whenThereIsAnError_showsNotification_andClickingNotification_returnsToApp() {
         testDependencies.server.alwaysReturnError()
 
         rule.startAtMainMenu()
@@ -72,7 +72,7 @@ class MatchExactlyTest {
                 "ODK Collect",
                 "Form update failed",
                 FillBlankFormPage()
-            ).pressBack(MainMenuPage()) // Check we return to Fill Blank Form, not open a new one
+            ).pressBack(MainMenuPage())
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.kt
@@ -94,11 +94,11 @@ class MatchExactlyTest {
             .clickAction(
                 "ODK Collect",
                 "Show details",
-                ErrorPage()
+                ErrorPage(),
+                cancelsNotification = true
             ).assertText(org.odk.collect.strings.R.string.form_update_error)
             .assertText("Demo project")
             .assertText("The server https://server.example.com returned status code 500. If you keep having this problem, report it to the person who asked you to collect data.")
-            .pressBack(FillBlankFormPage())
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.kt
@@ -10,6 +10,7 @@ import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.odk.collect.android.R
 import org.odk.collect.android.support.TestDependencies
+import org.odk.collect.android.support.pages.ErrorPage
 import org.odk.collect.android.support.pages.FillBlankFormPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
@@ -67,12 +68,37 @@ class MatchExactlyTest {
 
         notificationDrawerRule
             .open()
-            .assertNotification("ODK Collect", "Form update failed", "The server https://server.example.com returned status code 500. If you keep having this problem, report it to the person who asked you to collect data.")
+            .assertNotification("ODK Collect", "Form update failed", "Demo project")
             .clickNotification(
                 "ODK Collect",
                 "Form update failed",
                 FillBlankFormPage()
             ).pressBack(MainMenuPage())
+    }
+
+    @Test
+    fun whenMatchExactlyEnabled_clickingFillBlankForm_andClickingRefresh_whenThereIsAnError_showsNotification_andClickingShowDetails_showsErrorDetails() {
+        testDependencies.server.alwaysReturnError()
+
+        rule.startAtMainMenu()
+            .copyForm("one-question.xml")
+            .copyForm("one-question-repeat.xml")
+            .setServer(testDependencies.server.url)
+            .enableMatchExactly()
+            .clickFillBlankForm()
+            .clickRefreshWithError()
+
+        notificationDrawerRule
+            .open()
+            .assertNotification("ODK Collect", "Form update failed", "Demo project")
+            .clickAction(
+                "ODK Collect",
+                "Show details",
+                ErrorPage()
+            ).assertText(org.odk.collect.strings.R.string.form_update_error)
+            .assertText("Demo project")
+            .assertText("The server https://server.example.com returned status code 500. If you keep having this problem, report it to the person who asked you to collect data.")
+            .pressBack(FillBlankFormPage())
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
@@ -68,7 +68,7 @@ class PreviouslyDownloadedOnlyTest {
                 "ODK Collect",
                 "Form updates available",
                 MainMenuPage()
-            ).pressBackKillingApp()
+            )
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
@@ -81,9 +81,6 @@ class PreviouslyDownloadedOnlyTest {
 
         testDependencies.scheduler.runDeferredTasks()
 
-        page.clickFillBlankForm()
-            .assertText("One Question Updated")
-
         notificationDrawerRule.open()
             .assertNotification(
                 "ODK Collect",
@@ -93,8 +90,9 @@ class PreviouslyDownloadedOnlyTest {
             .clickNotification(
                 "ODK Collect",
                 "Forms download succeeded",
-                FillBlankFormPage()
-            )
+                MainMenuPage()
+            ).clickFillBlankForm()
+            .assertText("One Question Updated")
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
@@ -11,7 +11,6 @@ import org.junit.rules.RuleChain
 import org.odk.collect.android.R
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.ErrorPage
-import org.odk.collect.android.support.pages.FillBlankFormPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.NotificationDrawerRule

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
@@ -12,7 +12,6 @@ import org.odk.collect.android.R
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.ErrorPage
 import org.odk.collect.android.support.pages.FillBlankFormPage
-import org.odk.collect.android.support.pages.GetBlankFormPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.NotificationDrawerRule
@@ -62,8 +61,8 @@ class PreviouslyDownloadedOnlyTest {
             .clickNotification(
                 "ODK Collect",
                 "Form updates available",
-                GetBlankFormPage()
-            )
+                MainMenuPage()
+            ).pressBackKillingApp()
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
@@ -66,7 +66,7 @@ class PreviouslyDownloadedOnlyTest {
 
     @Test
     fun whenPreviouslyDownloadedOnlyEnabledWithAutomaticDownload_checkingAutoDownload_downloadsUpdatedForms_andDisplaysNotification() {
-        val page = MainMenuPage().assertOnPage()
+        MainMenuPage().assertOnPage()
             .setServer(testDependencies.server.url)
             .enablePreviouslyDownloadedOnlyUpdatesWithAutomaticDownload()
             .copyForm("one-question.xml")
@@ -121,10 +121,11 @@ class PreviouslyDownloadedOnlyTest {
                 "Forms download failed",
                 "1 of 1 downloads failed!"
             )
-            .clickNotification(
+            .clickAction(
                 "ODK Collect",
-                "Forms download failed",
-                ErrorPage()
+                "Show details",
+                ErrorPage(),
+                cancelsNotification = true
             )
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
@@ -28,7 +28,7 @@ class AutoSendTest {
     fun whenAutoSendEnabled_fillingAndFinalizingForm_sendsFormAndNotifiesUser() {
         val mainMenuPage = rule.startAtMainMenu()
             .setServer(testDependencies.server.url)
-            .enableAutoSend()
+            .enableAutoSend(testDependencies.scheduler)
             .copyForm("one-question.xml")
             .startBlankForm("One Question")
             .inputText("31")
@@ -57,7 +57,7 @@ class AutoSendTest {
 
         val mainMenuPage = rule.startAtMainMenu()
             .setServer(testDependencies.server.url)
-            .enableAutoSend()
+            .enableAutoSend(testDependencies.scheduler)
             .copyForm("one-question.xml")
             .startBlankForm("One Question")
             .inputText("31")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
@@ -8,7 +8,6 @@ import org.junit.runner.RunWith
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.ErrorPage
 import org.odk.collect.android.support.pages.MainMenuPage
-import org.odk.collect.android.support.pages.SendFinalizedFormPage
 import org.odk.collect.android.support.pages.ViewSentFormPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.NotificationDrawerRule
@@ -67,10 +66,6 @@ class AutoSendTest {
 
         testDependencies.scheduler.runDeferredTasks()
 
-        mainMenuPage
-            .clickViewSentForm(1)
-            .assertText("One Question")
-
         notificationDrawerRule
             .open()
             .assertNotification("ODK Collect", "Forms upload failed", "1 of 1 uploads failed!")
@@ -78,14 +73,16 @@ class AutoSendTest {
                 "ODK Collect",
                 "Show details",
                 ErrorPage()
-            )
+            ).pressBack(MainMenuPage())
+            .clickViewSentForm(1)
+            .assertText("One Question")
 
         notificationDrawerRule
             .open()
             .clickNotification(
                 "ODK Collect",
                 "Forms upload failed",
-                SendFinalizedFormPage()
+                ViewSentFormPage()
             )
     }
 
@@ -129,17 +126,23 @@ class AutoSendTest {
 
         testDependencies.scheduler.runDeferredTasks()
 
-        mainMenuPage
+        notificationDrawerRule
+            .open()
+            .assertNotification("ODK Collect", "Forms upload failed", "1 of 1 uploads failed!")
+            .clickAction(
+                "ODK Collect",
+                "Show details",
+                ErrorPage()
+            ).pressBack(MainMenuPage())
             .clickViewSentForm(1)
             .assertText("One Question Autosend")
 
         notificationDrawerRule
             .open()
-            .assertNotification("ODK Collect", "Forms upload failed", "1 of 1 uploads failed!")
             .clickNotification(
                 "ODK Collect",
                 "Forms upload failed",
-                SendFinalizedFormPage()
+                ViewSentFormPage()
             )
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
@@ -66,23 +66,17 @@ class AutoSendTest {
 
         testDependencies.scheduler.runDeferredTasks()
 
+        mainMenuPage.clickViewSentForm(1)
+            .assertText("One Question")
+
         notificationDrawerRule
             .open()
             .assertNotification("ODK Collect", "Forms upload failed", "1 of 1 uploads failed!")
             .clickAction(
                 "ODK Collect",
                 "Show details",
-                ErrorPage()
-            ).pressBack(MainMenuPage())
-            .clickViewSentForm(1)
-            .assertText("One Question")
-
-        notificationDrawerRule
-            .open()
-            .clickNotification(
-                "ODK Collect",
-                "Forms upload failed",
-                ViewSentFormPage()
+                ErrorPage(),
+                cancelsNotification = true
             )
     }
 
@@ -126,23 +120,17 @@ class AutoSendTest {
 
         testDependencies.scheduler.runDeferredTasks()
 
+        mainMenuPage.clickViewSentForm(1)
+            .assertText("One Question Autosend")
+
         notificationDrawerRule
             .open()
             .assertNotification("ODK Collect", "Forms upload failed", "1 of 1 uploads failed!")
             .clickAction(
                 "ODK Collect",
                 "Show details",
-                ErrorPage()
-            ).pressBack(MainMenuPage())
-            .clickViewSentForm(1)
-            .assertText("One Question Autosend")
-
-        notificationDrawerRule
-            .open()
-            .clickNotification(
-                "ODK Collect",
-                "Forms upload failed",
-                ViewSentFormPage()
+                ErrorPage(),
+                cancelsNotification = true
             )
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
@@ -9,6 +9,7 @@ import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.ErrorPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.SendFinalizedFormPage
+import org.odk.collect.android.support.pages.ViewSentFormPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.NotificationDrawerRule
 import org.odk.collect.android.support.rules.TestRuleChain
@@ -47,8 +48,8 @@ class AutoSendTest {
             .clickNotification(
                 "ODK Collect",
                 "Forms upload succeeded",
-                MainMenuPage()
-            )
+                ViewSentFormPage()
+            ).pressBack(MainMenuPage())
     }
 
     @Test
@@ -110,8 +111,8 @@ class AutoSendTest {
             .clickNotification(
                 "ODK Collect",
                 "Forms upload succeeded",
-                MainMenuPage()
-            )
+                ViewSentFormPage()
+            ).pressBack(MainMenuPage())
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -14,6 +14,7 @@ import static org.hamcrest.core.StringContains.containsString;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.StorageUtils;
+import org.odk.collect.android.support.TestScheduler;
 import org.odk.collect.android.support.WaitFor;
 
 import java.io.IOException;
@@ -180,14 +181,17 @@ public class MainMenuPage extends Page<MainMenuPage> {
                 .pressBack(new MainMenuPage());
     }
 
-    public MainMenuPage enableAutoSend() {
-        return openProjectSettingsDialog()
+    public MainMenuPage enableAutoSend(TestScheduler scheduler) {
+        MainMenuPage mainMenuPage = openProjectSettingsDialog()
                 .clickSettings()
                 .clickFormManagement()
                 .clickOnString(org.odk.collect.strings.R.string.autosend)
                 .clickOnString(org.odk.collect.strings.R.string.wifi_cellular_autosend)
                 .pressBack(new ProjectSettingsPage())
                 .pressBack(new MainMenuPage());
+
+        scheduler.runDeferredTasks(); // Run autosend scheduled after enabling
+        return mainMenuPage;
     }
 
     public MainMenuPage addAndSwitchToProject(String serverUrl) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -5,6 +5,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.CoreMatchers.nullValue
@@ -53,7 +54,8 @@ class NotificationDrawer {
     fun <D : Page<D>> clickAction(
         appName: String,
         actionText: String,
-        destination: D
+        destination: D,
+        cancelsNotification: Boolean = false
     ): D {
         val device = waitForNotification(appName)
 
@@ -65,9 +67,15 @@ class NotificationDrawer {
             throw AssertionError("Could not find \"$actionText\"")
         }
 
-        return waitFor {
+        val page = waitFor {
             destination.assertOnPage()
         }
+
+        open()
+        assertNoNotification(appName)
+        pressBack()
+
+        return page
     }
 
     fun <D : Page<D>> clickNotification(
@@ -104,6 +112,12 @@ class NotificationDrawer {
         device.wait(Until.gone(By.text("Notifications")), 1000L)
 
         isOpen = false
+    }
+
+    fun assertNoNotification(appName: String) {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        val result = device.wait(Until.hasObject(By.textStartsWith(appName)), 0L)
+        assertThat("Expected no notification for app: $appName", result, equalTo(false))
     }
 
     private fun assertText(device: UiDevice, text: String): UiObject2 {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -67,13 +67,15 @@ class NotificationDrawer {
             throw AssertionError("Could not find \"$actionText\"")
         }
 
+        if (cancelsNotification) {
+            device.openNotification()
+            assertNoNotification(appName)
+            device.pressBack()
+        }
+
         val page = waitFor {
             destination.assertOnPage()
         }
-
-        open()
-        assertNoNotification(appName)
-        pressBack()
 
         return page
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -31,7 +31,7 @@ class NotificationDrawer {
     fun assertNotification(
         appName: String,
         title: String,
-        subtext: String,
+        subtext: String? = null,
         body: String? = null
     ): NotificationDrawer {
         val device = waitForNotification(appName)
@@ -39,20 +39,13 @@ class NotificationDrawer {
         val titleElement = device.findObject(By.text(title))
         assertThat(titleElement, not(nullValue()))
 
-        var subtextElement = device.findObject(By.text(subtext))
-        if (subtextElement == null) {
-            device.findObject(By.text(appName)).click() // Expand notification to show subtext
-            subtextElement = device.findObject(By.text(subtext))
+        if (subtext != null) {
+            assertExpandedText(device, appName, subtext)
         }
 
-        assertThat(subtextElement.text, `is`(subtext))
-
-        body?.let {
-            val bodyElement = device.findObject(By.text(body))
-            assertThat(bodyElement, not(nullValue()))
+        if (body != null) {
+            assertExpandedText(device, appName, body)
         }
-
-        assertExpandedText(device, appName, subtext)
 
         return this
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -116,7 +116,7 @@ class NotificationDrawer {
         isOpen = false
     }
 
-    fun assertNoNotification(appName: String) {
+    private fun assertNoNotification(appName: String) {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         val result = device.wait(Until.hasObject(By.textStartsWith(appName)), 0L)
         assertThat("Expected no notification for app: $appName", result, equalTo(false))

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.NoActivityResumedException
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions
@@ -41,6 +42,7 @@ import org.hamcrest.Matchers.allOf
 import org.hamcrest.core.StringContains.containsString
 import org.hamcrest.core.StringEndsWith.endsWith
 import org.junit.Assert
+import org.junit.Assert.fail
 import org.odk.collect.android.BuildConfig
 import org.odk.collect.android.R
 import org.odk.collect.android.application.Collect
@@ -94,6 +96,15 @@ abstract class Page<T : Page<T>> {
     fun <D : Page<D>> pressBack(destination: D): D {
         Espresso.pressBack()
         return destination.assertOnPage()
+    }
+
+    fun pressBackKillingApp() {
+        try {
+            Espresso.pressBack()
+            fail("App was not killed!")
+        } catch (e: NoActivityResumedException) {
+            // App killed as expected
+        }
     }
 
     fun assertTexts(vararg texts: String): T {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/CollectTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/CollectTestRule.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import org.odk.collect.android.BuildConfig.APPLICATION_ID
 import org.odk.collect.android.external.AndroidShortcutsActivity
+import org.odk.collect.android.support.StubOpenRosaServer
 import org.odk.collect.android.support.pages.FirstLaunchPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.Page
@@ -35,11 +36,25 @@ class CollectTestRule @JvmOverloads constructor(
 
     fun startAtFirstLaunch() = FirstLaunchPage()
 
-    fun withProject(serverUrl: String): MainMenuPage =
-        startAtFirstLaunch()
+    fun withProject(serverUrl: String): MainMenuPage {
+        return startAtFirstLaunch()
             .clickManuallyEnterProjectDetails()
             .inputUrl(serverUrl)
             .addProject()
+    }
+
+    fun withProject(testServer: StubOpenRosaServer, vararg formFiles: String): MainMenuPage {
+        val mainMenuPage = startAtFirstLaunch()
+            .clickManuallyEnterProjectDetails()
+            .inputUrl(testServer.url)
+            .addProject()
+
+        return if (formFiles.isNotEmpty()) {
+            formFiles.fold(mainMenuPage) { page, formFile -> page.copyForm(formFile, testServer.hostName) }
+        } else {
+            mainMenuPage
+        }
+    }
 
     fun launchShortcuts(): ShortcutsPage {
         val scenario = launchForResult(AndroidShortcutsActivity::class.java)

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -48,7 +48,6 @@ import org.odk.collect.android.fragments.dialogs.FormsDownloadResultDialog;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.DownloadFormsTaskListener;
 import org.odk.collect.android.listeners.FormListDownloaderListener;
-import org.odk.collect.androidshared.network.NetworkStateProvider;
 import org.odk.collect.android.openrosa.HttpCredentialsInterface;
 import org.odk.collect.android.tasks.DownloadFormListTask;
 import org.odk.collect.android.tasks.DownloadFormsTask;
@@ -57,6 +56,7 @@ import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 import org.odk.collect.android.views.DayNightProgressDialog;
+import org.odk.collect.androidshared.network.NetworkStateProvider;
 import org.odk.collect.androidshared.ui.DialogFragmentUtils;
 import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.forms.FormSourceException;
@@ -95,8 +95,6 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         AdapterView.OnItemClickListener, RefreshFormListDialogFragment.RefreshFormListDialogFragmentListener,
         FormsDownloadResultDialog.FormDownloadResultDialogListener {
     private static final String FORM_DOWNLOAD_LIST_SORTING_ORDER = "formDownloadListSortingOrder";
-
-    public static final String DISPLAY_ONLY_UPDATED_FORMS = "displayOnlyUpdatedForms";
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
 
     public static final String FORMNAME = "formname";
@@ -117,8 +115,6 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
     private final ArrayList<HashMap<String, String>> filteredFormList = new ArrayList<>();
 
     private static final boolean DO_NOT_EXIT = false;
-
-    private boolean displayOnlyUpdatedForms;
 
     private FormDownloadListViewModel viewModel;
 
@@ -152,10 +148,6 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
     private void init(Bundle savedInstanceState) {
         Bundle bundle = getIntent().getExtras();
         if (bundle != null) {
-            if (bundle.containsKey(DISPLAY_ONLY_UPDATED_FORMS)) {
-                displayOnlyUpdatedForms = (boolean) bundle.get(DISPLAY_ONLY_UPDATED_FORMS);
-            }
-
             if (bundle.containsKey(ApplicationConstants.BundleKeys.FORM_IDS)) {
                 viewModel.setDownloadOnlyMode(true);
                 viewModel.setFormIdsToDownload(bundle.getStringArray(ApplicationConstants.BundleKeys.FORM_IDS));
@@ -507,30 +499,28 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
                 String formDetailsKey = ids.get(i);
                 ServerFormDetails details = viewModel.getFormDetailsByFormId().get(formDetailsKey);
 
-                if (!displayOnlyUpdatedForms || details.isUpdated()) {
-                    HashMap<String, String> item = new HashMap<>();
-                    item.put(FORMNAME, details.getFormName());
-                    item.put(FORMID_DISPLAY,
-                            ((details.getFormVersion() == null) ? "" : (getString(org.odk.collect.strings.R.string.version) + " "
-                                    + details.getFormVersion() + " ")) + "ID: " + details.getFormId());
-                    item.put(FORMDETAIL_KEY, formDetailsKey);
-                    item.put(FORM_ID_KEY, details.getFormId());
-                    item.put(FORM_VERSION_KEY, details.getFormVersion());
+                HashMap<String, String> item = new HashMap<>();
+                item.put(FORMNAME, details.getFormName());
+                item.put(FORMID_DISPLAY,
+                        ((details.getFormVersion() == null) ? "" : (getString(org.odk.collect.strings.R.string.version) + " "
+                                + details.getFormVersion() + " ")) + "ID: " + details.getFormId());
+                item.put(FORMDETAIL_KEY, formDetailsKey);
+                item.put(FORM_ID_KEY, details.getFormId());
+                item.put(FORM_VERSION_KEY, details.getFormVersion());
 
-                    // Insert the new form in alphabetical order.
-                    if (viewModel.getFormList().isEmpty()) {
-                        viewModel.addForm(item);
-                    } else {
-                        int j;
-                        for (j = 0; j < viewModel.getFormList().size(); j++) {
-                            HashMap<String, String> compareMe = viewModel.getFormList().get(j);
-                            String name = compareMe.get(FORMNAME);
-                            if (name.compareTo(viewModel.getFormDetailsByFormId().get(ids.get(i)).getFormName()) > 0) {
-                                break;
-                            }
+                // Insert the new form in alphabetical order.
+                if (viewModel.getFormList().isEmpty()) {
+                    viewModel.addForm(item);
+                } else {
+                    int j;
+                    for (j = 0; j < viewModel.getFormList().size(); j++) {
+                        HashMap<String, String> compareMe = viewModel.getFormList().get(j);
+                        String name = compareMe.get(FORMNAME);
+                        if (name.compareTo(viewModel.getFormDetailsByFormId().get(ids.get(i)).getFormName()) > 0) {
+                            break;
                         }
-                        viewModel.addForm(j, item);
                     }
+                    viewModel.addForm(j, item);
                 }
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -66,6 +66,16 @@ class MainMenuActivity : LocalizedActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         initSplashScreen()
 
+        /*
+        Don't reopen if the app is already open - allows notifications to use this Activity
+        as a target to reopen the app without interrupting an ongoing session
+        */
+        if (!isTaskRoot) {
+            super.onCreate(null)
+            finish()
+            return
+        }
+
         CrashHandler.getInstance(this)?.also {
             if (it.hasCrashed(this)) {
                 super.onCreate(null)

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -67,8 +67,8 @@ class MainMenuActivity : LocalizedActivity() {
         initSplashScreen()
 
         /*
-        Don't reopen if the app is already open - allows notifications to use this Activity
-        as a target to reopen the app without interrupting an ongoing session
+        Don't reopen if the app is already open - allows entry points like notifications to use
+        this Activity as a target to reopen the app without interrupting an ongoing session
         */
         if (!isTaskRoot) {
             super.onCreate(null)

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.kt
@@ -36,7 +36,8 @@ class NotificationManagerNotifier(
                 FORM_UPDATE_NOTIFICATION_ID,
                 FormUpdatesAvailableNotificationBuilder.build(
                     application,
-                    getProjectName(projectId)
+                    getProjectName(projectId),
+                    FORM_UPDATE_NOTIFICATION_ID
                 )
             )
             metaPrefs.save(MetaKeys.LAST_UPDATED_NOTIFICATION, updateId)

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.kt
@@ -5,7 +5,6 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
-import org.odk.collect.android.R
 import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.android.notifications.builders.FormUpdatesAvailableNotificationBuilder
@@ -50,7 +49,8 @@ class NotificationManagerNotifier(
             FormUpdatesDownloadedNotificationBuilder.build(
                 application,
                 result,
-                getProjectName(projectId)
+                getProjectName(projectId),
+                FORM_UPDATE_NOTIFICATION_ID
             )
         )
     }
@@ -64,7 +64,8 @@ class NotificationManagerNotifier(
                 FormsSyncFailedNotificationBuilder.build(
                     application,
                     exception,
-                    getProjectName(projectId)
+                    getProjectName(projectId),
+                    FORM_SYNC_NOTIFICATION_ID
                 )
             )
         }
@@ -76,7 +77,8 @@ class NotificationManagerNotifier(
             FormsSubmissionNotificationBuilder.build(
                 application,
                 result,
-                getProjectName(projectId)
+                getProjectName(projectId),
+                AUTO_SEND_RESULT_NOTIFICATION_ID
             )
         )
     }

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationUtils.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.notifications
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import org.odk.collect.android.BuildConfig
 import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.errors.ErrorActivity
 import org.odk.collect.errors.ErrorItem
@@ -16,7 +17,9 @@ object NotificationUtils {
      * [Intent] will either land the user where they were last or reopen the app.
      */
     fun createOpenAppContentIntent(context: Context, requestCode: Int): PendingIntent {
-        val intent = Intent(context, MainMenuActivity::class.java)
+        val intent = context
+            .packageManager
+            .getLaunchIntentForPackage(BuildConfig.APPLICATION_ID)
 
         return PendingIntent.getActivity(
             context,

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationUtils.kt
@@ -16,14 +16,14 @@ object NotificationUtils {
      * finishes automatically if it's not started as the root of a task, so that means the
      * [Intent] will either land the user where they were last or reopen the app.
      */
-    fun createOpenAppContentIntent(context: Context, requestCode: Int): PendingIntent {
+    fun createOpenAppContentIntent(context: Context, notificationId: Int): PendingIntent {
         val intent = context
             .packageManager
             .getLaunchIntentForPackage(BuildConfig.APPLICATION_ID)
 
         return PendingIntent.getActivity(
             context,
-            requestCode,
+            notificationId,
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationUtils.kt
@@ -1,0 +1,46 @@
+package org.odk.collect.android.notifications
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import org.odk.collect.android.mainmenu.MainMenuActivity
+import org.odk.collect.errors.ErrorActivity
+import org.odk.collect.errors.ErrorItem
+import java.io.Serializable
+
+object NotificationUtils {
+
+    /**
+     * Creates a [PendingIntent] that will start the [MainMenuActivity]. [MainMenuActivity]
+     * finishes automatically if it's not started as the root of a task, so that means the
+     * [Intent] will either land the user where they were last or reopen the app.
+     */
+    fun createOpenAppContentIntent(context: Context, requestCode: Int): PendingIntent {
+        val intent = Intent(context, MainMenuActivity::class.java)
+
+        return PendingIntent.getActivity(
+            context,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    fun createOpenErrorsActionIntent(
+        context: Context,
+        errorItems: List<ErrorItem>,
+        notificationId: Int
+    ): PendingIntent {
+        val showDetailsIntent = Intent(context, ErrorActivity::class.java).apply {
+            putExtra(ErrorActivity.EXTRA_ERRORS, errorItems as Serializable)
+            putExtra(ErrorActivity.EXTRA_NOTIFICATION_ID, notificationId)
+        }
+
+        return PendingIntent.getActivity(
+            context,
+            notificationId,
+            showDetailsIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesAvailableNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesAvailableNotificationBuilder.kt
@@ -5,19 +5,16 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Intent
 import androidx.core.app.NotificationCompat
-import org.odk.collect.android.R
-import org.odk.collect.android.activities.FormDownloadListActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
 import org.odk.collect.android.utilities.ApplicationConstants.RequestCodes
+import org.odk.collect.androidshared.ui.ReturnToAppActivity
 import org.odk.collect.strings.localization.getLocalizedString
 
 object FormUpdatesAvailableNotificationBuilder {
 
     @JvmStatic
     fun build(application: Application, projectName: String): Notification {
-        val intent = Intent(application, FormDownloadListActivity::class.java).apply {
-            putExtra(FormDownloadListActivity.DISPLAY_ONLY_UPDATED_FORMS, true)
-        }
+        val intent = Intent(application, ReturnToAppActivity::class.java)
 
         val contentIntent = PendingIntent.getActivity(
             application,

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesAvailableNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesAvailableNotificationBuilder.kt
@@ -5,16 +5,16 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Intent
 import androidx.core.app.NotificationCompat
+import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
 import org.odk.collect.android.utilities.ApplicationConstants.RequestCodes
-import org.odk.collect.androidshared.ui.ReturnToAppActivity
 import org.odk.collect.strings.localization.getLocalizedString
 
 object FormUpdatesAvailableNotificationBuilder {
 
     @JvmStatic
     fun build(application: Application, projectName: String): Notification {
-        val intent = Intent(application, ReturnToAppActivity::class.java)
+        val intent = Intent(application, MainMenuActivity::class.java)
 
         val contentIntent = PendingIntent.getActivity(
             application,

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesAvailableNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesAvailableNotificationBuilder.kt
@@ -2,11 +2,9 @@ package org.odk.collect.android.notifications.builders
 
 import android.app.Application
 import android.app.Notification
-import android.app.PendingIntent
-import android.content.Intent
 import androidx.core.app.NotificationCompat
-import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
+import org.odk.collect.android.notifications.NotificationUtils
 import org.odk.collect.android.utilities.ApplicationConstants.RequestCodes
 import org.odk.collect.strings.localization.getLocalizedString
 
@@ -14,13 +12,9 @@ object FormUpdatesAvailableNotificationBuilder {
 
     @JvmStatic
     fun build(application: Application, projectName: String): Notification {
-        val intent = Intent(application, MainMenuActivity::class.java)
-
-        val contentIntent = PendingIntent.getActivity(
+        val contentIntent = NotificationUtils.createOpenAppContentIntent(
             application,
-            RequestCodes.FORM_UPDATES_AVAILABLE_NOTIFICATION,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            RequestCodes.FORM_UPDATES_AVAILABLE_NOTIFICATION
         )
 
         return NotificationCompat.Builder(

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesAvailableNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesAvailableNotificationBuilder.kt
@@ -5,16 +5,15 @@ import android.app.Notification
 import androidx.core.app.NotificationCompat
 import org.odk.collect.android.notifications.NotificationManagerNotifier
 import org.odk.collect.android.notifications.NotificationUtils
-import org.odk.collect.android.utilities.ApplicationConstants.RequestCodes
 import org.odk.collect.strings.localization.getLocalizedString
 
 object FormUpdatesAvailableNotificationBuilder {
 
     @JvmStatic
-    fun build(application: Application, projectName: String): Notification {
+    fun build(application: Application, projectName: String, notificationId: Int): Notification {
         val contentIntent = NotificationUtils.createOpenAppContentIntent(
             application,
-            RequestCodes.FORM_UPDATES_AVAILABLE_NOTIFICATION
+            notificationId
         )
 
         return NotificationCompat.Builder(

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
@@ -5,8 +5,6 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Intent
 import androidx.core.app.NotificationCompat
-import org.odk.collect.android.R
-import org.odk.collect.android.formlists.blankformlist.BlankFormListActivity
 import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.android.mainmenu.MainMenuActivity

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
@@ -2,40 +2,29 @@ package org.odk.collect.android.notifications.builders
 
 import android.app.Application
 import android.app.Notification
-import android.app.PendingIntent
-import android.content.Intent
 import androidx.core.app.NotificationCompat
 import org.odk.collect.android.R
 import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
-import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
+import org.odk.collect.android.notifications.NotificationUtils
 import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.android.utilities.FormsDownloadResultInterpreter
-import org.odk.collect.errors.ErrorActivity
 import org.odk.collect.strings.localization.getLocalizedString
-import java.io.Serializable
 
 object FormUpdatesDownloadedNotificationBuilder {
 
     fun build(application: Application, result: Map<ServerFormDetails, FormDownloadException?>, projectName: String, notificationId: Int): Notification {
         val allFormsDownloadedSuccessfully = FormsDownloadResultInterpreter.allFormsDownloadedSuccessfully(result)
 
-        val intent = Intent(application, MainMenuActivity::class.java)
-        val showDetailsIntent = Intent(application, ErrorActivity::class.java).apply {
-            putExtra(
-                ErrorActivity.EXTRA_ERRORS,
-                FormsDownloadResultInterpreter.getFailures(result, application) as Serializable
-            )
-            putExtra(ErrorActivity.EXTRA_NOTIFICATION_ID, notificationId)
-        }
-
-        val contentIntent = PendingIntent.getActivity(
+        val contentIntent = NotificationUtils.createOpenAppContentIntent(
             application,
-            ApplicationConstants.RequestCodes.FORMS_DOWNLOADED_NOTIFICATION,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            ApplicationConstants.RequestCodes.FORMS_DOWNLOADED_NOTIFICATION
         )
+
+        val errorItems = FormsDownloadResultInterpreter.getFailures(result, application)
+        val showDetailsIntent =
+            NotificationUtils.createOpenErrorsActionIntent(application, errorItems, notificationId)
 
         val title =
             if (allFormsDownloadedSuccessfully) {
@@ -70,12 +59,7 @@ object FormUpdatesDownloadedNotificationBuilder {
                 addAction(
                     R.drawable.ic_outline_info_small,
                     application.getLocalizedString(org.odk.collect.strings.R.string.show_details),
-                    PendingIntent.getActivity(
-                        application,
-                        ApplicationConstants.RequestCodes.FORMS_DOWNLOADED_NOTIFICATION,
-                        showDetailsIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                    )
+                    showDetailsIntent
                 )
             }
         }.build()

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
@@ -9,6 +9,7 @@ import org.odk.collect.android.R
 import org.odk.collect.android.formlists.blankformlist.BlankFormListActivity
 import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
+import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
 import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.android.utilities.FormsDownloadResultInterpreter
@@ -22,9 +23,7 @@ object FormUpdatesDownloadedNotificationBuilder {
         val allFormsDownloadedSuccessfully = FormsDownloadResultInterpreter.allFormsDownloadedSuccessfully(result)
 
         val intent = if (allFormsDownloadedSuccessfully) {
-            Intent(application, BlankFormListActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-            }
+            Intent(application, MainMenuActivity::class.java)
         } else {
             Intent(application, ErrorActivity::class.java).apply {
                 putExtra(ErrorActivity.EXTRA_ERRORS, FormsDownloadResultInterpreter.getFailures(result, application) as Serializable)

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
@@ -5,6 +5,7 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Intent
 import androidx.core.app.NotificationCompat
+import org.odk.collect.android.R
 import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.android.mainmenu.MainMenuActivity
@@ -17,15 +18,16 @@ import java.io.Serializable
 
 object FormUpdatesDownloadedNotificationBuilder {
 
-    fun build(application: Application, result: Map<ServerFormDetails, FormDownloadException?>, projectName: String): Notification {
+    fun build(application: Application, result: Map<ServerFormDetails, FormDownloadException?>, projectName: String, notificationId: Int): Notification {
         val allFormsDownloadedSuccessfully = FormsDownloadResultInterpreter.allFormsDownloadedSuccessfully(result)
 
-        val intent = if (allFormsDownloadedSuccessfully) {
-            Intent(application, MainMenuActivity::class.java)
-        } else {
-            Intent(application, ErrorActivity::class.java).apply {
-                putExtra(ErrorActivity.EXTRA_ERRORS, FormsDownloadResultInterpreter.getFailures(result, application) as Serializable)
-            }
+        val intent = Intent(application, MainMenuActivity::class.java)
+        val showDetailsIntent = Intent(application, ErrorActivity::class.java).apply {
+            putExtra(
+                ErrorActivity.EXTRA_ERRORS,
+                FormsDownloadResultInterpreter.getFailures(result, application) as Serializable
+            )
+            putExtra(ErrorActivity.EXTRA_NOTIFICATION_ID, notificationId)
         }
 
         val contentIntent = PendingIntent.getActivity(
@@ -63,6 +65,19 @@ object FormUpdatesDownloadedNotificationBuilder {
             setSubText(projectName)
             setSmallIcon(org.odk.collect.icons.R.drawable.ic_notification_small)
             setAutoCancel(true)
+
+            if (!allFormsDownloadedSuccessfully) {
+                addAction(
+                    R.drawable.ic_outline_info_small,
+                    application.getLocalizedString(org.odk.collect.strings.R.string.show_details),
+                    PendingIntent.getActivity(
+                        application,
+                        ApplicationConstants.RequestCodes.FORMS_DOWNLOADED_NOTIFICATION,
+                        showDetailsIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    )
+                )
+            }
         }.build()
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
@@ -8,7 +8,6 @@ import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.android.notifications.NotificationManagerNotifier
 import org.odk.collect.android.notifications.NotificationUtils
-import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.android.utilities.FormsDownloadResultInterpreter
 import org.odk.collect.strings.localization.getLocalizedString
 
@@ -19,7 +18,7 @@ object FormUpdatesDownloadedNotificationBuilder {
 
         val contentIntent = NotificationUtils.createOpenAppContentIntent(
             application,
-            ApplicationConstants.RequestCodes.FORMS_DOWNLOADED_NOTIFICATION
+            notificationId
         )
 
         val errorItems = FormsDownloadResultInterpreter.getFailures(result, application)

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSubmissionNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSubmissionNotificationBuilder.kt
@@ -7,7 +7,6 @@ import org.odk.collect.android.R
 import org.odk.collect.android.notifications.NotificationManagerNotifier
 import org.odk.collect.android.notifications.NotificationUtils
 import org.odk.collect.android.upload.FormUploadException
-import org.odk.collect.android.utilities.ApplicationConstants.RequestCodes
 import org.odk.collect.android.utilities.FormsUploadResultInterpreter
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.strings.localization.getLocalizedString
@@ -29,7 +28,7 @@ object FormsSubmissionNotificationBuilder {
             setContentIntent(
                 NotificationUtils.createOpenAppContentIntent(
                     application,
-                    RequestCodes.FORMS_UPLOADED_NOTIFICATION
+                    notificationId
                 )
             )
             setContentTitle(getTitle(application, allFormsUploadedSuccessfully))

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSubmissionNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSubmissionNotificationBuilder.kt
@@ -6,7 +6,6 @@ import android.app.PendingIntent
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import org.odk.collect.android.R
-import org.odk.collect.android.instancemanagement.send.InstanceUploaderListActivity
 import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
 import org.odk.collect.android.upload.FormUploadException
@@ -64,13 +63,7 @@ object FormsSubmissionNotificationBuilder {
     }
 
     private fun getNotificationPendingIntent(application: Application, allFormsUploadedSuccessfully: Boolean): PendingIntent {
-        val notifyIntent = if (allFormsUploadedSuccessfully) {
-            Intent(application, MainMenuActivity::class.java)
-        } else {
-            Intent(application, InstanceUploaderListActivity::class.java)
-        }.apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
+        val notifyIntent = Intent(application, MainMenuActivity::class.java)
 
         return PendingIntent.getActivity(
             application,

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSubmissionNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSubmissionNotificationBuilder.kt
@@ -18,14 +18,19 @@ import java.io.Serializable
 
 object FormsSubmissionNotificationBuilder {
 
-    fun build(application: Application, result: Map<Instance, FormUploadException?>, projectName: String): Notification {
+    fun build(
+        application: Application,
+        result: Map<Instance, FormUploadException?>,
+        projectName: String,
+        notificationId: Int
+    ): Notification {
         val allFormsUploadedSuccessfully = FormsUploadResultInterpreter.allFormsUploadedSuccessfully(result)
 
         return NotificationCompat.Builder(
             application,
             NotificationManagerNotifier.COLLECT_NOTIFICATION_CHANNEL
         ).apply {
-            setContentIntent(getNotificationPendingIntent(application, allFormsUploadedSuccessfully))
+            setContentIntent(getNotificationPendingIntent(application))
             setContentTitle(getTitle(application, allFormsUploadedSuccessfully))
             setContentText(getMessage(application, allFormsUploadedSuccessfully, result))
             setSubText(projectName)
@@ -36,7 +41,7 @@ object FormsSubmissionNotificationBuilder {
                 addAction(
                     R.drawable.ic_outline_info_small,
                     application.getLocalizedString(org.odk.collect.strings.R.string.show_details),
-                    getShowDetailsPendingIntent(application, result)
+                    getShowDetailsPendingIntent(application, result, notificationId)
                 )
             }
         }.build()
@@ -62,7 +67,7 @@ object FormsSubmissionNotificationBuilder {
         }
     }
 
-    private fun getNotificationPendingIntent(application: Application, allFormsUploadedSuccessfully: Boolean): PendingIntent {
+    private fun getNotificationPendingIntent(application: Application): PendingIntent {
         val notifyIntent = Intent(application, MainMenuActivity::class.java)
 
         return PendingIntent.getActivity(
@@ -73,9 +78,14 @@ object FormsSubmissionNotificationBuilder {
         )
     }
 
-    private fun getShowDetailsPendingIntent(application: Application, result: Map<Instance, FormUploadException?>): PendingIntent {
+    private fun getShowDetailsPendingIntent(
+        application: Application,
+        result: Map<Instance, FormUploadException?>,
+        notificationId: Int
+    ): PendingIntent {
         val showDetailsIntent = Intent(application, ErrorActivity::class.java).apply {
             putExtra(ErrorActivity.EXTRA_ERRORS, FormsUploadResultInterpreter.getFailures(result, application) as Serializable)
+            putExtra(ErrorActivity.EXTRA_NOTIFICATION_ID, notificationId)
         }
 
         return PendingIntent.getActivity(

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSyncFailedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSyncFailedNotificationBuilder.kt
@@ -9,7 +9,6 @@ import org.odk.collect.android.R
 import org.odk.collect.android.formmanagement.FormSourceExceptionMapper
 import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
-import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.errors.ErrorActivity
 import org.odk.collect.errors.ErrorItem
 import org.odk.collect.forms.FormSourceException
@@ -18,7 +17,7 @@ import java.io.Serializable
 
 object FormsSyncFailedNotificationBuilder {
 
-    fun build(application: Application, exception: FormSourceException, projectName: String): Notification {
+    fun build(application: Application, exception: FormSourceException, projectName: String, notificationId: Int): Notification {
         val contentIntent = PendingIntent.getActivity(
             application,
             NotificationManagerNotifier.FORM_SYNC_NOTIFICATION_ID,
@@ -38,12 +37,17 @@ object FormsSyncFailedNotificationBuilder {
             addAction(
                 R.drawable.ic_outline_info_small,
                 application.getLocalizedString(org.odk.collect.strings.R.string.show_details),
-                getShowDetailsPendingIntent(application, projectName, exception)
+                getShowDetailsPendingIntent(application, projectName, exception, notificationId)
             )
         }.build()
     }
 
-    private fun getShowDetailsPendingIntent(application: Application, projectName: String, exception: FormSourceException): PendingIntent {
+    private fun getShowDetailsPendingIntent(
+        application: Application,
+        projectName: String,
+        exception: FormSourceException,
+        notificationId: Int
+    ): PendingIntent {
         val errorItem = ErrorItem(
             application.getLocalizedString(org.odk.collect.strings.R.string.form_update_error),
             projectName,
@@ -51,11 +55,12 @@ object FormsSyncFailedNotificationBuilder {
         )
         val showDetailsIntent = Intent(application, ErrorActivity::class.java).apply {
             putExtra(ErrorActivity.EXTRA_ERRORS, listOf(errorItem) as Serializable)
+            putExtra(ErrorActivity.EXTRA_NOTIFICATION_ID, notificationId)
         }
 
         return PendingIntent.getActivity(
             application,
-            ApplicationConstants.RequestCodes.FORMS_UPLOADED_NOTIFICATION,
+            NotificationManagerNotifier.FORM_SYNC_NOTIFICATION_ID,
             showDetailsIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSyncFailedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSyncFailedNotificationBuilder.kt
@@ -3,27 +3,20 @@ package org.odk.collect.android.notifications.builders
 import android.app.Application
 import android.app.Notification
 import android.app.PendingIntent
-import android.content.Intent
 import androidx.core.app.NotificationCompat
 import org.odk.collect.android.R
 import org.odk.collect.android.formmanagement.FormSourceExceptionMapper
-import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
-import org.odk.collect.errors.ErrorActivity
+import org.odk.collect.android.notifications.NotificationUtils
+import org.odk.collect.android.notifications.NotificationUtils.createOpenErrorsActionIntent
 import org.odk.collect.errors.ErrorItem
 import org.odk.collect.forms.FormSourceException
 import org.odk.collect.strings.localization.getLocalizedString
-import java.io.Serializable
 
 object FormsSyncFailedNotificationBuilder {
 
     fun build(application: Application, exception: FormSourceException, projectName: String, notificationId: Int): Notification {
-        val contentIntent = PendingIntent.getActivity(
-            application,
-            NotificationManagerNotifier.FORM_SYNC_NOTIFICATION_ID,
-            Intent(application, MainMenuActivity::class.java),
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
+        val contentIntent = NotificationUtils.createOpenAppContentIntent(application, notificationId)
 
         return NotificationCompat.Builder(
             application,
@@ -53,16 +46,7 @@ object FormsSyncFailedNotificationBuilder {
             projectName,
             FormSourceExceptionMapper(application).getMessage(exception)
         )
-        val showDetailsIntent = Intent(application, ErrorActivity::class.java).apply {
-            putExtra(ErrorActivity.EXTRA_ERRORS, listOf(errorItem) as Serializable)
-            putExtra(ErrorActivity.EXTRA_NOTIFICATION_ID, notificationId)
-        }
 
-        return PendingIntent.getActivity(
-            application,
-            NotificationManagerNotifier.FORM_SYNC_NOTIFICATION_ID,
-            showDetailsIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
+        return createOpenErrorsActionIntent(application, listOf(errorItem), notificationId)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSyncFailedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSyncFailedNotificationBuilder.kt
@@ -5,11 +5,16 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Intent
 import androidx.core.app.NotificationCompat
+import org.odk.collect.android.R
 import org.odk.collect.android.formmanagement.FormSourceExceptionMapper
 import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
+import org.odk.collect.android.utilities.ApplicationConstants
+import org.odk.collect.errors.ErrorActivity
+import org.odk.collect.errors.ErrorItem
 import org.odk.collect.forms.FormSourceException
 import org.odk.collect.strings.localization.getLocalizedString
+import java.io.Serializable
 
 object FormsSyncFailedNotificationBuilder {
 
@@ -28,12 +33,31 @@ object FormsSyncFailedNotificationBuilder {
             setContentIntent(contentIntent)
             setContentTitle(application.getLocalizedString(org.odk.collect.strings.R.string.form_update_error))
             setSubText(projectName)
-            setStyle(
-                NotificationCompat.BigTextStyle()
-                    .bigText(FormSourceExceptionMapper(application).getMessage(exception))
-            )
             setSmallIcon(org.odk.collect.icons.R.drawable.ic_notification_small)
             setAutoCancel(true)
+            addAction(
+                R.drawable.ic_outline_info_small,
+                application.getLocalizedString(org.odk.collect.strings.R.string.show_details),
+                getShowDetailsPendingIntent(application, projectName, exception)
+            )
         }.build()
+    }
+
+    private fun getShowDetailsPendingIntent(application: Application, projectName: String, exception: FormSourceException): PendingIntent {
+        val errorItem = ErrorItem(
+            application.getLocalizedString(org.odk.collect.strings.R.string.form_update_error),
+            projectName,
+            FormSourceExceptionMapper(application).getMessage(exception)
+        )
+        val showDetailsIntent = Intent(application, ErrorActivity::class.java).apply {
+            putExtra(ErrorActivity.EXTRA_ERRORS, listOf(errorItem) as Serializable)
+        }
+
+        return PendingIntent.getActivity(
+            application,
+            ApplicationConstants.RequestCodes.FORMS_UPLOADED_NOTIFICATION,
+            showDetailsIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSyncFailedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormsSyncFailedNotificationBuilder.kt
@@ -5,9 +5,8 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.content.Intent
 import androidx.core.app.NotificationCompat
-import org.odk.collect.android.R
-import org.odk.collect.android.formlists.blankformlist.BlankFormListActivity
 import org.odk.collect.android.formmanagement.FormSourceExceptionMapper
+import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.notifications.NotificationManagerNotifier
 import org.odk.collect.forms.FormSourceException
 import org.odk.collect.strings.localization.getLocalizedString
@@ -18,9 +17,7 @@ object FormsSyncFailedNotificationBuilder {
         val contentIntent = PendingIntent.getActivity(
             application,
             NotificationManagerNotifier.FORM_SYNC_NOTIFICATION_ID,
-            Intent(application, BlankFormListActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-            },
+            Intent(application, MainMenuActivity::class.java),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -78,9 +78,6 @@ public class ApplicationConstants {
         public static final int EX_AUDIO_CHOOSER  = 26;
         public static final int CHANGE_SETTINGS = 27;
         public static final int MEDIA_FILE_PATH = 28;
-
-        public static final int FORMS_DOWNLOADED_NOTIFICATION = 98;
-        public static final int FORM_UPDATES_AVAILABLE_NOTIFICATION = 99;
     }
 
     public abstract static class Namespaces {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -79,7 +79,6 @@ public class ApplicationConstants {
         public static final int CHANGE_SETTINGS = 27;
         public static final int MEDIA_FILE_PATH = 28;
 
-        public static final int FORMS_UPLOADED_NOTIFICATION = 97;
         public static final int FORMS_DOWNLOADED_NOTIFICATION = 98;
         public static final int FORM_UPDATES_AVAILABLE_NOTIFICATION = 99;
     }

--- a/errors/src/main/java/org/odk/collect/errors/ErrorActivity.kt
+++ b/errors/src/main/java/org/odk/collect/errors/ErrorActivity.kt
@@ -1,5 +1,7 @@
 package org.odk.collect.errors
 
+import android.app.NotificationManager
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
@@ -11,6 +13,7 @@ import org.odk.collect.strings.localization.getLocalizedString
 class ErrorActivity : LocalizedActivity() {
     companion object {
         const val EXTRA_ERRORS = "ERRORS"
+        const val EXTRA_NOTIFICATION_ID = "NOTIFICATION_ID"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,6 +33,13 @@ class ErrorActivity : LocalizedActivity() {
             }
         } else {
             finish()
+        }
+
+        val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+        if (notificationId != -1) {
+            val notificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.cancel(notificationId)
         }
     }
 }


### PR DESCRIPTION
Closes #5811 

The solution here is to make all (event) notifications follow these rules:

- Success notifications have title and subtitle, clicking returns to or opens app
- Failure notifications have title and subtitle and "Show details" action, clicking returns to or opens app, clicking action shows errors screen (on top of current task)
- Clicking notification or action dismisses notification

#### Why is this the best possible solution? Were any other approaches considered?

For each case, there are probably better solutions, but for now we want to get on solid ground and avoid any weird problems from notification flows (like that encountered in the issue). The biggest sacrifice we're making here is that we're removing ways for users to fix problems that the notifications are flagging (like failed match exactly syncs). However, these were half baked anyway as they would only work if the user was currently in the correct project and could cause issues if they were midway through form entry.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should only change the behaviour of notifications. It'd be good to try and find if the new flows allow any weird navigation scenarios.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
