### PR TITLE
Fixed setting background color used in pills

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/ContextUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/ContextUtils.kt
@@ -6,6 +6,11 @@ import androidx.annotation.AttrRes
 
 object ContextUtils {
 
+    /**
+     * Be careful when using this method to retrieve colors, especially for those defined
+     * using selectors as it might not work well.
+     * In such cases consider using [com.google.android.material.color.MaterialColors.getColor] instead.
+     */
     @JvmStatic
     fun getThemeAttributeValue(context: Context, @AttrRes resId: Int): Int {
         val outValue = TypedValue()

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceListItemView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
+import com.google.android.material.color.MaterialColors
 import org.odk.collect.android.R
 import org.odk.collect.android.utilities.FormsRepositoryProvider
 import org.odk.collect.androidshared.system.ContextUtils.getThemeAttributeValue
@@ -35,7 +36,7 @@ object InstanceListItemView {
                     pill.visibility = View.VISIBLE
                     pill.setIcon(org.odk.collect.icons.R.drawable.ic_baseline_rule_24)
                     pill.setText(string.draft_errors)
-                    pill.setPillBackgroundColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorErrorContainer))
+                    pill.setPillBackgroundColor(MaterialColors.getColor(pill, com.google.android.material.R.attr.colorErrorContainer))
                     pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
                     pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnErrorContainer))
                 }
@@ -43,7 +44,7 @@ object InstanceListItemView {
                     pill.visibility = View.VISIBLE
                     pill.setIcon(R.drawable.baseline_check_24)
                     pill.setText(string.draft_no_errors)
-                    pill.setPillBackgroundColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorSurfaceContainerHighest))
+                    pill.setPillBackgroundColor(MaterialColors.getColor(pill, com.google.android.material.R.attr.colorSurfaceContainerHighest))
                     pill.setTextColor(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
                     pill.setIconTint(getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
                 }


### PR DESCRIPTION
Closes #5926 

#### Why is this the best possible solution? Were any other approaches considered?
It looks like our getThemeAttributeValue method does not work well with colors that are defined as selectors. I could have tried to improve that method but it doesn't make sense if `MaterialColors` provides one that works well.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that the background color used in the pills with `Errors`/`No Errors` messages is correct. Nothing else can be affected since the changes are only in that one place where those two pills are generated.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
