### PR TITLE
Fixed testing notifications

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.kt
@@ -94,8 +94,7 @@ class MatchExactlyTest {
             .clickAction(
                 "ODK Collect",
                 "Show details",
-                ErrorPage(),
-                cancelsNotification = true
+                ErrorPage()
             ).assertText(org.odk.collect.strings.R.string.form_update_error)
             .assertText("Demo project")
             .assertText("The server https://server.example.com returned status code 500. If you keep having this problem, report it to the person who asked you to collect data.")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
@@ -128,8 +128,7 @@ class PreviouslyDownloadedOnlyTest {
             .clickAction(
                 "ODK Collect",
                 "Show details",
-                ErrorPage(),
-                cancelsNotification = true
+                ErrorPage()
             )
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
@@ -75,8 +75,7 @@ class AutoSendTest {
             .clickAction(
                 "ODK Collect",
                 "Show details",
-                ErrorPage(),
-                cancelsNotification = true
+                ErrorPage()
             )
     }
 
@@ -129,8 +128,7 @@ class AutoSendTest {
             .clickAction(
                 "ODK Collect",
                 "Show details",
-                ErrorPage(),
-                cancelsNotification = true
+                ErrorPage()
             )
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -70,10 +70,7 @@ class NotificationDrawer {
             destination.assertOnPage()
         }
 
-        device.openNotification()
         assertNoNotification(appName)
-        device.pressBack()
-
         return page
     }
 
@@ -115,8 +112,10 @@ class NotificationDrawer {
 
     private fun assertNoNotification(appName: String) {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        device.openNotification()
         val result = device.wait(Until.hasObject(By.textStartsWith(appName)), 0L)
         assertThat("Expected no notification for app: $appName", result, equalTo(false))
+        device.pressBack()
     }
 
     private fun assertText(device: UiDevice, text: String): UiObject2 {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -66,13 +66,13 @@ class NotificationDrawer {
             throw AssertionError("Could not find \"$actionText\"")
         }
 
-        device.openNotification()
-        assertNoNotification(appName)
-        device.pressBack()
-
         val page = waitFor {
             destination.assertOnPage()
         }
+
+        device.openNotification()
+        assertNoNotification(appName)
+        device.pressBack()
 
         return page
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -54,8 +54,7 @@ class NotificationDrawer {
     fun <D : Page<D>> clickAction(
         appName: String,
         actionText: String,
-        destination: D,
-        cancelsNotification: Boolean = false
+        destination: D
     ): D {
         val device = waitForNotification(appName)
 
@@ -67,11 +66,9 @@ class NotificationDrawer {
             throw AssertionError("Could not find \"$actionText\"")
         }
 
-        if (cancelsNotification) {
-            device.openNotification()
-            assertNoNotification(appName)
-            device.pressBack()
-        }
+        device.openNotification()
+        assertNoNotification(appName)
+        device.pressBack()
 
         val page = waitFor {
             destination.assertOnPage()


### PR DESCRIPTION
Closes #5882 

#### Why is this the best possible solution? Were any other approaches considered?
The problem seems to be that we tried to assert the notification is gone just after clicking the action button. There was not enough time between those two operations and probably closing the notification was not finished. As a result, the `pressBack` action we called here: https://github.com/getodk/collect/compare/master...grzesiek2010:COLLECT-5882?expand=1#diff-773e5d389deef88d804ae0627fb56a49a87b6b6999831175dc7645847a0a66daL73
closed the error page (that we wanted to verify later) not the list of notifications.

I've run all tests 3 times and every attempt was green so I think it's a reliable solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
