### PR TITLE
Avoid NPE when scrolling to the edited widget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -2279,7 +2279,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                     try {
                         updateFieldListQuestions(changedWidget.getFormEntryPrompt().getIndex());
                         odkView.post(() -> {
-                            if (!odkView.isDisplayed(changedWidget)) {
+                            if (odkView != null && !odkView.isDisplayed(changedWidget)) {
                                 odkView.scrollToTopOf(changedWidget);
                             }
                         });


### PR DESCRIPTION
Closes #5986 

#### Why is this the best possible solution? Were any other approaches considered?
It seems like it's possible that the view we call `post()` on is null at the time the runnable is performed (see a related question on StackOverflow https://stackoverflow.com/questions/50857364/can-a-post-runnable-get-a-null-reference-on-the-view-it-was-run-on). It shouldn't be something common since the time difference between calling `post()` and executing the runnable is 
negligible, typically milliseconds. A simple null check in this case should be enough.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think we can skip testing. Reproducing the issue is rather not possible and the introduced change is safe so I don't think the QA team can help here.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
