### PR TITLE
Show error when trying to load form that doesn't exist

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -165,6 +165,11 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
             form = candidateForms.get(0);
         } else if (uriMimeType != null && uriMimeType.equals(FormsContract.CONTENT_ITEM_TYPE)) {
             form = new FormsRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(uri));
+            if (form == null) {
+                Timber.e(new Error("form is null"));
+                errorMsg = "This form no longer exists, please email support@getodk.org with a description of what you were doing when this happened.";
+                return null;
+            }
 
             /**
              * This is the fill-blank-form code path.See if there is a savepoint for this form

--- a/test-shared/src/main/java/org/odk/collect/testshared/EspressoHelpers.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/EspressoHelpers.kt
@@ -6,6 +6,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
@@ -23,12 +24,22 @@ object EspressoHelpers {
             .check(matches(not(doesNotExist())))
     }
 
+    fun assertTextInDialog(text: String) {
+        onView(allOf(withText(text), withEffectiveVisibility(VISIBLE)))
+            .inRoot(isDialog())
+            .check(matches(not(doesNotExist())))
+    }
+
     fun clickOnContentDescription(string: Int) {
         onView(withContentDescription(string)).perform(click())
     }
 
     fun clickOnText(string: Int) {
         onView(withText(string)).perform(click())
+    }
+
+    fun clickOnTextInDialog(string: Int) {
+        onView(withText(string)).inRoot(isDialog()).perform(click())
     }
 
     fun assertIntents(vararg matchers: Matcher<Intent>) {


### PR DESCRIPTION
Closes #5987

#### Why is this the best possible solution? Were any other approaches considered?

Discussed in #5987.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We don't have any way to reproduce the crash as of yet. It's worth playing around to see if there's some way of deleting the form and then returning to the app while it's open. As far as I can tell, the app itself needs to be restarted as well which is hard to do without a crash.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
