### PR TITLE
Reduce amount of index updates on UI thread

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -2056,7 +2056,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                         // happens because if audit logging is enabled, the refresh logs a question event
                         // and we want that to show up after initialization events.
                         activityDisplayed();
-                        formEntryViewModel.refreshSync();
+                        formEntryViewModel.refresh();
 
                         if (warningMsg != null) {
                             showLongToast(this, warningMsg);
@@ -2084,7 +2084,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                                 if (formIndex != null) {
                                     formController.jumpToIndex(formIndex);
                                     formControllerAvailable(formController);
-                                    formEntryViewModel.refreshSync();
+                                    formEntryViewModel.refresh();
                                     return;
                                 }
                             }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -156,18 +156,21 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             return;
         }
 
-        if (jumpBackIndex != null) {
-            formController.jumpToIndex(jumpBackIndex);
-            jumpBackIndex = null;
-        } else {
-            try {
-                this.formController.stepToNextScreenEvent();
-            } catch (JavaRosaException exception) {
-                error.setValue(new FormError.NonFatal(exception.getCause().getMessage()));
+        worker.immediate((Supplier<Void>) () -> {
+            if (jumpBackIndex != null) {
+                formController.jumpToIndex(jumpBackIndex);
+                jumpBackIndex = null;
+            } else {
+                try {
+                    this.formController.stepToNextScreenEvent();
+                } catch (JavaRosaException exception) {
+                    error.postValue(new FormError.NonFatal(exception.getCause().getMessage()));
+                }
             }
-        }
 
-        updateIndex(false);
+            updateIndex(true);
+            return null;
+        }, ignored -> {});
     }
 
     public void errorDisplayed() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -194,17 +194,16 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             if (updateSuccess) {
                 try {
                     formController.stepToNextScreenEvent();
+                    formController.getAuditEventLogger().flushSynchronized(); // Close events waiting for an end time
+                    updateIndex(true);
                 } catch (JavaRosaException e) {
                     error.postValue(new FormError.NonFatal(e.getCause().getMessage()));
                 }
             }
 
-            return updateSuccess;
-        }, updateSuccess -> {
-            if (updateSuccess) {
-                formController.getAuditEventLogger().flush(); // Close events waiting for an end time
-                updateIndex(false);
-            }
+            return null;
+        }, ignored -> {
+
         });
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -116,12 +116,24 @@ public class AuditEventLogger {
         }
     }
 
-    /*
-     * Finalizes and writes events
+    /**
+     * @deprecated use {@link #flushSynchronized()} instead.
      */
+    @Deprecated
     public void flush() {
         checkAndroidUIThread();
+        internalFlush();
+    }
 
+    /*
+     * Finalizes and writes events. Can safely be used on a background thread, but should not be
+     * used on the UI thread.
+     */
+    public void flushSynchronized() {
+        internalFlush();
+    }
+
+    private void internalFlush() {
         if (isAuditEnabled()) {
             finalizeEvents();
             writeEvents();


### PR DESCRIPTION
Closes #5229
~~Blocked by #5918~~

This doesn't fix the problem for all cases in form entry, but should catch the majority of them. We'll now show progress when loading selects when:

* loading the first question of a form
* moving forward
* moving backwards
* moving back to a question after cancelling adding a repeat
* moving back to a question after a failed validation check

#### Why is this the best possible solution? Were any other approaches considered?

There will still be many cases where we load select choices on the UI thread and don't show progress that are riskier to tackle like returning to a select question from an external app or when adding a repeat that starts with a select. These cases all require much more rework as they often involve navigation between activities which makes an async operation more tricky. 

We (@lognaturel  and I) previously discussed this and decided just targeting the highest traffic paths (like moving forward) was a good first step to reducing our ANRs and smoothing out performance in this area.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There shouldn't really be any obvious changes to the behaviour of the app so validating form entry (especially for forms with selects) is the best approach here. As we found before reverting the first attempt at these changes, it's likely that form entry might appear a little slower on fast devices: this is because we show that something is happening rather than letting the app freeze which can ironically feel "faster". We'll likely want to revise exactly how we display progress to improve this.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
