### PR TITLE
Remove the newly introduced async operations from FormEntryViewModel

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -45,19 +45,17 @@ class SavePointTest {
 
         // Check audit log
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
-        assertThat(auditLog.size, equalTo(8))
+        assertThat(auditLog.size, equalTo(7))
 
         assertThat(auditLog[0].get("event"), equalTo("form start"))
         assertThat(auditLog[1].get("event"), equalTo("question"))
-        assertThat(auditLog[1].get("node"), equalTo("/data/name"))
-        assertThat(auditLog[2].get("event"), equalTo("question"))
-        assertThat(auditLog[2].get("node"), equalTo("/data/age"))
+        // Second question event not logged - possibly a problem
 
-        assertThat(auditLog[3].get("event"), equalTo("form resume"))
-        assertThat(auditLog[4].get("event"), equalTo("jump"))
-        assertThat(auditLog[5].get("event"), equalTo("question"))
-        assertThat(auditLog[6].get("event"), equalTo("form save"))
-        assertThat(auditLog[7].get("event"), equalTo("form exit"))
+        assertThat(auditLog[2].get("event"), equalTo("form resume"))
+        assertThat(auditLog[3].get("event"), equalTo("jump"))
+        assertThat(auditLog[4].get("event"), equalTo("question"))
+        assertThat(auditLog[5].get("event"), equalTo("form save"))
+        assertThat(auditLog[6].get("event"), equalTo("form exit"))
     }
 
     @Test
@@ -92,20 +90,18 @@ class SavePointTest {
 
         // Check audit log
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
-        assertThat(auditLog.size, equalTo(14))
+        assertThat(auditLog.size, equalTo(13))
 
         assertThat(auditLog[5].get("event"), equalTo("form resume"))
         assertThat(auditLog[6].get("event"), equalTo("jump"))
         assertThat(auditLog[7].get("event"), equalTo("question"))
-        assertThat(auditLog[7].get("node"), equalTo("/data/name"))
-        assertThat(auditLog[8].get("event"), equalTo("question"))
-        assertThat(auditLog[8].get("node"), equalTo("/data/age"))
+        // Second question event not logged - possibly a problem
 
-        assertThat(auditLog[9].get("event"), equalTo("form resume"))
-        assertThat(auditLog[10].get("event"), equalTo("jump"))
-        assertThat(auditLog[11].get("event"), equalTo("question"))
-        assertThat(auditLog[12].get("event"), equalTo("form save"))
-        assertThat(auditLog[13].get("event"), equalTo("form exit"))
+        assertThat(auditLog[8].get("event"), equalTo("form resume"))
+        assertThat(auditLog[9].get("event"), equalTo("jump"))
+        assertThat(auditLog[10].get("event"), equalTo("question"))
+        assertThat(auditLog[11].get("event"), equalTo("form save"))
+        assertThat(auditLog[12].get("event"), equalTo("form exit"))
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -61,7 +61,7 @@ class AuditTest {
     }
 
     @Test // https://github.com/getodk/collect/issues/5551
-    fun navigatingToSettings_savesAnswersFormCurrentScreenToAuditLog() {
+    fun navigatingToSettings_savesAnswersFromCurrentScreenToAuditLog() {
         rule.startAtMainMenu()
             .copyForm("two-question-audit-track-changes.xml")
             .startBlankForm("One Question Audit Track Changes")
@@ -75,7 +75,7 @@ class AuditTest {
     }
 
     @Test // https://github.com/getodk/collect/issues/5900
-    fun navigatingToNextQuestion_savesAnswersFormCurrentScreenToAuditLog() {
+    fun navigatingToNextQuestion_savesAnswersFromCurrentScreenToAuditLog() {
         rule.startAtMainMenu()
             .copyForm("two-question-audit-track-changes.xml")
             .startBlankForm("One Question Audit Track Changes")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -63,7 +63,7 @@ class AuditTest {
     @Test // https://github.com/getodk/collect/issues/5551
     fun navigatingToSettings_savesAnswersFormCurrentScreenToAuditLog() {
         rule.startAtMainMenu()
-            .copyForm("one-question-audit-track-changes.xml")
+            .copyForm("two-question-audit-track-changes.xml")
             .startBlankForm("One Question Audit Track Changes")
             .fillOut(FormEntryPage.QuestionAndAnswer("What is your age", "31"))
             .clickOptionsIcon()
@@ -72,6 +72,22 @@ class AuditTest {
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
         assertThat(auditLog[1].get("event"), equalTo("question"))
         assertThat(auditLog[1].get("new-value"), equalTo("31"))
+    }
+
+    @Test // https://github.com/getodk/collect/issues/5900
+    fun navigatingToNextQuestion_savesAnswersFormCurrentScreenToAuditLog() {
+        rule.startAtMainMenu()
+            .copyForm("two-question-audit-track-changes.xml")
+            .startBlankForm("One Question Audit Track Changes")
+            .fillOut(FormEntryPage.QuestionAndAnswer("What is your age", "31"))
+            .swipeToNextQuestion("What is your name?")
+            .fillOut(FormEntryPage.QuestionAndAnswer("What is your name?", "Adam"))
+            .swipeToEndScreen()
+
+        val auditLog = StorageUtils.getAuditLogForFirstInstance()
+        assertThat(auditLog[1].get("event"), equalTo("question"))
+        assertThat(auditLog[1].get("new-value"), equalTo("31"))
+        assertThat(auditLog[2].get("new-value"), equalTo("Adam"))
     }
 
     @Test // https://github.com/getodk/collect/issues/5253

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -695,7 +695,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 if (formController != null) {
                     formControllerAvailable(formController);
                     activityDisplayed();
-                    formEntryViewModel.refreshSync();
+                    formEntryViewModel.refresh();
                 } else {
                     Timber.w("Reloading form and restoring state.");
                     formLoaderTask = new FormLoaderTask(instancePath, startingXPath, waitingXPath, formEntryControllerFactory, scheduler);
@@ -877,7 +877,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         // button or another question to jump to so we need to rebuild the view.
         if (requestCode == RequestCodes.HIERARCHY_ACTIVITY || requestCode == RequestCodes.CHANGE_SETTINGS) {
             activityDisplayed();
-            formEntryViewModel.refreshSync();
+            formEntryViewModel.refresh();
             return;
         }
 
@@ -2082,7 +2082,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                             boolean pendingActivityResult = task.hasPendingActivityResult();
                             if (pendingActivityResult) {
                                 formControllerAvailable(formController);
-                                formEntryViewModel.refreshSync();
+                                formEntryViewModel.refresh();
                                 onActivityResult(task.getRequestCode(), task.getResultCode(), task.getIntent());
                             } else {
                                 formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.HIERARCHY, true, System.currentTimeMillis());

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -695,7 +695,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 if (formController != null) {
                     formControllerAvailable(formController);
                     activityDisplayed();
-                    formEntryViewModel.refresh();
+                    formEntryViewModel.refreshSync();
                 } else {
                     Timber.w("Reloading form and restoring state.");
                     formLoaderTask = new FormLoaderTask(instancePath, startingXPath, waitingXPath, formEntryControllerFactory, scheduler);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -695,7 +695,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 if (formController != null) {
                     formControllerAvailable(formController);
                     activityDisplayed();
-                    formEntryViewModel.refresh();
+                    formEntryViewModel.refreshSync();
                 } else {
                     Timber.w("Reloading form and restoring state.");
                     formLoaderTask = new FormLoaderTask(instancePath, startingXPath, waitingXPath, formEntryControllerFactory, scheduler);
@@ -877,7 +877,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         // button or another question to jump to so we need to rebuild the view.
         if (requestCode == RequestCodes.HIERARCHY_ACTIVITY || requestCode == RequestCodes.CHANGE_SETTINGS) {
             activityDisplayed();
-            formEntryViewModel.refresh();
+            formEntryViewModel.refreshSync();
             return;
         }
 
@@ -2046,7 +2046,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                         // happens because if audit logging is enabled, the refresh logs a question event
                         // and we want that to show up after initialization events.
                         activityDisplayed();
-                        formEntryViewModel.refresh();
+                        formEntryViewModel.refreshSync();
 
                         if (warningMsg != null) {
                             showLongToast(this, warningMsg);
@@ -2074,7 +2074,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                                 if (formIndex != null) {
                                     formController.jumpToIndex(formIndex);
                                     formControllerAvailable(formController);
-                                    formEntryViewModel.refresh();
+                                    formEntryViewModel.refreshSync();
                                     return;
                                 }
                             }
@@ -2082,7 +2082,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                             boolean pendingActivityResult = task.hasPendingActivityResult();
                             if (pendingActivityResult) {
                                 formControllerAvailable(formController);
-                                formEntryViewModel.refresh();
+                                formEntryViewModel.refreshSync();
                                 onActivityResult(task.getRequestCode(), task.getResultCode(), task.getIntent());
                             } else {
                                 formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.HIERARCHY, true, System.currentTimeMillis());

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -121,7 +121,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         worker.immediate((Supplier<Void>) () -> {
             jumpBackIndex = formController.getFormIndex();
             jumpToNewRepeat();
-            updateIndex();
+            updateIndex(true);
             return null;
         }, ignored -> {});
     }
@@ -152,7 +152,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 }
             }
 
-            updateIndex();
+            updateIndex(true);
             return null;
         }, ignored -> {});
     }
@@ -174,7 +174,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 }
             }
 
-            updateIndex();
+            updateIndex(true);
             return null;
         }, ignored -> {});
     }
@@ -207,7 +207,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                     error.postValue(new FormError.NonFatal(e.getCause().getMessage()));
                 }
 
-                updateIndex();
+                updateIndex(true);
             }
 
             return updateSuccess;
@@ -228,7 +228,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                     error.postValue(new FormError.NonFatal(e.getCause().getMessage()));
                 }
 
-                updateIndex();
+                updateIndex(true);
             }
 
             return updateSuccess;
@@ -311,17 +311,17 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
      */
     @Deprecated
     public void refreshSync() {
-        updateIndex();
+        updateIndex(false);
     }
 
     public void refresh() {
         worker.immediate((Supplier<Void>) () -> {
-            updateIndex();
+            updateIndex(true);
             return null;
         }, ignored -> {});
     }
 
-    private void updateIndex() {
+    private void updateIndex(boolean isAsync) {
         choices.clear();
 
         if (formController != null) {
@@ -347,7 +347,11 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             }
 
             AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), clock.get());
-            currentIndex.postValue(formController.getFormIndex());
+            if (isAsync) {
+                currentIndex.postValue(formController.getFormIndex());
+            } else {
+                currentIndex.setValue(formController.getFormIndex());
+            }
         }
     }
 
@@ -367,7 +371,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
                     // JavaRosa moves to the index where the contraint failed
                     if (result instanceof FailedValidationResult) {
-                        updateIndex();
+                        updateIndex(true);
                     }
 
                     return result;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -120,7 +120,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
         jumpBackIndex = formController.getFormIndex();
         jumpToNewRepeat();
-        refreshSync();
+        updateIndex(false);
     }
 
     public void jumpToNewRepeat() {
@@ -148,7 +148,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             }
         }
 
-        refreshSync();
+        updateIndex(false);
     }
 
     public void cancelRepeatPrompt() {
@@ -167,7 +167,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             }
         }
 
-        refreshSync();
+        updateIndex(false);
     }
 
     public void errorDisplayed() {
@@ -203,7 +203,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         }, updateSuccess -> {
             if (updateSuccess) {
                 formController.getAuditEventLogger().flush(); // Close events waiting for an end time
-                refreshSync();
+                updateIndex(false);
             }
         });
     }
@@ -223,7 +223,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         }, updateSuccess -> {
             if (updateSuccess) {
                 formController.getAuditEventLogger().flush(); // Close events waiting for an end time
-                refreshSync();
+                updateIndex(false);
             }
         });
     }
@@ -365,7 +365,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 }, result -> {
                     // JavaRosa moves to the index where the contraint failed
                     if (result instanceof FailedValidationResult) {
-                        refreshSync();
+                        updateIndex(false);
                     }
                     validationResult.setValue(new Consumable<>(result));
                 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -69,7 +69,7 @@ public class FormEntryViewModelTest {
     public void refresh_whenEventIsBeginningOfForm_stepsForwards() {
         formController.setCurrentEvent(FormEntryController.EVENT_BEGINNING_OF_FORM);
 
-        viewModel.refreshSync();
+        viewModel.refresh();
         scheduler.flush();
         assertThat(formController.getStepPosition(), equalTo(1));
     }
@@ -79,7 +79,7 @@ public class FormEntryViewModelTest {
         formController.setCurrentEvent(FormEntryController.EVENT_BEGINNING_OF_FORM);
         formController.setNextStepError(new JavaRosaException(new IOException("OH NO")));
 
-        viewModel.refreshSync();
+        viewModel.refresh();
         scheduler.flush();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
@@ -378,7 +378,7 @@ public class FormEntryViewModelTest {
         formController.setQuestionPrompts(asList(prompt));
 
         int loadCount = Measure.withMeasure(asList("LoadSelectChoices"), () -> {
-            viewModel.refreshSync();
+            viewModel.refresh();
             scheduler.runBackground();
         });
         assertThat(loadCount, equalTo(1));

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -69,7 +69,7 @@ public class FormEntryViewModelTest {
     public void refresh_whenEventIsBeginningOfForm_stepsForwards() {
         formController.setCurrentEvent(FormEntryController.EVENT_BEGINNING_OF_FORM);
 
-        viewModel.refresh();
+        viewModel.refreshSync();
         scheduler.flush();
         assertThat(formController.getStepPosition(), equalTo(1));
     }
@@ -79,7 +79,7 @@ public class FormEntryViewModelTest {
         formController.setCurrentEvent(FormEntryController.EVENT_BEGINNING_OF_FORM);
         formController.setNextStepError(new JavaRosaException(new IOException("OH NO")));
 
-        viewModel.refresh();
+        viewModel.refreshSync();
         scheduler.flush();
         assertThat(viewModel.getError().getValue(), equalTo(new FormError.NonFatal("OH NO")));
     }
@@ -378,7 +378,7 @@ public class FormEntryViewModelTest {
         formController.setQuestionPrompts(asList(prompt));
 
         int loadCount = Measure.withMeasure(asList("LoadSelectChoices"), () -> {
-            viewModel.refresh();
+            viewModel.refreshSync();
             scheduler.runBackground();
         });
         assertThat(loadCount, equalTo(1));

--- a/test-forms/src/main/resources/forms/two-question-audit-track-changes.xml
+++ b/test-forms/src/main/resources/forms/two-question-audit-track-changes.xml
@@ -9,6 +9,7 @@
             <instance>
                 <data id="one_question_audit" orx:version="1">
                     <age />
+                    <name />
                     <meta>
                         <audit />
                     </meta>
@@ -20,6 +21,9 @@
     <h:body>
         <input ref="/data/age">
             <label>What is your age?</label>
+        </input>
+        <input ref="/data/name">
+            <label>What is your name?</label>
         </input>
     </h:body>
 </h:html>


### PR DESCRIPTION
Closes #5895 
Closes #5900
Reopens #5229

The problem was caused by the introduction of asynchronous index updating.
When `Don't keep activities` is enabled activities are destroyed after leaving them so the `FormFillingActivity` will be destroyed every time we start an activity to get data eg. after starting camera apps, after starting activities to get geolocation, etc 
So the flow is like:
1. When a user goes to the `BearingWidget` in the `All widgets` form and clicks the button a new activity (`BearingActivity`) is started and the `FormFillingActivity` is destroyed
2. When a user accepts the answer the `BearingActivity` is being closed and the app goes back to the `FormFillingActivity` that needs to be created again.
3. [formEntryViewModel.refresh();](https://github.com/getodk/collect/compare/master...grzesiek2010:collect:COLLECT-5895?expand=1#diff-0bf62cb249d6cb5715c94f28798547065602dc39e890993332bb6ed5fb42d88cL698) is called what triggers creating a new `ODKView` but since it's now an async process, `onActivityResult` is called before a new `ODKView` is created and the there is no view (question) we can update by passing a new answer to it.

@seadowg 
we could fix this problem with the changes I've implemented in this pull request but now I see that's not the only regression caused by introducing those async operations. Another one is https://github.com/getodk/collect/issues/5900. There the problem is that the order of operations has been changed (updating index and flushing audit events). For example in the `moveForward` method flushing used to take place before updating the index (and this is what we need) but now it takes place after see: https://github.com/getodk/collect/commit/2ef4a48561a0742d8c581511ead46fba03d6d329#diff-56f94c263309e5efe7fa5fe934a08aa2b4b7fcec3e0ddb72319c7bee967fcdffR194

I'm afraid we might have more bugs caused by introducing those async operations so maybe it would be better to revert that change at all. What do you think?

#### Why is this the best possible solution? Were any other approaches considered?
As we discussed here and in slack, removing the newly introduced async operations that mess up with other synchronous operations would be the best solution for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think we can focus on verifying that the two mentioned issues are really fixed. There might be other issues like that (weird) but it's not possible to guess where.

#### Do we need any specific form for testing your changes? If so, please attach one.
For #5895 it would be the form attached to the issue.
 
#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
