### PR TITLE
Add icons to 'Save as draft' and 'Finalize'

### DIFF
--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -90,7 +90,7 @@ the specific language governing permissions and limitations under the License.
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/save_as_draft"
-                style="?materialButtonOutlinedStyle"
+                style="?materialButtonOutlinedIconStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@string/save_as_draft"
@@ -99,11 +99,13 @@ the specific language governing permissions and limitations under the License.
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/finalize"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:icon="@drawable/ic_save_menu_24"
+                app:iconGravity="textStart" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/finalize"
-                style="?materialButtonStyle"
+                style="?materialButtonIconStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@string/finalize"
@@ -112,7 +114,9 @@ the specific language governing permissions and limitations under the License.
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/save_as_draft"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:icon="@drawable/ic_send_24"
+                app:iconGravity="textStart" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Closes #5935 

| Before  | After |
| ------------- | ------------- |
 | ![Screenshot_1706135323](https://github.com/getodk/collect/assets/3276264/3d10bab5-0045-4a36-b49a-6059f8e4ae6f) | ![Screenshot_1706283029](https://github.com/getodk/collect/assets/3276264/ce0e86d1-4226-4553-b198-3af347f7593f)  |

#### Why is this the best possible solution? Were any other approaches considered?
I've just added icons to the two buttons mentioned in the issue. @alyblenkin in https://www.figma.com/file/KFi9hIQdrRgo0rLqIC7Sg8/ODK-user-flows?type=design&node-id=4092-15997&mode=design&t=LxacBD1eYjJoYsp3-0 the first button uses black color but it's just a mockup and the color shouldn't be changed right?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Just make sure the icons look good. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
