### PR TITLE
Fixed marking converted projects as old GD projects

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/GoogleDriveProjectsDeleter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/GoogleDriveProjectsDeleter.kt
@@ -27,7 +27,7 @@ class GoogleDriveProjectsDeleter(
                 if (result == DeleteProjectResult.UnsentInstances || result == DeleteProjectResult.RunningBackgroundJobs) {
                     unprotectedSettings.save(ProjectKeys.KEY_PROTOCOL, ProjectKeys.PROTOCOL_SERVER)
                     unprotectedSettings.save(ProjectKeys.KEY_SERVER_URL, "https://example.com")
-                    it.isOldGoogleDriveProject = true
+                    projectsRepository.save(it.copy(isOldGoogleDriveProject = true))
                 }
             }
         }

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/GoogleDriveProjectsDeleterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/GoogleDriveProjectsDeleterTest.kt
@@ -1,25 +1,39 @@
 package org.odk.collect.android.application.initialization
 
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.projects.DeleteProjectResult
 import org.odk.collect.android.projects.ProjectDeleter
-import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
-import org.odk.collect.settings.InMemSettingsProvider
+import org.odk.collect.projects.ProjectsRepository
+import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys
 
+@RunWith(AndroidJUnit4::class)
 class GoogleDriveProjectsDeleterTest {
-    private val projectsRepository = InMemProjectsRepository()
-    private val settingsProvider = InMemSettingsProvider()
+    private lateinit var projectsRepository: ProjectsRepository
+    private lateinit var settingsProvider: SettingsProvider
     private val projectDeleter = mock<ProjectDeleter>()
+    private lateinit var googleDriveProjectsDeleter: GoogleDriveProjectsDeleter
 
-    private val googleDriveProjectsDeleter = GoogleDriveProjectsDeleter(projectsRepository, settingsProvider, projectDeleter)
+    @Before
+    fun setup() {
+        val component = DaggerUtils.getComponent(ApplicationProvider.getApplicationContext<Application>())
+        projectsRepository = component.projectsRepository()
+        settingsProvider = component.settingsProvider()
+        googleDriveProjectsDeleter = GoogleDriveProjectsDeleter(projectsRepository, settingsProvider, projectDeleter)
+    }
 
     @Test
     fun `GoogleDriveProjectsDeleter should have null key`() {

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/GoogleDriveProjectsDeleterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/GoogleDriveProjectsDeleterTest.kt
@@ -1,39 +1,25 @@
 package org.odk.collect.android.application.initialization
 
-import android.app.Application
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
-import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.projects.DeleteProjectResult
 import org.odk.collect.android.projects.ProjectDeleter
+import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
-import org.odk.collect.projects.ProjectsRepository
-import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys
 
-@RunWith(AndroidJUnit4::class)
 class GoogleDriveProjectsDeleterTest {
-    private lateinit var projectsRepository: ProjectsRepository
-    private lateinit var settingsProvider: SettingsProvider
+    private val projectsRepository = InMemProjectsRepository()
+    private val settingsProvider = InMemSettingsProvider()
     private val projectDeleter = mock<ProjectDeleter>()
-    private lateinit var googleDriveProjectsDeleter: GoogleDriveProjectsDeleter
 
-    @Before
-    fun setup() {
-        val component = DaggerUtils.getComponent(ApplicationProvider.getApplicationContext<Application>())
-        projectsRepository = component.projectsRepository()
-        settingsProvider = component.settingsProvider()
-        googleDriveProjectsDeleter = GoogleDriveProjectsDeleter(projectsRepository, settingsProvider, projectDeleter)
-    }
+    private val googleDriveProjectsDeleter = GoogleDriveProjectsDeleter(projectsRepository, settingsProvider, projectDeleter)
 
     @Test
     fun `GoogleDriveProjectsDeleter should have null key`() {

--- a/projects/src/main/java/org/odk/collect/projects/Project.kt
+++ b/projects/src/main/java/org/odk/collect/projects/Project.kt
@@ -16,7 +16,7 @@ sealed class Project {
         override val name: String,
         override val icon: String,
         override val color: String,
-        var isOldGoogleDriveProject: Boolean = false
+        val isOldGoogleDriveProject: Boolean = false
     ) : Project() {
 
         constructor(uuid: String, project: New) : this(


### PR DESCRIPTION
Closes #5903

#### Why is this the best possible solution? Were any other approaches considered?
The problem was the way we implemented marking projects as old GD projects see: https://github.com/getodk/collect/pull/5909/files#diff-a091971b93c91fe4e50308d51b4b3abebac66e51711552f955e75feb504ea928L30
it worked well with existing tests because they used test implementation of `ProjectsRepository` and simply updating the objects stored on a list (not in shared prefs) worked well.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is a small fix so we can focus on testing the scenario described in the issue. I don't think there is any bigger risk here.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
