### PR TITLE
Fixed playing audio

### DIFF
--- a/audioclips/src/main/java/org/odk/collect/audioclips/AudioClipViewModel.kt
+++ b/audioclips/src/main/java/org/odk/collect/audioclips/AudioClipViewModel.kt
@@ -85,6 +85,7 @@ class AudioClipViewModel(private val mediaPlayerFactory: Supplier<MediaPlayer>, 
     private fun playNext(playlist: Queue<Clip>) {
         val nextClip = playlist.poll()
         if (nextClip != null) {
+            stop()
             if (!isCurrentPlayingClip(nextClip.clipID, currentlyPlaying.value)) {
                 loadNewClip(
                     nextClip.uRI,

--- a/audioclips/src/test/java/org/odk/collect/audioclips/AudioClipViewModelTest.kt
+++ b/audioclips/src/test/java/org/odk/collect/audioclips/AudioClipViewModelTest.kt
@@ -46,14 +46,33 @@ class AudioClipViewModelTest {
     }
 
     @Test
-    fun play_whenAlreadyingPlayingClip_startsMediaPlayer() {
+    fun play_whenAlreadyingPlayingClip_restartsMediaPlayer() {
         viewModel.play(Clip("clip1", "file://audio.mp3"))
         fakeScheduler.flush()
         viewModel.play(Clip("clip1", "file://audio.mp3"))
         fakeScheduler.flush()
 
-        verify(mediaPlayer, times(1)).reset()
-        verify(mediaPlayer, times(2)).start()
+        val inOrder = inOrder(mediaPlayer)
+        inOrder.verify(mediaPlayer).reset()
+        inOrder.verify(mediaPlayer).start()
+        inOrder.verify(mediaPlayer).stop()
+        inOrder.verify(mediaPlayer).reset()
+        inOrder.verify(mediaPlayer).start()
+    }
+
+    @Test
+    fun play_whenAlreadyingPlayingAnotherClip_restartsMediaPlayer() {
+        viewModel.play(Clip("clip1", "file://audio.mp3"))
+        fakeScheduler.flush()
+        viewModel.play(Clip("clip2", "file://audio2.mp3"))
+        fakeScheduler.flush()
+
+        val inOrder = inOrder(mediaPlayer)
+        inOrder.verify(mediaPlayer).reset()
+        inOrder.verify(mediaPlayer).start()
+        inOrder.verify(mediaPlayer).stop()
+        inOrder.verify(mediaPlayer).reset()
+        inOrder.verify(mediaPlayer).start()
     }
 
     @Test
@@ -322,7 +341,7 @@ class AudioClipViewModelTest {
     }
 
     @Test
-    fun position_worksWhenMultipleClipsArePlayed() {
+    fun position_ofAlreadyPlayedClipIsRestartedWhenANewOneIsStarted() {
         `when`(mediaPlayer.currentPosition).thenReturn(0)
         val position1 = viewModel.getPosition("clip1")
         val position2 = viewModel.getPosition("clip2")
@@ -340,7 +359,7 @@ class AudioClipViewModelTest {
 
         `when`(mediaPlayer.currentPosition).thenReturn(2500)
         fakeScheduler.runForeground()
-        assertThat(position1.getOrAwaitValue(), equalTo(1000))
+        assertThat(position1.getOrAwaitValue(), equalTo(0))
         assertThat(position2.getOrAwaitValue(), equalTo(2500))
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -93,9 +93,11 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
                 binding.audioPlayer.recordingDuration.setText(formatLength(session.first));
                 binding.audioPlayer.waveform.addAmplitude(session.second);
             } else {
-                recordingInProgress = false;
-                updateVisibilities();
-                updatePlayerMedia();
+                if (recordingInProgress) {
+                    recordingInProgress = false;
+                    updateVisibilities();
+                    updatePlayerMedia();
+                }
             }
         });
     }


### PR DESCRIPTION
Closes #5989 

#### Why is this the best possible solution? Were any other approaches considered?
There were two regressions that I have addressed in this pull request:
- the audio player was flashing (after executing the steps described in the issue). This was caused because the widget kept receiving redundant updates which I handled in https://github.com/getodk/collect/pull/5992/commits/bfa07c5ea409a3865f00ceb2add814eb611f9cab. I don't know if we should send so many updates when the session is null at all but didn't feel confident enough (especially now as it will be a point release) to introduce deeper changes
- the seekbar was sometimes moved to the start position sometimes with the wrong time even (this can be reproduced by recording two audios and then playing them one by one multiple times). The problem was introduced (or rather revealed) by putting some operations in the background (specifically I'm talking about creating a new player https://github.com/getodk/collect/pull/5836/commits/f754e0778f48a1e8d3bf6d92d5ef7a0c47f43b53#diff-dd7070cc2905fbf7e644eac39e7590ff53ccf92fc0dfb39512a55315099e9619R202). The real issue according to my investigation was that before playing a new audio we never explicitly stopped the one that was already started. That means the updates were still being produced https://github.com/getodk/collect/pull/5836/commits/b4e9400f28e3dba636b085288b4d1702d00c7d08#diff-dd7070cc2905fbf7e644eac39e7590ff53ccf92fc0dfb39512a55315099e9619R158 even during the process of setting up a new media player for a new clip (see above). As a result, some updates were received after creating a new media player but before finishing its setup (before the two operations were in different threads), and those values were for example negative integers.

@seadowg you know that functionality better since you are the author so please review carefully.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please be creative. We have had multiple issues related to this functionality recently so that shows it's a very tricky area. I can't pinpoint one exact thing that should be tested, just everything audio-related.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue and other forms with audio widgets or even audio attachments.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
