### PR TITLE
Add `hidden-answer` appearance for barcode questions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
@@ -69,6 +69,7 @@ object Appearances {
     const val NEW_FRONT = "new-front"
     const val NEW = "new"
     const val FRONT = "front"
+    const val NO_ANSWER = "no-answer"
 
     // Maps appearances
     const val PLACEMENT_MAP = "placement-map"

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
@@ -69,7 +69,7 @@ object Appearances {
     const val NEW_FRONT = "new-front"
     const val NEW = "new"
     const val FRONT = "front"
-    const val NO_ANSWER = "no-answer"
+    const val HIDDEN_ANSWER = "hidden-answer"
 
     // Maps appearances
     const val PLACEMENT_MAP = "placement-map"

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -15,6 +15,7 @@
 package org.odk.collect.android.widgets;
 
 import static org.odk.collect.android.utilities.Appearances.FRONT;
+import static org.odk.collect.android.utilities.Appearances.hasAppearance;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -72,17 +73,18 @@ public class BarcodeWidget extends QuestionWidget implements WidgetDataReceiver 
             binding.barcodeButton.setText(getContext().getString(org.odk.collect.strings.R.string.replace_barcode));
             binding.barcodeAnswerText.setText(answer);
         }
-        binding.barcodeAnswerText.setVisibility(binding.barcodeAnswerText.getText().toString().isBlank() ? GONE : VISIBLE);
 
+        updateVisibility();
         return binding.getRoot();
     }
 
     @Override
     public void clearAnswer() {
         binding.barcodeAnswerText.setText(null);
-        binding.barcodeAnswerText.setVisibility(GONE);
         binding.barcodeButton.setText(getContext().getString(org.odk.collect.strings.R.string.get_barcode));
         widgetValueChanged();
+
+        updateVisibility();
     }
 
     @Override
@@ -94,10 +96,20 @@ public class BarcodeWidget extends QuestionWidget implements WidgetDataReceiver 
     @Override
     public void setData(Object answer) {
         String response = (String) answer;
+
         binding.barcodeAnswerText.setText(stripInvalidCharacters(response));
-        binding.barcodeAnswerText.setVisibility(binding.barcodeAnswerText.getText().toString().isBlank() ? GONE : VISIBLE);
         binding.barcodeButton.setText(getContext().getString(org.odk.collect.strings.R.string.replace_barcode));
+        updateVisibility();
+
         widgetValueChanged();
+    }
+
+    private void updateVisibility() {
+        if (hasAppearance(getFormEntryPrompt(), Appearances.NO_ANSWER)) {
+            binding.barcodeAnswerText.setVisibility(GONE);
+        } else {
+            binding.barcodeAnswerText.setVisibility(binding.barcodeAnswerText.getText().toString().isBlank() ? GONE : VISIBLE);
+        }
     }
 
     // Remove control characters, invisible characters and unused code points.

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -105,7 +105,7 @@ public class BarcodeWidget extends QuestionWidget implements WidgetDataReceiver 
     }
 
     private void updateVisibility() {
-        if (hasAppearance(getFormEntryPrompt(), Appearances.NO_ANSWER)) {
+        if (hasAppearance(getFormEntryPrompt(), Appearances.HIDDEN_ANSWER)) {
             binding.barcodeAnswerText.setVisibility(GONE);
         } else {
             binding.barcodeAnswerText.setVisibility(binding.barcodeAnswerText.getText().toString().isBlank() ? GONE : VISIBLE);

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
@@ -186,7 +186,7 @@ public class BarcodeWidgetTest {
     }
 
     @Test
-    public void whenPromptHasNoAnswerAppearance_answerIsNotDisplayed() {
+    public void whenPromptHasHiddenAnswerAppearance_answerIsNotDisplayed() {
         FormEntryPrompt prompt = new MockFormEntryPromptBuilder(promptWithAppearance(Appearances.HIDDEN_ANSWER))
                 .withAnswer(new StringData("original contents"))
                 .build();

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
@@ -1,5 +1,20 @@
 package org.odk.collect.android.widgets;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.mockValueChangedListener;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAnswer;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAppearance;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithReadOnly;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.widgetTestActivity;
+import static org.robolectric.Shadows.shadowOf;
+
 import android.view.View;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -13,26 +28,13 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.fakes.FakePermissionsProvider;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.listeners.WidgetValueChangedListener;
+import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.support.WidgetTestActivity;
 import org.odk.collect.android.utilities.Appearances;
-import org.odk.collect.androidshared.system.CameraUtils;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
+import org.odk.collect.androidshared.system.CameraUtils;
 import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowToast;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.mockValueChangedListener;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAnswer;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAppearance;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithReadOnly;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.widgetTestActivity;
-import static org.robolectric.Shadows.shadowOf;
 
 /**
  * @author James Knight
@@ -181,6 +183,23 @@ public class BarcodeWidgetTest {
         widget.binding.barcodeButton.performClick();
 
         assertThat(shadowActivity.getNextStartedActivity().getBooleanExtra(Appearances.FRONT, false), is(true));
+    }
+
+    @Test
+    public void whenPromptHasNoAnswerAppearance_answerIsNotDisplayed() {
+        FormEntryPrompt prompt = new MockFormEntryPromptBuilder(promptWithAppearance(Appearances.NO_ANSWER))
+                .withAnswer(new StringData("original contents"))
+                .build();
+
+        BarcodeWidget widget = createWidget(prompt);
+        assertThat(widget.binding.barcodeAnswerText.getVisibility(), equalTo(View.GONE));
+        assertThat(widget.binding.barcodeButton.getText(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
+        assertThat(widget.getAnswer(), equalTo(new StringData("original contents")));
+
+        widget.setData("updated contents");
+        assertThat(widget.binding.barcodeAnswerText.getVisibility(), equalTo(View.GONE));
+        assertThat(widget.binding.barcodeButton.getText(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
+        assertThat(widget.getAnswer(), equalTo(new StringData("updated contents")));
     }
 
     public BarcodeWidget createWidget(FormEntryPrompt prompt) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
@@ -192,10 +192,13 @@ public class BarcodeWidgetTest {
                 .build();
 
         BarcodeWidget widget = createWidget(prompt);
+
+        // Check initial value is not shown
         assertThat(widget.binding.barcodeAnswerText.getVisibility(), equalTo(View.GONE));
         assertThat(widget.binding.barcodeButton.getText(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
         assertThat(widget.getAnswer(), equalTo(new StringData("original contents")));
 
+        // Check updates aren't shown
         widget.setData("updated contents");
         assertThat(widget.binding.barcodeAnswerText.getVisibility(), equalTo(View.GONE));
         assertThat(widget.binding.barcodeButton.getText(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
@@ -187,7 +187,7 @@ public class BarcodeWidgetTest {
 
     @Test
     public void whenPromptHasNoAnswerAppearance_answerIsNotDisplayed() {
-        FormEntryPrompt prompt = new MockFormEntryPromptBuilder(promptWithAppearance(Appearances.NO_ANSWER))
+        FormEntryPrompt prompt = new MockFormEntryPromptBuilder(promptWithAppearance(Appearances.HIDDEN_ANSWER))
                 .withAnswer(new StringData("original contents"))
                 .build();
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.widgets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -63,19 +62,19 @@ public class BarcodeWidgetTest {
 
     @Test
     public void usingReaDOnly_shouldHideBarcodeButton() {
-        assertThat(createWidget(promptWithReadOnly()).binding.barcodeButton.getVisibility(), is(View.GONE));
+        assertThat(createWidget(promptWithReadOnly()).binding.barcodeButton.getVisibility(), equalTo(View.GONE));
     }
 
     @Test
     public void whenPromptHasAnswer_replaceBarcodeButtonIsDisplayed() {
         BarcodeWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
-        assertThat(widget.binding.barcodeButton.getText().toString(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
+        assertThat(widget.binding.barcodeButton.getText().toString(), equalTo(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
     }
 
     @Test
     public void whenPromptHasAnswer_answerTextViewShowsCorrectAnswer() {
         BarcodeWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
-        assertThat(widget.binding.barcodeAnswerText.getText().toString(), is("blah"));
+        assertThat(widget.binding.barcodeAnswerText.getText().toString(), equalTo("blah"));
     }
 
     @Test
@@ -87,7 +86,7 @@ public class BarcodeWidgetTest {
     @Test
     public void getAnswer_whenPromptHasAnswer_returnsCorrectAnswer() {
         BarcodeWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
-        assertThat(widget.getAnswer().getDisplayText(), is("blah"));
+        assertThat(widget.getAnswer().getDisplayText(), equalTo("blah"));
     }
 
     @Test
@@ -95,8 +94,8 @@ public class BarcodeWidgetTest {
         BarcodeWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
         widget.clearAnswer();
 
-        assertThat(widget.binding.barcodeAnswerText.getText().toString(), is(""));
-        assertThat(widget.binding.barcodeButton.getText().toString(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.get_barcode)));
+        assertThat(widget.binding.barcodeAnswerText.getText().toString(), equalTo(""));
+        assertThat(widget.binding.barcodeButton.getText().toString(), equalTo(widgetTestActivity.getString(org.odk.collect.strings.R.string.get_barcode)));
     }
 
     @Test
@@ -112,14 +111,14 @@ public class BarcodeWidgetTest {
     public void setData_updatesWidgetAnswer_afterStrippingInvalidCharacters() {
         BarcodeWidget widget = createWidget(promptWithAnswer(null));
         widget.setData("\ud800blah\b");
-        assertThat(widget.binding.barcodeAnswerText.getText().toString(), is("blah"));
+        assertThat(widget.binding.barcodeAnswerText.getText().toString(), equalTo("blah"));
     }
 
     @Test
     public void setData_updatesButtonLabel() {
         BarcodeWidget widget = createWidget(promptWithAnswer(null));
         widget.setData("\ud800blah\b");
-        assertThat(widget.binding.barcodeButton.getText(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
+        assertThat(widget.binding.barcodeButton.getText(), equalTo(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
     }
 
     @Test
@@ -150,7 +149,7 @@ public class BarcodeWidgetTest {
         widget.binding.barcodeButton.performClick();
 
         assertThat(shadowActivity.getNextStartedActivity(), nullValue());
-        assertThat(waitingForDataRegistry.waiting.isEmpty(), is(true));
+        assertThat(waitingForDataRegistry.waiting.isEmpty(), equalTo(true));
     }
 
     @Test
@@ -162,7 +161,7 @@ public class BarcodeWidgetTest {
         widget.setPermissionsProvider(permissionsProvider);
         widget.binding.barcodeButton.performClick();
 
-        assertThat(waitingForDataRegistry.waiting.contains(formIndex), is(true));
+        assertThat(waitingForDataRegistry.waiting.contains(formIndex), equalTo(true));
     }
 
     @Test
@@ -172,7 +171,7 @@ public class BarcodeWidgetTest {
         widget.setPermissionsProvider(permissionsProvider);
         widget.binding.barcodeButton.performClick();
 
-        assertThat(ShadowToast.getTextOfLatestToast(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.error_front_camera_unavailable)));
+        assertThat(ShadowToast.getTextOfLatestToast(), equalTo(widgetTestActivity.getString(org.odk.collect.strings.R.string.error_front_camera_unavailable)));
     }
 
     @Test
@@ -182,7 +181,7 @@ public class BarcodeWidgetTest {
         widget.setPermissionsProvider(permissionsProvider);
         widget.binding.barcodeButton.performClick();
 
-        assertThat(shadowActivity.getNextStartedActivity().getBooleanExtra(Appearances.FRONT, false), is(true));
+        assertThat(shadowActivity.getNextStartedActivity().getBooleanExtra(Appearances.FRONT, false), equalTo(true));
     }
 
     @Test
@@ -195,13 +194,13 @@ public class BarcodeWidgetTest {
 
         // Check initial value is not shown
         assertThat(widget.binding.barcodeAnswerText.getVisibility(), equalTo(View.GONE));
-        assertThat(widget.binding.barcodeButton.getText(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
+        assertThat(widget.binding.barcodeButton.getText(), equalTo(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
         assertThat(widget.getAnswer(), equalTo(new StringData("original contents")));
 
         // Check updates aren't shown
         widget.setData("updated contents");
         assertThat(widget.binding.barcodeAnswerText.getVisibility(), equalTo(View.GONE));
-        assertThat(widget.binding.barcodeButton.getText(), is(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
+        assertThat(widget.binding.barcodeButton.getText(), equalTo(widgetTestActivity.getString(org.odk.collect.strings.R.string.replace_barcode)));
         assertThat(widget.getAnswer(), equalTo(new StringData("updated contents")));
     }
 

--- a/docs/CODE-GUIDELINES.md
+++ b/docs/CODE-GUIDELINES.md
@@ -22,10 +22,10 @@ assertNull(ClassToTest.methodReturnsNull());
 Preferred style using Hamcrest:
 ```java
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
 ...
-assertThat(ClassToTest.methodToTest("input"), is("expected"));
-assertThat(ClassToTest.methodReturnsNull(), is(nullValue()));
+assertThat(ClassToTest.methodToTest("input"), equalTo("expected"));
+assertThat(ClassToTest.methodReturnsNull(), equalTo(null));
 ```
 
 ## XML style guidelines


### PR DESCRIPTION
As discussed at https://forum.getodk.org/t/addition-of-minimal-or-no-answer-appearance-for-question-types-that-launch-an-external-selector/41151/3.

This adds support for a new `hidden-answer` appearance for `barcode` questions. If present, barcode contents will never be shown under the "Scan Barcode"/"Replace Barcode" button. It might be that we want to add some indication that the barcode has been scanned (other than the button changing to "Replace Barcode"). For the moment, the intention is for it to be used with a `note` on the same screen to display a formatted version of the barcode contents.

#### Why is this the best possible solution? Were any other approaches considered?

New tests and verified manually.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just add the new appearance. It'd be good to check that the barcode still behaves correctly without the appearance. Other than, not much has been touched.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any form with `barcode` (and the new appearance).

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

https://github.com/getodk/docs/issues/1723

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
