### PR TITLE
Use darker colors for dark theme

### DIFF
--- a/collect_app/src/main/res/layout/empty_list_view.xml
+++ b/collect_app/src/main/res/layout/empty_list_view.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="@dimen/margin_standard"
-    android:background="?colorSurfaceContainerLow">
+    android:background="?colorSurface">
 
     <ImageView
         android:id="@+id/icon"

--- a/collect_app/src/main/res/values-night/colors.xml
+++ b/collect_app/src/main/res/values-night/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#6dd2ff</color>
+    <color name="colorPrimary">#4cbcf0</color>
     <color name="colorOnPrimary">#003547</color>
     <color name="colorPrimaryContainer">#004d65</color>
     <color name="colorOnPrimaryContainer">#bfe9ff</color>
@@ -11,15 +11,15 @@
     <color name="colorErrorContainer">#ffb4ab</color>
     <color name="colorOnErrorContainer">#690005</color>
 
-    <color name="colorBackground">#001f2a</color>
-    <color name="colorOnBackground">#bfe9ff</color>
+    <color name="colorBackground">#001117</color>
+    <color name="colorOnBackground">#d3e5ef</color>
 
-    <color name="colorSurface">#001f2a</color>
+    <color name="colorSurface">#001117</color>
     <color name="colorSurfaceVariant">#40484c</color>
-    <color name="colorOnSurface">#bfe9ff</color>
+    <color name="colorOnSurface">#d3e5ef</color>
     <color name="colorOnSurfaceVariant">#c0c8cd</color>
-    <color name="colorSurfaceContainerLow">#00141E</color>
-    <color name="elevationOverlayColor">#6dd2ff</color>
+    <color name="colorSurfaceContainerLow">#293134</color>
+    <color name="elevationOverlayColor">#4cbcf0</color>
     <color name="colorSurfaceInverse">#BFE9FF</color>
     <color name="colorOnSurfaceInverse">#001F2A</color>
 


### PR DESCRIPTION
This makes the dark theme colors darker. @alyblenkin and I paired on these changes after I decided I didn't like the new (Material 3) dark theme once I'd seen it on an actual device.