### PR TITLE
Fixed displaying answers in external widgets with thousands separator 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/WidgetAnswerText.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/views/WidgetAnswerText.kt
@@ -144,7 +144,7 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
 
     fun setAnswer(answer: String?) {
         binding.editText.setText(answer)
-        binding.textView.text = answer
+        binding.textView.text = binding.editText.text
         Selection.setSelection(binding.editText.text, binding.editText.text.toString().length)
 
         if (answer == null && !isEditableState()) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/StringWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/StringWidgetUtils.java
@@ -1,11 +1,5 @@
 package org.odk.collect.android.widgets.utilities;
 
-import android.text.InputFilter;
-import android.text.InputType;
-import android.text.Selection;
-import android.text.method.DigitsKeyListener;
-import android.widget.EditText;
-
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
@@ -13,9 +7,6 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.listeners.ThousandsSeparatorTextWatcher;
 import org.odk.collect.android.utilities.Appearances;
-
-import java.text.NumberFormat;
-import java.util.Locale;
 
 public final class StringWidgetUtils {
 
@@ -104,41 +95,6 @@ public final class StringWidgetUtils {
             } catch (Exception numberFormatException) {
                 return null;
             }
-        }
-    }
-
-    public static void adjustEditTextAnswerToDecimalWidget(EditText answerText, FormEntryPrompt prompt) {
-        boolean useThousandSeparator = Appearances.useThousandSeparator(prompt);
-        if (useThousandSeparator) {
-            answerText.addTextChangedListener(new ThousandsSeparatorTextWatcher(answerText));
-        }
-
-        answerText.setInputType(InputType.TYPE_NUMBER_FLAG_DECIMAL);
-        // only numbers are allowed
-        answerText.setKeyListener(new DigitsKeyListener(true, true));
-
-        // only 15 characters allowed
-        InputFilter[] fa = new InputFilter[1];
-        fa[0] = new InputFilter.LengthFilter(15);
-        if (useThousandSeparator) {
-            fa[0] = new InputFilter.LengthFilter(19);
-        }
-        answerText.setFilters(fa);
-
-        Double d = getDoubleAnswerValueFromIAnswerData(prompt.getAnswerValue());
-
-        if (d != null) {
-            // truncate to 15 digits max in US locale
-            // use US locale because DigitsKeyListener can't be localized before API 26
-            NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
-            nf.setMaximumFractionDigits(15);
-            nf.setMaximumIntegerDigits(15);
-            nf.setGroupingUsed(false);
-
-            String formattedValue = nf.format(d);
-            answerText.setText(formattedValue);
-
-            Selection.setSelection(answerText.getText(), answerText.getText().length());
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
@@ -200,6 +200,9 @@ public class DecimalWidgetTest extends GeneralStringWidgetTest<DecimalWidget, De
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
         getWidget().widgetAnswerText.setAnswer("123456789.54");
+
         assertEquals("123,456,789.54", getWidget().widgetAnswerText.getAnswer());
+        assertEquals("123,456,789.54", getWidget().widgetAnswerText.getBinding().editText.getText().toString());
+        assertEquals("123,456,789.54", getWidget().widgetAnswerText.getBinding().textView.getText().toString());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
@@ -83,6 +83,9 @@ public class ExDecimalWidgetTest extends GeneralExStringWidgetTest<ExDecimalWidg
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
         getWidget().widgetAnswerText.setAnswer("123456789.54");
+
         assertEquals("123,456,789.54", getWidget().widgetAnswerText.getAnswer());
+        assertEquals("123,456,789.54", getWidget().widgetAnswerText.getBinding().editText.getText().toString());
+        assertEquals("123,456,789.54", getWidget().widgetAnswerText.getBinding().textView.getText().toString());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
@@ -55,6 +55,9 @@ public class ExIntegerWidgetTest extends GeneralExStringWidgetTest<ExIntegerWidg
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
         getWidget().widgetAnswerText.setAnswer("123456789");
+
         assertEquals("123,456,789", getWidget().widgetAnswerText.getAnswer());
+        assertEquals("123,456,789", getWidget().widgetAnswerText.getBinding().editText.getText().toString());
+        assertEquals("123,456,789", getWidget().widgetAnswerText.getBinding().textView.getText().toString());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
@@ -42,6 +42,9 @@ public class IntegerWidgetTest extends GeneralStringWidgetTest<IntegerWidget, In
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
         getWidget().widgetAnswerText.setAnswer("123456789");
+
         assertEquals("123,456,789", getWidget().widgetAnswerText.getAnswer());
+        assertEquals("123,456,789", getWidget().widgetAnswerText.getBinding().editText.getText().toString());
+        assertEquals("123,456,789", getWidget().widgetAnswerText.getBinding().textView.getText().toString());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
@@ -40,6 +40,9 @@ public class StringNumberWidgetTest extends GeneralStringWidgetTest<StringNumber
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
         getWidget().widgetAnswerText.setAnswer("123456789123456789123456789123456789");
+
         assertEquals("123,456,789,123,456,789,123,456,789,123,456,789", getWidget().widgetAnswerText.getAnswer());
+        assertEquals("123,456,789,123,456,789,123,456,789,123,456,789", getWidget().widgetAnswerText.getBinding().editText.getText().toString());
+        assertEquals("123,456,789,123,456,789,123,456,789,123,456,789", getWidget().widgetAnswerText.getBinding().textView.getText().toString());
     }
 }


### PR DESCRIPTION
Closes #5952 

#### Why is this the best possible solution? Were any other approaches considered?
The representation with separators is something that we only display. Under the hood, we always operate using plain numbers. When we create the `WidgetAnswerText` and set the answer it's also a plain number (in the case of numerical widgets). Only when we pass it to the EditText it's formatted so that separators are used (because the EditText has a special text watcher). If we want to display a formatted value in the TextView then taking that value from the EditText is the easiest solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It can only affect text widgets that display answers in non-editable text views like external widgets or text widgets that are read-only so please test those widgets to make sure there is no regression in the way we display answers.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form that is attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
