### PR TITLE
Extract Main Menu to Fragment to prevent lifecycle crashes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -1,49 +1,20 @@
 package org.odk.collect.android.mainmenu
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuItem
-import android.view.View
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.widget.Toolbar
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.ActivityUtils
 import org.odk.collect.android.activities.CrashHandlerActivity
-import org.odk.collect.android.activities.DeleteSavedFormActivity
 import org.odk.collect.android.activities.FirstLaunchActivity
-import org.odk.collect.android.activities.FormDownloadListActivity
-import org.odk.collect.android.activities.InstanceChooserList
-import org.odk.collect.android.activities.InstanceUploaderListActivity
-import org.odk.collect.android.activities.WebViewActivity
-import org.odk.collect.android.application.MapboxClassInstanceCreator.createMapBoxInitializationFragment
-import org.odk.collect.android.application.MapboxClassInstanceCreator.isMapboxAvailable
-import org.odk.collect.android.databinding.MainMenuBinding
-import org.odk.collect.android.formlists.blankformlist.BlankFormListActivity
-import org.odk.collect.android.formmanagement.FormFillingIntentFactory
-import org.odk.collect.android.gdrive.GoogleDriveActivity
 import org.odk.collect.android.injection.DaggerUtils
-import org.odk.collect.android.projects.ProjectIconView
 import org.odk.collect.android.projects.ProjectSettingsDialog
-import org.odk.collect.android.utilities.ApplicationConstants
-import org.odk.collect.android.utilities.ApplicationConstants.AppStateKeys.EDITED_FINALIZED_FORM
-import org.odk.collect.android.utilities.PlayServicesChecker
 import org.odk.collect.android.utilities.ThemeUtils
-import org.odk.collect.androidshared.data.getState
-import org.odk.collect.androidshared.ui.DialogFragmentUtils.showIfNotShowing
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
-import org.odk.collect.androidshared.ui.SnackbarUtils
-import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard.allowClick
 import org.odk.collect.crashhandler.CrashHandler
 import org.odk.collect.permissions.PermissionsProvider
-import org.odk.collect.projects.Project.Saved
 import org.odk.collect.settings.SettingsProvider
-import org.odk.collect.settings.keys.ProjectKeys
-import org.odk.collect.strings.R.string
 import org.odk.collect.strings.localization.LocalizedActivity
 import javax.inject.Inject
 
@@ -58,14 +29,7 @@ class MainMenuActivity : LocalizedActivity() {
     @Inject
     lateinit var permissionsProvider: PermissionsProvider
 
-    private lateinit var binding: MainMenuBinding
-    private lateinit var mainMenuViewModel: MainMenuViewModel
     private lateinit var currentProjectViewModel: CurrentProjectViewModel
-
-    private val formEntryFlowLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            displayFormSavedSnackbar(it.data?.data)
-        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         initSplashScreen()
@@ -81,98 +45,40 @@ class MainMenuActivity : LocalizedActivity() {
         DaggerUtils.getComponent(this).inject(this)
 
         val viewModelProvider = ViewModelProvider(this, viewModelFactory)
-        mainMenuViewModel = viewModelProvider[MainMenuViewModel::class.java]
         currentProjectViewModel = viewModelProvider[CurrentProjectViewModel::class.java]
-        val permissionsViewModel = viewModelProvider[RequestPermissionsViewModel::class.java]
-
-        this.supportFragmentManager.fragmentFactory = FragmentFactoryBuilder()
-            .forClass(PermissionsDialogFragment::class) {
-                PermissionsDialogFragment(
-                    permissionsProvider,
-                    permissionsViewModel
-                )
-            }
-            .forClass(ProjectSettingsDialog::class) {
-                ProjectSettingsDialog(viewModelFactory)
-            }
-            .build()
-
-        super.onCreate(savedInstanceState)
-        binding = MainMenuBinding.inflate(layoutInflater)
 
         ThemeUtils(this).setDarkModeForCurrentProject()
 
         if (!currentProjectViewModel.hasCurrentProject()) {
+            super.onCreate(null)
             ActivityUtils.startActivityAndCloseAllOthers(this, FirstLaunchActivity::class.java)
             return
+        } else {
+            this.supportFragmentManager.fragmentFactory = FragmentFactoryBuilder()
+                .forClass(PermissionsDialogFragment::class) {
+                    PermissionsDialogFragment(
+                        permissionsProvider,
+                        viewModelProvider[RequestPermissionsViewModel::class.java]
+                    )
+                }
+                .forClass(ProjectSettingsDialog::class) {
+                    ProjectSettingsDialog(viewModelFactory)
+                }
+                .forClass(MainMenuFragment::class) {
+                    MainMenuFragment(viewModelFactory, settingsProvider)
+                }
+                .build()
+
+            super.onCreate(savedInstanceState)
+            setContentView(R.layout.main_menu_activity)
+
+            if (savedInstanceState == null) {
+                supportFragmentManager
+                    .beginTransaction()
+                    .add(R.id.fragment_container, MainMenuFragment::class.java, null)
+                    .commit()
+            }
         }
-
-        setContentView(binding.root)
-
-        currentProjectViewModel.currentProject.observe(this) { (_, name): Saved ->
-            invalidateOptionsMenu()
-            title = name
-        }
-
-        initToolbar()
-        initMapbox()
-        initButtons()
-        initAppName()
-
-        if (permissionsViewModel.shouldAskForPermissions()) {
-            showIfNotShowing(PermissionsDialogFragment::class.java, this.supportFragmentManager)
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        if (isFinishing) {
-            return // Guard against onResume calls after we've finished in onCreate
-        }
-
-        currentProjectViewModel.refresh()
-        mainMenuViewModel.refreshInstances()
-        setButtonsVisibility()
-        setupDeprecationBanner()
-    }
-
-    private fun setButtonsVisibility() {
-        binding.reviewData.visibility =
-            if (mainMenuViewModel.shouldEditSavedFormButtonBeVisible()) View.VISIBLE else View.GONE
-        binding.sendData.visibility =
-            if (mainMenuViewModel.shouldSendFinalizedFormButtonBeVisible()) View.VISIBLE else View.GONE
-        binding.viewSentForms.visibility =
-            if (mainMenuViewModel.shouldViewSentFormButtonBeVisible()) View.VISIBLE else View.GONE
-        binding.getForms.visibility =
-            if (mainMenuViewModel.shouldGetBlankFormButtonBeVisible()) View.VISIBLE else View.GONE
-        binding.manageForms.visibility =
-            if (mainMenuViewModel.shouldDeleteSavedFormButtonBeVisible()) View.VISIBLE else View.GONE
-    }
-
-    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
-        val projectsMenuItem = menu.findItem(R.id.projects)
-        (projectsMenuItem.actionView as ProjectIconView).apply {
-            project = currentProjectViewModel.currentProject.value
-            setOnClickListener { onOptionsItemSelected(projectsMenuItem) }
-            contentDescription = getString(string.projects)
-        }
-        return super.onPrepareOptionsMenu(menu)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.main_menu, menu)
-        return super.onCreateOptionsMenu(menu)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (!allowClick(javaClass.name)) {
-            return true
-        }
-        if (item.itemId == R.id.projects) {
-            showIfNotShowing(ProjectSettingsDialog::class.java, supportFragmentManager)
-            return true
-        }
-        return super.onOptionsItemSelected(item)
     }
 
     private fun initSplashScreen() {
@@ -185,157 +91,6 @@ class MainMenuActivity : LocalizedActivity() {
             installSplashScreen()
         } else {
             setTheme(R.style.Theme_Collect)
-        }
-    }
-
-    private fun initToolbar() {
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        setSupportActionBar(toolbar)
-    }
-
-    private fun initMapbox() {
-        if (isMapboxAvailable()) {
-            supportFragmentManager
-                .beginTransaction()
-                .add(R.id.map_box_initialization_fragment, createMapBoxInitializationFragment()!!)
-                .commit()
-        }
-    }
-
-    private fun initButtons() {
-        binding.enterData.setOnClickListener {
-            formEntryFlowLauncher.launch(
-                Intent(this, BlankFormListActivity::class.java)
-            )
-        }
-
-        binding.reviewData.setOnClickListener {
-            formEntryFlowLauncher.launch(
-                Intent(this, InstanceChooserList::class.java).apply {
-                    putExtra(
-                        ApplicationConstants.BundleKeys.FORM_MODE,
-                        ApplicationConstants.FormModes.EDIT_SAVED
-                    )
-                }
-            )
-        }
-
-        binding.sendData.setOnClickListener {
-            formEntryFlowLauncher.launch(Intent(this, InstanceUploaderListActivity::class.java))
-        }
-
-        binding.viewSentForms.setOnClickListener {
-            startActivity(
-                Intent(this, InstanceChooserList::class.java).apply {
-                    putExtra(
-                        ApplicationConstants.BundleKeys.FORM_MODE,
-                        ApplicationConstants.FormModes.VIEW_SENT
-                    )
-                }
-            )
-        }
-
-        binding.getForms.setOnClickListener(
-            View.OnClickListener {
-                val protocol =
-                    settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_PROTOCOL)
-                val intent =
-                    if (protocol.equals(ProjectKeys.PROTOCOL_GOOGLE_SHEETS, ignoreCase = true)) {
-                        if (PlayServicesChecker().isGooglePlayServicesAvailable(this@MainMenuActivity)) {
-                            Intent(
-                                applicationContext,
-                                GoogleDriveActivity::class.java
-                            )
-                        } else {
-                            PlayServicesChecker().showGooglePlayServicesAvailabilityErrorDialog(this@MainMenuActivity)
-                            return@OnClickListener
-                        }
-                    } else {
-                        Intent(
-                            applicationContext,
-                            FormDownloadListActivity::class.java
-                        )
-                    }
-                startActivity(intent)
-            }
-        )
-
-        binding.manageForms.setOnClickListener {
-            startActivity(Intent(this, DeleteSavedFormActivity::class.java))
-        }
-
-        mainMenuViewModel.sendableInstancesCount.observe(this) { finalized: Int ->
-            binding.sendData.setNumberOfForms(finalized)
-        }
-        mainMenuViewModel.editableInstancesCount.observe(this) { unsent: Int ->
-            binding.reviewData.setNumberOfForms(unsent)
-        }
-        mainMenuViewModel.sentInstancesCount.observe(this) { sent: Int ->
-            binding.viewSentForms.setNumberOfForms(sent)
-        }
-    }
-
-    private fun initAppName() {
-        binding.appName.text = String.format(
-            "%s %s",
-            getString(string.collect_app_name),
-            mainMenuViewModel.version
-        )
-
-        val versionSHA = mainMenuViewModel.versionCommitDescription
-        if (versionSHA != null) {
-            binding.versionSha.text = versionSHA
-        } else {
-            binding.versionSha.visibility = View.GONE
-        }
-    }
-
-    private fun setupDeprecationBanner() {
-        val unprotectedSettings = settingsProvider.getUnprotectedSettings()
-        val protocol = unprotectedSettings.getString(ProjectKeys.KEY_PROTOCOL)
-        val usingGoogleDrive = ProjectKeys.PROTOCOL_GOOGLE_SHEETS == protocol
-        val editedFinalizedForm =
-            application.getState().get<Boolean>(EDITED_FINALIZED_FORM) ?: false
-
-        if (usingGoogleDrive) {
-            binding.deprecationBanner.root.visibility = View.VISIBLE
-            binding.deprecationBanner.message.setText(string.google_drive_deprecation_message)
-            binding.deprecationBanner.learnMoreButton.setOnClickListener {
-                val intent = Intent(this, WebViewActivity::class.java)
-                intent.putExtra("url", "https://forum.getodk.org/t/40097")
-                startActivity(intent)
-            }
-        } else if (editedFinalizedForm) {
-            binding.deprecationBanner.root.visibility = View.VISIBLE
-            binding.deprecationBanner.message.setText(string.edit_finalized_form_deprecation_message)
-            binding.deprecationBanner.learnMoreButton.setOnClickListener {
-                val intent = Intent(this, WebViewActivity::class.java)
-                intent.putExtra("url", "https://forum.getodk.org/t/42007")
-                startActivity(intent)
-            }
-        } else {
-            binding.deprecationBanner.root.visibility = View.GONE
-        }
-    }
-
-    private fun displayFormSavedSnackbar(uri: Uri?) {
-        if (uri == null) {
-            return
-        }
-
-        val formSavedSnackbarDetails = mainMenuViewModel.getFormSavedSnackbarDetails(uri)
-
-        formSavedSnackbarDetails?.let {
-            SnackbarUtils.showLongSnackbar(
-                binding.root,
-                getString(it.first),
-                action = it.second?.let { action ->
-                    SnackbarUtils.Action(getString(action)) {
-                        formEntryFlowLauncher.launch(FormFillingIntentFactory.editInstanceIntent(this, uri))
-                    }
-                },
-                displayDismissButton = true
-            )
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -71,13 +71,6 @@ class MainMenuActivity : LocalizedActivity() {
 
             super.onCreate(savedInstanceState)
             setContentView(R.layout.main_menu_activity)
-
-            if (savedInstanceState == null) {
-                supportFragmentManager
-                    .beginTransaction()
-                    .add(R.id.fragment_container, MainMenuFragment::class.java, null)
-                    .commit()
-            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
@@ -1,0 +1,311 @@
+package org.odk.collect.android.mainmenu
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import org.odk.collect.android.activities.DeleteSavedFormActivity
+import org.odk.collect.android.activities.FormDownloadListActivity
+import org.odk.collect.android.activities.InstanceChooserList
+import org.odk.collect.android.activities.InstanceUploaderListActivity
+import org.odk.collect.android.activities.WebViewActivity
+import org.odk.collect.android.application.MapboxClassInstanceCreator
+import org.odk.collect.android.databinding.MainMenuBinding
+import org.odk.collect.android.formlists.blankformlist.BlankFormListActivity
+import org.odk.collect.android.formmanagement.FormFillingIntentFactory
+import org.odk.collect.android.gdrive.GoogleDriveActivity
+import org.odk.collect.android.projects.ProjectIconView
+import org.odk.collect.android.projects.ProjectSettingsDialog
+import org.odk.collect.android.utilities.ApplicationConstants
+import org.odk.collect.android.utilities.PlayServicesChecker
+import org.odk.collect.androidshared.data.getState
+import org.odk.collect.androidshared.ui.DialogFragmentUtils
+import org.odk.collect.androidshared.ui.SnackbarUtils
+import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
+import org.odk.collect.projects.Project
+import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.keys.ProjectKeys
+import org.odk.collect.strings.R
+
+class MainMenuFragment(
+    private val viewModelFactory: ViewModelProvider.Factory,
+    private val settingsProvider: SettingsProvider
+) : Fragment() {
+
+    private lateinit var mainMenuViewModel: MainMenuViewModel
+    private lateinit var currentProjectViewModel: CurrentProjectViewModel
+    private lateinit var permissionsViewModel: RequestPermissionsViewModel
+
+    private val formEntryFlowLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            displayFormSavedSnackbar(it.data?.data)
+        }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        val viewModelProvider = ViewModelProvider(this, viewModelFactory)
+        mainMenuViewModel = viewModelProvider[MainMenuViewModel::class.java]
+        currentProjectViewModel = viewModelProvider[CurrentProjectViewModel::class.java]
+        permissionsViewModel = viewModelProvider[RequestPermissionsViewModel::class.java]
+
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return MainMenuBinding.inflate(inflater, container, false).root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        currentProjectViewModel.currentProject.observe(viewLifecycleOwner) { (_, name): Project.Saved ->
+            requireActivity().invalidateOptionsMenu()
+            requireActivity().title = name
+        }
+
+        val binding = MainMenuBinding.bind(view)
+        initToolbar(binding)
+        initMapbox()
+        initButtons(binding)
+        initAppName(binding)
+
+        if (permissionsViewModel.shouldAskForPermissions()) {
+            DialogFragmentUtils.showIfNotShowing(
+                PermissionsDialogFragment::class.java,
+                this.parentFragmentManager
+            )
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        currentProjectViewModel.refresh()
+        mainMenuViewModel.refreshInstances()
+
+        val binding = MainMenuBinding.bind(requireView())
+        setButtonsVisibility(binding)
+        setupDeprecationBanner(binding)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        val projectsMenuItem = menu.findItem(org.odk.collect.android.R.id.projects)
+        (projectsMenuItem.actionView as ProjectIconView).apply {
+            project = currentProjectViewModel.currentProject.value
+            setOnClickListener { onOptionsItemSelected(projectsMenuItem) }
+            contentDescription = getString(R.string.projects)
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(org.odk.collect.android.R.menu.main_menu, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (!MultiClickGuard.allowClick(javaClass.name)) {
+            return true
+        }
+        if (item.itemId == org.odk.collect.android.R.id.projects) {
+            DialogFragmentUtils.showIfNotShowing(
+                ProjectSettingsDialog::class.java,
+                parentFragmentManager
+            )
+            return true
+        }
+
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun initToolbar(binding: MainMenuBinding) {
+        val toolbar = binding.root.findViewById<Toolbar>(org.odk.collect.android.R.id.toolbar)
+        (requireActivity() as AppCompatActivity).setSupportActionBar(toolbar)
+    }
+
+    private fun initMapbox() {
+        if (MapboxClassInstanceCreator.isMapboxAvailable()) {
+            childFragmentManager
+                .beginTransaction()
+                .add(
+                    org.odk.collect.android.R.id.map_box_initialization_fragment,
+                    MapboxClassInstanceCreator.createMapBoxInitializationFragment()!!
+                )
+                .commit()
+        }
+    }
+
+    private fun initButtons(binding: MainMenuBinding) {
+        binding.enterData.setOnClickListener {
+            formEntryFlowLauncher.launch(
+                Intent(requireActivity(), BlankFormListActivity::class.java)
+            )
+        }
+
+        binding.reviewData.setOnClickListener {
+            formEntryFlowLauncher.launch(
+                Intent(requireActivity(), InstanceChooserList::class.java).apply {
+                    putExtra(
+                        ApplicationConstants.BundleKeys.FORM_MODE,
+                        ApplicationConstants.FormModes.EDIT_SAVED
+                    )
+                }
+            )
+        }
+
+        binding.sendData.setOnClickListener {
+            formEntryFlowLauncher.launch(
+                Intent(
+                    requireActivity(),
+                    InstanceUploaderListActivity::class.java
+                )
+            )
+        }
+
+        binding.viewSentForms.setOnClickListener {
+            startActivity(
+                Intent(requireActivity(), InstanceChooserList::class.java).apply {
+                    putExtra(
+                        ApplicationConstants.BundleKeys.FORM_MODE,
+                        ApplicationConstants.FormModes.VIEW_SENT
+                    )
+                }
+            )
+        }
+
+        binding.getForms.setOnClickListener(
+            View.OnClickListener {
+                val protocol =
+                    settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_PROTOCOL)
+                val intent =
+                    if (protocol.equals(ProjectKeys.PROTOCOL_GOOGLE_SHEETS, ignoreCase = true)) {
+                        if (PlayServicesChecker().isGooglePlayServicesAvailable(requireContext())) {
+                            Intent(
+                                requireContext().applicationContext,
+                                GoogleDriveActivity::class.java
+                            )
+                        } else {
+                            PlayServicesChecker().showGooglePlayServicesAvailabilityErrorDialog(
+                                requireContext()
+                            )
+                            return@OnClickListener
+                        }
+                    } else {
+                        Intent(
+                            requireContext().applicationContext,
+                            FormDownloadListActivity::class.java
+                        )
+                    }
+                startActivity(intent)
+            }
+        )
+
+        binding.manageForms.setOnClickListener {
+            startActivity(Intent(requireContext(), DeleteSavedFormActivity::class.java))
+        }
+
+        mainMenuViewModel.sendableInstancesCount.observe(viewLifecycleOwner) { finalized: Int ->
+            binding.sendData.setNumberOfForms(finalized)
+        }
+        mainMenuViewModel.editableInstancesCount.observe(viewLifecycleOwner) { unsent: Int ->
+            binding.reviewData.setNumberOfForms(unsent)
+        }
+        mainMenuViewModel.sentInstancesCount.observe(viewLifecycleOwner) { sent: Int ->
+            binding.viewSentForms.setNumberOfForms(sent)
+        }
+    }
+
+    private fun initAppName(binding: MainMenuBinding) {
+        binding.appName.text = String.format(
+            "%s %s",
+            getString(R.string.collect_app_name),
+            mainMenuViewModel.version
+        )
+
+        val versionSHA = mainMenuViewModel.versionCommitDescription
+        if (versionSHA != null) {
+            binding.versionSha.text = versionSHA
+        } else {
+            binding.versionSha.visibility = View.GONE
+        }
+    }
+
+    private fun setButtonsVisibility(binding: MainMenuBinding) {
+        binding.reviewData.visibility =
+            if (mainMenuViewModel.shouldEditSavedFormButtonBeVisible()) View.VISIBLE else View.GONE
+        binding.sendData.visibility =
+            if (mainMenuViewModel.shouldSendFinalizedFormButtonBeVisible()) View.VISIBLE else View.GONE
+        binding.viewSentForms.visibility =
+            if (mainMenuViewModel.shouldViewSentFormButtonBeVisible()) View.VISIBLE else View.GONE
+        binding.getForms.visibility =
+            if (mainMenuViewModel.shouldGetBlankFormButtonBeVisible()) View.VISIBLE else View.GONE
+        binding.manageForms.visibility =
+            if (mainMenuViewModel.shouldDeleteSavedFormButtonBeVisible()) View.VISIBLE else View.GONE
+    }
+
+    private fun setupDeprecationBanner(binding: MainMenuBinding) {
+        val unprotectedSettings = settingsProvider.getUnprotectedSettings()
+        val protocol = unprotectedSettings.getString(ProjectKeys.KEY_PROTOCOL)
+        val usingGoogleDrive = ProjectKeys.PROTOCOL_GOOGLE_SHEETS == protocol
+        val editedFinalizedForm =
+            requireContext().getState()
+                .get<Boolean>(ApplicationConstants.AppStateKeys.EDITED_FINALIZED_FORM) ?: false
+
+        if (usingGoogleDrive) {
+            binding.deprecationBanner.root.visibility = View.VISIBLE
+            binding.deprecationBanner.message.setText(R.string.google_drive_deprecation_message)
+            binding.deprecationBanner.learnMoreButton.setOnClickListener {
+                val intent = Intent(requireActivity(), WebViewActivity::class.java)
+                intent.putExtra("url", "https://forum.getodk.org/t/40097")
+                startActivity(intent)
+            }
+        } else if (editedFinalizedForm) {
+            binding.deprecationBanner.root.visibility = View.VISIBLE
+            binding.deprecationBanner.message.setText(R.string.edit_finalized_form_deprecation_message)
+            binding.deprecationBanner.learnMoreButton.setOnClickListener {
+                val intent = Intent(requireActivity(), WebViewActivity::class.java)
+                intent.putExtra("url", "https://forum.getodk.org/t/42007")
+                startActivity(intent)
+            }
+        } else {
+            binding.deprecationBanner.root.visibility = View.GONE
+        }
+    }
+
+    private fun displayFormSavedSnackbar(uri: Uri?) {
+        if (uri == null) {
+            return
+        }
+
+        val formSavedSnackbarDetails = mainMenuViewModel.getFormSavedSnackbarDetails(uri)
+
+        formSavedSnackbarDetails?.let {
+            SnackbarUtils.showLongSnackbar(
+                requireView(),
+                getString(it.first),
+                action = it.second?.let { action ->
+                    SnackbarUtils.Action(getString(action)) {
+                        formEntryFlowLauncher.launch(
+                            FormFillingIntentFactory.editInstanceIntent(
+                                requireContext(),
+                                uri
+                            )
+                        )
+                    }
+                },
+                displayDismissButton = true
+            )
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
@@ -10,7 +10,6 @@ import android.view.View.VISIBLE
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import org.odk.collect.android.R
 import org.odk.collect.android.activities.AboutActivity
 import org.odk.collect.android.activities.ActivityUtils
 import org.odk.collect.android.databinding.ProjectSettingsDialogLayoutBinding
@@ -45,6 +44,7 @@ class ProjectSettingsDialog(private val viewModelFactory: ViewModelProvider.Fact
             requireActivity(),
             viewModelFactory
         )[CurrentProjectViewModel::class.java]
+        currentProjectViewModel.refresh()
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/collect_app/src/main/res/layout/main_menu_activity.xml
+++ b/collect_app/src/main/res/layout/main_menu_activity.xml
@@ -6,6 +6,7 @@
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:name="org.odk.collect.android.mainmenu.MainMenuFragment"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/main_menu_activity.xml
+++ b/collect_app/src/main/res/layout/main_menu_activity.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
A few crashes we're seeing seem to be due to `MainMenuActivity#onResume` being called after we've returned from `onCreate` early (like in the case of there being no project or if there was a crash previously) even though we don't think that should be possible. Example reports can be found [here](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/659334e6745f2091c278553fcd6cd324?time=last-seven-days&types=crash&versions=v2023.3.0%20(4724)&sessionEventKey=654CC65D012C00012DB57BFD4EA85A9E_1877872807391578392) and [here](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/36d734b2df2245b1bf696b339012067d?time=last-seven-days&types=crash&versions=v2023.3.0%20(4724)&sessionEventKey=654CC6A802C800013532974F40671EBA_1877873127641981130).

I wanted to have a quick go at moving the Main Menu view and logic into a Fragment as this would allow us to only load the Fragment when we want to actually display it which prevents problems with lifecycle being called that we want to skip. 

#### Why is this the best possible solution? Were any other approaches considered?

The original solution to this was to have a "launch" Activity with `noHistory=true` (or that finishes itself) that handles the initial navigation. However, this causes problems for application restarts as that Activity would not be part of the back stack so the logic would be skipped. 

Like we've experimented with in `EntityBrowserActivity`, I think we most likely want the "form management" portion of the app to be hosted in a single Activity and multiple Fragments using the new(ish) Jetpack Navigation component, and this is a good first step towards that. I should also note that I've not made the switch to things like Fragment results or MenuProvider in `MainMenuFragment` to keep this a short piece of work. That's definitely something we can add on later.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Only the main menu has changed, but it's obviously an important part of the app so playing with it as much as possible would be good.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
