### PR TITLE
Log original exception in retry rule and ignore test failing on Test Lab

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -57,6 +57,7 @@ import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.espresso.matcher.ViewMatchers;
 
 import org.hamcrest.Matcher;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -392,6 +393,7 @@ public class FieldListUpdateTest {
     }
 
     @Test
+    @Ignore("https://github.com/getodk/collect/issues/5996")
     public void listOfQuestionsShouldNotBeScrolledToTheLastEditedQuestionAfterClickingOnAQuestion() {
         new FormEntryPage("fieldlist-updates")
                 .clickGoToArrow()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
@@ -15,9 +15,11 @@ class RetryOnDeviceErrorRule : TestRule {
                 } catch (e: Exception) {
                     if (e is PerformException) {
                         Timber.w("RetryOnDeviceErrorRule: Retrying due to PerformException!")
+                        Timber.e(e)
                         base.evaluate()
                     } else if (e::class.simpleName == "RootViewWithoutFocusException") {
                         Timber.w("RetryOnDeviceErrorRule: Retrying due to RootViewWithoutFocusException!")
+                        Timber.e(e)
                         base.evaluate()
                     } else {
                         throw e


### PR DESCRIPTION
`RetryOnDeviceErrorRule` currently obscures the  original exception. This can make it hard to diagnose failures that only happen on CI.

I've added an [issue](https://github.com/getodk/collect/issues/5996) to track fixing the ignored test.