### PR TITLE
Make sure form end buttons grow together

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -104,7 +104,7 @@ class AuditTest {
             .pressBack(MainMenuPage())
             .startBlankForm("One Question Audit")
             .fillOut(FormEntryPage.QuestionAndAnswer("what is your age", "31"))
-            .killAndReopenApp(MainMenuPage())
+            .killAndReopenApp(rule, MainMenuPage())
             .startBlankForm("One Question Audit")
             .swipeToEndScreen()
             .clickFinalize()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/BulkFinalizationTest.kt
@@ -113,7 +113,7 @@ class BulkFinalizationTest {
 
             .clickDrafts()
             .clickOnForm("One Question")
-            .killAndReopenApp(MainMenuPage())
+            .killAndReopenApp(rule, MainMenuPage())
 
             .clickDrafts(false)
             .clickFinalizeAll(1)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/ActivityHelpers.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/ActivityHelpers.java
@@ -7,13 +7,16 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.core.AllOf.allOf;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.view.ContextThemeWrapper;
 import android.view.View;
 
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.hamcrest.Matcher;
+import org.odk.collect.android.BuildConfig;
 
 public final class ActivityHelpers {
 
@@ -47,5 +50,15 @@ public final class ActivityHelpers {
 
         onView(allOf(withId(android.R.id.content), isDisplayed())).perform(getActivityViewAction);
         return currentActivity[0];
+    }
+
+    public static Intent getLaunchIntent() {
+        Intent launchIntentForPackage = InstrumentationRegistry.getInstrumentation()
+                .getTargetContext()
+                .getPackageManager()
+                .getLaunchIntentForPackage(BuildConfig.APPLICATION_ID);
+
+        launchIntentForPackage.addCategory(Intent.CATEGORY_LAUNCHER);
+        return launchIntentForPackage;
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.android.support.pages
 
+import android.app.Activity
 import android.app.Application
 import android.content.pm.ActivityInfo
 import android.view.View
@@ -47,12 +48,14 @@ import org.odk.collect.android.BuildConfig
 import org.odk.collect.android.R
 import org.odk.collect.android.application.Collect
 import org.odk.collect.android.storage.StoragePathProvider
+import org.odk.collect.android.support.ActivityHelpers.getLaunchIntent
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.WaitFor.wait250ms
 import org.odk.collect.android.support.WaitFor.waitFor
 import org.odk.collect.android.support.actions.RotateAction
 import org.odk.collect.android.support.matchers.CustomMatchers.withIndex
 import org.odk.collect.androidshared.ui.ToastUtils.popRecordedToasts
+import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.strings.localization.getLocalizedQuantityString
 import org.odk.collect.strings.localization.getLocalizedString
 import org.odk.collect.testshared.EspressoHelpers
@@ -492,7 +495,7 @@ abstract class Page<T : Page<T>> {
         return destination!!.assertOnPage()
     }
 
-    fun <D : Page<D>?> killAndReopenApp(destination: D): D {
+    fun <D : Page<D>> killAndReopenApp(rule: ActivityScenarioLauncherRule, destination: D): D {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         // kill
@@ -504,11 +507,8 @@ abstract class Page<T : Page<T>> {
             }
 
         // reopen
-        InstrumentationRegistry.getInstrumentation().targetContext.apply {
-            val intent = packageManager.getLaunchIntentForPackage(BuildConfig.APPLICATION_ID)!!
-            startActivity(intent)
-        }
-        return destination!!.assertOnPage()
+        rule.launch<Activity>(getLaunchIntent())
+        return destination.assertOnPage()
     }
 
     fun assertNoOptionsMenu(): T {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/CollectTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/CollectTestRule.kt
@@ -2,11 +2,9 @@ package org.odk.collect.android.support.rules
 
 import android.app.Activity
 import android.app.Instrumentation
-import android.content.Context
 import android.content.Intent
-import androidx.test.core.app.ApplicationProvider
-import org.odk.collect.android.BuildConfig.APPLICATION_ID
 import org.odk.collect.android.external.AndroidShortcutsActivity
+import org.odk.collect.android.support.ActivityHelpers.getLaunchIntent
 import org.odk.collect.android.support.StubOpenRosaServer
 import org.odk.collect.android.support.pages.FirstLaunchPage
 import org.odk.collect.android.support.pages.MainMenuPage
@@ -79,15 +77,5 @@ class CollectTestRule @JvmOverloads constructor(
         destination.assertOnPage()
         actions.accept(destination)
         return scenario.result
-    }
-
-    private fun getLaunchIntent(): Intent {
-        return ApplicationProvider
-            .getApplicationContext<Context>()
-            .packageManager
-            .getLaunchIntentForPackage(APPLICATION_ID)!!
-            .apply {
-                this.addCategory(Intent.CATEGORY_LAUNCHER)
-            }
     }
 }

--- a/collect_app/src/main/res/drawable/margin_standard_list_divider.xml
+++ b/collect_app/src/main/res/drawable/margin_standard_list_divider.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <size android:width="@dimen/margin_standard" />
+            <size android:height="@dimen/margin_standard" />
+        </shape>
+    </item>
+</layer-list>

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -82,6 +82,8 @@ the specific language governing permissions and limitations under the License.
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="64dp"
+            android:divider="@drawable/margin_standard_list_divider"
+            android:showDividers="middle"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -93,32 +95,20 @@ the specific language governing permissions and limitations under the License.
                 style="?materialButtonOutlinedIconStyle"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
-                android:layout_marginEnd="@dimen/margin_extra_small"
                 android:layout_weight="1"
                 android:text="@string/save_as_draft"
                 app:icon="@drawable/ic_save_menu_24"
-                app:iconGravity="textStart"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@id/finalize"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_goneMarginEnd="0dp" />
+                app:iconGravity="textStart" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/finalize"
                 style="?materialButtonIconStyle"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
-                android:layout_marginStart="@dimen/margin_extra_small"
                 android:layout_weight="1"
                 android:text="@string/finalize"
                 app:icon="@drawable/ic_send_24"
-                app:iconGravity="textStart"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/save_as_draft"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_goneMarginStart="0dp" />
+                app:iconGravity="textStart" />
         </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.core.widget.NestedScrollView>

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -86,7 +86,7 @@ the specific language governing permissions and limitations under the License.
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/form_edits_warning"
-            app:layout_constraintWidth_max="640dp">
+            app:layout_constraintWidth_max="@dimen/max_content_width">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/save_as_draft"

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -77,46 +77,48 @@ the specific language governing permissions and limitations under the License.
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:id="@+id/buttons_container"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="64dp"
-            app:layout_constraintWidth_max="640dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/form_edits_warning">
+            app:layout_constraintTop_toBottomOf="@+id/form_edits_warning"
+            app:layout_constraintWidth_max="640dp">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/save_as_draft"
                 style="?materialButtonOutlinedIconStyle"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/save_as_draft"
+                android:layout_height="match_parent"
                 android:layout_marginEnd="@dimen/margin_extra_small"
-                app:layout_goneMarginEnd="0dp"
+                android:layout_weight="1"
+                android:text="@string/save_as_draft"
+                app:icon="@drawable/ic_save_menu_24"
+                app:iconGravity="textStart"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/finalize"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:icon="@drawable/ic_save_menu_24"
-                app:iconGravity="textStart" />
+                app:layout_goneMarginEnd="0dp" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/finalize"
                 style="?materialButtonIconStyle"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/finalize"
+                android:layout_height="match_parent"
                 android:layout_marginStart="@dimen/margin_extra_small"
-                app:layout_goneMarginStart="0dp"
+                android:layout_weight="1"
+                android:text="@string/finalize"
+                app:icon="@drawable/ic_send_24"
+                app:iconGravity="textStart"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/save_as_draft"
                 app:layout_constraintTop_toTopOf="parent"
-                app:icon="@drawable/ic_send_24"
-                app:iconGravity="textStart" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                app:layout_goneMarginStart="0dp" />
+        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Closes #5942

I also made a change to `killAndReopenApp` as I ran into some flakes while running checks.

#### Why is this the best possible solution? Were any other approaches considered?

I used the same solution here that we used for the bottom selection controls on other screens. As far as I can remember, we don't think there's a way to get two elements to grow width/heigh in sync using `ConstraintLayout`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is really low risk. Probably enough to make sure the bug is fixed!

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [ ] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
