### PR TITLE
Load select choices off the UI thread

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/async/TrackableWorker.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/async/TrackableWorker.kt
@@ -1,4 +1,4 @@
-package org.odk.collect.android.async
+package org.odk.collect.androidshared.async
 
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidshared.livedata.NonNullLiveData
@@ -6,7 +6,7 @@ import org.odk.collect.async.Scheduler
 import java.util.function.Consumer
 import java.util.function.Supplier
 
-class ViewModelWorker(private val scheduler: Scheduler) {
+class TrackableWorker(private val scheduler: Scheduler) {
 
     private val _isWorking = MutableNonNullLiveData(false)
     val isWorking: NonNullLiveData<Boolean> = _isWorking

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -45,17 +45,19 @@ class SavePointTest {
 
         // Check audit log
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
-        assertThat(auditLog.size, equalTo(7))
+        assertThat(auditLog.size, equalTo(8))
 
         assertThat(auditLog[0].get("event"), equalTo("form start"))
         assertThat(auditLog[1].get("event"), equalTo("question"))
-        // Second question event not logged - possibly a problem
+        assertThat(auditLog[1].get("node"), equalTo("/data/name"))
+        assertThat(auditLog[2].get("event"), equalTo("question"))
+        assertThat(auditLog[2].get("node"), equalTo("/data/age"))
 
-        assertThat(auditLog[2].get("event"), equalTo("form resume"))
-        assertThat(auditLog[3].get("event"), equalTo("jump"))
-        assertThat(auditLog[4].get("event"), equalTo("question"))
-        assertThat(auditLog[5].get("event"), equalTo("form save"))
-        assertThat(auditLog[6].get("event"), equalTo("form exit"))
+        assertThat(auditLog[3].get("event"), equalTo("form resume"))
+        assertThat(auditLog[4].get("event"), equalTo("jump"))
+        assertThat(auditLog[5].get("event"), equalTo("question"))
+        assertThat(auditLog[6].get("event"), equalTo("form save"))
+        assertThat(auditLog[7].get("event"), equalTo("form exit"))
     }
 
     @Test
@@ -90,18 +92,20 @@ class SavePointTest {
 
         // Check audit log
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
-        assertThat(auditLog.size, equalTo(13))
+        assertThat(auditLog.size, equalTo(14))
 
         assertThat(auditLog[5].get("event"), equalTo("form resume"))
         assertThat(auditLog[6].get("event"), equalTo("jump"))
         assertThat(auditLog[7].get("event"), equalTo("question"))
-        // Second question event not logged - possibly a problem
+        assertThat(auditLog[7].get("node"), equalTo("/data/name"))
+        assertThat(auditLog[8].get("event"), equalTo("question"))
+        assertThat(auditLog[8].get("node"), equalTo("/data/age"))
 
-        assertThat(auditLog[8].get("event"), equalTo("form resume"))
-        assertThat(auditLog[9].get("event"), equalTo("jump"))
-        assertThat(auditLog[10].get("event"), equalTo("question"))
-        assertThat(auditLog[11].get("event"), equalTo("form save"))
-        assertThat(auditLog[12].get("event"), equalTo("form exit"))
+        assertThat(auditLog[9].get("event"), equalTo("form resume"))
+        assertThat(auditLog[10].get("event"), equalTo("jump"))
+        assertThat(auditLog[11].get("event"), equalTo("question"))
+        assertThat(auditLog[12].get("event"), equalTo("form save"))
+        assertThat(auditLog[13].get("event"), equalTo("form exit"))
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CountingTaskExecutorIdlingResource.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CountingTaskExecutorIdlingResource.java
@@ -24,6 +24,8 @@ public class CountingTaskExecutorIdlingResource extends CountingTaskExecutorRule
 
     @Override
     protected void onIdle() {
-        resourceCallback.onTransitionToIdle();
+        if (resourceCallback != null) {
+            resourceCallback.onTransitionToIdle();
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -860,7 +860,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         // button or another question to jump to so we need to rebuild the view.
         if (requestCode == RequestCodes.HIERARCHY_ACTIVITY || requestCode == RequestCodes.CHANGE_SETTINGS) {
             activityDisplayed();
-            formEntryViewModel.refresh();
+            formEntryViewModel.refreshSync();
             return;
         }
 
@@ -2109,7 +2109,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                             boolean pendingActivityResult = task.hasPendingActivityResult();
                             if (pendingActivityResult) {
                                 formControllerAvailable(formController);
-                                formEntryViewModel.refresh();
+                                formEntryViewModel.refreshSync();
                                 onActivityResult(task.getRequestCode(), task.getResultCode(), task.getIntent());
                             } else {
                                 formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.HIERARCHY, true, System.currentTimeMillis());

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -567,6 +567,24 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
             }
         });
 
+        formEntryViewModel.getValidationResult().observe(this, consumable -> {
+            if (consumable.isConsumed()) {
+                return;
+            }
+            ValidationResult validationResult = consumable.getValue();
+            if (validationResult instanceof FailedValidationResult failedValidationResult) {
+                String errorMessage = failedValidationResult.getCustomErrorMessage();
+                if (errorMessage == null) {
+                    errorMessage = getString(failedValidationResult.getDefaultErrorMessage());
+                }
+                getCurrentViewIfODKView().setErrorForQuestionWithIndex(failedValidationResult.getIndex(), errorMessage);
+                swipeHandler.setBeenSwiped(false);
+            } else if (validationResult instanceof SuccessValidationResult) {
+                SnackbarUtils.showLongSnackbar(findViewById(R.id.llParent), getString(org.odk.collect.strings.R.string.success_form_validation), findViewById(R.id.buttonholder));
+            }
+            consumable.consume();
+        });
+
         formSaveViewModel = viewModelProvider.get(FormSaveViewModel.class);
         formSaveViewModel.getSaveResult().observe(this, this::handleSaveResult);
         formSaveViewModel.isSavingAnswerFile().observe(this, isSavingAnswerFile -> {
@@ -1190,27 +1208,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 odkViewLifecycle
         );
 
-        ODKView view = new ODKView(this, prompts, groups, advancingPage, formSaveViewModel, waitingForDataRegistry, viewModelAudioPlayer, audioRecorder, formEntryViewModel, internalRecordingRequester, externalAppRecordingRequester, audioHelperFactory.create(this));
-
-        formEntryViewModel.getValidationResult().observe(this, consumable -> {
-            if (consumable.isConsumed()) {
-                return;
-            }
-            ValidationResult validationResult = consumable.getValue();
-            if (validationResult instanceof FailedValidationResult failedValidationResult) {
-                String errorMessage = failedValidationResult.getCustomErrorMessage();
-                if (errorMessage == null) {
-                    errorMessage = getString(failedValidationResult.getDefaultErrorMessage());
-                }
-                getCurrentViewIfODKView().setErrorForQuestionWithIndex(failedValidationResult.getIndex(), errorMessage);
-                swipeHandler.setBeenSwiped(false);
-            } else if (validationResult instanceof SuccessValidationResult) {
-                SnackbarUtils.showLongSnackbar(findViewById(R.id.llParent), getString(org.odk.collect.strings.R.string.success_form_validation), findViewById(R.id.buttonholder));
-            }
-            consumable.consume();
-        });
-
-        return view;
+        return new ODKView(this, prompts, groups, advancingPage, formSaveViewModel, waitingForDataRegistry, viewModelAudioPlayer, audioRecorder, formEntryViewModel, internalRecordingRequester, externalAppRecordingRequester, audioHelperFactory.create(this));
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -113,7 +113,6 @@ import org.odk.collect.android.formentry.RecordingHandler;
 import org.odk.collect.android.formentry.RecordingWarningDialogFragment;
 import org.odk.collect.android.formentry.SwipeHandler;
 import org.odk.collect.android.formentry.audit.AuditEvent;
-import org.odk.collect.android.formentry.audit.AuditUtils;
 import org.odk.collect.android.formentry.audit.ChangesReasonPromptDialogFragment;
 import org.odk.collect.android.formentry.audit.IdentifyUserPromptDialogFragment;
 import org.odk.collect.android.formentry.audit.IdentityPromptViewModel;
@@ -1127,8 +1126,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         }
 
         switch (event) {
-            case FormEntryController.EVENT_BEGINNING_OF_FORM:
-                return createViewForFormBeginning(formController);
             case FormEntryController.EVENT_END_OF_FORM:
                 return createViewForFormEnd(formController);
             case FormEntryController.EVENT_QUESTION:
@@ -1136,8 +1133,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
             case FormEntryController.EVENT_REPEAT:
                 // should only be a group here if the event_group is a field-list
                 try {
-                    AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), System.currentTimeMillis());
-
                     FormEntryCaption[] groups = formController
                             .getGroupsForCurrentIndex();
                     FormEntryPrompt[] prompts = formController.getQuestionPrompts();
@@ -1234,26 +1229,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         if (odkView != null) {
             odkView = null;
         }
-    }
-
-    /**
-     * Steps to the next screen and creates a view for it. Always sets {@code advancingPage} to true
-     * to auto-play media.
-     */
-    private SwipeHandler.View createViewForFormBeginning(FormController formController) {
-        int event = FormEntryController.EVENT_BEGINNING_OF_FORM;
-        try {
-            event = formController.stepToNextScreenEvent();
-        } catch (JavaRosaException e) {
-            Timber.d(e);
-            if (e.getMessage().equals(e.getCause().getMessage())) {
-                createErrorDialog(new FormError.NonFatal(e.getMessage()));
-            } else {
-                createErrorDialog(new FormError.NonFatal(e.getMessage() + "\n\n" + e.getCause().getMessage()));
-            }
-        }
-
-        return createView(event, true);
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -568,24 +568,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
             }
         });
 
-        formEntryViewModel.getValidationResult().observe(this, consumable -> {
-            if (consumable.isConsumed()) {
-                return;
-            }
-            ValidationResult validationResult = consumable.getValue();
-            if (validationResult instanceof FailedValidationResult failedValidationResult) {
-                String errorMessage = failedValidationResult.getCustomErrorMessage();
-                if (errorMessage == null) {
-                    errorMessage = getString(failedValidationResult.getDefaultErrorMessage());
-                }
-                getCurrentViewIfODKView().setErrorForQuestionWithIndex(failedValidationResult.getIndex(), errorMessage);
-                swipeHandler.setBeenSwiped(false);
-            } else if (validationResult instanceof SuccessValidationResult) {
-                SnackbarUtils.showLongSnackbar(findViewById(R.id.llParent), getString(org.odk.collect.strings.R.string.success_form_validation), findViewById(R.id.buttonholder));
-            }
-            consumable.consume();
-        });
-
         formSaveViewModel = viewModelProvider.get(FormSaveViewModel.class);
         formSaveViewModel.getSaveResult().observe(this, this::handleSaveResult);
         formSaveViewModel.isSavingAnswerFile().observe(this, isSavingAnswerFile -> {
@@ -1213,7 +1195,27 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 odkViewLifecycle
         );
 
-        return new ODKView(this, prompts, groups, advancingPage, formSaveViewModel, waitingForDataRegistry, viewModelAudioPlayer, audioRecorder, formEntryViewModel, internalRecordingRequester, externalAppRecordingRequester, audioHelperFactory.create(this));
+        ODKView view = new ODKView(this, prompts, groups, advancingPage, formSaveViewModel, waitingForDataRegistry, viewModelAudioPlayer, audioRecorder, formEntryViewModel, internalRecordingRequester, externalAppRecordingRequester, audioHelperFactory.create(this));
+
+        formEntryViewModel.getValidationResult().observe(this, consumable -> {
+            if (consumable.isConsumed()) {
+                return;
+            }
+            ValidationResult validationResult = consumable.getValue();
+            if (validationResult instanceof FailedValidationResult failedValidationResult) {
+                String errorMessage = failedValidationResult.getCustomErrorMessage();
+                if (errorMessage == null) {
+                    errorMessage = getString(failedValidationResult.getDefaultErrorMessage());
+                }
+                getCurrentViewIfODKView().setErrorForQuestionWithIndex(failedValidationResult.getIndex(), errorMessage);
+                swipeHandler.setBeenSwiped(false);
+            } else if (validationResult instanceof SuccessValidationResult) {
+                SnackbarUtils.showLongSnackbar(findViewById(R.id.llParent), getString(org.odk.collect.strings.R.string.success_form_validation), findViewById(R.id.buttonholder));
+            }
+            consumable.consume();
+        });
+
+        return view;
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/async/ViewModelWorker.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/async/ViewModelWorker.kt
@@ -1,0 +1,21 @@
+package org.odk.collect.android.async
+
+import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
+import org.odk.collect.androidshared.livedata.NonNullLiveData
+import org.odk.collect.async.Scheduler
+import java.util.function.Consumer
+import java.util.function.Supplier
+
+class ViewModelWorker(private val scheduler: Scheduler) {
+
+    private val _isWorking = MutableNonNullLiveData(false)
+    val isWorking: NonNullLiveData<Boolean> = _isWorking
+
+    fun <T> immediate(background: Supplier<T>, foreground: Consumer<T>) {
+        _isWorking.value = true
+        scheduler.immediate(background) { result ->
+            _isWorking.value = false
+            foreground.accept(result)
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -11,7 +11,6 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
-import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
@@ -39,12 +38,10 @@ import org.odk.collect.async.Cancellable;
 import org.odk.collect.async.Scheduler;
 
 import java.io.FileNotFoundException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader {
 
@@ -334,10 +331,10 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             }
 
             try {
-                    /*
-                     We can't load for field lists as their choices might change on screen (before
-                     updateIndex is called again).
-                    */
+                /*
+                 We can't load for field lists as their choices might change on screen (before
+                 updateIndex is called again).
+                */
                 if (!formController.indexIsInFieldList()) {
                     preloadSelectChoices();
                 }
@@ -384,15 +381,9 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
     private void preloadSelectChoices() throws RepeatsInFieldListException, FileNotFoundException, XPathSyntaxException {
         int event = formController.getEvent();
-        if (event == FormEntryController.EVENT_QUESTION || event == FormEntryController.EVENT_GROUP || event == FormEntryController.EVENT_REPEAT) {
+        if (event == FormEntryController.EVENT_QUESTION) {
             FormEntryPrompt[] prompts = formController.getQuestionPrompts();
-            List<FormEntryPrompt> selectPrompts = Arrays.stream(prompts).filter((prompt) -> {
-                boolean isSelect = prompt.getControlType() == Constants.CONTROL_SELECT_ONE || prompt.getControlType() == Constants.CONTROL_SELECT_MULTI || prompt.getControlType() == Constants.CONTROL_RANK;
-
-                boolean isSelectOneExternal = prompt.getControlType() == Constants.CONTROL_INPUT && prompt.getDataType() == Constants.DATATYPE_TEXT && prompt.getQuestion().getAdditionalAttribute(null, "query") != null;
-                return isSelect || isSelectOneExternal;
-            }).collect(Collectors.toList());
-            for (FormEntryPrompt prompt : selectPrompts) {
+            for (FormEntryPrompt prompt : prompts) {
                 List<SelectChoice> selectChoices = SelectChoiceUtils.loadSelectChoices(prompt, formController);
                 choices.put(prompt.getIndex(), selectChoices);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -25,6 +25,7 @@ import org.odk.collect.android.async.ViewModelWorker;
 import org.odk.collect.android.exception.ExternalDataException;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.formentry.audit.AuditEvent;
+import org.odk.collect.android.formentry.audit.AuditUtils;
 import org.odk.collect.android.formentry.questions.SelectChoiceUtils;
 import org.odk.collect.android.javarosawrapper.FailedValidationResult;
 import org.odk.collect.android.javarosawrapper.FormController;
@@ -324,6 +325,14 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         choices.clear();
 
         if (formController != null) {
+            if (formController.getEvent() == FormEntryController.EVENT_BEGINNING_OF_FORM) {
+                try {
+                    formController.stepToNextScreenEvent();
+                } catch (JavaRosaException e) {
+                    // Ignored
+                }
+            }
+
             try {
                     /*
                      We can't load for field lists as their choices might change on screen (before
@@ -336,6 +345,8 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                      FileNotFoundException e) {
                 // Ignored
             }
+
+            AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), clock.get());
 
             if (Looper.getMainLooper().getThread() == Thread.currentThread()) {
                 currentIndex.setValue(formController.getFormIndex());

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -378,8 +378,9 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
     private void preloadSelectChoices() throws RepeatsInFieldListException, FileNotFoundException, XPathSyntaxException {
         int event = formController.getEvent();
         if (event == FormEntryController.EVENT_QUESTION) {
-            FormEntryPrompt[] prompts = formController.getQuestionPrompts();
-            for (FormEntryPrompt prompt : prompts) {
+            FormEntryPrompt prompt = formController.getQuestionPrompt();
+
+            if (prompt != null) {
                 List<SelectChoice> selectChoices = SelectChoiceUtils.loadSelectChoices(prompt, formController);
                 choices.put(prompt.getIndex(), selectChoices);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -293,7 +293,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         if (selectChoices != null) {
             return selectChoices;
         } else {
-            // Not all select choices are loaded preemptively yet
+            // Choice lists from some questions aren't preloaded yet
             return SelectChoiceUtils.loadSelectChoices(prompt, formController);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -141,14 +141,14 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             try {
                 formController.newRepeat();
             } catch (RuntimeException e) {
-                error.setValue(new FormError.NonFatal(e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
+                error.postValue(new FormError.NonFatal(e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
             }
 
             if (!formController.indexIsInFieldList()) {
                 try {
                     formController.stepToNextScreenEvent();
                 } catch (JavaRosaException e) {
-                    error.setValue(new FormError.NonFatal(e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
+                    error.postValue(new FormError.NonFatal(e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
                 }
             }
 
@@ -170,7 +170,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 try {
                     this.formController.stepToNextScreenEvent();
                 } catch (JavaRosaException exception) {
-                    error.setValue(new FormError.NonFatal(exception.getCause().getMessage()));
+                    error.postValue(new FormError.NonFatal(exception.getCause().getMessage()));
                 }
             }
 
@@ -225,7 +225,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 try {
                     formController.stepToPreviousScreenEvent();
                 } catch (JavaRosaException e) {
-                    error.setValue(new FormError.NonFatal(e.getCause().getMessage()));
+                    error.postValue(new FormError.NonFatal(e.getCause().getMessage()));
                 }
 
                 updateIndex();
@@ -329,7 +329,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 try {
                     formController.stepToNextScreenEvent();
                 } catch (JavaRosaException e) {
-                    error.setValue(new FormError.NonFatal(e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
+                    error.postValue(new FormError.NonFatal(e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
                 }
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -18,7 +18,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.xpath.parser.XPathSyntaxException;
-import org.odk.collect.android.async.ViewModelWorker;
+import org.odk.collect.androidshared.async.TrackableWorker;
 import org.odk.collect.android.exception.ExternalDataException;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.formentry.audit.AuditEvent;
@@ -67,13 +67,13 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
     private final Map<FormIndex, List<SelectChoice>> choices = new HashMap<>();
 
-    private final ViewModelWorker worker;
+    private final TrackableWorker worker;
 
     @SuppressWarnings("WeakerAccess")
     public FormEntryViewModel(Supplier<Long> clock, Scheduler scheduler, FormSessionRepository formSessionRepository, String sessionId) {
         this.clock = clock;
         this.formSessionRepository = formSessionRepository;
-        worker = new ViewModelWorker(scheduler);
+        worker = new TrackableWorker(scheduler);
 
         this.sessionId = sessionId;
         formSessionObserver = observe(formSessionRepository.get(this.sessionId), formSession -> {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -3,8 +3,6 @@ package org.odk.collect.android.formentry;
 import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getRepeatGroupIndex;
 import static org.odk.collect.androidshared.livedata.LiveDataUtils.observe;
 
-import android.os.Looper;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
@@ -306,6 +304,9 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         formSessionObserver.cancel();
     }
 
+    /**
+     * Use {@link #refresh()} instead.
+     */
     @Deprecated
     public void refreshSync() {
         updateIndex();
@@ -344,12 +345,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             }
 
             AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), clock.get());
-
-            if (Looper.getMainLooper().getThread() == Thread.currentThread()) {
-                currentIndex.setValue(formController.getFormIndex());
-            } else {
-                currentIndex.postValue(formController.getFormIndex());
-            }
+            currentIndex.postValue(formController.getFormIndex());
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -219,7 +219,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
     }
 
     public void moveBackward(HashMap<FormIndex, IAnswerData> answers) {
-        worker.immediate((Supplier<Void>) () -> {
+        worker.immediate((Supplier<Boolean>) () -> {
             boolean updateSuccess = saveScreenAnswersToFormController(answers, false);
             if (updateSuccess) {
                 try {
@@ -231,9 +231,11 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 updateIndex();
             }
 
-            return null;
-        }, ignored -> {
-            formController.getAuditEventLogger().flush(); // Close events waiting for an end time
+            return updateSuccess;
+        }, updateSuccess -> {
+            if (updateSuccess) {
+                formController.getAuditEventLogger().flush(); // Close events waiting for an end time
+            }
         });
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -329,7 +329,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 try {
                     formController.stepToNextScreenEvent();
                 } catch (JavaRosaException e) {
-                    // Ignored
+                    error.setValue(new FormError.NonFatal(e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
                 }
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -58,7 +58,15 @@ public class AuditEventLogger {
     public void logEvent(AuditEvent.AuditEventType eventType, FormIndex formIndex,
                          boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
         checkAndroidUIThread();
+        internalLog(eventType, formIndex, writeImmediatelyToDisk, questionAnswer, currentTime, changeReason);
+    }
 
+    public synchronized void logEventSynchronized(AuditEvent.AuditEventType eventType, FormIndex formIndex,
+                         boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
+        internalLog(eventType, formIndex, writeImmediatelyToDisk, questionAnswer, currentTime, changeReason);
+    }
+
+    private void internalLog(AuditEvent.AuditEventType eventType, FormIndex formIndex, boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
         if (!isAuditEnabled() || shouldBeIgnored(eventType)) {
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -48,19 +48,28 @@ public class AuditEventLogger {
         this.formController = formController;
     }
 
+    /**
+     * @deprecated use {@link #logEventSynchronized(AuditEvent.AuditEventType, FormIndex, boolean, String, long, String)} instead
+     */
+    @Deprecated
     public void logEvent(AuditEvent.AuditEventType eventType, boolean writeImmediatelyToDisk, long currentTime) {
         logEvent(eventType, null, writeImmediatelyToDisk, null, currentTime, null);
     }
 
-    /*
-     * Log a new event
+    /**
+     * @deprecated use {@link #logEventSynchronized(AuditEvent.AuditEventType, FormIndex, boolean, String, long, String)} instead
      */
+    @Deprecated
     public void logEvent(AuditEvent.AuditEventType eventType, FormIndex formIndex,
                          boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
         checkAndroidUIThread();
         internalLog(eventType, formIndex, writeImmediatelyToDisk, questionAnswer, currentTime, changeReason);
     }
 
+    /**
+     * Logs events to the audit log. Can safely be used on a background thread, but should not be
+     * used on the UI thread.
+     */
     public synchronized void logEventSynchronized(AuditEvent.AuditEventType eventType, FormIndex formIndex,
                          boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
         internalLog(eventType, formIndex, writeImmediatelyToDisk, questionAnswer, currentTime, changeReason);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.kt
@@ -24,7 +24,7 @@ object AuditUtils {
                             null
                         }
 
-                    auditEventLogger.logEvent(
+                    auditEventLogger.logEventSynchronized(
                         AuditEvent.AuditEventType.QUESTION,
                         question.index,
                         true,

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/SelectChoiceUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/SelectChoiceUtils.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.formentry.questions
 
 import org.javarosa.core.model.SelectChoice
 import org.javarosa.form.api.FormEntryPrompt
+import org.javarosa.measure.Measure
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.odk.collect.android.dynamicpreload.ExternalDataUtil
 import org.odk.collect.android.exception.ExternalDataException
@@ -16,6 +17,8 @@ object SelectChoiceUtils {
     @JvmStatic
     @Throws(FileNotFoundException::class, XPathSyntaxException::class, ExternalDataException::class)
     fun loadSelectChoices(prompt: FormEntryPrompt, formController: FormController): List<SelectChoice> {
+        Measure.log("LoadSelectChoices")
+
         return when {
             isFastExternalItemsetUsed(prompt) -> readFastExternalItems(prompt, formController)
             isSearchPulldataItemsetUsed(prompt) -> readSearchPulldataItems(prompt, formController)

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/SelectChoiceUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/SelectChoiceUtils.kt
@@ -22,7 +22,7 @@ object SelectChoiceUtils {
         return when {
             isFastExternalItemsetUsed(prompt) -> readFastExternalItems(prompt, formController)
             isSearchPulldataItemsetUsed(prompt) -> readSearchPulldataItems(prompt, formController)
-            else -> prompt.selectChoices
+            else -> prompt.selectChoices ?: emptyList()
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -21,7 +21,6 @@ import org.odk.collect.android.dao.helpers.InstancesDaoHelper;
 import org.odk.collect.android.dynamicpreload.ExternalDataManager;
 import org.odk.collect.android.formentry.FormSession;
 import org.odk.collect.android.formentry.audit.AuditEvent;
-import org.odk.collect.android.formentry.audit.AuditUtils;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.projects.ProjectsDataService;
 import org.odk.collect.android.tasks.SaveFormToDisk;
@@ -255,8 +254,6 @@ public class FormSaveViewModel extends ViewModel implements MaterialProgressDial
                     } else {
                         formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_EXIT, true, clock.get());
                     }
-                } else {
-                    AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), clock.get());
                 }
 
                 saveResult.setValue(new SaveResult(SaveResult.State.SAVED, saveRequest, taskResult.getSaveErrorMessage()));

--- a/collect_app/src/test/java/org/odk/collect/android/configure/qr/QRCodeMenuProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/configure/qr/QRCodeMenuProviderTest.kt
@@ -99,7 +99,7 @@ class QRCodeMenuProviderTest {
     fun clickingOnShare_whenQRCodeIsGenerated_startsShareIntent() {
         whenever(qrCodeGenerator.generateQRCode(any(), any())).thenReturn("qr.png")
         whenever(fileProvider.getURIForFile("qr.png")).thenReturn(Uri.parse("uri"))
-        fakeScheduler.runBackground()
+        fakeScheduler.flush()
         menuProvider.onMenuItemSelected(RoboMenuItem(R.id.menu_item_share))
         val intent = Shadows.shadowOf(activity).nextStartedActivity
 

--- a/collect_app/src/test/java/org/odk/collect/android/configure/qr/QRCodeViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/configure/qr/QRCodeViewModelTest.kt
@@ -4,12 +4,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.odk.collect.android.R
 import org.odk.collect.android.TestSettingsProvider.getProtectedSettings
 import org.odk.collect.android.TestSettingsProvider.getUnprotectedSettings
 import org.odk.collect.settings.keys.ProjectKeys
@@ -24,21 +22,9 @@ class QRCodeViewModelTest {
     private val generalSettings = getUnprotectedSettings()
     private val adminSettings = getProtectedSettings()
 
-    private lateinit var viewModel: QRCodeViewModel
-
-    @Before
-    fun setup() {
-        viewModel = QRCodeViewModel(
-            qrCodeGenerator,
-            appConfigurationGenerator,
-            generalSettings,
-            adminSettings,
-            fakeScheduler
-        )
-    }
-
     @Test
     fun setIncludedKeys_generatesQRCodeWithKeys() {
+        val viewModel = createViewModel()
         viewModel.setIncludedKeys(listOf("foo", "bar"))
         fakeScheduler.runBackground()
 
@@ -47,6 +33,7 @@ class QRCodeViewModelTest {
 
     @Test
     fun warning_whenNeitherServerOrAdminPasswordSet_isNull() {
+        val viewModel = createViewModel()
         assertThat(viewModel.warning.value, nullValue())
     }
 
@@ -54,8 +41,21 @@ class QRCodeViewModelTest {
     fun warning_whenServerAndAdminPasswordSet_isForBoth() {
         generalSettings.save(ProjectKeys.KEY_PASSWORD, "blah")
         adminSettings.save(ProtectedProjectKeys.KEY_ADMIN_PW, "blah")
+        val viewModel = createViewModel()
 
-        fakeScheduler.runBackground()
         assertThat(viewModel.warning.value, equalTo(org.odk.collect.strings.R.string.qrcode_with_both_passwords))
+    }
+
+    private fun createViewModel(): QRCodeViewModel {
+        val viewModel = QRCodeViewModel(
+            qrCodeGenerator,
+            appConfigurationGenerator,
+            generalSettings,
+            adminSettings,
+            fakeScheduler
+        )
+
+        fakeScheduler.runBackground() // Run initial QR generation
+        return viewModel
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/configure/qr/QRCodeViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/configure/qr/QRCodeViewModelTest.kt
@@ -55,7 +55,7 @@ class QRCodeViewModelTest {
             fakeScheduler
         )
 
-        fakeScheduler.runBackground() // Run initial QR generation
+        fakeScheduler.flush() // Run initial QR generation
         return viewModel
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -75,6 +75,7 @@ public class FormEntryViewModelTest {
     @Test
     public void addRepeat_stepsToNextScreenEvent() throws Exception {
         viewModel.addRepeat();
+        scheduler.runBackground();
         verify(formController).stepToNextScreenEvent();
     }
 
@@ -83,6 +84,7 @@ public class FormEntryViewModelTest {
         doThrow(new RuntimeException(new IOException("OH NO"))).when(formController).newRepeat();
 
         viewModel.addRepeat();
+        scheduler.runBackground();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
 
@@ -95,6 +97,8 @@ public class FormEntryViewModelTest {
         doThrow(runtimeException).when(formController).newRepeat();
 
         viewModel.addRepeat();
+        scheduler.runBackground();
+
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("Unknown issue occurred while adding a new group")));
     }
 
@@ -103,6 +107,7 @@ public class FormEntryViewModelTest {
         when(formController.stepToNextScreenEvent()).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.addRepeat();
+        scheduler.runBackground();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
 
@@ -115,6 +120,8 @@ public class FormEntryViewModelTest {
         when(formController.stepToNextScreenEvent()).thenThrow(javaRosaException);
 
         viewModel.addRepeat();
+        scheduler.runBackground();
+
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("Unknown issue occurred while adding a new group")));
     }
 
@@ -130,7 +137,11 @@ public class FormEntryViewModelTest {
     @Test
     public void cancelRepeatPrompt_afterPromptForNewRepeatAndCancelRepeatPrompt_doesNotJumpBack() {
         viewModel.promptForNewRepeat();
+        scheduler.runBackground();
+
         viewModel.cancelRepeatPrompt();
+        scheduler.runBackground();
+
         verify(formController).jumpToIndex(startingIndex);
 
         viewModel.cancelRepeatPrompt();
@@ -142,6 +153,7 @@ public class FormEntryViewModelTest {
         when(formController.stepToNextScreenEvent()).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.cancelRepeatPrompt();
+        scheduler.runBackground();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
 
@@ -208,7 +220,7 @@ public class FormEntryViewModelTest {
             return 0;
         });
 
-        viewModel.refresh();
+        viewModel.refreshSync();
         assertThat(getOrAwaitValue(viewModel.getCurrentIndex()), equalTo(startingIndex));
 
         viewModel.moveForward(new HashMap<>());
@@ -323,7 +335,7 @@ public class FormEntryViewModelTest {
             return 0;
         });
 
-        viewModel.refresh();
+        viewModel.refreshSync();
         assertThat(getOrAwaitValue(viewModel.getCurrentIndex()), equalTo(startingIndex));
 
         viewModel.moveBackward(new HashMap<>());

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -324,6 +324,19 @@ public class FormEntryViewModelTest {
         assertThat(formController.getStepPosition(), equalTo(0));
     }
 
+    /**
+     * We don't want to flush the log before answers are actually committed.
+     */
+    @Test
+    public void moveBackward_whenThereIsAnErrorSaving_doesNotFlushAuditLog() throws Exception {
+        formController.setSaveError(new JavaRosaException(new IOException("OH NO")));
+
+        viewModel.moveBackward(new HashMap<>());
+        scheduler.flush();
+
+        verify(auditEventLogger, never()).flush();
+    }
+
     @Test
     public void moveBackward_setsLoadingToTrueWhileBackgroundWorkHappens() throws Exception {
         assertThat(getOrAwaitValue(viewModel.isLoading()), equalTo(false));

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -16,6 +16,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Rule;
@@ -57,6 +58,25 @@ public class FormEntryViewModelTest {
 
         formSessionRepository.set("blah", formController, mock());
         viewModel = new FormEntryViewModel(() -> 0L, scheduler, formSessionRepository, "blah");
+    }
+
+    @Test
+    public void refresh_whenEventIsBeginningOfForm_stepsForwards() {
+        formController.setCurrentEvent(FormEntryController.EVENT_BEGINNING_OF_FORM);
+
+        viewModel.refresh();
+        scheduler.flush();
+        assertThat(formController.getStepPosition(), equalTo(1));
+    }
+
+    @Test
+    public void refresh_whenEventIsBeginningOfForm_andThereIsAnErrorSteppingForward_setsError() {
+        formController.setCurrentEvent(FormEntryController.EVENT_BEGINNING_OF_FORM);
+        formController.setNextStepError(new JavaRosaException(new IOException("OH NO")));
+
+        viewModel.refresh();
+        scheduler.flush();
+        assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
 
     @Test
@@ -329,5 +349,4 @@ public class FormEntryViewModelTest {
         scheduler.flush();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
-
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -76,7 +76,7 @@ public class FormEntryViewModelTest {
     @Test
     public void addRepeat_stepsToNextScreenEvent() throws Exception {
         viewModel.addRepeat();
-        scheduler.runBackground();
+        scheduler.flush();
         verify(formController).stepToNextScreenEvent();
     }
 
@@ -85,7 +85,7 @@ public class FormEntryViewModelTest {
         doThrow(new RuntimeException(new IOException("OH NO"))).when(formController).newRepeat();
 
         viewModel.addRepeat();
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
 
@@ -98,7 +98,7 @@ public class FormEntryViewModelTest {
         doThrow(runtimeException).when(formController).newRepeat();
 
         viewModel.addRepeat();
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("Unknown issue occurred while adding a new group")));
     }
@@ -108,7 +108,7 @@ public class FormEntryViewModelTest {
         when(formController.stepToNextScreenEvent()).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.addRepeat();
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
 
@@ -121,7 +121,7 @@ public class FormEntryViewModelTest {
         when(formController.stepToNextScreenEvent()).thenThrow(javaRosaException);
 
         viewModel.addRepeat();
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("Unknown issue occurred while adding a new group")));
     }
@@ -138,10 +138,10 @@ public class FormEntryViewModelTest {
     @Test
     public void cancelRepeatPrompt_afterPromptForNewRepeatAndCancelRepeatPrompt_doesNotJumpBack() {
         viewModel.promptForNewRepeat();
-        scheduler.runBackground();
+        scheduler.flush();
 
         viewModel.cancelRepeatPrompt();
-        scheduler.runBackground();
+        scheduler.flush();
 
         verify(formController).jumpToIndex(startingIndex);
 
@@ -154,7 +154,7 @@ public class FormEntryViewModelTest {
         when(formController.stepToNextScreenEvent()).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.cancelRepeatPrompt();
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
 
@@ -221,11 +221,12 @@ public class FormEntryViewModelTest {
             return 0;
         });
 
-        viewModel.refreshSync();
+        viewModel.refresh();
+        scheduler.flush();
         assertThat(getOrAwaitValue(viewModel.getCurrentIndex()), equalTo(startingIndex));
 
         viewModel.moveForward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(getOrAwaitValue(viewModel.getCurrentIndex()), equalTo(nextIndex));
     }
 
@@ -234,7 +235,7 @@ public class FormEntryViewModelTest {
         when(formController.stepToNextScreenEvent()).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.moveForward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
@@ -246,7 +247,7 @@ public class FormEntryViewModelTest {
         when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenReturn(failedValidationResult.getValue());
 
         viewModel.moveForward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(getOrAwaitValue(viewModel.getValidationResult()), equalTo(failedValidationResult));
     }
@@ -260,7 +261,7 @@ public class FormEntryViewModelTest {
         when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenReturn(failedValidationResult);
 
         viewModel.moveForward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
 
         verify(auditEventLogger, never()).flush();
     }
@@ -271,7 +272,7 @@ public class FormEntryViewModelTest {
         when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenReturn(failedValidationResult);
 
         viewModel.moveForward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
 
         verify(formController, never()).stepToNextScreenEvent();
     }
@@ -281,7 +282,7 @@ public class FormEntryViewModelTest {
         when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.moveForward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
@@ -291,7 +292,7 @@ public class FormEntryViewModelTest {
         when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.moveForward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
 
         verify(formController, never()).stepToNextScreenEvent();
     }
@@ -312,7 +313,7 @@ public class FormEntryViewModelTest {
         HashMap<FormIndex, IAnswerData> answers = new HashMap<>();
         viewModel.moveForward(answers, true);
 
-        scheduler.runBackground();
+        scheduler.flush();
         verify(formController).saveAllScreenAnswers(answers, true);
     }
 
@@ -336,11 +337,12 @@ public class FormEntryViewModelTest {
             return 0;
         });
 
-        viewModel.refreshSync();
+        viewModel.refresh();
+        scheduler.flush();
         assertThat(getOrAwaitValue(viewModel.getCurrentIndex()), equalTo(startingIndex));
 
         viewModel.moveBackward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(getOrAwaitValue(viewModel.getCurrentIndex()), equalTo(nextIndex));
     }
 
@@ -349,7 +351,7 @@ public class FormEntryViewModelTest {
         when(formController.stepToPreviousScreenEvent()).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.moveBackward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
@@ -359,7 +361,7 @@ public class FormEntryViewModelTest {
         when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.moveBackward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
@@ -369,7 +371,7 @@ public class FormEntryViewModelTest {
         when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.moveBackward(new HashMap<>());
-        scheduler.runBackground();
+        scheduler.flush();
 
         verify(formController, never()).stepToPreviousScreenEvent();
     }
@@ -401,7 +403,7 @@ public class FormEntryViewModelTest {
         when(formController.validateAnswers(true, true)).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.validate();
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -205,7 +205,7 @@ public class FormEntryViewModelTest {
         HashMap<FormIndex, IAnswerData> answers = new HashMap<>();
         viewModel.moveForward(answers);
 
-        scheduler.runBackground();
+        scheduler.flush();
         InOrder verifier = inOrder(formController, auditEventLogger);
         verifier.verify(formController).saveAllScreenAnswers(answers, false);
         verifier.verify(formController).stepToNextScreenEvent();
@@ -302,7 +302,7 @@ public class FormEntryViewModelTest {
         viewModel.moveForward(new HashMap<>());
         assertThat(getOrAwaitValue(viewModel.isLoading()), equalTo(true));
 
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(getOrAwaitValue(viewModel.isLoading()), equalTo(false));
     }
 
@@ -320,7 +320,7 @@ public class FormEntryViewModelTest {
         HashMap<FormIndex, IAnswerData> answers = new HashMap<>();
         viewModel.moveBackward(answers);
 
-        scheduler.runBackground();
+        scheduler.flush();
         InOrder verifier = inOrder(formController, auditEventLogger);
         verifier.verify(formController).saveAllScreenAnswers(answers, false);
         verifier.verify(formController).stepToPreviousScreenEvent();
@@ -380,7 +380,7 @@ public class FormEntryViewModelTest {
         viewModel.moveBackward(new HashMap<>());
         assertThat(getOrAwaitValue(viewModel.isLoading()), equalTo(true));
 
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(getOrAwaitValue(viewModel.isLoading()), equalTo(false));
     }
 
@@ -391,7 +391,7 @@ public class FormEntryViewModelTest {
         viewModel.validate();
         assertThat(getOrAwaitValue(viewModel.isLoading()), equalTo(true));
 
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(getOrAwaitValue(viewModel.isLoading()), equalTo(false));
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -22,6 +22,7 @@ import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Rule;
@@ -40,7 +41,6 @@ import org.odk.collect.testshared.FakeScheduler;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.function.Supplier;
 
 @RunWith(AndroidJUnit4.class)
 @SuppressWarnings("PMD.DoubleBraceInitialization")
@@ -62,6 +62,7 @@ public class FormEntryViewModelTest {
         startingIndex = new FormIndex(null, 0, 0, new TreeReference());
         when(formController.getFormIndex()).thenReturn(startingIndex);
         when(formController.getFormDef()).thenReturn(new FormDef());
+        when(formController.getEvent()).thenReturn(FormEntryController.EVENT_END_OF_FORM);
 
         auditEventLogger = mock(AuditEventLogger.class);
         when(formController.getAuditEventLogger()).thenReturn(auditEventLogger);
@@ -69,7 +70,7 @@ public class FormEntryViewModelTest {
         scheduler = new FakeScheduler();
 
         formSessionRepository.set("blah", formController, mock());
-        viewModel = new FormEntryViewModel(mock(Supplier.class), scheduler, formSessionRepository, "blah");
+        viewModel = new FormEntryViewModel(() -> 0L, scheduler, formSessionRepository, "blah");
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -10,17 +10,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.androidtest.LiveDataTestUtilsKt.getOrAwaitValue;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
-import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,18 +25,13 @@ import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.formentry.support.InMemFormSessionRepository;
 import org.odk.collect.android.javarosawrapper.FailedValidationResult;
-import org.odk.collect.android.javarosawrapper.SuccessValidationResult;
-import org.odk.collect.android.javarosawrapper.ValidationResult;
+import org.odk.collect.android.javarosawrapper.FakeFormController;
 import org.odk.collect.android.support.MockFormEntryPromptBuilder;
-import org.odk.collect.android.utilities.StubFormController;
 import org.odk.collect.androidshared.data.Consumable;
 import org.odk.collect.testshared.FakeScheduler;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 
 @RunWith(AndroidJUnit4.class)
 @SuppressWarnings("PMD.DoubleBraceInitialization")
@@ -340,166 +330,4 @@ public class FormEntryViewModelTest {
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
 
-    private static class FakeFormController extends StubFormController {
-        private FormIndex index;
-        private final AuditEventLogger auditEventLogger;
-        private final LinkedList<Integer> nextEvents = new LinkedList<>();
-        private Integer currentEvent = FormEntryController.EVENT_END_OF_FORM;
-        private int step;
-        private RuntimeException newRepeatError;
-        private JavaRosaException nextStepError;
-        private JavaRosaException saveError;
-        private Map<FormIndex, FormEntryPrompt> prompts = new HashMap<>();
-        private FailedValidationResult failedConstraint;
-        private JavaRosaException validationError;
-        private JavaRosaException previousStepError;
-        private FormIndex nextRepeatPrompt;
-
-        FakeFormController(FormIndex startingIndex, AuditEventLogger auditEventLogger) {
-            this.index = startingIndex;
-            this.auditEventLogger = auditEventLogger;
-        }
-
-        @Nullable
-        @Override
-        public FormIndex getFormIndex() {
-            return index;
-        }
-
-        @Nullable
-        @Override
-        public FormDef getFormDef() {
-            return new FormDef();
-        }
-
-        @Override
-        public int getEvent() {
-            return currentEvent;
-        }
-
-        @Nullable
-        @Override
-        public AuditEventLogger getAuditEventLogger() {
-            return auditEventLogger;
-        }
-
-        @Override
-        public int stepToNextScreenEvent() throws JavaRosaException {
-            if (nextStepError != null) {
-                throw nextStepError;
-            }
-
-            step = step + 1;
-            index = new FormIndex(null, index.getLocalIndex() + 1, 0, new TreeReference());
-
-            if (!nextEvents.isEmpty()) {
-                currentEvent = nextEvents.pop();
-            } else {
-                currentEvent = FormEntryController.EVENT_END_OF_FORM;
-            }
-
-            return currentEvent;
-        }
-
-        @Override
-        public void newRepeat() {
-            if (newRepeatError != null) {
-                throw newRepeatError;
-            }
-        }
-
-        @NonNull
-        @Override
-        public ValidationResult saveAllScreenAnswers(@Nullable HashMap<FormIndex, IAnswerData> answers, boolean evaluateConstraints) throws JavaRosaException {
-            if (saveError != null) {
-                throw saveError;
-            } else if (failedConstraint != null) {
-                return failedConstraint;
-            } else {
-                return SuccessValidationResult.INSTANCE;
-            }
-        }
-
-        @Nullable
-        @Override
-        public FormEntryPrompt getQuestionPrompt(FormIndex index) {
-            return prompts.get(index);
-        }
-
-        @NonNull
-        @Override
-        public ValidationResult validateAnswers(boolean markCompleted, boolean moveToInvalidIndex) throws JavaRosaException {
-            if (validationError != null) {
-                throw validationError;
-            } else {
-                return SuccessValidationResult.INSTANCE;
-            }
-        }
-
-        @Override
-        public int stepToPreviousScreenEvent() throws JavaRosaException {
-            if (previousStepError != null) {
-                throw previousStepError;
-            }
-
-            step = step - 1;
-            index = new FormIndex(null, index.getLocalIndex() - 1, 0, new TreeReference());
-            return FormEntryController.EVENT_BEGINNING_OF_FORM;
-        }
-
-        @Override
-        public void jumpToNewRepeatPrompt() {
-            if (nextRepeatPrompt != null) {
-                index = nextRepeatPrompt;
-            } else {
-                throw new IllegalStateException("No repeat prompt index set!");
-            }
-        }
-
-        @Override
-        public int jumpToIndex(@Nullable FormIndex index) {
-                this.index = index;
-                return FormEntryController.EVENT_END_OF_FORM;
-        }
-
-        public void addNextEvents(List<Integer> events) {
-            nextEvents.addAll(events);
-        }
-
-        public int getStepPosition() {
-            return step;
-        }
-
-        public void setNewRepeatError(RuntimeException exception) {
-            this.newRepeatError = exception;
-        }
-
-        public void setNextStepError(JavaRosaException exception) {
-            this.nextStepError = exception;
-        }
-
-        public void setPreviousStepError(JavaRosaException exception) {
-            this.previousStepError = exception;
-        }
-
-        public void setSaveError(JavaRosaException exception) {
-            this.saveError = exception;
-        }
-
-        public void setPrompt(FormIndex index, FormEntryPrompt prompt) {
-            prompts.put(index, prompt);
-        }
-
-        public void setFailedConstraint(FailedValidationResult result) {
-            this.failedConstraint = result;
-        }
-
-        public void setValidationError(JavaRosaException exception) {
-            this.validationError = exception;
-        }
-
-        public void setNextRepeatPrompt(FormIndex nextRepeatPrompt) {
-            this.nextRepeatPrompt = nextRepeatPrompt;
-        }
-    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/RecordingHandlerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/RecordingHandlerTest.java
@@ -20,7 +20,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.odk.collect.android.audio.AudioFileAppender;
 import org.odk.collect.android.javarosawrapper.FormController;
-import org.odk.collect.android.utilities.DummyFormController;
+import org.odk.collect.android.utilities.StubFormController;
 import org.odk.collect.android.widgets.support.FakeQuestionMediaManager;
 import org.odk.collect.androidtest.FakeLifecycleOwner;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
@@ -218,7 +218,7 @@ public class RecordingHandlerTest {
         assertThat(questionMediaManager.getAnswerFile(newRecording.getName()).exists(), is(false));
     }
 
-    private class TestFormController extends DummyFormController {
+    private class TestFormController extends StubFormController {
         @Override
         public FormDef getFormDef() {
             return formDef;

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -521,7 +521,7 @@ public class FormSaveViewModelTest {
 
         File externalFile = File.createTempFile("external", ".file");
         LiveData<Result<File>> answerFile = viewModel.createAnswerFile(externalFile);
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(tempDir.listFiles().length, is(1));
         assertThat(answerFile.getValue().getOrNull().getName(), is(tempDir.listFiles()[0].getName()));
@@ -535,7 +535,7 @@ public class FormSaveViewModelTest {
 
         File externalFile = File.createTempFile("external", ".file");
         LiveData<Result<File>> answerFile = viewModel.createAnswerFile(externalFile);
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(answerFile.getValue().getOrNull(), nullValue());
         assertThat(viewModel.getAnswerFileError().getValue(), equalTo(externalFile.getAbsolutePath()));
@@ -548,9 +548,9 @@ public class FormSaveViewModelTest {
 
         File externalFile = File.createTempFile("external", ".file");
         LiveData<Result<File>> fileName1 = viewModel.createAnswerFile(externalFile);
-        scheduler.runBackground();
+        scheduler.flush();
         LiveData<Result<File>> fileName2 = viewModel.createAnswerFile(externalFile);
-        scheduler.runBackground();
+        scheduler.flush();
 
         assertThat(fileName1.getValue().getOrNull(), is(fileName2.getValue().getOrNull()));
     }
@@ -567,7 +567,7 @@ public class FormSaveViewModelTest {
         viewModel.createAnswerFile(File.createTempFile("external", ".file"));
         assertThat(viewModel.isSavingAnswerFile().getValue(), is(true));
 
-        scheduler.runBackground();
+        scheduler.flush();
         assertThat(viewModel.isSavingAnswerFile().getValue(), is(false));
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -4,9 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
-import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
-import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -30,7 +27,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.io.Files;
 
 import org.javarosa.form.api.FormEntryController;
-import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,10 +35,8 @@ import org.odk.collect.android.formentry.FormSession;
 import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.formentry.saving.FormSaver;
 import org.odk.collect.android.javarosawrapper.FormController;
-import org.odk.collect.android.javarosawrapper.RepeatsInFieldListException;
 import org.odk.collect.android.projects.ProjectsDataService;
 import org.odk.collect.android.support.CollectHelpers;
-import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.tasks.SaveFormToDisk;
 import org.odk.collect.android.tasks.SaveToDiskResult;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -61,7 +55,6 @@ import org.robolectric.annotation.LooperMode;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 
 @RunWith(AndroidJUnit4.class)
 @LooperMode(LooperMode.Mode.LEGACY)
@@ -156,93 +149,6 @@ public class FormSaveViewModelTest {
 
         whenFormSaverFinishes(SaveFormToDisk.SAVED);
         assertThat(saveResult.getValue().getState(), equalTo(SAVED));
-    }
-
-    @Test
-    public void whenFormSaverFinishes_saved_andFormIsCurrentlyOnQuestion_logsSaveAndQuestionAuditEventsAfterFlush() throws RepeatsInFieldListException {
-        when(formController.getEvent()).thenReturn(EVENT_QUESTION);
-        FormEntryPrompt prompt = new MockFormEntryPromptBuilder()
-                .withIndex("index1")
-                .withAnswerDisplayText("answer")
-                .build();
-        when(formController.getQuestionPrompts()).thenReturn(Arrays.asList(prompt).toArray(new FormEntryPrompt[]{}));
-
-        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-        whenFormSaverFinishes(SaveFormToDisk.SAVED);
-
-        InOrder verifier = inOrder(logger);
-        verifier.verify(logger).flush();
-        verifier.verify(logger).logEvent(
-                AuditEvent.AuditEventType.FORM_SAVE,
-                false,
-                CURRENT_TIME
-        );
-        verifier.verify(logger).logEvent(
-                AuditEvent.AuditEventType.QUESTION,
-                prompt.getIndex(),
-                true,
-                prompt.getAnswerValue().getDisplayText(),
-                CURRENT_TIME,
-                null
-        );
-    }
-
-    @Test
-    public void whenFormSaverFinishes_saved_andFormIsCurrentlyOnGroup_logsSaveAndQuestionAuditEventsAfterFlush() throws RepeatsInFieldListException {
-        when(formController.getEvent()).thenReturn(EVENT_GROUP);
-        FormEntryPrompt prompt = new MockFormEntryPromptBuilder()
-                .withIndex("index1")
-                .withAnswerDisplayText("answer")
-                .build();
-        when(formController.getQuestionPrompts()).thenReturn(Arrays.asList(prompt).toArray(new FormEntryPrompt[]{}));
-
-        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-        whenFormSaverFinishes(SaveFormToDisk.SAVED);
-
-        InOrder verifier = inOrder(logger);
-        verifier.verify(logger).flush();
-        verifier.verify(logger).logEvent(
-                AuditEvent.AuditEventType.FORM_SAVE,
-                false,
-                CURRENT_TIME
-        );
-        verifier.verify(logger).logEvent(
-                AuditEvent.AuditEventType.QUESTION,
-                prompt.getIndex(),
-                true,
-                prompt.getAnswerValue().getDisplayText(),
-                CURRENT_TIME,
-                null
-        );
-    }
-
-    @Test
-    public void whenFormSaverFinishes_saved_andFormIsCurrentlyOnRepeat_logsSaveAndQuestionAuditEventsAfterFlush() throws RepeatsInFieldListException {
-        when(formController.getEvent()).thenReturn(EVENT_REPEAT);
-        FormEntryPrompt prompt = new MockFormEntryPromptBuilder()
-                .withIndex("index1")
-                .withAnswerDisplayText("answer")
-                .build();
-        when(formController.getQuestionPrompts()).thenReturn(Arrays.asList(prompt).toArray(new FormEntryPrompt[]{}));
-
-        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-        whenFormSaverFinishes(SaveFormToDisk.SAVED);
-
-        InOrder verifier = inOrder(logger);
-        verifier.verify(logger).flush();
-        verifier.verify(logger).logEvent(
-                AuditEvent.AuditEventType.FORM_SAVE,
-                false,
-                CURRENT_TIME
-        );
-        verifier.verify(logger).logEvent(
-                AuditEvent.AuditEventType.QUESTION,
-                prompt.getIndex(),
-                true,
-                prompt.getAnswerValue().getDisplayText(),
-                CURRENT_TIME,
-                null
-        );
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
@@ -61,8 +61,7 @@ class BlankFormListViewModelTest {
         generalSettings.save(ProjectKeys.KEY_SERVER_URL, "https://sample.com")
         doReturn(true).whenever(formsDataService).matchFormsWithServer(projectId)
         val result = viewModel.syncWithServer()
-        scheduler.runBackground()
-        scheduler.runBackground()
+        scheduler.flush()
         assertThat(result.value, `is`(true))
     }
 
@@ -72,8 +71,7 @@ class BlankFormListViewModelTest {
         generalSettings.save(ProjectKeys.KEY_SERVER_URL, "https://sample.com")
         doReturn(false).whenever(formsDataService).matchFormsWithServer(projectId)
         val result = viewModel.syncWithServer()
-        scheduler.runBackground()
-        scheduler.runBackground()
+        scheduler.flush()
         assertThat(result.value, `is`(false))
     }
 
@@ -451,8 +449,7 @@ class BlankFormListViewModelTest {
         )
 
         if (runAllBackgroundTasks) {
-            scheduler.runBackground()
-            scheduler.runBackground()
+            scheduler.flush()
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
@@ -511,13 +511,14 @@ class FormMapViewModelTest {
         assertThat(viewModel.getMappableItems().value, equalTo(null))
 
         scheduler.runBackground()
+        scheduler.runForeground()
         assertThat(viewModel.isLoading().value, equalTo(false))
     }
 
     private fun createAndLoadViewModel(form: Form): FormMapViewModel {
         val viewModel = createViewModel(form)
         viewModel.load()
-        scheduler.runBackground()
+        scheduler.flush()
         return viewModel
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/send/ReadyToSendViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/send/ReadyToSendViewModelTest.kt
@@ -79,26 +79,26 @@ class ReadyToSendViewModelTest {
 
     @Test
     fun `numberOfSentInstances should represent the real number of instances with STATUS_SUBMITTED in the database`() {
-        scheduler.runBackground()
+        scheduler.flush()
         assertThat(viewModel.data.value!!.numberOfSentInstances, equalTo(2))
     }
 
     @Test
     fun `numberOfInstancesReadyToSend should represent the real number of instances with STATUS_COMPLETE and STATUS_SUBMISSION_FAILED in the database`() {
-        scheduler.runBackground()
+        scheduler.flush()
         assertThat(viewModel.data.value!!.numberOfInstancesReadyToSend, equalTo(4))
     }
 
     @Test
     fun `lastInstanceSentTimeMillis should be correctly calculate when the last instance has been sent`() {
-        scheduler.runBackground()
+        scheduler.flush()
         assertThat(viewModel.data.value!!.lastInstanceSentTimeMillis, equalTo(4000L))
     }
 
     @Test
     fun `lastInstanceSentTimeMillis should be 0 if there are no sent instances`() {
         instancesRepository.deleteAll()
-        scheduler.runBackground()
+        scheduler.flush()
         assertThat(viewModel.data.value!!.lastInstanceSentTimeMillis, equalTo(0L))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
@@ -179,4 +179,8 @@ public class FakeFormController extends StubFormController {
     public void setNextRepeatPrompt(FormIndex nextRepeatPrompt) {
         this.nextRepeatPrompt = nextRepeatPrompt;
     }
+
+    public void setCurrentEvent(int event) {
+        this.currentEvent = event;
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
@@ -105,6 +105,12 @@ public class FakeFormController extends StubFormController {
         return prompts.get(index);
     }
 
+    @Nullable
+    @Override
+    public FormEntryPrompt getQuestionPrompt() {
+        return currentPrompts.get(0);
+    }
+
     @NonNull
     @Override
     public ValidationResult validateAnswers(boolean markCompleted, boolean moveToInvalidIndex) throws JavaRosaException {

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
@@ -32,6 +32,7 @@ public class FakeFormController extends StubFormController {
     private JavaRosaException validationError;
     private JavaRosaException previousStepError;
     private FormIndex nextRepeatPrompt;
+    private List<FormEntryPrompt> currentPrompts;
 
     public FakeFormController(FormIndex startingIndex, AuditEventLogger auditEventLogger) {
         this.index = startingIndex;
@@ -140,6 +141,12 @@ public class FakeFormController extends StubFormController {
         return FormEntryController.EVENT_END_OF_FORM;
     }
 
+    @NonNull
+    @Override
+    public FormEntryPrompt[] getQuestionPrompts() {
+        return currentPrompts.toArray(new FormEntryPrompt[] {});
+    }
+
     public void addNextEvents(List<Integer> events) {
         nextEvents.addAll(events);
     }
@@ -182,5 +189,9 @@ public class FakeFormController extends StubFormController {
 
     public void setCurrentEvent(int event) {
         this.currentEvent = event;
+    }
+
+    public void setQuestionPrompts(List<FormEntryPrompt> prompts) {
+        this.currentPrompts = prompts;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
@@ -1,0 +1,182 @@
+package org.odk.collect.android.javarosawrapper;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.exception.JavaRosaException;
+import org.odk.collect.android.formentry.audit.AuditEventLogger;
+import org.odk.collect.android.utilities.StubFormController;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class FakeFormController extends StubFormController {
+    private FormIndex index;
+    private final AuditEventLogger auditEventLogger;
+    private final LinkedList<Integer> nextEvents = new LinkedList<>();
+    private Integer currentEvent = FormEntryController.EVENT_END_OF_FORM;
+    private int step;
+    private RuntimeException newRepeatError;
+    private JavaRosaException nextStepError;
+    private JavaRosaException saveError;
+    private Map<FormIndex, FormEntryPrompt> prompts = new HashMap<>();
+    private FailedValidationResult failedConstraint;
+    private JavaRosaException validationError;
+    private JavaRosaException previousStepError;
+    private FormIndex nextRepeatPrompt;
+
+    public FakeFormController(FormIndex startingIndex, AuditEventLogger auditEventLogger) {
+        this.index = startingIndex;
+        this.auditEventLogger = auditEventLogger;
+    }
+
+    @Nullable
+    @Override
+    public FormIndex getFormIndex() {
+        return index;
+    }
+
+    @Nullable
+    @Override
+    public FormDef getFormDef() {
+        return new FormDef();
+    }
+
+    @Override
+    public int getEvent() {
+        return currentEvent;
+    }
+
+    @Nullable
+    @Override
+    public AuditEventLogger getAuditEventLogger() {
+        return auditEventLogger;
+    }
+
+    @Override
+    public int stepToNextScreenEvent() throws JavaRosaException {
+        if (nextStepError != null) {
+            throw nextStepError;
+        }
+
+        step = step + 1;
+        index = new FormIndex(null, index.getLocalIndex() + 1, 0, new TreeReference());
+
+        if (!nextEvents.isEmpty()) {
+            currentEvent = nextEvents.pop();
+        } else {
+            currentEvent = FormEntryController.EVENT_END_OF_FORM;
+        }
+
+        return currentEvent;
+    }
+
+    @Override
+    public void newRepeat() {
+        if (newRepeatError != null) {
+            throw newRepeatError;
+        }
+    }
+
+    @NonNull
+    @Override
+    public ValidationResult saveAllScreenAnswers(@Nullable HashMap<FormIndex, IAnswerData> answers, boolean evaluateConstraints) throws JavaRosaException {
+        if (saveError != null) {
+            throw saveError;
+        } else if (failedConstraint != null) {
+            return failedConstraint;
+        } else {
+            return SuccessValidationResult.INSTANCE;
+        }
+    }
+
+    @Nullable
+    @Override
+    public FormEntryPrompt getQuestionPrompt(FormIndex index) {
+        return prompts.get(index);
+    }
+
+    @NonNull
+    @Override
+    public ValidationResult validateAnswers(boolean markCompleted, boolean moveToInvalidIndex) throws JavaRosaException {
+        if (validationError != null) {
+            throw validationError;
+        } else {
+            return SuccessValidationResult.INSTANCE;
+        }
+    }
+
+    @Override
+    public int stepToPreviousScreenEvent() throws JavaRosaException {
+        if (previousStepError != null) {
+            throw previousStepError;
+        }
+
+        step = step - 1;
+        index = new FormIndex(null, index.getLocalIndex() - 1, 0, new TreeReference());
+        return FormEntryController.EVENT_BEGINNING_OF_FORM;
+    }
+
+    @Override
+    public void jumpToNewRepeatPrompt() {
+        if (nextRepeatPrompt != null) {
+            index = nextRepeatPrompt;
+        } else {
+            throw new IllegalStateException("No repeat prompt index set!");
+        }
+    }
+
+    @Override
+    public int jumpToIndex(@Nullable FormIndex index) {
+        this.index = index;
+        return FormEntryController.EVENT_END_OF_FORM;
+    }
+
+    public void addNextEvents(List<Integer> events) {
+        nextEvents.addAll(events);
+    }
+
+    public int getStepPosition() {
+        return step;
+    }
+
+    public void setNewRepeatError(RuntimeException exception) {
+        this.newRepeatError = exception;
+    }
+
+    public void setNextStepError(JavaRosaException exception) {
+        this.nextStepError = exception;
+    }
+
+    public void setPreviousStepError(JavaRosaException exception) {
+        this.previousStepError = exception;
+    }
+
+    public void setSaveError(JavaRosaException exception) {
+        this.saveError = exception;
+    }
+
+    public void setPrompt(FormIndex index, FormEntryPrompt prompt) {
+        prompts.put(index, prompt);
+    }
+
+    public void setFailedConstraint(FailedValidationResult result) {
+        this.failedConstraint = result;
+    }
+
+    public void setValidationError(JavaRosaException exception) {
+        this.validationError = exception;
+    }
+
+    public void setNextRepeatPrompt(FormIndex nextRepeatPrompt) {
+        this.nextRepeatPrompt = nextRepeatPrompt;
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/StubFormController.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/StubFormController.kt
@@ -7,6 +7,7 @@ import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.core.services.transport.payload.ByteArrayPayload
 import org.javarosa.form.api.FormEntryCaption
 import org.javarosa.form.api.FormEntryPrompt
+import org.odk.collect.android.exception.JavaRosaException
 import org.odk.collect.android.formentry.audit.AuditEventLogger
 import org.odk.collect.android.javarosawrapper.FormController
 import org.odk.collect.android.javarosawrapper.InstanceMetadata
@@ -16,7 +17,7 @@ import org.odk.collect.entities.Entity
 import java.io.File
 import java.util.stream.Stream
 
-open class DummyFormController : FormController {
+open class StubFormController : FormController {
     override fun getFormDef(): FormDef? = null
 
     override fun getMediaFolder(): File? = null
@@ -75,6 +76,7 @@ open class DummyFormController : FormController {
 
     override fun answerQuestion(index: FormIndex?, data: IAnswerData?): Int = -1
 
+    @Throws(JavaRosaException::class)
     override fun validateAnswers(markCompleted: Boolean, moveToInvalidIndex: Boolean): ValidationResult = SuccessValidationResult
 
     override fun saveAnswer(index: FormIndex?, data: IAnswerData?): Boolean = false
@@ -87,8 +89,10 @@ open class DummyFormController : FormController {
 
     override fun stepOverGroup(): Int = -1
 
+    @Throws(JavaRosaException::class)
     override fun stepToPreviousScreenEvent(): Int = -1
 
+    @Throws(JavaRosaException::class)
     override fun stepToNextScreenEvent(): Int = -1
 
     override fun stepToOuterScreenEvent(): Int = -1
@@ -103,6 +107,7 @@ open class DummyFormController : FormController {
         evaluateConstraints: Boolean
     ): ValidationResult = SuccessValidationResult
 
+    @Throws(JavaRosaException::class)
     override fun saveAllScreenAnswers(
         answers: HashMap<FormIndex, IAnswerData>?,
         evaluateConstraints: Boolean

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -151,6 +151,9 @@ class SelectChoicesMapDataTest {
         assertThat(data.getMappableItems().value, equalTo(null))
 
         scheduler.runBackground()
+        assertThat(data.isLoading().value, equalTo(true))
+
+        scheduler.runForeground()
         assertThat(data.isLoading().value, equalTo(false))
     }
 
@@ -264,7 +267,7 @@ class SelectChoicesMapDataTest {
     private fun loadDataForPrompt(prompt: FormEntryPrompt): SelectChoicesMapData {
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
         val data = SelectChoicesMapData(resources, scheduler, prompt, null)
-        scheduler.runBackground()
+        scheduler.flush()
         return data
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
@@ -122,7 +122,7 @@ class SelectOneFromMapDialogFragmentTest {
             }
         )
 
-        scheduler.runBackground()
+        scheduler.flush()
 
         scenario.onFragment {
             Espresso.pressBack()
@@ -166,7 +166,7 @@ class SelectOneFromMapDialogFragmentTest {
             val fragment = binding.selectionMap.getFragment<SelectionMapFragment>()
 
             val data = fragment.selectionMapData
-            scheduler.runBackground()
+            scheduler.flush()
 
             assertThat(data.getMapTitle().value, equalTo(prompt.longText))
             assertThat(data.getItemCount().value, equalTo(prompt.selectChoices.size))
@@ -230,7 +230,7 @@ class SelectOneFromMapDialogFragmentTest {
             }
         )
 
-        scheduler.runBackground()
+        scheduler.flush()
 
         scenario.onFragment {
             val binding = SelectOneFromMapDialogLayoutBinding.bind(it.view!!)

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeScheduler.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeScheduler.kt
@@ -72,9 +72,8 @@ class FakeScheduler : Scheduler {
     }
 
     fun runBackground() {
-        if (backgroundTasks.isNotEmpty()) {
-            backgroundTasks.first().run()
-            backgroundTasks.removeFirst()
+        while (backgroundTasks.isNotEmpty()) {
+            backgroundTasks.remove().run()
         }
     }
 


### PR DESCRIPTION
Closes #5229
Closes #5263

This makes changes to how we load select choices so that some screen's won't have select choices loaded on the UI thread. This does not include field list screens as choice lists on those screens can change based on answers on the same screen - recalculating these lists asynchronously requires larger (and more fundamental) changes to form entry so we're punting on it for the moment (https://github.com/getodk/collect/issues/5841).

I had to make changes to audit logging for this to work which eventually meant doing some audit logging off the UI thread (solving #5263). I'd hope we can expand on this in the future, as audit logging can (and often) involves file IO and is not something we should be blocking the UI thread with.

#### Why is this the best possible solution? Were any other approaches considered?

I did experiment with going down a an alternative path which got us closer to something not unlike "unidirectional data flow" where we'd refresh the screen (asynchronously) on any widget change. This would allow us to safely preload choice lists for field list questions, but sadly still involved a lot more work to get everything working performantly. I have some hopes that that is a path we can go down soon, but that can wait until #5841.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Nothing should have changed obviously from a user perspective although forms with slower choice lists should now show a loading screen for longer rather than appearing to "freeze" (or crash). It's worth testing forms with normal selects as well as `select_one_external` and `search` selects on both single question screens and field lists though to check that none of the changes I've made introduce any problems.

There's also some risk to the audit log as a few log calls have been moved around. It would be good to check forms with the log enabled.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
