### PR TITLE
Prevent concurrent modifications of audit log

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -203,7 +203,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             if (updateSuccess) {
                 try {
                     formController.stepToNextScreenEvent();
-                    formController.getAuditEventLogger().flushSynchronized(); // Close events waiting for an end time
+                    formController.getAuditEventLogger().flush(); // Close events waiting for an end time
                     updateIndex(true);
                 } catch (JavaRosaException e) {
                     error.postValue(new FormError.NonFatal(e.getCause().getMessage()));
@@ -222,7 +222,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             if (updateSuccess) {
                 try {
                     formController.stepToPreviousScreenEvent();
-                    formController.getAuditEventLogger().flushSynchronized(); // Close events waiting for an end time
+                    formController.getAuditEventLogger().flush(); // Close events waiting for an end time
                     updateIndex(true);
                 } catch (JavaRosaException e) {
                     error.postValue(new FormError.NonFatal(e.getCause().getMessage()));

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -106,10 +106,6 @@ public class AuditEventLogger {
      * used on the UI thread.
      */
     public synchronized void flush() {
-        internalFlush();
-    }
-
-    private void internalFlush() {
         if (isAuditEnabled()) {
             finalizeEvents();
             writeEvents();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -5,7 +5,6 @@ import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PROVIDERS_ENABLED;
 
 import android.location.Location;
-import android.os.Looper;
 import android.os.SystemClock;
 
 import androidx.annotation.Nullable;
@@ -48,34 +47,20 @@ public class AuditEventLogger {
         this.formController = formController;
     }
 
-    /**
-     * @deprecated use {@link #logEventSynchronized(AuditEvent.AuditEventType, FormIndex, boolean, String, long, String)} instead
-     */
-    @Deprecated
     public void logEvent(AuditEvent.AuditEventType eventType, boolean writeImmediatelyToDisk, long currentTime) {
         logEvent(eventType, null, writeImmediatelyToDisk, null, currentTime, null);
-    }
-
-    /**
-     * @deprecated use {@link #logEventSynchronized(AuditEvent.AuditEventType, FormIndex, boolean, String, long, String)} instead
-     */
-    @Deprecated
-    public void logEvent(AuditEvent.AuditEventType eventType, FormIndex formIndex,
-                         boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
-        checkAndroidUIThread();
-        internalLog(eventType, formIndex, writeImmediatelyToDisk, questionAnswer, currentTime, changeReason);
     }
 
     /**
      * Logs events to the audit log. Can safely be used on a background thread, but should not be
      * used on the UI thread.
      */
-    public synchronized void logEventSynchronized(AuditEvent.AuditEventType eventType, FormIndex formIndex,
+    public void logEvent(AuditEvent.AuditEventType eventType, FormIndex formIndex,
                          boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
         internalLog(eventType, formIndex, writeImmediatelyToDisk, questionAnswer, currentTime, changeReason);
     }
 
-    private void internalLog(AuditEvent.AuditEventType eventType, FormIndex formIndex, boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
+    private synchronized void internalLog(AuditEvent.AuditEventType eventType, FormIndex formIndex, boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
         if (!isAuditEnabled() || shouldBeIgnored(eventType)) {
             return;
         }
@@ -116,20 +101,11 @@ public class AuditEventLogger {
         }
     }
 
-    /**
-     * @deprecated use {@link #flushSynchronized()} instead.
-     */
-    @Deprecated
-    public void flush() {
-        checkAndroidUIThread();
-        internalFlush();
-    }
-
     /*
      * Finalizes and writes events. Can safely be used on a background thread, but should not be
      * used on the UI thread.
      */
-    public synchronized void flushSynchronized() {
+    public synchronized void flush() {
         internalFlush();
     }
 
@@ -137,13 +113,6 @@ public class AuditEventLogger {
         if (isAuditEnabled()) {
             finalizeEvents();
             writeEvents();
-        }
-    }
-
-    private void checkAndroidUIThread() {
-        Looper mainLooper = Looper.getMainLooper();
-        if (mainLooper != null && mainLooper.getThread() != Thread.currentThread()) {
-            throw new IllegalStateException("Cannot modify audit log from background thread!");
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -129,7 +129,7 @@ public class AuditEventLogger {
      * Finalizes and writes events. Can safely be used on a background thread, but should not be
      * used on the UI thread.
      */
-    public void flushSynchronized() {
+    public synchronized void flushSynchronized() {
         internalFlush();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.kt
@@ -24,7 +24,7 @@ object AuditUtils {
                             null
                         }
 
-                    auditEventLogger.logEventSynchronized(
+                    auditEventLogger.logEvent(
                         AuditEvent.AuditEventType.QUESTION,
                         question.index,
                         true,


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/0042502b5f5c4406170167ac2c6bfcee?time=last-seven-days&types=crash&versions=v2024.1.0%20(4789)&sessionEventKey=65D31F26014F00014D92CD4DD21230F6_1915688732070940097).

This makes sure that `logEvent` and `flush` are never executed concurrently which could cause problems.

#### Why is this the best possible solution? Were any other approaches considered?

We should also remove all uses of `logEvent` and `flush` on the UI thread, but that's part of ongoing ANR work (#5867).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It'll be hard to reproduce the linked crash (or we probably would have caught it ourselves). I think the best thing to test here is general audit log behaviour - I've made some changes here to how events are logged and that could be risky.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any forms with audit enabled.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
