### PR TITLE
Catch exception when preloading select choices

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataSelects.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataSelects.java
@@ -47,11 +47,20 @@ public class DynamicPreLoadedDataSelects {
     }
 
     @Test
-    public void shouldDisplayFriendlyMessageWhenFilesAreMissing() {
+    public void displayErrorWhenFilesAreMissing() {
         rule.setUpProjectAndCopyForm("external_data_questions.xml")
                 .fillNewForm("external_data_questions.xml", "externalDataQuestions")
                 .assertText(org.odk.collect.strings.R.string.file_missing, new StoragePathProvider().getOdkDirPath(StorageSubdirectory.FORMS) + "/external_data_questions-media/fruits.csv")
                 .swipeToNextQuestion("External csv")
                 .assertText(org.odk.collect.strings.R.string.file_missing, new StoragePathProvider().getOdkDirPath(StorageSubdirectory.FORMS) + "/external_data_questions-media/itemsets.csv");
+    }
+
+    @Test
+    public void displayWarningWhenQueryIsBad() {
+        rule.setUpProjectAndCopyForm("external-csv-search-broken.xml", Collections.singletonList("external-csv-search-produce.csv"))
+                .fillNewForm("external-csv-search-broken.xml", "external-csv-search")
+                .answerQuestion("Produce search", "blah")
+                .swipeToNextQuestion("Produce")
+                .assertText("no such column: c_wat (code 1 SQLITE_ERROR): , while compiling: SELECT c_name, c_label FROM externalData WHERE c_wat LIKE ?");
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataSelects.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataSelects.java
@@ -24,22 +24,17 @@ public class DynamicPreLoadedDataSelects {
             .around(rule);
 
     @Test
-    public void withoutFilter_displaysAllChoices() {
+    public void withoutFilterAndWithoutFilter_displaysMatchingChoices() {
         rule.setUpProjectAndCopyForm("external-csv-search.xml", Collections.singletonList("external-csv-search-produce.csv"))
                 .fillNewForm("external-csv-search.xml", "external-csv-search")
+                .assertQuestion("Multiple produce")
                 .assertText("Artichoke")
                 .assertText("Apple")
                 .assertText("Banana")
                 .assertText("Blueberry")
                 .assertText("Cherimoya")
-                .assertText("Carrot");
-    }
+                .assertText("Carrot")
 
-    @Test
-    // Regression: https://github.com/getodk/collect/issues/3132
-    public void withFilter_showsMatchingChoices() {
-        rule.setUpProjectAndCopyForm("external-csv-search.xml", Collections.singletonList("external-csv-search-produce.csv"))
-                .fillNewForm("external-csv-search.xml", "external-csv-search")
                 .swipeToNextQuestion("Produce search")
                 .inputText("A")
                 .swipeToNextQuestion("Produce")
@@ -48,16 +43,7 @@ public class DynamicPreLoadedDataSelects {
                 .assertText("Banana")
                 .assertText("Cherimoya")
                 .assertText("Carrot")
-                .assertTextDoesNotExist("Blueberry")
-                .swipeToPreviousQuestion("Produce search")
-                .inputText("B")
-                .swipeToNextQuestion("Produce")
-                .assertText("Banana")
-                .assertText("Blueberry")
-                .assertTextDoesNotExist("Artichoke")
-                .assertTextDoesNotExist("Apple")
-                .assertTextDoesNotExist("Cherimoya")
-                .assertTextDoesNotExist("Carrot");
+                .assertTextDoesNotExist("Blueberry");
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataSelects.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataSelects.java
@@ -24,7 +24,7 @@ public class DynamicPreLoadedDataSelects {
             .around(rule);
 
     @Test
-    public void withoutFilterAndWithoutFilter_displaysMatchingChoices() {
+    public void withoutFilterAndWithFilter_displaysMatchingChoices() {
         rule.setUpProjectAndCopyForm("external-csv-search.xml", Collections.singletonList("external-csv-search-produce.csv"))
                 .fillNewForm("external-csv-search.xml", "external-csv-search")
                 .assertQuestion("Multiple produce")

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -386,8 +386,12 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             FormEntryPrompt prompt = formController.getQuestionPrompt();
 
             if (prompt != null) {
-                List<SelectChoice> selectChoices = SelectChoiceUtils.loadSelectChoices(prompt, formController);
-                choices.put(prompt.getIndex(), selectChoices);
+                try {
+                    List<SelectChoice> selectChoices = SelectChoiceUtils.loadSelectChoices(prompt, formController);
+                    choices.put(prompt.getIndex(), selectChoices);
+                } catch (Exception e) {
+                    // Let the widget load choices and handle the error
+                }
             }
         }
     }

--- a/test-forms/src/main/resources/forms/external-csv-search-broken.xml
+++ b/test-forms/src/main/resources/forms/external-csv-search-broken.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>external-csv-search</h:title>
+    <model>
+      <instance>
+        <external-csv-search id="external-csv-search">
+          <produce_search/>
+          <produce/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </external-csv-search>
+      </instance>
+      <bind nodeset="/external-csv-search/produce_search" type="string"/>
+      <bind nodeset="/external-csv-search/produce" type="select1"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/external-csv-search/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/external-csv-search/produce_search">
+      <label>Produce search</label>
+    </input>
+    <select1 appearance="search('external-csv-search-produce', 'contains', 'wat',  /external-csv-search/produce_search )" ref="/external-csv-search/produce">
+      <label>Produce</label>
+      <item>
+        <label>label</label>
+        <value>name</value>
+      </item>
+    </select1>
+  </h:body>
+</h:html>


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/ca76907fe2adf027df9891269058806f?time=last-seven-days&types=crash&versions=2024.1.1%20(4793)&sessionEventKey=65E5840A019300011DB114E91523A0DB_1920865615394712952)

#### Why is this the best possible solution? Were any other approaches considered?

We could move to catching and actually handling the error when preloading, but seeing as the widget already deals with this, it felt like a better fix to just ignore the exception. If we eventually move to only preloading, we'll need to deal with the errors there.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The crash can be reproduced using a "broken" search/pulldata form that references a non existent field in the external data. An example `search` (where `wat` is not a field in the data) would be:

```
search('external-data', 'contains', 'wat',  /data/search)
```

Other than testing that case, I think testing other "broken" forms for selects with external secondary instances, `search` and external selects would be a good idea.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
