### PR TITLE
Fixed updating the list of questions with audio widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -93,11 +93,13 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
                 binding.audioPlayer.recordingDuration.setText(formatLength(session.first));
                 binding.audioPlayer.waveform.addAmplitude(session.second);
             } else {
-                recordingInProgress = false;
                 binaryName = questionDetails.getPrompt().getAnswerText();
+                if (binaryName != null && recordingInProgress) {
+                    widgetValueChanged();
+                }
+                recordingInProgress = false;
                 updateVisibilities();
                 updatePlayerMedia();
-                widgetValueChanged();
             }
         });
     }


### PR DESCRIPTION
Closes #5955
Closes #5956 

#### Why is this the best possible solution? Were any other approaches considered?
If there are multiple audio widgets on one page they all receive updates (recording status) if one of them is working. Those updates just pass null values so this doesn't change their state. If it's such a null value we shouldn't call the `WidgetValueChangedListener` because then it causes problems like the ones I have fixed in this pull request.

BTW. I'm not sure if other (not active) audio widgets should receive such null values as states (it might be redundant) but there is a [test](https://github.com/getodk/collect/blob/master/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/AudioRecorderRecordingStatusHandlerTest.java#L80) for that scenario so I didn't feel confident enough to change this behavior.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We can focus on testing audio widgets here. The problem seemed to be visible only when more than one audio widget was used in a field-list but let's test simple cases with just one widget too.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
