### PR TITLE
Apply M3 styling to user identity and change reason text fields

### DIFF
--- a/collect_app/src/main/res/layout/changes_reason_dialog.xml
+++ b/collect_app/src/main/res/layout/changes_reason_dialog.xml
@@ -62,7 +62,7 @@
             </LinearLayout>
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+                style="?textInputFilledStyle"
                 android:layout_width="280dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large">

--- a/collect_app/src/main/res/layout/identify_user_dialog.xml
+++ b/collect_app/src/main/res/layout/identify_user_dialog.xml
@@ -61,7 +61,7 @@
             </LinearLayout>
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+                style="?textInputFilledStyle"
                 android:layout_width="280dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large">

--- a/collect_app/src/main/res/layout/widget_answer_text.xml
+++ b/collect_app/src/main/res/layout/widget_answer_text.xml
@@ -5,11 +5,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <com.google.android.material.textfield.TextInputLayout
-        style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+        style="?textInputFilledStyle"
         android:id="@+id/text_input_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:boxBackgroundColor="?colorSurfaceContainerLow"
         app:errorTextAppearance="?textAppearanceBodyLarge">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -19,7 +19,7 @@
     <color name="colorSurfaceContainerLow">#f7f7f7</color>
     <color name="colorSurfaceContainer">#f7f7f7</color>
     <color name="colorSurfaceContainerHigh">#f7f7f7</color>
-    <color name="colorSurfaceContainerHighest">#ecf5fa</color>
+    <color name="colorSurfaceContainerHighest">#f2f2f2</color>
     <color name="colorSurfaceInverse">#003547</color>
     <color name="colorOnSurfaceInverse">#E1F4FF</color>
 


### PR DESCRIPTION
Closes #5949 

#### Why is this the best possible solution? Were any other approaches considered?
I've decided to create a new style for `TextInputLayouts` to share the common attributes with custom values. For now, it's only the background color but it might be something else in the future too.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just confirm that the text fields (in text questions,  user identity, and change reason) have the same background color.

#### Do we need any specific form for testing your changes? If so, please attach one.
I've used: 
[audit.xlsx](https://github.com/getodk/collect/files/14625036/audit.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
