### PR TITLE
Finish activity when the dialog is canceled

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -195,6 +195,7 @@ class FormUriActivity : ComponentActivity() {
         MaterialAlertDialogBuilder(this)
             .setMessage(message)
             .setPositiveButton(org.odk.collect.strings.R.string.ok) { _, _ -> finish() }
+            .setOnCancelListener { finish() }
             .create()
             .show()
     }


### PR DESCRIPTION
Closes #5872 

#### Why is this the best possible solution? Were any other approaches considered?
When the dialog is closed the activity should be finished too. No matter if we close the dialog by clicking the cancel button or press the device back button.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I've just fixed the issue making sure the activity is always finished when we close the error dialog. It's a safe change so we can focus on testing the scenario described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
