### PR TITLE
Fixed displaying errors after validating answers

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -372,11 +372,9 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                     if (result instanceof FailedValidationResult) {
                         updateIndex(true);
                     }
-
-                    return result;
-                }, result -> {
-                    validationResult.setValue(new Consumable<>(result));
-                }
+                    validationResult.postValue(new Consumable<>(result));
+                    return null;
+                }, ignored -> {}
         );
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -361,6 +361,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
     public void validate() {
         worker.immediate(
                 () -> {
+                    FormIndex originalIndex = formController.getFormIndex();
                     ValidationResult result = null;
                     try {
                         result = formController.validateAnswers(true, true);
@@ -369,7 +370,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                     }
 
                     // JavaRosa moves to the index where the contraint failed
-                    if (result instanceof FailedValidationResult) {
+                    if (result instanceof FailedValidationResult && !((FailedValidationResult) result).getIndex().equals(originalIndex)) {
                         updateIndex(true);
                     }
                     validationResult.postValue(new Consumable<>(result));

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -372,6 +372,35 @@ public class FormEntryViewModelTest {
     }
 
     @Test
+    public void doNotUpdateCurrentIndex_whenValidationFails_butTheIndexOfAQuestionThatWeShouldBeMovedToIsTheOneWeCurrentlyDisplay() {
+        Consumable<FailedValidationResult> failedValidationResult =
+                new Consumable<>(new FailedValidationResult(formController.getFormIndex(), 0, null, org.odk.collect.strings.R.string.invalid_answer_error));
+        formController.setFailedConstraint(failedValidationResult.getValue());
+
+        FormIndex oldIndex = viewModel.getCurrentIndex().getValue();
+        viewModel.validate();
+        scheduler.flush();
+
+        FormIndex newIndex = viewModel.getCurrentIndex().getValue();
+        assertThat(oldIndex == newIndex, is(true));
+    }
+
+    @Test
+    public void updateCurrentIndex_whenValidationFails_butTheIndexOfAQuestionThatWeShouldBeMovedToIsNotTheOneWeCurrentlyDisplay() {
+        FormIndex index = new FormIndex(null, formController.getFormIndex().getLocalIndex() + 2, 0, new TreeReference());
+        Consumable<FailedValidationResult> failedValidationResult =
+                new Consumable<>(new FailedValidationResult(index, 0, null, org.odk.collect.strings.R.string.invalid_answer_error));
+        formController.setFailedConstraint(failedValidationResult.getValue());
+
+        FormIndex oldIndex = viewModel.getCurrentIndex().getValue();
+        viewModel.validate();
+        scheduler.flush();
+
+        FormIndex newIndex = viewModel.getCurrentIndex().getValue();
+        assertThat(oldIndex == newIndex, is(false));
+    }
+
+    @Test
     public void refresh_whenThereIsASelectOnePrompt_preloadsSelectChoices() {
         formController.setCurrentEvent(FormEntryController.EVENT_QUESTION);
 

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FakeFormController.java
@@ -116,6 +116,8 @@ public class FakeFormController extends StubFormController {
     public ValidationResult validateAnswers(boolean markCompleted, boolean moveToInvalidIndex) throws JavaRosaException {
         if (validationError != null) {
             throw validationError;
+        } else if (failedConstraint != null) {
+            return failedConstraint;
         } else {
             return SuccessValidationResult.INSTANCE;
         }


### PR DESCRIPTION
Closes #5939 

#### Why is this the best possible solution? Were any other approaches considered?
It was a race condition. The problem was that we always updated the index after validating answers which caused building a new widget. As a result, sometimes errors were displayed before creating a new widget and not displayed again after rebuilding the widget.
I've fixed the problem in https://github.com/getodk/collect/pull/6005/commits/7ca429330c64062db653c7ad9a6071c5a7c3f74c The action that triggers creating a new widget is also triggered by calling `postValue` on `livedata` so if we do the same with displaying errors the order of events should be correct.
I've also noticed that it doesn't make sense to update the index and rebuild the widget if it's currently displayed widget so I've added a small improvement in https://github.com/getodk/collect/pull/6005/commits/3589b984e6e5dfa8cb822f1fc47d39d8e67b565e.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Everything around displaying errors and updating indexes (moving to the questions with errors) is at risk.
Please test validating answers in different scenarios:
- when the question with an invalid answer in a single question on the screen
- when the question with an invalid answer is displayed along with other questions on the same screen
- when the question with an invalid answer is the one we currently display
- when the question with an invalid answer is not the one we currently display (so we should be moved to that question)

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form that can throw errors like a form with constraints or required questions.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
