### PR TITLE
Specify when formIndex should be updated when there are errors during validating answers

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredQuestionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredQuestionTest.java
@@ -113,4 +113,13 @@ public class RequiredQuestionTest {
                 .clickGoToEnd()
                 .clickSaveAndExitWithError("Custom required message2");
     }
+
+    @Test // https://github.com/getodk/collect/issues/5847
+    public void savingFormWithInvalidQuestion_shouldNotChangeTheCurrentQuestionIndex() {
+        rule.startAtMainMenu()
+                .copyForm("two-question-required.xml")
+                .startBlankForm("Two Question Required")
+                .clickSave()
+                .swipeToNextQuestion("What is your age?");
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryUseCases.kt
@@ -167,7 +167,7 @@ object FormEntryUseCases {
         formController: FormController,
         entitiesRepository: EntitiesRepository
     ): Boolean {
-        val validationResult = formController.validateAnswers(markCompleted = true, moveToInvalidateIndex = false)
+        val validationResult = formController.validateAnswers(markCompleted = true, moveToInvalidIndex = false)
         if (validationResult is FailedValidationResult) {
             return false
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryUseCases.kt
@@ -167,7 +167,7 @@ object FormEntryUseCases {
         formController: FormController,
         entitiesRepository: EntitiesRepository
     ): Boolean {
-        val validationResult = formController.validateAnswers(true)
+        val validationResult = formController.validateAnswers(markCompleted = true, moveToInvalidateIndex = false)
         if (validationResult is FailedValidationResult) {
             return false
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -298,7 +298,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 () -> {
                     ValidationResult result = null;
                     try {
-                        result = formController.validateAnswers(true);
+                        result = formController.validateAnswers(true, true);
                     } catch (JavaRosaException e) {
                         error.postValue(new FormError.NonFatal(e.getMessage()));
                     }

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.kt
@@ -139,7 +139,7 @@ interface FormController {
      * type.
      */
     @Throws(JavaRosaException::class)
-    fun validateAnswers(markCompleted: Boolean): ValidationResult
+    fun validateAnswers(markCompleted: Boolean, moveToInvalidateIndex: Boolean): ValidationResult
 
     /**
      * saveAnswer attempts to save the current answer into the data model without doing any

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.kt
@@ -139,7 +139,7 @@ interface FormController {
      * type.
      */
     @Throws(JavaRosaException::class)
-    fun validateAnswers(markCompleted: Boolean, moveToInvalidateIndex: Boolean): ValidationResult
+    fun validateAnswers(markCompleted: Boolean, moveToInvalidIndex: Boolean): ValidationResult
 
     /**
      * saveAnswer attempts to save the current answer into the data model without doing any

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
@@ -395,13 +395,15 @@ public class JavaRosaFormController implements FormController {
         }
     }
 
-    public ValidationResult validateAnswers(boolean markCompleted) throws JavaRosaException {
+    public ValidationResult validateAnswers(boolean markCompleted, boolean moveToInvalidateIndex) throws JavaRosaException {
         try {
             ValidateOutcome validateOutcome = getFormDef().validate(markCompleted);
             if (validateOutcome != null) {
-                this.jumpToIndex(validateOutcome.failedPrompt);
-                if (indexIsInFieldList()) {
-                    stepToPreviousScreenEvent();
+                if (moveToInvalidateIndex) {
+                    this.jumpToIndex(validateOutcome.failedPrompt);
+                    if (indexIsInFieldList()) {
+                        stepToPreviousScreenEvent();
+                    }
                 }
                 return new FailedValidationResult(validateOutcome.failedPrompt, validateOutcome.outcome);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
@@ -395,11 +395,11 @@ public class JavaRosaFormController implements FormController {
         }
     }
 
-    public ValidationResult validateAnswers(boolean markCompleted, boolean moveToInvalidateIndex) throws JavaRosaException {
+    public ValidationResult validateAnswers(boolean markCompleted, boolean moveToInvalidIndex) throws JavaRosaException {
         try {
             ValidateOutcome validateOutcome = getFormDef().validate(markCompleted);
             if (validateOutcome != null) {
-                if (moveToInvalidateIndex) {
+                if (moveToInvalidIndex) {
                     this.jumpToIndex(validateOutcome.failedPrompt);
                     if (indexIsInFieldList()) {
                         stepToPreviousScreenEvent();

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -115,7 +115,7 @@ public class SaveFormToDisk {
 
         ValidationResult validationResult;
         try {
-            validationResult = formController.validateAnswers(true);
+            validationResult = formController.validateAnswers(true, shouldFinalize);
             if (shouldFinalize && validationResult instanceof FailedValidationResult) {
                 // validation failed, pass specific failure
                 saveToDiskResult.setSaveResult(((FailedValidationResult) validationResult).getStatus(), shouldFinalize);

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -385,7 +385,7 @@ public class FormEntryViewModelTest {
 
     @Test
     public void validate_whenThereIsAnErrorValidating_setsError() throws Exception {
-        when(formController.validateAnswers(true)).thenThrow(new JavaRosaException(new IOException("OH NO")));
+        when(formController.validateAnswers(true, true)).thenThrow(new JavaRosaException(new IOException("OH NO")));
 
         viewModel.validate();
         scheduler.runBackground();

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerTest.java
@@ -8,10 +8,12 @@ import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xform.util.XFormUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
+import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -20,6 +22,35 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class FormControllerTest {
+    @Test
+    public void validateAnswers_shouldNotChangeFormIndexToTheIndexOfInvalidQuestionIfAskedNotToDoThat() throws Exception {
+        String form = new String(
+                FileUtils.getResourceAsStream("forms/two-question-required.xml").readAllBytes(),
+                StandardCharsets.UTF_8
+        );
+
+        FormController formController = createFormController(form);
+        formController.stepToNextScreenEvent();
+
+        assertThat(formController.getFormIndex().toString(), equalTo("0, "));
+        formController.validateAnswers(true, false);
+        assertThat(formController.getFormIndex().toString(), equalTo("0, "));
+    }
+
+    @Test
+    public void validateAnswers_shouldChangeFormIndexToTheIndexOfInvalidQuestionIfAskedToDoThat() throws Exception {
+        String form = new String(
+                FileUtils.getResourceAsStream("forms/two-question-required.xml").readAllBytes(),
+                StandardCharsets.UTF_8
+        );
+
+        FormController formController = createFormController(form);
+        formController.stepToNextScreenEvent();
+
+        assertThat(formController.getFormIndex().toString(), equalTo("0, "));
+        formController.validateAnswers(true, true);
+        assertThat(formController.getFormIndex().toString(), equalTo("1, "));
+    }
 
     @Test
     public void jumpToNewRepeatPrompt_whenIndexIsInRepeat_jumpsToRepeatPrompt() throws Exception {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DummyFormController.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DummyFormController.kt
@@ -75,7 +75,7 @@ open class DummyFormController : FormController {
 
     override fun answerQuestion(index: FormIndex?, data: IAnswerData?): Int = -1
 
-    override fun validateAnswers(markCompleted: Boolean): ValidationResult = SuccessValidationResult
+    override fun validateAnswers(markCompleted: Boolean, moveToInvalidateIndex: Boolean): ValidationResult = SuccessValidationResult
 
     override fun saveAnswer(index: FormIndex?, data: IAnswerData?): Boolean = false
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DummyFormController.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DummyFormController.kt
@@ -75,7 +75,7 @@ open class DummyFormController : FormController {
 
     override fun answerQuestion(index: FormIndex?, data: IAnswerData?): Int = -1
 
-    override fun validateAnswers(markCompleted: Boolean, moveToInvalidateIndex: Boolean): ValidationResult = SuccessValidationResult
+    override fun validateAnswers(markCompleted: Boolean, moveToInvalidIndex: Boolean): ValidationResult = SuccessValidationResult
 
     override fun saveAnswer(index: FormIndex?, data: IAnswerData?): Boolean = false
 


### PR DESCRIPTION
Closes #5847 

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that every time we validated a form if there were errors the form index was changed. This should not happen if we just save the form using the save icon from the toolbar (we still need to validate answers to know if there are errors in this case). Updating the index is needed when we `Check for errors` or try to finalize a form to move a user to the invalid question. So the solution was to introduce a new parameter to explicitly tell the method that validates answers if the index should be updated.

Another option would be to move updating index out of the `validateAnswers` method but then we would need to add this to more than one method and those methods are not better places for such an operation.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test validating answers carefully:
- finalizing forms with errors
- using the `Check for errors` option from the toolbar (with errors)
- saving forms using the save icon from the toolbar

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with required questions that could be invalid so required questions without answers or questions with constraints.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
