### PR TITLE
Fix `WebView` workaround causing Activity to be shown with incorrect theme

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -53,7 +53,6 @@ import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.animation.Animation;
 import android.view.animation.Animation.AnimationListener;
-import android.webkit.WebView;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -399,16 +398,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
      */
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        // Workaround for https://issuetracker.google.com/issues/37124582. Some widgets trigger
-        // this issue by including WebViews
-        if (Build.VERSION.SDK_INT >= 24) {
-            try {
-                new WebView(this);
-            } catch (Exception | Error e) {
-                // Don't crash if WebView not available
-            }
-        }
-
         Collect.getInstance().getComponent().inject(this);
 
         if (savedInstanceState == null) {

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.kt
@@ -53,6 +53,7 @@ class ApplicationInitializer(
             settingsProvider,
             context
         ).initialize()
+        SystemThemeMismatchFixInitializer(context).initialize()
     }
 
     private fun initializeFrameworks() {

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/SystemThemeMismatchFixInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/SystemThemeMismatchFixInitializer.kt
@@ -1,0 +1,29 @@
+package org.odk.collect.android.application.initialization
+
+import android.content.Context
+import android.os.Build
+import android.webkit.WebView
+
+/**
+ * When the app's theme doesn't match the system, the first [WebView] created will cause the host
+ * Activity to be recreated with incorrect resource loading (the system ones instead of the custom
+ * set dark/light resources). This doesn't happen for subsequent [WebView] creations however.
+ *
+ * Running this initializer will make sure that this problem doesn't occur in an actual Activity.
+ *
+ * See [this issue](https://issuetracker.google.com/issues/37124582) for more details.
+ */
+class SystemThemeMismatchFixInitializer(private val context: Context) {
+
+    fun initialize() {
+        if (Build.VERSION.SDK_INT >= 24) {
+            try {
+                WebView(context)
+            } catch (e: Exception) {
+                // Ignore
+            } catch (e: Error) {
+                // Ignore
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes an issue where form entry starts with the dark/light theme when the other is selected. To reproduce using v2023.3.0:

1. Set the project to use the opposite of the system (i.e. light if the system is dark)
2. Kill the app
3. Reopen the app and start a form

You'll see the first screen loads as the system theme in some parts, and the project theme in others. 

#### Why is this the best possible solution? Were any other approaches considered?

We were previously avoiding a very similar issue from occurring if the image select widget was in a form: once the widget was viewed, moving backwards or forwards in a form would cause some parts of the view to use the system theme rather than the project one. See [this Android issue](https://issuetracker.google.com/issues/37124582) for more details.

The solution here is mostly described in my comment in `FixMismatchThemeProblemsActivity`:

> When the app's theme doesn't match the system, the first [WebView] created will cause the host Activity to be recreated with incorrect resource loading (the system ones instead of the custom set dark/light resources). This doesn't happen for subsequent [WebView] creations however. 
>
> This Activity can be started at launch to be "sacrificed" so no other Activity has to deal with the problem.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue as described. It would be good to try and mess around with different projects using different themes to see if there's still a way to reproduce.

The problems the `WebView` was actually dealing with was that if you opened a form with a select one from image widget, moved to it and then moved to another widget (backwards or forwards), parts of the UI would use the system theme rather than the app one. You can see conversations about that [here](https://github.com/getodk/collect/pull/4803#issuecomment-906168621).

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
