### PR TITLE
Fixed using the quick appearance in SelectOneFromMapWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -54,6 +54,7 @@ import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.audio.AudioHelper;
 import org.odk.collect.android.exception.ExternalParamsException;
@@ -196,7 +197,8 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
                 viewLifecycle,
                 new FileRequesterImpl(intentLauncher, externalAppIntentProvider, formController),
                 new StringRequesterImpl(intentLauncher, externalAppIntentProvider, formController),
-                formController
+                formController,
+                (FormFillingActivity) context
         );
 
         widgets = new ArrayList<>();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -31,6 +31,7 @@ import org.odk.collect.android.formentry.PrinterWidgetViewModel;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.geo.MapConfiguratorProvider;
 import org.odk.collect.android.javarosawrapper.FormController;
+import org.odk.collect.android.listeners.AdvanceToNextListener;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.ExternalWebPageHelper;
@@ -89,6 +90,7 @@ public class WidgetFactory {
     private final FileRequester fileRequester;
     private final StringRequester stringRequester;
     private final FormController formController;
+    private final AdvanceToNextListener advanceToNextListener;
 
     public WidgetFactory(Activity activity,
                          boolean readOnlyOverride,
@@ -103,7 +105,9 @@ public class WidgetFactory {
                          LifecycleOwner viewLifecycle,
                          FileRequester fileRequester,
                          StringRequester stringRequester,
-                         FormController formController) {
+                         FormController formController,
+                         AdvanceToNextListener advanceToNextListener
+    ) {
         this.activity = activity;
         this.readOnlyOverride = readOnlyOverride;
         this.useExternalRecorder = useExternalRecorder;
@@ -118,6 +122,7 @@ public class WidgetFactory {
         this.fileRequester = fileRequester;
         this.stringRequester = stringRequester;
         this.formController = formController;
+        this.advanceToNextListener = advanceToNextListener;
     }
 
     public QuestionWidget createWidgetFromPrompt(FormEntryPrompt prompt, PermissionsProvider permissionsProvider) {
@@ -315,7 +320,7 @@ public class WidgetFactory {
         } else if (appearance.contains(Appearances.IMAGE_MAP)) {
             questionWidget = new SelectOneImageMapWidget(activity, questionDetails, isQuick, formEntryViewModel);
         } else if (appearance.contains(Appearances.MAP)) {
-            questionWidget = new SelectOneFromMapWidget(activity, questionDetails, isQuick);
+            questionWidget = new SelectOneFromMapWidget(activity, questionDetails, isQuick, advanceToNextListener);
         } else {
             questionWidget = new SelectOneWidget(activity, questionDetails, isQuick, formController, formEntryViewModel);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -315,7 +315,7 @@ public class WidgetFactory {
         } else if (appearance.contains(Appearances.IMAGE_MAP)) {
             questionWidget = new SelectOneImageMapWidget(activity, questionDetails, isQuick, formEntryViewModel);
         } else if (appearance.contains(Appearances.MAP)) {
-            questionWidget = new SelectOneFromMapWidget(activity, questionDetails);
+            questionWidget = new SelectOneFromMapWidget(activity, questionDetails, isQuick);
         } else {
             questionWidget = new SelectOneWidget(activity, questionDetails, isQuick, formController, formEntryViewModel);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
@@ -14,6 +14,7 @@ import org.javarosa.core.model.data.helper.Selection
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.databinding.SelectOneFromMapWidgetAnswerBinding
 import org.odk.collect.android.formentry.questions.QuestionDetails
+import org.odk.collect.android.listeners.AdvanceToNextListener
 import org.odk.collect.android.widgets.QuestionWidget
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver
 import org.odk.collect.android.widgets.items.SelectOneFromMapDialogFragment.Companion.ARG_FORM_INDEX
@@ -22,10 +23,18 @@ import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.permissions.PermissionListener
 
 @SuppressLint("ViewConstructor")
-class SelectOneFromMapWidget(context: Context, questionDetails: QuestionDetails) :
-    QuestionWidget(context, questionDetails), WidgetDataReceiver {
+class SelectOneFromMapWidget(
+    context: Context,
+    questionDetails: QuestionDetails,
+    private val autoAdvance: Boolean
+) : QuestionWidget(context, questionDetails), WidgetDataReceiver {
+
+    lateinit var autoAdvanceListener: AdvanceToNextListener
 
     init {
+        if (context is AdvanceToNextListener) {
+            autoAdvanceListener = context
+        }
         render()
     }
 
@@ -79,6 +88,9 @@ class SelectOneFromMapWidget(context: Context, questionDetails: QuestionDetails)
     override fun setData(answer: Any?) {
         updateAnswer(answer as SelectOneData)
         widgetValueChanged()
+        if (autoAdvance) {
+            autoAdvanceListener.advance()
+        }
     }
 
     private fun updateAnswer(answer: SelectOneData?) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
@@ -26,15 +26,11 @@ import org.odk.collect.permissions.PermissionListener
 class SelectOneFromMapWidget(
     context: Context,
     questionDetails: QuestionDetails,
-    private val autoAdvance: Boolean
+    private val autoAdvance: Boolean,
+    private val autoAdvanceListener: AdvanceToNextListener
 ) : QuestionWidget(context, questionDetails), WidgetDataReceiver {
 
-    lateinit var autoAdvanceListener: AdvanceToNextListener
-
     init {
-        if (context is AdvanceToNextListener) {
-            autoAdvanceListener = context
-        }
         render()
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/WidgetFactoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/WidgetFactoryTest.java
@@ -37,7 +37,7 @@ public class WidgetFactoryTest {
     @Before
     public void setup() {
         Activity activity = CollectHelpers.buildThemedActivity(WidgetTestActivity.class).get();
-        widgetFactory = new WidgetFactory(activity, false, false, null, null, null, null, mock(FormEntryViewModel.class), null, null, null, null, null, null);
+        widgetFactory = new WidgetFactory(activity, false, false, null, null, null, null, mock(FormEntryViewModel.class), null, null, null, null, null, null, mock());
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidgetTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidgetTest.kt
@@ -84,7 +84,8 @@ class SelectOneFromMapWidgetTest {
         val widget = SelectOneFromMapWidget(
             activityController.get(),
             QuestionDetails(promptWithAnswer(null)),
-            false
+            false,
+            mock()
         )
 
         assertThat(
@@ -109,7 +110,7 @@ class SelectOneFromMapWidgetTest {
 
         val prompt = promptWithAnswer(null)
         val widget =
-            SelectOneFromMapWidget(activity, QuestionDetails(prompt), false)
+            SelectOneFromMapWidget(activity, QuestionDetails(prompt), false, mock())
         whenever(formEntryViewModel.getQuestionPrompt(prompt.index)).doReturn(prompt)
 
         widget.binding.button.performClick()
@@ -131,7 +132,8 @@ class SelectOneFromMapWidgetTest {
         val widget = SelectOneFromMapWidget(
             activityController.get(),
             QuestionDetails(promptWithAnswer(null)),
-            false
+            false,
+            mock()
         )
 
         permissionsProvider.setPermissionGranted(false)
@@ -153,7 +155,7 @@ class SelectOneFromMapWidgetTest {
             .withAnswer(SelectOneData(choices[0].selection()))
             .build()
 
-        val widget = SelectOneFromMapWidget(activityController.get(), QuestionDetails(prompt), false)
+        val widget = SelectOneFromMapWidget(activityController.get(), QuestionDetails(prompt), false, mock())
         assertThat(widget.binding.answer.text, equalTo("A"))
     }
 
@@ -163,7 +165,8 @@ class SelectOneFromMapWidgetTest {
         val widget = SelectOneFromMapWidget(
             activityController.get(),
             QuestionDetails(promptWithAnswer(null)),
-            false
+            false,
+            mock()
         )
 
         assertThat(
@@ -180,7 +183,8 @@ class SelectOneFromMapWidgetTest {
         val widget = SelectOneFromMapWidget(
             activityController.get(),
             QuestionDetails(promptWithAnswer(answer)),
-            false
+            false,
+            mock()
         )
         assertThat(widget.answer, equalTo(answer))
     }
@@ -193,7 +197,8 @@ class SelectOneFromMapWidgetTest {
         val widget = SelectOneFromMapWidget(
             activityController.get(),
             QuestionDetails(promptWithAnswer(answer)),
-            false
+            false,
+            mock()
         )
         widget.clearAnswer()
         assertThat(widget.answer, equalTo(null))
@@ -207,7 +212,8 @@ class SelectOneFromMapWidgetTest {
         val widget = SelectOneFromMapWidget(
             activityController.get(),
             QuestionDetails(promptWithAnswer(answer)),
-            false
+            false,
+            mock()
         )
 
         val mockValueChangedListener = mockValueChangedListener(widget)
@@ -224,7 +230,7 @@ class SelectOneFromMapWidgetTest {
             .withAnswer(SelectOneData(choices[0].selection()))
             .build()
 
-        val widget = SelectOneFromMapWidget(activityController.get(), QuestionDetails(prompt), false)
+        val widget = SelectOneFromMapWidget(activityController.get(), QuestionDetails(prompt), false, mock())
 
         widget.clearAnswer()
         assertThat(widget.binding.answer.text, equalTo(""))
@@ -235,7 +241,8 @@ class SelectOneFromMapWidgetTest {
         val widget = SelectOneFromMapWidget(
             activityController.get(),
             QuestionDetails(promptWithAnswer(null)),
-            false
+            false,
+            mock()
         )
 
         val selectChoice = selectChoice(value = "a", index = 101)
@@ -253,7 +260,7 @@ class SelectOneFromMapWidgetTest {
                 mapOf(choices[0] to "A", choices[1] to "B")
             )
             .build()
-        val widget = SelectOneFromMapWidget(activityController.get(), QuestionDetails(prompt), false)
+        val widget = SelectOneFromMapWidget(activityController.get(), QuestionDetails(prompt), false, mock())
 
         widget.setData(SelectOneData(choices[1].selection()))
         assertThat(widget.binding.answer.text, equalTo("B"))
@@ -267,7 +274,7 @@ class SelectOneFromMapWidgetTest {
             .withSelectChoiceText(mapOf(choices[0] to "A"))
             .build()
 
-        val widget = SelectOneFromMapWidget(activityController.get(), QuestionDetails(prompt), false)
+        val widget = SelectOneFromMapWidget(activityController.get(), QuestionDetails(prompt), false, mock())
 
         val mockValueChangedListener = mockValueChangedListener(widget)
         widget.setData(SelectOneData(choices[0].selection()))
@@ -295,7 +302,7 @@ class SelectOneFromMapWidgetTest {
             .build()
 
         val widget =
-            SelectOneFromMapWidget(activity, QuestionDetails(prompt), false)
+            SelectOneFromMapWidget(activity, QuestionDetails(prompt), false, mock())
         widget.setData(SelectOneData(choices[1].selection()))
 
         whenever(formEntryViewModel.getQuestionPrompt(prompt.index)).doReturn(prompt)
@@ -315,13 +322,13 @@ class SelectOneFromMapWidgetTest {
 
     @Test
     fun `setData calls AdvanceToNextListener when the 'quick' appearance is used`() {
+        val listener = mock<AdvanceToNextListener>()
         val widget = SelectOneFromMapWidget(
             activityController.get(),
             QuestionDetails(promptWithAnswer(null)),
-            true
+            true,
+            listener
         )
-        val listener = mock<AdvanceToNextListener>()
-        widget.autoAdvanceListener = listener
 
         val selectChoice = selectChoice(value = "a", index = 101)
         val answer = SelectOneData(selectChoice.selection())
@@ -331,13 +338,13 @@ class SelectOneFromMapWidgetTest {
 
     @Test
     fun `setData does not call AdvanceToNextListener when the 'quick' appearance is not used`() {
+        val listener = mock<AdvanceToNextListener>()
         val widget = SelectOneFromMapWidget(
             activityController.get(),
             QuestionDetails(promptWithAnswer(null)),
-            false
+            false,
+            listener
         )
-        val listener = mock<AdvanceToNextListener>()
-        widget.autoAdvanceListener = listener
 
         val selectChoice = selectChoice(value = "a", index = 101)
         val answer = SelectOneData(selectChoice.selection())

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -334,7 +334,7 @@ class SelectionMapFragment(
         if (selectedItem != null) {
             val featureId = featureIdsByItemId[selectedItem.id]
             if (featureId != null) {
-                onFeatureClicked(featureId)
+                onFeatureClicked(featureId, selectedByUser = false)
             }
         } else if (previouslySelectedItem != null) {
             onFeatureClicked(previouslySelectedItem, maintainZoom = false, selectedByUser = false)

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -22,7 +22,6 @@ import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.androidshared.ui.multiclicksafe.setMultiClickSafeOnClickListener
 import org.odk.collect.geo.GeoDependencyComponentProvider
-import org.odk.collect.geo.R
 import org.odk.collect.geo.ReferenceLayerSettingsNavigator
 import org.odk.collect.geo.databinding.SelectionMapLayoutBinding
 import org.odk.collect.maps.MapFragment
@@ -197,7 +196,7 @@ class SelectionMapFragment(
 
         map.setGpsLocationEnabled(true)
 
-        map.setFeatureClickListener(::onFeatureClicked)
+        map.setFeatureClickListener(::onFeatureSelected)
         map.setClickListener { onClick() }
 
         selectionMapData.getMappableItems().observe(viewLifecycleOwner) {
@@ -265,7 +264,7 @@ class SelectionMapFragment(
         }
     }
 
-    private fun onFeatureClicked(featureId: Int, maintainZoom: Boolean = true, selectedByUser: Boolean = true) {
+    private fun onFeatureSelected(featureId: Int, maintainZoom: Boolean = true, selectedByUser: Boolean = true) {
         val item = itemsByFeatureId[featureId]
         val selectedItem = selectedItemViewModel.getSelectedItem()
 
@@ -334,10 +333,10 @@ class SelectionMapFragment(
         if (selectedItem != null) {
             val featureId = featureIdsByItemId[selectedItem.id]
             if (featureId != null) {
-                onFeatureClicked(featureId, selectedByUser = false)
+                onFeatureSelected(featureId, selectedByUser = false)
             }
         } else if (previouslySelectedItem != null) {
-            onFeatureClicked(previouslySelectedItem, maintainZoom = false, selectedByUser = false)
+            onFeatureSelected(previouslySelectedItem, maintainZoom = false, selectedByUser = false)
         } else if (!map.hasCenter()) {
             if (zoomToFitItems && points.isNotEmpty()) {
                 map.zoomToBoundingBox(points, 0.8, false)

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -265,7 +265,7 @@ class SelectionMapFragment(
         }
     }
 
-    private fun onFeatureClicked(featureId: Int, maintainZoom: Boolean = true) {
+    private fun onFeatureClicked(featureId: Int, maintainZoom: Boolean = true, selectedByUser: Boolean = true) {
         val item = itemsByFeatureId[featureId]
         val selectedItem = selectedItemViewModel.getSelectedItem()
 
@@ -274,7 +274,14 @@ class SelectionMapFragment(
                 resetIcon(selectedItem)
             }
 
-            if (!skipSummary) {
+            if (skipSummary && selectedByUser) {
+                parentFragmentManager.setFragmentResult(
+                    REQUEST_SELECT_ITEM,
+                    Bundle().also {
+                        it.putLong(RESULT_SELECTED_ITEM, item.id)
+                    }
+                )
+            } else {
                 if (item.points.size > 1) {
                     map.zoomToBoundingBox(item.points, 0.8, true)
                 } else {
@@ -305,13 +312,6 @@ class SelectionMapFragment(
                 )
 
                 selectedItemViewModel.setSelectedItem(item)
-            } else {
-                parentFragmentManager.setFragmentResult(
-                    REQUEST_SELECT_ITEM,
-                    Bundle().also {
-                        it.putLong(RESULT_SELECTED_ITEM, item.id)
-                    }
-                )
             }
         }
     }
@@ -337,7 +337,7 @@ class SelectionMapFragment(
                 onFeatureClicked(featureId)
             }
         } else if (previouslySelectedItem != null) {
-            onFeatureClicked(previouslySelectedItem, maintainZoom = false)
+            onFeatureClicked(previouslySelectedItem, maintainZoom = false, selectedByUser = false)
         } else if (!map.hasCenter()) {
             if (zoomToFitItems && points.isNotEmpty()) {
                 map.zoomToBoundingBox(points, 0.8, false)

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -804,7 +804,7 @@ class SelectionMapFragmentTest {
         scenario.moveToState(Lifecycle.State.DESTROYED)
     }
 
-    @Test // https://github.com/getodk/collect/issues/5540
+    @Test
     fun `opening the map with already selected item when skipSummary is true does not close the map`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
@@ -838,7 +838,7 @@ class SelectionMapFragmentTest {
         assertThat(actualResult, equalTo(null))
     }
 
-    @Test // https://github.com/getodk/collect/issues/5540
+    @Test
     fun `recreating the map with already selected item when skipSummary is true does not close the map`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -838,6 +838,41 @@ class SelectionMapFragmentTest {
         assertThat(actualResult, equalTo(null))
     }
 
+    @Test // https://github.com/getodk/collect/issues/5540
+    fun `recreating the map with already selected item when skipSummary is true does not close the map`() {
+        val items = listOf(
+            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
+            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)), selected = true)
+        )
+        whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
+
+        val scenario = launcherRule.launchInContainer(
+            SelectionMapFragment::class.java,
+            factory = FragmentFactoryBuilder()
+                .forClass(SelectionMapFragment::class.java) {
+                    SelectionMapFragment(
+                        data,
+                        skipSummary = true,
+                        onBackPressedDispatcher = { onBackPressedDispatcher }
+                    )
+                }.build()
+        )
+        map.ready()
+        scenario.recreate()
+        var actualResult: Bundle? = null
+        scenario.onFragment {
+            it.parentFragmentManager.setFragmentResultListener(
+                SelectionMapFragment.REQUEST_SELECT_ITEM,
+                it
+            ) { _: String?, result: Bundle ->
+                actualResult = result
+            }
+        }
+        map.ready()
+
+        assertThat(actualResult, equalTo(null))
+    }
+
     private fun MappableSelectItem.toMapPoint(): MapPoint {
         return MapPoint(this.points[0].latitude, this.points[0].longitude)
     }


### PR DESCRIPTION
Closes #5540

#### Why is this the best possible solution? Were any other approaches considered?
We have one method `onFeatureClicked` (renamed to `onFeatureSelected`) to handle both cases - selecting items by a user and selecting items (automatically) after opening a map where there is already a selected item. Because of that, we weren't able to distinguish those two cases without introducing a new parameter `selectedByUser`. Only if the action is performed by a user we should close the map (if the `quick` appearance is used).
When it comes to the second part of the issue - navigating automatically to the next question it works in a similar way to normal selects. There is a listener and when there is a new answer we call the listener.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The changes can only affect the SelectOneFromMap widget so we can focus on testing it. Please make sure the issue is fixed and there is everything fine with that widget.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
