### PR TITLE
Update JavaRosa to 4.3.2 to fix type issue

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -36,7 +36,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.1.0"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.8"
-    const val javarosa_online = "org.getodk:javarosa:4.3.1"
+    const val javarosa_online = "org.getodk:javarosa:4.3.2"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val javarosa = javarosa_online
     const val karumi_dexter = "com.karumi:dexter:6.2.3"


### PR DESCRIPTION
Addresses [forum type coercion issue](https://forum.getodk.org/t/choice-filter-niveau-1-fails-with-collect-2024-1-1-but-niveau-1-is-ok/45580) 

#### Why is this the best possible solution? Were any other approaches considered?
We've decided to bypass the index cache when values to filter by are not strings for now. We think this is the lowest-risk approach.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The biggest risk is that this solution is incomplete and misses other type issues in this area. We can address those separately. We don't believe there's a risk to existing behavior that is working as intended.

#### Do we need any specific form for testing your changes? If so, please attach one.
See forum issue or JavaRosa test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
