### PR TITLE
Stop using the deprecated validate method

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryUseCases.kt
@@ -180,7 +180,7 @@ object FormEntryUseCases {
         formController: FormController,
         entitiesRepository: EntitiesRepository
     ): Boolean {
-        val validationResult = formController.validateAnswers(markCompleted = true, moveToInvalidIndex = false)
+        val validationResult = formController.validateAnswers(false)
         if (validationResult is FailedValidationResult) {
             return false
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -363,7 +363,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 () -> {
                     ValidationResult result = null;
                     try {
-                        result = formController.validateAnswers(true, true);
+                        result = formController.validateAnswers(true);
                     } catch (JavaRosaException e) {
                         error.postValue(new FormError.NonFatal(e.getMessage()));
                     }

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.kt
@@ -139,7 +139,7 @@ interface FormController {
      * type.
      */
     @Throws(JavaRosaException::class)
-    fun validateAnswers(markCompleted: Boolean, moveToInvalidIndex: Boolean): ValidationResult
+    fun validateAnswers(moveToInvalidIndex: Boolean): ValidationResult
 
     /**
      * saveAnswer attempts to save the current answer into the data model without doing any

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
@@ -395,9 +395,9 @@ public class JavaRosaFormController implements FormController {
         }
     }
 
-    public ValidationResult validateAnswers(boolean markCompleted, boolean moveToInvalidIndex) throws JavaRosaException {
+    public ValidationResult validateAnswers(boolean moveToInvalidIndex) throws JavaRosaException {
         try {
-            ValidateOutcome validateOutcome = getFormDef().validate(markCompleted);
+            ValidateOutcome validateOutcome = getFormDef().validate();
             if (validateOutcome != null) {
                 if (moveToInvalidIndex) {
                     this.jumpToIndex(validateOutcome.failedPrompt);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -115,7 +115,7 @@ public class SaveFormToDisk {
 
         ValidationResult validationResult;
         try {
-            validationResult = formController.validateAnswers(true, shouldFinalize);
+            validationResult = formController.validateAnswers(shouldFinalize);
             if (shouldFinalize && validationResult instanceof FailedValidationResult) {
                 // validation failed, pass specific failure
                 saveToDiskResult.setSaveResult(((FailedValidationResult) validationResult).getStatus(), shouldFinalize);

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
@@ -113,7 +113,7 @@ public class FakeFormController extends StubFormController {
 
     @NonNull
     @Override
-    public ValidationResult validateAnswers(boolean markCompleted, boolean moveToInvalidIndex) throws JavaRosaException {
+    public ValidationResult validateAnswers(boolean moveToInvalidIndex) throws JavaRosaException {
         if (validationError != null) {
             throw validationError;
         } else {

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerTest.java
@@ -33,7 +33,7 @@ public class FormControllerTest {
         formController.stepToNextScreenEvent();
 
         assertThat(formController.getFormIndex().toString(), equalTo("0, "));
-        formController.validateAnswers(true, false);
+        formController.validateAnswers(false);
         assertThat(formController.getFormIndex().toString(), equalTo("0, "));
     }
 
@@ -48,7 +48,7 @@ public class FormControllerTest {
         formController.stepToNextScreenEvent();
 
         assertThat(formController.getFormIndex().toString(), equalTo("0, "));
-        formController.validateAnswers(true, true);
+        formController.validateAnswers(true);
         assertThat(formController.getFormIndex().toString(), equalTo("1, "));
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/StubFormController.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/StubFormController.kt
@@ -77,7 +77,7 @@ open class StubFormController : FormController {
     override fun answerQuestion(index: FormIndex?, data: IAnswerData?): Int = -1
 
     @Throws(JavaRosaException::class)
-    override fun validateAnswers(markCompleted: Boolean, moveToInvalidIndex: Boolean): ValidationResult = SuccessValidationResult
+    override fun validateAnswers(moveToInvalidIndex: Boolean): ValidationResult = SuccessValidationResult
 
     override fun saveAnswer(index: FormIndex?, data: IAnswerData?): Boolean = false
 


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?
In https://github.com/getodk/javarosa/pull/736 I've deprecated methods that forced us to use the `markCompleted` parameter when validating forms. We had to always pass `true` in such cases because we always wanted to get the validation result but the parameter name indicated that we validate and finalize forms which was confusing. Now as we have alternative method declarations (without that parameter) we can use them.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think it doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
