### PR TITLE
Fixed setting up the sort menu

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteSavedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteSavedFormTest.java
@@ -6,6 +6,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
+import org.odk.collect.android.R;
+import org.odk.collect.android.support.pages.DeleteSavedFormPage;
 import org.odk.collect.android.support.rules.CollectTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.android.support.pages.MainMenuPage;
@@ -35,5 +37,19 @@ public class DeleteSavedFormTest {
                 .assertTextDoesNotExist("One Question")
                 .pressBack(new MainMenuPage())
                 .assertNumberOfFinalizedForms(0);
+    }
+
+    @Test
+    public void accessingSortMenuInDeleteSavedInstancesShouldNotCrashTheAppAfterRotatingTheDevice() {
+        rule.startAtMainMenu()
+                .copyForm("one-question.xml")
+                .startBlankForm("One Question")
+                .answerQuestion("what is your age", "30")
+                .swipeToEndScreen()
+                .clickFinalize()
+                .clickDeleteSavedForm()
+                .rotateToLandscape(new DeleteSavedFormPage())
+                .clickOnId(R.id.menu_sort)
+                .assertText(org.odk.collect.strings.R.string.sort_by);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
@@ -163,7 +163,7 @@ public abstract class AppListFragment extends ListFragment {
             new FormListSortingBottomSheetDialog(
                     requireContext(),
                     sortingOptions,
-                    selectedSortingOrder,
+                    getSelectedSortingOrder(),
                     selectedOption -> {
                         saveSelectedSortingOrder(selectedOption);
                         updateAdapter();


### PR DESCRIPTION
Closes #5856

#### Why is this the best possible solution? Were any other approaches considered?
We should use `getSelectedSortingOrder()` method to make sure the returned value is not null instead of directly accessing `selectedSortingOrder` field.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe and isolated change so we can focus on verifying that the problem described in the issue is fixed. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
