### PR TITLE
Improvements to the typography used in the form

### DIFF
--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="TextAppearance.Collect.Headline4" parent="TextAppearance.MaterialComponents.Headline4">
         <item name="android:textColor">@color/color_on_surface_high_emphasis</item>
     </style>
@@ -34,6 +34,8 @@
 
     <style name="TextAppearance.Collect.TitleLarge" parent="TextAppearance.Material3.TitleLarge">
         <item name="android:textSize">20sp</item>
+        <item name="android:lineHeight" tools:targetApi="p">24sp</item>
+        <item name="lineHeight">24sp</item>
     </style>
 
     <style name="TextAppearance.Collect.Button" parent="TextAppearance.MaterialComponents.Button">

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -36,6 +36,7 @@
         <item name="android:textSize">20sp</item>
         <item name="android:lineHeight" tools:targetApi="p">24sp</item>
         <item name="lineHeight">24sp</item>
+        <item name="fontFamily">sans-serif-medium</item>
     </style>
 
     <style name="TextAppearance.Collect.Button" parent="TextAppearance.MaterialComponents.Button">


### PR DESCRIPTION
Closes #5953 

#### Why is this the best possible solution? Were any other approaches considered?
We have discussed on slack that the space between the lines in question labels is too big now. I've investigated it and it turns out it's 28sp and in v2023.3.1 it was 24sp for the labels displayed in a form and 26sp for labels displayed in the hierarchy view. I think 24sp looks ok so that's the value I applied for both views.

When it comes to the fontWeight @lognaturel and @alyblenkin wanted to see if something bolder (like it was before in the case of the form view) would look better so please take a look and let me know what you like more:

| Before (master) | After |
| ------------- | ------------- |
| ![Screenshot_1707738882](https://github.com/getodk/collect/assets/3276264/8ce41cb3-9b3a-49f9-b89a-2a2005dac9a4) | ![Screenshot_1707738550](https://github.com/getodk/collect/assets/3276264/1c71dfbc-3cb3-487b-bac9-eeae95856bf4)|
| ![Screenshot_1707738880](https://github.com/getodk/collect/assets/3276264/343f97e0-9ae7-4b93-b27d-eb24fe39335a) | ![Screenshot_1707738547](https://github.com/getodk/collect/assets/3276264/09b99991-1845-4b44-93ae-dfe88a8df40a) |

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Just make sure that question labels in the form view and the hierarchy view are bold. Typography in other parts of the app should not change. The only exception is the app bar where the text will be bold too.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
