### PR TITLE
Remove Picnic resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,8 +230,8 @@ jobs:
           command: ./gradlew assembleSelfSignedRelease
 
       - run:
-          name: Check APK size isn't larger than 11.1MB (11639193 * 1024 * 1024)
-          command: if [ $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') -gt 11639193 ]; then exit 1; fi
+          name: Check APK size isn't larger than 10.4MB
+          command: if [ $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') -gt 10400000 ]; then exit 1; fi
 
       - run:
           name: Copy APK to predictable path for artifact storage

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -176,6 +176,12 @@ android {
             exclude 'lib/x86_64/libmapbox-common.so'
             exclude 'lib/x86_64/libc++_shared.so'
         }
+
+        /* Exclude large properties files used by BouncyCastle's Picnic implementation (which
+           Collect doesn't use). */
+        exclude 'org/bouncycastle/pqc/crypto/picnic/lowmcL5.bin.properties'
+        exclude 'org/bouncycastle/pqc/crypto/picnic/lowmcL3.bin.properties'
+        exclude 'org/bouncycastle/pqc/crypto/picnic/lowmcL1.bin.properties'
     }
 
     compileOptions {


### PR DESCRIPTION
Closes #5879 

This removes the config files that Bouncy Castle needs for its Picnic algorithm implementation. These files are responsible for the vast majority of the APK size increase we saw when we added `extract-signed`.

#### Why is this the best possible solution? Were any other approaches considered?

For me, removing files only used by Picnic feels like the lowest risk/highest reward option as we don't have to do any manipulation of Bouncy Castle itself **AND** we would now have the ability to use pretty much anything in Bouncy Castle without adding to the APK size. In total we still end up with a 200kb increase, but that seems ok to me for now.

I did briefly look into using ProGuard to exclude classes, but as far as I could see ProGuard only allows us to keep classes not mark them for exclusion (as it assumes it will have excluded anything it needs to). 

An option we should look into in future is removing `dontobfuscate` from our ProGuard rules. Removing this currently breaks the app, but gets to an APK size even smaller than v2023.3.1 with Bouncy Castle included.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The app boots fine so I'd imagine the only risk would be to forms using `extract-signed` itself.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
