### PR TITLE
Add desugaring dependency for mapbox

### DIFF
--- a/mapbox/build.gradle.kts
+++ b/mapbox/build.gradle.kts
@@ -35,6 +35,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Dependencies.desugar)
+
     implementation(project(":androidshared"))
     implementation(project(":icons"))
     implementation(project(":location"))


### PR DESCRIPTION
In the conversion of the mapbox module's gradle file to kotlin, a dependency was omitted. Without this, it's not possible to build a release build with mapbox.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [ ] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
