### PR TITLE
Update copy on end screen

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
@@ -1,12 +1,24 @@
 package org.odk.collect.android.formentry
 
 import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.text.SpannableStringBuilder
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
 import android.view.LayoutInflater
 import android.view.View
+import androidx.core.text.bold
+import androidx.core.text.color
+import androidx.core.text.inSpans
+import androidx.core.text.underline
 import androidx.core.view.isVisible
 import androidx.core.widget.NestedScrollView
 import org.odk.collect.android.R
+import org.odk.collect.android.activities.WebViewActivity
 import org.odk.collect.android.databinding.FormEntryEndBinding
+import org.odk.collect.androidshared.system.ContextUtils
+import org.odk.collect.strings.localization.getLocalizedString
 
 class FormEndView(
     context: Context,
@@ -36,16 +48,50 @@ class FormEndView(
         }
 
         if (!binding.saveAsDraft.isVisible && !shouldFormBeSentAutomatically) {
-            binding.formEditsWarningMessage.setText(org.odk.collect.strings.R.string.form_edits_warning_only_finalize_enabled)
+            binding.formEditsWarningTitle.setText(org.odk.collect.strings.R.string.form_edits_warning_title)
+            binding.formEditsWarningMessage.apply {
+                text = getLearnMoreLink()
+                movementMethod = LinkMovementMethod.getInstance()
+                highlightColor = Color.TRANSPARENT
+            }
         } else if (binding.saveAsDraft.isVisible && binding.finalize.isVisible) {
             if (shouldFormBeSentAutomatically) {
-                binding.formEditsWarningMessage.setText(org.odk.collect.strings.R.string.form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled)
+                binding.formEditsWarningTitle.setText(org.odk.collect.strings.R.string.form_edits_warning_title_auto_send_enabled)
             } else {
-                binding.formEditsWarningMessage.setText(org.odk.collect.strings.R.string.form_edits_warning_save_as_draft_and_finalize_enabled)
+                binding.formEditsWarningTitle.setText(org.odk.collect.strings.R.string.form_edits_warning_title)
+            }
+            binding.formEditsWarningMessage.apply {
+                text = SpannableStringBuilder()
+                    .append(context.getLocalizedString(org.odk.collect.strings.R.string.form_edits_warning_message))
+                    .append(" ")
+                    .append(getLearnMoreLink())
+                movementMethod = LinkMovementMethod.getInstance()
+                highlightColor = Color.TRANSPARENT
             }
         } else {
             binding.formEditsWarning.visibility = View.GONE
         }
+    }
+
+    private fun getLearnMoreLink(): SpannableStringBuilder {
+        return SpannableStringBuilder().inSpans(
+            span = object : ClickableSpan() {
+                override fun onClick(view: View) {
+                    val intent = Intent(context, WebViewActivity::class.java)
+                    intent.putExtra("url", "https://forum.getodk.org/t/42007")
+                    context.startActivity(intent)
+                }
+            },
+            builderAction = {
+                color(ContextUtils.getThemeAttributeValue(context, com.google.android.material.R.attr.colorAccent)) {
+                    underline {
+                        bold {
+                            append(context.getLocalizedString(org.odk.collect.strings.R.string.form_edits_warning_learn_more))
+                        }
+                    }
+                }
+            }
+        )
     }
 
     override fun shouldSuppressFlingGesture() = false

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
@@ -6,9 +6,9 @@ import android.graphics.Color
 import android.text.SpannableStringBuilder
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
+import android.text.style.TextAppearanceSpan
 import android.view.LayoutInflater
 import android.view.View
-import androidx.core.text.bold
 import androidx.core.text.color
 import androidx.core.text.inSpans
 import androidx.core.text.underline
@@ -83,13 +83,16 @@ class FormEndView(
                 }
             },
             builderAction = {
-                color(ContextUtils.getThemeAttributeValue(context, com.google.android.material.R.attr.colorAccent)) {
-                    underline {
-                        bold {
-                            append(context.getLocalizedString(org.odk.collect.strings.R.string.form_edits_warning_learn_more))
+                inSpans(
+                    span = TextAppearanceSpan(context, com.google.android.material.R.style.TextAppearance_Material3_TitleMedium),
+                    builderAction = {
+                        color(ContextUtils.getThemeAttributeValue(context, com.google.android.material.R.attr.colorAccent)) {
+                            underline {
+                                append(context.getLocalizedString(org.odk.collect.strings.R.string.form_edits_warning_learn_more))
+                            }
                         }
                     }
-                }
+                )
             }
         )
     }

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -64,16 +64,28 @@ the specific language governing permissions and limitations under the License.
                     app:tint="?colorPrimary" />
 
                 <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/form_edits_warning_message"
+                    android:id="@+id/form_edits_warning_title"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin"
-                    android:textAppearance="?textAppearanceBodyLarge"
+                    android:textAppearance="?textAppearanceTitleMedium"
                     android:textColor="?colorOnSurface"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/instance_name_info_icon"
                     app:layout_constraintTop_toTopOf="@id/instance_name_info_icon"
-                    tools:text="@string/form_edits_warning_save_as_draft_and_finalize_enabled" />
+                    tools:text="@string/form_edits_warning_title" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/form_edits_warning_message"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin"
+                    android:textAppearance="?textAppearanceBodyLarge"
+                    android:textColor="?colorOnSurface"
+                    app:layout_constraintStart_toStartOf="@id/form_edits_warning_title"
+                    app:layout_constraintEnd_toEndOf="@id/form_edits_warning_title"
+                    app:layout_constraintTop_toBottomOf="@id/form_edits_warning_title"
+                    tools:text="@string/form_edits_warning_message" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -52,7 +52,8 @@ the specific language governing permissions and limitations under the License.
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="@dimen/margin">
+                android:paddingHorizontal="@dimen/margin_standard"
+                android:paddingVertical="@dimen/margin_large">
 
                 <ImageView
                     android:id="@+id/instance_name_info_icon"
@@ -67,7 +68,7 @@ the specific language governing permissions and limitations under the License.
                     android:id="@+id/form_edits_warning_title"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/margin"
+                    android:layout_marginStart="@dimen/margin_standard"
                     android:textAppearance="?textAppearanceTitleMedium"
                     android:textColor="?colorOnSurface"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -79,7 +80,7 @@ the specific language governing permissions and limitations under the License.
                     android:id="@+id/form_edits_warning_message"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin"
+                    android:layout_marginTop="@dimen/margin_standard"
                     android:textAppearance="?textAppearanceBodyLarge"
                     android:textColor="?colorOnSurface"
                     app:layout_constraintStart_toStartOf="@id/form_edits_warning_title"

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
@@ -140,10 +140,18 @@ class FormEndViewTest {
             equalTo(View.VISIBLE)
         )
         assertThat(
-            view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text,
+            view.findViewById<MaterialTextView>(R.id.form_edits_warning_title).text,
             equalTo(
                 context.getString(
-                    org.odk.collect.strings.R.string.form_edits_warning_only_finalize_enabled
+                    org.odk.collect.strings.R.string.form_edits_warning_title
+                )
+            )
+        )
+        assertThat(
+            view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
+            equalTo(
+                context.getString(
+                    org.odk.collect.strings.R.string.form_edits_warning_learn_more
                 )
             )
         )
@@ -174,11 +182,17 @@ class FormEndViewTest {
             equalTo(View.VISIBLE)
         )
         assertThat(
-            view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text,
+            view.findViewById<MaterialTextView>(R.id.form_edits_warning_title).text,
             equalTo(
                 context.getString(
-                    org.odk.collect.strings.R.string.form_edits_warning_save_as_draft_and_finalize_enabled
+                    org.odk.collect.strings.R.string.form_edits_warning_title
                 )
+            )
+        )
+        assertThat(
+            view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
+            equalTo(
+                "${context.getString(org.odk.collect.strings.R.string.form_edits_warning_message)} ${context.getString(org.odk.collect.strings.R.string.form_edits_warning_learn_more)}"
             )
         )
     }
@@ -196,11 +210,17 @@ class FormEndViewTest {
             equalTo(View.VISIBLE)
         )
         assertThat(
-            view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text,
+            view.findViewById<MaterialTextView>(R.id.form_edits_warning_title).text,
             equalTo(
                 context.getString(
-                    org.odk.collect.strings.R.string.form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled
+                    org.odk.collect.strings.R.string.form_edits_warning_title_auto_send_enabled
                 )
+            )
+        )
+        assertThat(
+            view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
+            equalTo(
+                "${context.getString(org.odk.collect.strings.R.string.form_edits_warning_message)} ${context.getString(org.odk.collect.strings.R.string.form_edits_warning_learn_more)}"
             )
         )
     }

--- a/strings/src/main/res/values-ar/strings.xml
+++ b/strings/src/main/res/values-ar/strings.xml
@@ -113,9 +113,6 @@
   <string name="too_complex_form">هذه الاستمارة معقدة جدًا لهذا الجهاز. حاول تبسيط التعبيرات أو طلب المساعدة في المنتدى.</string>
   <string name="survey_internal_error">خطأ داخلي: فشل الخطأ الموجه.</string>
   <string name="save_enter_data_description">إنّك في نهاية الـ%s.</string>
-  <string name="form_edits_warning_only_finalize_enabled">لن تتمكن من تعديل هذه الاستمارة عندما تقوم بإرسالها.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">لن تتمكن من تعديل هذه الإستمارة عند ارسالها. اذا اردت التعديل يمكنك حفظها كمسودة إلى حين أن تكون جاهز للإرسال.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">إذا قمت بعملية الإرسال فلن تتمكن من اجراء أي تعديلات. إذا اردت اجراء المزيد من التعديلات \"فقم بحفظ النموذج كمسودة\" حتا يصبح النموذج جهازاً للإرسال.</string>
   <string name="save_as_draft">حفظ كمسودة</string>
   <string name="finalize">إنهاء</string>
   <string name="send">إرسال</string>

--- a/strings/src/main/res/values-cs/strings.xml
+++ b/strings/src/main/res/values-cs/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">Tento formulář je pro toto zařízení příliš složitý. Zkuste zjednodušit výrazy nebo požádat o pomoc na fóru.</string>
   <string name="survey_internal_error">Vnitřní chyba: přechod k otázce selhal.</string>
   <string name="save_enter_data_description">Jste na konci %s.</string>
-  <string name="form_edits_warning_only_finalize_enabled">Po dokončení nebudete moci provádět úpravy.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">Po dokončení nebudete moci provádět úpravy. Pokud potřebujete provést změny, \"Uložit jako návrh\", dokud nebudete připraveni k odeslání.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">Po odeslání již nebude možné provádět úpravy. Pokud potřebujete provést změny, \"Uložit jako návrh\", dokud nebudete připraveni k odeslání.</string>
   <string name="save_as_draft">Uložit jako návrh</string>
   <string name="finalize">Dokončit</string>
   <string name="send">Odeslat</string>

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">Dieses Formular ist zu komplex für dieses Gerät. Versuche Ausdrücke zu vereinfachen oder bitte im Forum um Hilfe.</string>
   <string name="survey_internal_error">Interner Fehler: Sprung zur Eingabe fehlgeschlagen.</string>
   <string name="save_enter_data_description">Sie sind am Ende von \"%s\" angelangt.</string>
-  <string name="form_edits_warning_only_finalize_enabled">Nach dem Abschließen sind keine Änderungen mehr möglich.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">Nach dem Abschließen sind keine Änderungen mehr möglich. Wenn noch Änderungen nötig sind, \"Als Entwurf speichern\" bis es bereit zum Senden ist.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">Nach dem Senden sind keine Änderungen mehr möglich. Wenn noch Änderungen nötig sind, \"Als Entwurf speichern\" bis es bereit zum Senden ist.</string>
   <string name="save_as_draft">Als Entwurf speichern</string>
   <string name="finalize">Abschließen</string>
   <string name="send">Senden</string>

--- a/strings/src/main/res/values-es/strings.xml
+++ b/strings/src/main/res/values-es/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">Este formulario es muy complejo para este dispositivo. Intente simplificar las expresiones o busque ayuda en el Foro.</string>
   <string name="survey_internal_error">Error interno: Ha fallado la entrada de datos.</string>
   <string name="save_enter_data_description">Esta al final de \"%s\".</string>
-  <string name="form_edits_warning_only_finalize_enabled">No podrá realizar ediciones una vez que finalice.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">No podrá realizar ediciones una vez que finalice. Si necesita hacer cambios, \"Guardar como borrador\" hasta que esté listo para enviar.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">No podrá realizar ediciones una vez que envíe. Si necesita hacer cambios, \"Guardar como borrador\" hasta que esté listo para enviar.</string>
   <string name="save_as_draft">Guardar como borrador</string>
   <string name="finalize">Finalizar</string>
   <string name="send">Enviar</string>

--- a/strings/src/main/res/values-fa-rAF/strings.xml
+++ b/strings/src/main/res/values-fa-rAF/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">این فرم برای این دستگاه بسیار پیچیده است. سعی کنید برای ساده سازی فرم  یا اصطلاحات کمک بخواهید.</string>
   <string name="survey_internal_error">خطای داخلی: گام به اعلان ناموفق بود.</string>
   <string name="save_enter_data_description">شما در پایان %sقرار دارید.</string>
-  <string name="form_edits_warning_only_finalize_enabled">پس از نهایی کردن، نمی توانید ویرایش کنید.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">پس از نهایی کردن، نمی توانید ویرایش کنید. اگر نیاز به ایجاد تغییرات دارید، «به‌عنوان پیش‌نویس ذخیره کنید» تا زمانی که آماده ارسال شوید.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">پس از نهایی کردن، نمی توانید ویرایش کنید. اگر نیاز به ایجاد تغییرات دارید، «به‌عنوان پیش‌نویس ذخیره کنید» تا زمانی که آماده ارسال شوید.</string>
   <string name="save_as_draft">ذخیره پیش نویس</string>
   <string name="finalize">نهایی</string>
   <string name="send">ارسال شد</string>

--- a/strings/src/main/res/values-fa/strings.xml
+++ b/strings/src/main/res/values-fa/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">این فرم برای این دستگاه بسیار پیچیده است. سعی کنید برای ساده سازی فرم  یا اصطلاحات کمک بخواهید.</string>
   <string name="survey_internal_error">خطای داخلی: گام به اعلان ناموفق بود.</string>
   <string name="save_enter_data_description">شما در پایان %sقرار دارید.</string>
-  <string name="form_edits_warning_only_finalize_enabled">پس از نهایی کردن، نمی توانید ویرایش کنید.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">پس از نهایی کردن، نمی توانید ویرایش کنید. اگر نیاز به ایجاد تغییرات دارید، «به‌عنوان پیش‌نویس ذخیره کنید» تا زمانی که آماده ارسال شوید.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">پس از نهایی کردن، نمی توانید ویرایش کنید. اگر نیاز به ایجاد تغییرات دارید، «به‌عنوان پیش‌نویس ذخیره کنید» تا زمانی که آماده ارسال شوید.</string>
   <string name="save_as_draft">ذخیره پیش نویس</string>
   <string name="finalize">نهایی</string>
   <string name="send">ارسال شد</string>

--- a/strings/src/main/res/values-fi/strings.xml
+++ b/strings/src/main/res/values-fi/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">Tämä lomake on liian monimutkainen tälle laitteelle. Yritä lausekkeiden yksinkertaistamista tai pyydä apua verkon keskusteluryhmästä.</string>
   <string name="survey_internal_error">Sisäinen virhe: siirtyminen kehotteeseen epäonnistui.</string>
   <string name="save_enter_data_description">Olet lomakkeen %s lopussa.</string>
-  <string name="form_edits_warning_only_finalize_enabled">Viimeistelyn jälkeen ei voi tehdä muutoksia.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">Et voi tehdä muokkauksia viimeistelyn jälkeen. Jos sinun on tehtävä muutoksia, \"Tallenna luonnoksena\", kunnes olet valmis lähettämään.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">Muutoksia ei voi tehdä enää lähettämisen jälkeen. Jos tarvitaan muutoksia, \"Tallenna luonnoksena\" kunnes olet valmis lähettämään.</string>
   <string name="save_as_draft">Tallenna luonnoksena</string>
   <string name="finalize">Viimeistele</string>
   <string name="send">Lähetä</string>

--- a/strings/src/main/res/values-fr/strings.xml
+++ b/strings/src/main/res/values-fr/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">Ce formulaire est trop complexe pour cet appareil. Essayez de simplifier les expressions ou demandez de l\'aide sur le forum.</string>
   <string name="survey_internal_error">Erreur interne : un ou plusieurs champs de saisie peuvent avoir été ignorés.</string>
   <string name="save_enter_data_description">Vous êtes à la fin de \"%s\".</string>
-  <string name="form_edits_warning_only_finalize_enabled">Vous ne pourrez plus éditer une fois que vous aurez finalisé.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">Vous ne pourrez plus modifier ce formulaire une fois que vous l\'aurez finalisé. Si vous comptez le modifier prochainement, choisissez \"Enregistrer comme ébauche\" jusqu\'à ce que vous soyez prêt à l\'envoyer.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">Vous ne pourrez plus éditer une fois que vous aurez envoyé. Si vous avez besoin de faire des changements, \"Enregistrer comme ébauche\" jusqu\'à ce que vous soyez prêts à envoyer.</string>
   <string name="save_as_draft">Enregistrer comme ébauche</string>
   <string name="finalize">Finaliser</string>
   <string name="send">Envoyer</string>

--- a/strings/src/main/res/values-ht/strings.xml
+++ b/strings/src/main/res/values-ht/strings.xml
@@ -99,8 +99,6 @@
   <string name="invalid_answer_error">Dezole, repons sa pa valid!</string>
   <string name="required_answer_error">Dezole repons sa nesesè!</string>
   <string name="success_form_validation">Siksè! Pa gen erè nan fòmilè a.</string>
-  <string name="form_edits_warning_only_finalize_enabled">Ou pa p ka modifye lè w fini.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">Ou pa p ka modifye lè w fini. Si w vle fè kèk chanjman,  \"Sovgade tankou bouyon\" jiskaske w pare pou w voye ale.</string>
   <string name="save_as_draft">Sovgade tankou bouyon</string>
   <string name="finalize">Finalize</string>
   <string name="send">Voye ale</string>

--- a/strings/src/main/res/values-in/strings.xml
+++ b/strings/src/main/res/values-in/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">Formulir ini terlalu rumit untuk perangkat ini. Coba sederhanakan ekspresi atau minta bantuan di forum.</string>
   <string name="survey_internal_error">Kesalahan internal: langkah menuju risalah tidak berhasil.</string>
   <string name="save_enter_data_description">Anda berada di akhir dari formulir\n\"%s\".</string>
-  <string name="form_edits_warning_only_finalize_enabled">Anda tidak akan dapat melakukan perubahan setelah anda memfinalisasi.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">Anda tidak akan dapat melakukan perubahan setelah anda memfinalisasi. Jika anda perlu melakukan perubahan, \"Simpan sebagai draf\" hingga anda siap mengirim.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">Anda tidak akan dapat melakukan perubahan setelah anda kirim. Jika anda perlu melakukan perubahan, \"Simpan sebagai draf\" hingga anda siap mengirim.</string>
   <string name="save_as_draft">Simpan sebagai draf</string>
   <string name="finalize">Finalisasi</string>
   <string name="send">Kirim</string>

--- a/strings/src/main/res/values-it/strings.xml
+++ b/strings/src/main/res/values-it/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">Questo modulo è troppo complesso per questo dispositivo. Prova a semplificare le espressioni o chiedi aiuto sul forum. </string>
   <string name="survey_internal_error">Errore interno: invio suggerimento fallito.</string>
   <string name="save_enter_data_description">Ti trovi alla fine di \"%s\".</string>
-  <string name="form_edits_warning_only_finalize_enabled">Non sarai in grado di apportare modifiche una volta finalizzato.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">Non sarai in grado di apportare modifiche una volta finalizzato. Se devi apportare modifiche, \"Salva come bozza\" finché non sei pronto per l\'invio.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">Non sarai in grado di apportare modifiche una volta inviato. Se devi apportare modifiche, \"Salva come bozza\" finché non sei pronto per l\'invio.</string>
   <string name="save_as_draft">Salva come bozza</string>
   <string name="finalize">Finalizzare</string>
   <string name="send">Invia</string>

--- a/strings/src/main/res/values-pt/strings.xml
+++ b/strings/src/main/res/values-pt/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">Este formulário é complexo demais para este dispositivo. Tente simplificar expressões ou peça ajuda no fórum.</string>
   <string name="survey_internal_error">Erro interno: falha ao abrir a questão.</string>
   <string name="save_enter_data_description">Você está no fim de \"%s\".</string>
-  <string name="form_edits_warning_only_finalize_enabled">Você não poderá fazer alterações após marcar o formulário como finalizado. </string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">Você não poderá fazer alterações após marcar o formulário como finalizado. Se você precisa fazer alterações, utilize \"Salvar como rascunho\" até que você esteja pronto para enviar.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">Você não poderá fazer alterações após o envio. Se você precisa fazer alterações, utilize \"Salvar como rascunho\" até que você esteja pronto para enviar.</string>
   <string name="save_as_draft">Salvar como rascunho</string>
   <string name="finalize">Finalizar</string>
   <string name="send">Enviar</string>

--- a/strings/src/main/res/values-ru/strings.xml
+++ b/strings/src/main/res/values-ru/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">Эта форма слишком сложна для этого устройства. Попробуйте упростить структуру или обратитесь за помощью на форум.</string>
   <string name="survey_internal_error">Внутренняя ошибка: step to prompt failed.</string>
   <string name="save_enter_data_description">Вы в конце опросника \"%s\"</string>
-  <string name="form_edits_warning_only_finalize_enabled">Вы не сможете вносить изменения после финализирования.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">Вы не сможете вносить изменения после завершения. Если вам нужно внести изменения, сохраните как черновик, пока вы не будете готовы к отправке.</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">Вы не сможете вносить изменения после отправки. Если вам нужно внести изменения, выберите «Сохранить как черновик», пока вы не будете готовы к отправке.</string>
   <string name="save_as_draft">Сохранить как черновик</string>
   <string name="finalize">Завершить</string>
   <string name="send">Отправить</string>

--- a/strings/src/main/res/values-ur/strings.xml
+++ b/strings/src/main/res/values-ur/strings.xml
@@ -115,9 +115,6 @@
   <string name="too_complex_form">یہ فارم اس فون کے لئے بہت پیچیدہ ہے۔ اس کو سادہ کرنے کی کوشش کریں، یا پھر فورم پہ مدد حاصل کریں۔</string>
   <string name="survey_internal_error">اندرونی خرابی: فوری طور پر سیٹ اپ ناکام ہوگیا</string>
   <string name="save_enter_data_description">آپ ‎%s‏ کے آخر پر ہیں۔</string>
-  <string name="form_edits_warning_only_finalize_enabled">فارم کو فائنل کرنے کے بعد آپ اس میں مزید ترامیم نہیں کر سکیں گے۔</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_enabled">ایک دفعہ فائنل کرنے کے بعد آپ ترامیم نہیں کر سکیں گے۔ اگر آپ نے تبدیلیاں کرنی ہیں، تو فارم کو پہلے ڈرافٹ میں محفوظ کریں، اور اس وقت تک وہاں رکھیں جب تک آپ اسے بھیجنے کے لئے تیار نہ ہوں۔</string>
-  <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">ایک دفعہ بھیجنے کے بعد آپ ترامیم نہیں کر سکیں گے۔ اگر آپ نے تبدیلیاں کرنی ہیں، تو فارم کو پہلے ڈرافٹ میں محفوظ کریں، اور اس وقت تک وہاں رکھیں جب تک آپ اسے بھیجنے کے لئے تیار نہ ہوں۔</string>
   <string name="save_as_draft">ڈرافٹ میں محفوظ کریں</string>
   <string name="finalize">فائنل کریں</string>
   <string name="send">بھیجیں</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -144,9 +144,10 @@
     <string name="survey_internal_error">Internal error: step to prompt failed.</string>
 
     <string name="save_enter_data_description">You are at the end of %s.</string>
-    <string name="form_edits_warning_only_finalize_enabled">You will not be able to make edits once you finalize.</string>
-    <string name="form_edits_warning_save_as_draft_and_finalize_enabled">You will not be able to make edits once you finalize. If you need to make changes, \"Save as draft\" until you\'re ready to send.</string>
-    <string name="form_edits_warning_save_as_draft_and_finalize_with_auto_send_enabled">You will not be able to make edits once you send. If you need to make changes, \"Save as draft\" until you\'re ready to send.</string>
+    <string name="form_edits_warning_title">Finalized forms are not editable.</string>
+    <string name="form_edits_warning_title_auto_send_enabled">Sent forms are not editable.</string>
+    <string name="form_edits_warning_message">If you need to make edits to your form, \“Save as draft\” until you\’re ready to send.</string>
+    <string name="form_edits_warning_learn_more">Learn more</string>
     <string name="save_as_draft">Save as draft</string>
     <string name="finalize">Finalize</string>
     <string name="send">Send</string>


### PR DESCRIPTION
Closes #5948

#### Why is this the best possible solution? Were any other approaches considered?
As in the issue:
> We are updating the end screen message to make it more scanable and adding the link to the forum so users can learn more.

| Auto send disabled | Auto send enabled | Saving as draft disabled |
| ------------- | ------------- | ------------- |
| ![Screenshot_1707487269](https://github.com/getodk/collect/assets/3276264/b0277f29-811b-4401-a6a2-7d6d5dde8fa9) | ![Screenshot_1707487286](https://github.com/getodk/collect/assets/3276264/6287079c-0296-47e5-88b7-fd1ef15887b2) | !![Screenshot_1707487356](https://github.com/getodk/collect/assets/3276264/63471fbf-df83-44b7-ba29-d22b0c68e77a) |

When it comes to the implementation there is nothing to discuss.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only think we need to test is the end screen in a form to make sure the new warning contains correct title and message depending on the state. Please also test the link that should open the forum thread.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
