### PR TITLE
Do not display the option to finalize drafts in the list of sent forms

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
@@ -29,7 +29,7 @@ class BulkFinalizationTest {
     val chain: RuleChain = TestRuleChain.chain(testDependencies).around(rule)
 
     @Test
-    fun canBulkFinalizeDrafts() {
+    fun canBulkFinalizeDraftsInTheListOfDrafts() {
         rule.withProject("http://example.com")
             .copyForm("one-question.xml", "example.com")
             .startBlankForm("One Question")
@@ -45,6 +45,16 @@ class BulkFinalizationTest {
             .pressBack(MainMenuPage())
 
             .assertNumberOfFinalizedForms(2)
+    }
+
+    @Test
+    fun canNotBulkFinalizeDraftsInTheListOfSentForms() {
+        rule.withProject("http://example.com")
+            .copyForm("one-question.xml", "example.com")
+            .startBlankForm("One Question")
+            .fillOutAndSave(QuestionAndAnswer("what is your age", "97"))
+            .clickViewSentForm(0)
+            .assertNoOptionsMenu()
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -168,7 +168,7 @@ public class InstanceChooserList extends AppListActivity implements AdapterView.
             return dialog;
         });
 
-        if (bulkFinalizationViewModel.isEnabled()) {
+        if (bulkFinalizationViewModel.isEnabled() && editMode) {
             DraftsMenuProvider draftsMenuProvider = new DraftsMenuProvider(this, bulkFinalizationViewModel::finalizeAllDrafts);
             addMenuProvider(draftsMenuProvider, this);
             bulkFinalizationViewModel.getDraftsCount().observe(this, draftsCount -> {


### PR DESCRIPTION
Closes #5857 

#### Why is this the best possible solution? Were any other approaches considered?
We share the same activity class to display the list of drafts and the list of sent forms so if we want to have different behavior between those two lists we need to use the `editMode` flag.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix so testing the scenario described in the issue should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
