### PR TITLE
Fix APK being uninstalled after test runs

### DIFF
--- a/audiorecorder/build.gradle.kts
+++ b/audiorecorder/build.gradle.kts
@@ -26,6 +26,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -37,6 +38,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
     implementation(project(":icons"))
     implementation(project(":strings"))

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath 'com.google.gms:google-services:4.4.0'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22"

--- a/crash-handler/build.gradle.kts
+++ b/crash-handler/build.gradle.kts
@@ -27,6 +27,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -43,6 +44,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(project(":androidshared"))
     implementation(project(":strings"))
     implementation(Dependencies.android_material)

--- a/draw/build.gradle.kts
+++ b/draw/build.gradle.kts
@@ -26,6 +26,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -38,6 +39,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(project(":shared"))
     implementation(project(":androidshared"))
     implementation(project(":strings"))

--- a/errors/build.gradle.kts
+++ b/errors/build.gradle.kts
@@ -25,6 +25,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -43,6 +44,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(project(":strings"))
     implementation(project(":androidshared"))
     implementation(Dependencies.androidx_core_ktx)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ org.gradle.jvmargs=-Xmx1536m
 org.gradle.parallel=true
 test.heap.max=1g
 android.nonTransitiveRClass=true
+android.injected.androidTest.leaveApksInstalledAfterRun=true

--- a/metadata/build.gradle.kts
+++ b/metadata/build.gradle.kts
@@ -27,6 +27,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -37,6 +38,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(project(":permissions"))
     implementation(project(":settings"))
     implementation(project(":shared"))

--- a/permissions/build.gradle.kts
+++ b/permissions/build.gradle.kts
@@ -50,9 +50,10 @@ dependencies {
     implementation(Dependencies.karumi_dexter)
     implementation(Dependencies.timber)
 
+    debugImplementation(project(":fragmentstest"))
+
     testImplementation(project(":androidtest"))
     testImplementation(project(":test-shared"))
-    testImplementation(project(":fragmentstest"))
     testImplementation(project(":strings"))
     testImplementation(Dependencies.androidx_test_ext_junit)
     testImplementation(Dependencies.androidx_test_espresso_core)

--- a/permissions/build.gradle.kts
+++ b/permissions/build.gradle.kts
@@ -25,6 +25,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -38,6 +39,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(project(":strings"))
     implementation(project(":androidshared"))
     implementation(project(":icons"))

--- a/qr-code/build.gradle.kts
+++ b/qr-code/build.gradle.kts
@@ -27,6 +27,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -43,6 +44,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(project(":androidshared"))
 
     implementation(Dependencies.zxing_android_embedded)

--- a/selfie-camera/build.gradle.kts
+++ b/selfie-camera/build.gradle.kts
@@ -28,6 +28,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -40,6 +41,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(project(":androidshared"))
     implementation(project(":strings"))
     implementation(project(":permissions"))

--- a/settings/build.gradle.kts
+++ b/settings/build.gradle.kts
@@ -26,6 +26,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -44,6 +45,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(project(":shared"))
     implementation(project(":projects"))
 

--- a/upgrade/build.gradle.kts
+++ b/upgrade/build.gradle.kts
@@ -26,6 +26,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -40,6 +41,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(Dependencies.androidx_core_ktx)
     implementation(project(":shared"))
 


### PR DESCRIPTION
Looks like APKs start getting uninstalled after tests in AGP v8.1. An option to prevent that was then added in v8.2 (https://issuetracker.google.com/issues/295039976).

I find being able to inspect state for failed tests really useful, so would massively prefer we disable this new behaviour.