### PR TITLE
Hide error when audio recording is started

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -107,6 +107,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
         binding = AudioWidgetAnswerBinding.inflate(LayoutInflater.from(context));
 
         binding.captureButton.setOnClickListener(v -> {
+            hideError();
             binding.audioPlayer.waveform.clear();
             recordingRequester.requestRecording(getFormEntryPrompt());
         });

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
@@ -304,6 +304,17 @@ public class AudioWidgetTest {
     }
 
     @Test
+    public void clickingCaptureButton_clearsError() {
+        FormEntryPrompt prompt = promptWithAnswer(null);
+        AudioWidget widget = createWidget(prompt);
+        widget.displayError("Required question!");
+
+        assertThat(widget.errorLayout.getVisibility(), equalTo(VISIBLE));
+        widget.binding.captureButton.performClick();
+        assertThat(widget.errorLayout.getVisibility(), equalTo(GONE));
+    }
+
+    @Test
     public void whenRecordingRequesterStopsRecording_enablesButtons() {
         AudioWidget widget = createWidget(promptWithAnswer(null));
 


### PR DESCRIPTION
Closes #5905 

#### Why is this the best possible solution? Were any other approaches considered?
The error should be removed when recording is started that seems obvious.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing the audio widget as described in the issue should be enough here. We do not need to verify other widgets.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
