### PR TITLE
Fixed scrolling to the edited question in a list of questions

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -399,8 +399,8 @@ public class FieldListUpdateTest {
                 .clickOnGroup("Long list of questions")
                 .clickOnQuestion("Question1")
                 .answerQuestion(0, "X")
-                .activateTextQuestion(8)
-                .checkIsTranslationDisplayed("Question9");
+                .activateTextQuestion(19)
+                .checkIsTranslationDisplayed("Question20");
     }
 
     // Scroll down until the desired group name is visible. This is needed to make the tests work

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -392,7 +392,7 @@ public class FieldListUpdateTest {
     }
 
     @Test
-    public void listOfQuestionsShouldNotBeScrolledToTheLastEditedQuestionAfterUpdatingTheLayout() {
+    public void listOfQuestionsShouldNotBeScrolledToTheLastEditedQuestionAfterClickingOnAQuestion() {
         new FormEntryPage("fieldlist-updates")
                 .clickGoToArrow()
                 .clickGoUpIcon()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -391,6 +391,18 @@ public class FieldListUpdateTest {
                 .assertSelectMinimalDialogAnswer("Strawberries");
     }
 
+    @Test
+    public void listOfQuestionsShouldNotBeScrolledToTheLastEditedQuestionAfterUpdatingTheLayout() {
+        new FormEntryPage("fieldlist-updates")
+                .clickGoToArrow()
+                .clickGoUpIcon()
+                .clickOnGroup("Long list of questions")
+                .clickOnQuestion("Question1")
+                .answerQuestion(0, "X")
+                .activateTextQuestion(8)
+                .checkIsTranslationDisplayed("Question9");
+    }
+
     // Scroll down until the desired group name is visible. This is needed to make the tests work
     // on devices with screens of different heights.
     private void jumpToGroupWithText(String text) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -296,6 +296,12 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
+    public FormEntryPage activateTextQuestion(int index) {
+        onView(withIndex(withClassName(endsWith("EditText")), index)).perform(scrollTo());
+        onView(withIndex(withClassName(endsWith("EditText")), index)).perform(click());
+        return this;
+    }
+
     public FormEntryPage assertQuestion(String text) {
         return assertQuestion(text, false);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -2273,14 +2273,9 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 public void run() {
                     try {
                         updateFieldListQuestions(changedWidget.getFormEntryPrompt().getIndex());
-
-                        odkView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
-                            @Override
-                            public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-                                if (!odkView.isDisplayed(changedWidget)) {
-                                    odkView.scrollToTopOf(changedWidget);
-                                }
-                                odkView.removeOnLayoutChangeListener(this);
+                        odkView.post(() -> {
+                            if (!odkView.isDisplayed(changedWidget)) {
+                                odkView.scrollToTopOf(changedWidget);
                             }
                         });
                     } catch (RepeatsInFieldListException e) {

--- a/test-forms/src/main/resources/forms/fieldlist-updates.xml
+++ b/test-forms/src/main/resources/forms/fieldlist-updates.xml
@@ -160,6 +160,17 @@
             <source15/>
             <target15/>
           </search_in_field_list_group>
+          <long_list_of_questions>
+            <question1/>
+            <question2/>
+            <question3/>
+            <question4/>
+            <question5/>
+            <question6/>
+            <question7/>
+            <question8/>
+            <question9/>
+          </long_list_of_questions>
           <meta>
             <instanceID/>
           </meta>
@@ -324,6 +335,15 @@
       <bind nodeset="/fieldlist-updates/external_app/target14" relevant=" /fieldlist-updates/external_app/source14  != ''" type="string"/>
       <bind nodeset="/fieldlist-updates/search_in_field_list_group/source15" type="select1"/>
       <bind nodeset="/fieldlist-updates/search_in_field_list_group/target15" relevant=" /fieldlist-updates/search_in_field_list_group/source15  != ''" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question1" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question2" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question3" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question4" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question5" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question6" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question7" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question8" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question9" type="integer"/>
       <bind calculate="concat('uuid:', uuid())" nodeset="/fieldlist-updates/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
@@ -607,6 +627,36 @@
       </select1>
       <input ref="/fieldlist-updates/search_in_field_list_group/target15">
         <label>Target15</label>
+      </input>
+    </group>
+    <group appearance="field-list" ref="/fieldlist-updates/long_list_of_questions">
+      <label>Long list of questions</label>
+      <input ref="/fieldlist-updates/long_list_of_questions/question1">
+        <label>Question1</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question2">
+        <label>Question2</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question3">
+        <label>Question3</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question4">
+        <label>Question4</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question5">
+        <label>Question5</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question6">
+        <label>Question6</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question7">
+        <label>Question7</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question8">
+        <label>Question8</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question9">
+        <label>Question9</label>
       </input>
     </group>
   </h:body>

--- a/test-forms/src/main/resources/forms/fieldlist-updates.xml
+++ b/test-forms/src/main/resources/forms/fieldlist-updates.xml
@@ -170,6 +170,17 @@
             <question7/>
             <question8/>
             <question9/>
+            <question10/>
+            <question11/>
+            <question12/>
+            <question13/>
+            <question14/>
+            <question15/>
+            <question16/>
+            <question17/>
+            <question18/>
+            <question19/>
+            <question20/>
           </long_list_of_questions>
           <meta>
             <instanceID/>
@@ -343,7 +354,18 @@
       <bind nodeset="/fieldlist-updates/long_list_of_questions/question6" type="string"/>
       <bind nodeset="/fieldlist-updates/long_list_of_questions/question7" type="string"/>
       <bind nodeset="/fieldlist-updates/long_list_of_questions/question8" type="string"/>
-      <bind nodeset="/fieldlist-updates/long_list_of_questions/question9" type="integer"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question9" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question10" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question11" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question12" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question13" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question14" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question15" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question16" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question17" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question18" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question19" type="string"/>
+      <bind nodeset="/fieldlist-updates/long_list_of_questions/question20" type="integer"/>
       <bind calculate="concat('uuid:', uuid())" nodeset="/fieldlist-updates/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
@@ -657,6 +679,39 @@
       </input>
       <input ref="/fieldlist-updates/long_list_of_questions/question9">
         <label>Question9</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question10">
+        <label>Question10</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question11">
+        <label>Question11</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question12">
+        <label>Question12</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question13">
+        <label>Question13</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question14">
+        <label>Question14</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question15">
+        <label>Question15</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question16">
+        <label>Question16</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question17">
+        <label>Question17</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question18">
+        <label>Question18</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question19">
+        <label>Question19</label>
+      </input>
+      <input ref="/fieldlist-updates/long_list_of_questions/question20">
+        <label>Question20</label>
       </input>
     </group>
   </h:body>


### PR DESCRIPTION
Closes #5963 

#### Why is this the best possible solution? Were any other approaches considered?
As discussed in the issue the problem was that in order to perform scrolling to the edited question in a field list we used `OnLayoutChangeListener`. This listener is called not only if we really update the list of questions but also for example when the keyboard is shown/hidden.
Initially, I thought that I could just remove that listener and perform scrolling immediately after updating the list of questions but it seems like it would be too early after updating the view (it's the same issue we have in other parts of the app https://github.com/getodk/collect/issues/5853) so I needed to the use `post` method.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue but... it's a type of change that might work in a different way on different devices so please test this pr on all the devices you have.
It's also important to test cases with multiple questions on one screen to make sure everything is fine when questions appear/disappear when they depend on each other and that scrolling to questions with new answers or errors works well etc.
And also be careful and observant because other weird cases like this one can also occur somewhere.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
