### PR TITLE
Fixed saving audio answers

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -403,6 +403,22 @@ public class FieldListUpdateTest {
                 .checkIsTranslationDisplayed("Question20");
     }
 
+    @Test
+    public void recordingAudio_ShouldChangeRelevanceOfRelatedField() {
+        new FormEntryPage("fieldlist-updates")
+                .clickGoToArrow()
+                .clickGoUpIcon()
+                .clickOnGroup("Audio")
+                .clickOnQuestion("Source16")
+                .assertTextDoesNotExist("Target16")
+                .clickOnString(org.odk.collect.strings.R.string.capture_audio)
+                .clickOnContentDescription(org.odk.collect.strings.R.string.stop_recording)
+                .checkIsTranslationDisplayed("Target16")
+                .clickOnString(org.odk.collect.strings.R.string.delete_answer_file)
+                .clickOnButtonInDialog(org.odk.collect.strings.R.string.delete_answer_file, new FormEntryPage("fieldlist-updates"))
+                .assertTextDoesNotExist("Target16");
+    }
+
     // Scroll down until the desired group name is visible. This is needed to make the tests work
     // on devices with screens of different heights.
     private void jumpToGroupWithText(String text) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -613,8 +613,13 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         RecordingHandler recordingHandler = new RecordingHandler(formSaveViewModel, this, audioRecorder, new AMRAppender(), new M4AAppender());
         audioRecorder.getCurrentSession().observe(this, session -> {
             if (session != null && session.getFile() != null) {
-                recordingHandler.handle(getFormController(), session, success -> {
-                    if (success) {
+                recordingHandler.handle(getFormController(), session, file -> {
+                    if (file != null) {
+                        if (session.getId() instanceof FormIndex) {
+                            waitingForDataRegistry.waitForData((FormIndex) session.getId());
+                            setWidgetData(file);
+                            session.getFile().delete();
+                        }
                         formSaveViewModel.resumeSave();
                     } else {
                         String path = session.getFile().getAbsolutePath();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -93,9 +93,6 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
                 binding.audioPlayer.recordingDuration.setText(formatLength(session.first));
                 binding.audioPlayer.waveform.addAmplitude(session.second);
             } else {
-                if (binaryName != null && recordingInProgress) {
-                    widgetValueChanged();
-                }
                 recordingInProgress = false;
                 updateVisibilities();
                 updatePlayerMedia();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -93,7 +93,6 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
                 binding.audioPlayer.recordingDuration.setText(formatLength(session.first));
                 binding.audioPlayer.waveform.addAmplitude(session.second);
             } else {
-                binaryName = questionDetails.getPrompt().getAnswerText();
                 if (binaryName != null && recordingInProgress) {
                     widgetValueChanged();
                 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
@@ -41,9 +41,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.testshared.RobolectricHelpers.setupMediaPlayerDataSource;
 import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.mockValueChangedListener;
@@ -379,45 +377,6 @@ public class AudioWidgetTest {
         assertThat(widget.binding.audioPlayer.waveform.getVisibility(), is(GONE));
         assertThat(widget.binding.captureButton.getVisibility(), is(VISIBLE));
         assertThat(widget.binding.chooseButton.getVisibility(), is(VISIBLE));
-    }
-
-    @Test
-    public void whenRecordingFinished_callValueChangeListenersIfAnswerIsNotNull() throws Exception {
-        File answerFile = questionMediaManager.addAnswerFile(File.createTempFile("blah", ".mp3"));
-        FormEntryPrompt prompt = promptWithAnswer(new StringData(answerFile.getName()));
-        AudioWidget widget = createWidget(prompt);
-        WidgetValueChangedListener valueChangedListener = mockValueChangedListener(widget);
-
-        recordingRequester.setDuration(prompt.getIndex().toString(), 5);
-        recordingRequester.reset();
-
-        verify(valueChangedListener).widgetValueChanged(widget);
-    }
-
-    @Test
-    public void whenRecordingFinished_doNotCallValueChangeListenersIfAnswerIsNull() {
-        FormEntryPrompt prompt = promptWithAnswer(null);
-        AudioWidget widget = createWidget(prompt);
-        WidgetValueChangedListener valueChangedListener = mockValueChangedListener(widget);
-
-        recordingRequester.setDuration(prompt.getIndex().toString(), 5);
-        recordingRequester.reset();
-
-        verifyNoInteractions(valueChangedListener);
-    }
-
-    @Test
-    public void whenRecordingFinished_doNotCallValueChangeListenersIfAnswerRecordingHasBeenAlreadyStopped() throws Exception {
-        File answerFile = questionMediaManager.addAnswerFile(File.createTempFile("blah", ".mp3"));
-        FormEntryPrompt prompt = promptWithAnswer(new StringData(answerFile.getName()));
-        AudioWidget widget = createWidget(prompt);
-        WidgetValueChangedListener valueChangedListener = mockValueChangedListener(widget);
-
-        recordingRequester.setDuration(prompt.getIndex().toString(), 5);
-        recordingRequester.reset();
-        recordingRequester.reset();
-
-        verify(valueChangedListener, times(1)).widgetValueChanged(widget);
     }
 
     @Test

--- a/test-forms/src/main/resources/forms/fieldlist-updates.xml
+++ b/test-forms/src/main/resources/forms/fieldlist-updates.xml
@@ -182,6 +182,10 @@
             <question19/>
             <question20/>
           </long_list_of_questions>
+          <audio>
+            <source16/>
+            <target16/>
+          </audio>
           <meta>
             <instanceID/>
           </meta>
@@ -366,6 +370,8 @@
       <bind nodeset="/fieldlist-updates/long_list_of_questions/question18" type="string"/>
       <bind nodeset="/fieldlist-updates/long_list_of_questions/question19" type="string"/>
       <bind nodeset="/fieldlist-updates/long_list_of_questions/question20" type="integer"/>
+      <bind nodeset="/fieldlist-updates/audio/source16" type="binary"/>
+      <bind nodeset="/fieldlist-updates/audio/target16" relevant=" /fieldlist-updates/audio/source16  != ''" type="string"/>
       <bind calculate="concat('uuid:', uuid())" nodeset="/fieldlist-updates/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
@@ -712,6 +718,15 @@
       </input>
       <input ref="/fieldlist-updates/long_list_of_questions/question20">
         <label>Question20</label>
+      </input>
+    </group>
+    <group appearance="field-list" ref="/fieldlist-updates/audio">
+      <label>Audio</label>
+      <upload mediatype="audio/*" ref="/fieldlist-updates/audio/source16">
+        <label>Source16</label>
+      </upload>
+      <input ref="/fieldlist-updates/audio/target16">
+        <label>Target16</label>
       </input>
     </group>
   </h:body>


### PR DESCRIPTION
Closes #5977

#### Why is this the best possible solution? Were any other approaches considered?
The implementation of passing new answers to the audio widget was incorrect. The issue stemmed from immediately saving the answer after recording audio, as seen here: https://github.com/getodk/collect/pull/5979/files#diff-06b81c70d38f41b152a55fd3c656029170b518aa952058c54e7b8d68041150b7L62

This approach diverges from the standard procedure followed by other widgets. Typically, answers are passed to the widget, with saving occurring later when answers for the current screen are saved.

Adopting the same process as with other widgets ensures consistency. When the answer is saved prematurely, as with the audio widget, it complicates the handling of question updates, especially on screens with multiple questions. This early saving prevents proper comparison of questions before and after saving answers for the current screen see: https://github.com/getodk/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java#L2301

Consequently, if a question depended on the audio widget and was displayed conditionally, it might not have been added to the list upon audio recording. Subsequently, attempting to remove such a question, which wasn't displayed, led to a crash when the audio was deleted.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Apart from testing the issue itself, it would be good to verify that the audio widget works well with no regressions. I would take a look at the similar issues we have had recently:
- https://github.com/getodk/collect/issues/5955
- https://github.com/getodk/collect/issues/5956 etc.

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
