### PR TITLE
Log current screen after saving a form

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -164,4 +164,43 @@ class AuditTest {
         assertThat(auditLog[13].get("event"), equalTo("form save"))
         assertThat(auditLog[14].get("event"), equalTo("form exit"))
     }
+
+    @Test // https://github.com/getodk/collect/issues/5915
+    fun changingTheAnswerAfterSavingAFormOnTheSamePage_shouldLogTheNewAnswer() {
+        rule.startAtMainMenu()
+            .copyForm("two-question-audit-track-changes.xml")
+            .startBlankForm("One Question Audit Track Changes")
+            .clickSave()
+            .fillOut(FormEntryPage.QuestionAndAnswer("What is your age?", "31"))
+            .swipeToNextQuestion("What is your name?")
+            .clickSave()
+            .fillOut(FormEntryPage.QuestionAndAnswer("What is your name?", "Adam"))
+            .swipeToEndScreen()
+            .clickSaveAsDraft()
+
+        val auditLog = StorageUtils.getAuditLogForFirstInstance()
+        assertThat(auditLog.size, equalTo(10))
+
+        assertThat(auditLog[0].get("event"), equalTo("form start"))
+
+        assertThat(auditLog[1].get("event"), equalTo("question"))
+        assertThat(auditLog[1].get("new-value"), equalTo(""))
+
+        assertThat(auditLog[2].get("event"), equalTo("form save"))
+
+        assertThat(auditLog[3].get("event"), equalTo("question"))
+        assertThat(auditLog[3].get("new-value"), equalTo("31"))
+
+        assertThat(auditLog[4].get("event"), equalTo("question"))
+        assertThat(auditLog[4].get("new-value"), equalTo(""))
+
+        assertThat(auditLog[5].get("event"), equalTo("form save"))
+
+        assertThat(auditLog[6].get("event"), equalTo("question"))
+        assertThat(auditLog[6].get("new-value"), equalTo("Adam"))
+
+        assertThat(auditLog[7].get("event"), equalTo("end screen"))
+        assertThat(auditLog[8].get("event"), equalTo("form save"))
+        assertThat(auditLog[9].get("event"), equalTo("form exit"))
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -184,19 +184,23 @@ class AuditTest {
         assertThat(auditLog[0].get("event"), equalTo("form start"))
 
         assertThat(auditLog[1].get("event"), equalTo("question"))
+        assertThat(auditLog[1].get("node"), equalTo("/data/age"))
         assertThat(auditLog[1].get("new-value"), equalTo(""))
 
         assertThat(auditLog[2].get("event"), equalTo("form save"))
 
         assertThat(auditLog[3].get("event"), equalTo("question"))
+        assertThat(auditLog[3].get("node"), equalTo("/data/age"))
         assertThat(auditLog[3].get("new-value"), equalTo("31"))
 
         assertThat(auditLog[4].get("event"), equalTo("question"))
+        assertThat(auditLog[4].get("node"), equalTo("/data/name"))
         assertThat(auditLog[4].get("new-value"), equalTo(""))
 
         assertThat(auditLog[5].get("event"), equalTo("form save"))
 
         assertThat(auditLog[6].get("event"), equalTo("question"))
+        assertThat(auditLog[6].get("node"), equalTo("/data/name"))
         assertThat(auditLog[6].get("new-value"), equalTo("Adam"))
 
         assertThat(auditLog[7].get("event"), equalTo("end screen"))

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -21,6 +21,7 @@ import org.odk.collect.android.dao.helpers.InstancesDaoHelper;
 import org.odk.collect.android.dynamicpreload.ExternalDataManager;
 import org.odk.collect.android.formentry.FormSession;
 import org.odk.collect.android.formentry.audit.AuditEvent;
+import org.odk.collect.android.formentry.audit.AuditUtils;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.projects.ProjectsDataService;
 import org.odk.collect.android.tasks.SaveFormToDisk;
@@ -254,6 +255,8 @@ public class FormSaveViewModel extends ViewModel implements MaterialProgressDial
                     } else {
                         formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_EXIT, true, clock.get());
                     }
+                } else {
+                    AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), clock.get());
                 }
 
                 saveResult.setValue(new SaveResult(SaveResult.State.SAVED, saveRequest, taskResult.getSaveErrorMessage()));


### PR DESCRIPTION
Closes #5915 

#### Why is this the best possible solution? Were any other approaches considered?
Logging the current screen was removed in this pr: https://github.com/getodk/collect/pull/5839 so to fix the issue I've just brought it back.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just solve the issue. I don't think it's risky since the fix brings back the code that already existed in v2023.3.1 and older versions but it's not the first issue with audits we have discovered recently so there might be more.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
