### PR TITLE
Fix `killAndReopenApp`

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -3,7 +3,6 @@ package org.odk.collect.android.feature.formentry.audit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -91,7 +90,6 @@ class AuditTest {
     }
 
     @Test // https://github.com/getodk/collect/issues/5253
-    @Ignore("killAndReopenApp is flakey")
     fun navigatingBackToTheFormAfterKillingTheAppWhenMovingBackwardsIsDisabled_savesFormResumeEventToAuditLog() {
         rule.startAtMainMenu()
             .copyForm("one-question-audit.xml")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
@@ -3,7 +3,6 @@ package org.odk.collect.android.feature.formmanagement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -105,7 +104,6 @@ class BulkFinalizationTest {
     }
 
     @Test
-    @Ignore("killAndReopenApp is flakey")
     fun doesNotFinalizeInstancesWithSavePoints() {
         rule.withProject("http://example.com")
             .copyForm("one-question.xml", "example.com")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -483,10 +483,6 @@ abstract class Page<T : Page<T>> {
 
         // kill
         device.pressRecentApps()
-        device.findObject(UiSelector().textContains("Select text and images to copy"))?.apply {
-            wait250ms()
-            device.pressBack() // the first time we open the list of recent apps, a tooltip might be displayed and we need to close it
-        }
         device
             .findObject(UiSelector().descriptionContains("Collect"))
             .swipeUp(10).also {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/UserInterfacePage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/UserInterfacePage.java
@@ -1,14 +1,10 @@
 package org.odk.collect.android.support.pages;
 
+import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-
-import static org.odk.collect.android.support.matchers.CustomMatchers.withIndex;
-
-import androidx.test.espresso.NoMatchingViewException;
-import androidx.test.espresso.action.ViewActions;
+import static org.hamcrest.Matchers.equalTo;
 
 public class UserInterfacePage extends Page<UserInterfacePage> {
 
@@ -24,15 +20,7 @@ public class UserInterfacePage extends Page<UserInterfacePage> {
     }
 
     public MainMenuPage clickOnSelectedLanguage(String language) {
-        try {
-            onView(withText(language)).perform(click());
-        } catch (NoMatchingViewException e) {
-            for (int i = 0; i < 10; i++) {
-                onView(withIndex(withId(android.R.id.text1), 1)).perform(ViewActions.swipeUp());
-            }
-            clickOnSelectedLanguage(language);
-        }
-
+        onData(equalTo(language)).perform(click());
         return new MainMenuPage().assertOnPage();
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
@@ -2,14 +2,14 @@ package org.odk.collect.android.support.rules
 
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
-import android.net.Uri
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
+import androidx.test.uiautomator.Until
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import org.odk.collect.android.support.WaitFor.wait250ms
+import org.odk.collect.testshared.DummyActivity
 
 /**
  * Disables animations and sets long press timeout to 3 seconds in an attempt to avoid flakiness.
@@ -35,23 +35,30 @@ class PrepDeviceForTestsRule : TestRule {
      */
     private fun removeRecentAppsTooltips() {
         if (firstRun) {
-            // Open browser so there is something in Recent Apps
+            val device = UiDevice.getInstance(getInstrumentation())
+
+            // Open dummy activity so there is something in Recent Apps
             getInstrumentation().targetContext.apply {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://www.google.com"))
+                val intent = Intent(this.applicationContext, DummyActivity::class.java)
                 intent.addFlags(FLAG_ACTIVITY_NEW_TASK)
                 startActivity(intent)
-                wait250ms()
+                device.wait(Until.hasObject(By.textStartsWith(DummyActivity.TEXT)), 1000)
             }
 
             // Open Recent Apps and dismiss tooltips if they're there
-            val device = UiDevice.getInstance(getInstrumentation())
             device.pressRecentApps()
-            device.findObject(UiSelector().textContains("Select text and images to copy"))?.apply {
-                wait250ms()
+            val foundToolTip = device.wait(
+                Until.hasObject(By.textStartsWith("Select text and images to copy")),
+                1000
+            )
+            if (foundToolTip) {
                 device.pressBack() // the first time we open the list of recent apps, a tooltip might be displayed and we need to close it
             }
 
             // Close recent apps
+            device.pressBack()
+
+            // Close dummy activity
             device.pressBack()
         }
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
@@ -3,7 +3,6 @@ package org.odk.collect.android.support.rules
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.net.Uri
-import android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
@@ -1,10 +1,16 @@
 package org.odk.collect.android.support.rules
 
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import android.net.Uri
+import android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import org.odk.collect.android.support.WaitFor.wait250ms
 
 /**
  * Disables animations and sets long press timeout to 3 seconds in an attempt to avoid flakiness.
@@ -14,20 +20,62 @@ class PrepDeviceForTestsRule : TestRule {
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
-                ANIMATIONS.forEach { executeShellCommand("settings put global $it 0") }
-                executeShellCommand("settings put secure long_press_timeout 3000")
+                disableAnimations()
+                increaseLongPressTimeout()
+                removeRecentAppsTooltips()
+                firstRun = false
+
                 base.evaluate()
             }
         }
     }
 
+    /**
+     * Makes sure `Page#killAndReopenApp` doesn't run into problems with tooltips by opening
+     * Recent Apps and dismissing before any test runs. Only needs to run once per test process.
+     */
+    private fun removeRecentAppsTooltips() {
+        if (firstRun) {
+            // Open browser so there is something in Recent Apps
+            getInstrumentation().targetContext.apply {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://www.google.com"))
+                intent.addFlags(FLAG_ACTIVITY_NEW_TASK)
+                startActivity(intent)
+                wait250ms()
+            }
+
+            // Open Recent Apps and dismiss tooltips if they're there
+            val device = UiDevice.getInstance(getInstrumentation())
+            device.pressRecentApps()
+            device.findObject(UiSelector().textContains("Select text and images to copy"))?.apply {
+                wait250ms()
+                device.pressBack() // the first time we open the list of recent apps, a tooltip might be displayed and we need to close it
+            }
+
+            // Close recent apps
+            device.pressBack()
+        }
+    }
+
+    private fun increaseLongPressTimeout() {
+        executeShellCommand("settings put secure long_press_timeout 3000")
+    }
+
+    private fun disableAnimations() {
+        ANIMATIONS.forEach { executeShellCommand("settings put global $it 0") }
+    }
+
     private fun executeShellCommand(command: String) {
         UiDevice.getInstance(getInstrumentation()).executeShellCommand(command)
     }
-}
 
-private val ANIMATIONS: List<String> = listOf(
-    "transition_animation_scale",
-    "window_animation_scale",
-    "animator_duration_scale"
-)
+    companion object {
+        var firstRun = true
+
+        private val ANIMATIONS: List<String> = listOf(
+            "transition_animation_scale",
+            "window_animation_scale",
+            "animator_duration_scale"
+        )
+    }
+}

--- a/test-shared/src/main/AndroidManifest.xml
+++ b/test-shared/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     /
+    <application>
+        <activity android:name="org.odk.collect.testshared.DummyActivity" />
+    </application>
 </manifest>

--- a/test-shared/src/main/java/org/odk/collect/testshared/DummyActivity.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/DummyActivity.kt
@@ -1,0 +1,21 @@
+package org.odk.collect.testshared
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.TextView
+
+class DummyActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(
+            TextView(this).also {
+                it.text = TEXT
+            }
+        )
+    }
+
+    companion object {
+        const val TEXT = "I AM DUMMY"
+    }
+}


### PR DESCRIPTION
Closes #5899 

The core change here was to move the code that deals with dismissing the tooltip to `PrepDeviceForTestRule` and to deal with it in a new task rather than the task being used for the current test flow. The idea here is to reduce the risk of running into problems by not interfering with the test task and also by reducing the amount of times the `UIDevice` code will actually need to run.

I've run this multiple times and not seen flakes locally or on Test Lab.