### PR TITLE
Ignore tests using killAndReopenApp

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.feature.formentry.audit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -74,6 +75,7 @@ class AuditTest {
     }
 
     @Test // https://github.com/getodk/collect/issues/5253
+    @Ignore("killAndReopenApp is flakey")
     fun navigatingBackToTheFormAfterKillingTheAppWhenMovingBackwardsIsDisabled_savesFormResumeEventToAuditLog() {
         rule.startAtMainMenu()
             .copyForm("one-question-audit.xml")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.feature.formmanagement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -104,6 +105,7 @@ class BulkFinalizationTest {
     }
 
     @Test
+    @Ignore("killAndReopenApp is flakey")
     fun doesNotFinalizeInstancesWithSavePoints() {
         rule.withProject("http://example.com")
             .copyForm("one-question.xml", "example.com")


### PR DESCRIPTION
Seeing sporadic fails locally and on CI in cases where the tooltip pops up and complicates closing the app. We should ignore tests using this (just two) until we find a more dependable implementation.