### PR TITLE
Center the icon in the toolbar in full screen dialogs

### DIFF
--- a/androidshared/src/main/res/values/toolbars.xml
+++ b/androidshared/src/main/res/values/toolbars.xml
@@ -3,6 +3,7 @@
     <style name="Widget.AndroidShared.Toolbar.Surface.HighEmphasisControls" parent="Widget.MaterialComponents.Toolbar.Surface">
         <!-- Note: this theme overlay will only work if the style is applied directly to a Toolbar. -->
         <item name="android:theme">@style/ThemeOverlay.AndroidShared.Toolbar.Surface.HighEmphasisControls</item>
+        <item name="buttonGravity">center_vertical</item>
     </style>
 
     <style name="ThemeOverlay.AndroidShared.Toolbar.Surface.HighEmphasisControls" parent="">


### PR DESCRIPTION
Closes #5889 

#### Why is this the best possible solution? Were any other approaches considered?
There is nothing to discuss here. I've just centered the icon so that it's aligned with the title.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We just need to test full-screen dialogs that use icons. The three dialogs mentioned in the issue should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
