### PR TITLE
Fixed duplicating projects in the project settings dialog

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/CurrentProjectViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/CurrentProjectViewModel.kt
@@ -23,7 +23,7 @@ class CurrentProjectViewModel(
 
     fun refresh() {
         if (currentProject.value != projectsDataService.getCurrentProject()) {
-            _currentProject.postValue(projectsDataService.getCurrentProject())
+            _currentProject.value = projectsDataService.getCurrentProject()
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
@@ -50,7 +50,7 @@ class MainMenuFragment(
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        val viewModelProvider = ViewModelProvider(this, viewModelFactory)
+        val viewModelProvider = ViewModelProvider(requireActivity(), viewModelFactory)
         mainMenuViewModel = viewModelProvider[MainMenuViewModel::class.java]
         currentProjectViewModel = viewModelProvider[CurrentProjectViewModel::class.java]
         permissionsViewModel = viewModelProvider[RequestPermissionsViewModel::class.java]

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
@@ -50,12 +50,10 @@ class ProjectSettingsDialog(private val viewModelFactory: ViewModelProvider.Fact
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding = ProjectSettingsDialogLayoutBinding.inflate(LayoutInflater.from(context))
 
-        currentProjectViewModel.currentProject.observe(this) { project ->
-            binding.currentProject.setupView(project, settingsProvider.getUnprotectedSettings())
-            binding.currentProject.contentDescription =
-                getString(org.odk.collect.strings.R.string.using_project, project.name)
-            inflateListOfInActiveProjects(requireContext(), project)
-        }
+        val project = currentProjectViewModel.currentProject.value
+        binding.currentProject.setupView(project, settingsProvider.getUnprotectedSettings())
+        binding.currentProject.contentDescription = getString(org.odk.collect.strings.R.string.using_project, project.name)
+        inflateListOfInActiveProjects(requireContext(), project)
 
         binding.closeIcon.setOnClickListener {
             dismiss()


### PR DESCRIPTION
Closes #5902 

#### Why is this the best possible solution? Were any other approaches considered?
The problem here was that we used to [observe the current project](https://github.com/getodk/collect/pull/5908/files#diff-07c27b35efda0a326f052d4adeba16f697274b43b4d1f4d519913882fe15d7e1L53) and build the list of projects based on the current value. The thing is that after editing project details (color or icon) first the old value was returned and then the new one. As a result, the list of projects was filled twice and we ended up with duplicated projects.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We can focus on testing that the `ProjectSettingDialog` displays proper projects on the list. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
