### PR TITLE
Make select preloading disableable

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryViewModelFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryViewModelFactory.kt
@@ -69,7 +69,8 @@ class FormEntryViewModelFactory(
                 scheduler,
                 formSessionRepository,
                 sessionId,
-                formsRepositoryProvider.get(projectId)
+                formsRepositoryProvider.get(projectId),
+                settingsProvider.getUnprotectedSettings()
             )
 
             FormSaveViewModel::class.java -> {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -36,6 +36,8 @@ import org.odk.collect.async.Cancellable;
 import org.odk.collect.async.Scheduler;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormsRepository;
+import org.odk.collect.settings.keys.ProjectKeys;
+import org.odk.collect.shared.settings.Settings;
 
 import java.io.FileNotFoundException;
 import java.util.HashMap;
@@ -68,15 +70,17 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
     private final Cancellable formSessionObserver;
     private final FormsRepository formsRepository;
+    private final Settings settings;
 
     private final Map<FormIndex, List<SelectChoice>> choices = new HashMap<>();
 
     private final TrackableWorker worker;
 
     @SuppressWarnings("WeakerAccess")
-    public FormEntryViewModel(Supplier<Long> clock, Scheduler scheduler, FormSessionRepository formSessionRepository, String sessionId, FormsRepository formsRepository) {
+    public FormEntryViewModel(Supplier<Long> clock, Scheduler scheduler, FormSessionRepository formSessionRepository, String sessionId, FormsRepository formsRepository, Settings settings) {
         this.clock = clock;
         this.formSessionRepository = formSessionRepository;
+        this.settings = settings;
         worker = new TrackableWorker(scheduler);
 
         this.sessionId = sessionId;
@@ -381,6 +385,10 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
     }
 
     private void preloadSelectChoices() throws RepeatsInFieldListException, FileNotFoundException, XPathSyntaxException {
+        if (!settings.getBoolean(ProjectKeys.KEY_EXPERIMENTAL_SELECT_CHOICE_PRELOADING)) {
+            return;
+        }
+
         int event = formController.getEvent();
         if (event == FormEntryController.EVENT_QUESTION) {
             FormEntryPrompt prompt = formController.getQuestionPrompt();

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
@@ -50,6 +50,8 @@ object Defaults {
             hashMap[ProjectKeys.KEY_USGS_MAP_STYLE] = "topographic"
             hashMap[ProjectKeys.KEY_GOOGLE_MAP_STYLE] = GoogleMap.MAP_TYPE_NORMAL.toString()
             hashMap[ProjectKeys.KEY_MAPBOX_MAP_STYLE] = "mapbox://styles/mapbox/streets-v11"
+            // experimental_preferences.xml
+            hashMap[ProjectKeys.KEY_EXPERIMENTAL_SELECT_CHOICE_PRELOADING] = true
             return hashMap
         }
 

--- a/collect_app/src/main/res/xml/experimental_preferences.xml
+++ b/collect_app/src/main/res/xml/experimental_preferences.xml
@@ -14,4 +14,9 @@
         android:key="dev_tools"
         app:persistent="false"/>
 
+    <SwitchPreferenceCompat
+        android:title="Select choice preloading"
+        android:key="select_choice_preloading"
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -35,6 +35,9 @@ import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.androidshared.data.Consumable;
 import org.odk.collect.forms.FormsRepository;
 import org.odk.collect.formstest.InMemFormsRepository;
+import org.odk.collect.settings.keys.ProjectKeys;
+import org.odk.collect.shared.settings.InMemSettings;
+import org.odk.collect.shared.settings.Settings;
 import org.odk.collect.testshared.FakeScheduler;
 
 import java.io.FileNotFoundException;
@@ -55,6 +58,7 @@ public class FormEntryViewModelTest {
 
     @Rule
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+    private final Settings settings = new InMemSettings();
 
     @Before
     public void setup() {
@@ -65,7 +69,9 @@ public class FormEntryViewModelTest {
         scheduler = new FakeScheduler();
 
         formSessionRepository.set("blah", formController, mock());
-        viewModel = new FormEntryViewModel(() -> 0L, scheduler, formSessionRepository, "blah", formsRepository);
+
+        settings.save(ProjectKeys.KEY_EXPERIMENTAL_SELECT_CHOICE_PRELOADING, true);
+        viewModel = new FormEntryViewModel(() -> 0L, scheduler, formSessionRepository, "blah", formsRepository, settings);
     }
 
     @Test

--- a/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
@@ -67,4 +67,6 @@ object ProjectKeys {
     const val BASEMAP_SOURCE_OSM = "osm"
     const val BASEMAP_SOURCE_USGS = "usgs"
     const val BASEMAP_SOURCE_CARTO = "carto"
+
+    const val KEY_EXPERIMENTAL_SELECT_CHOICE_PRELOADING = "select_choice_preloading"
 }


### PR DESCRIPTION
This adds a "Select choice preloading" experimental setting that allows the new select choice loading behaviour to be disabled.

@dbemke could you try your performance test with and see if you get different times running with the setting enabled and disabled?