### PR TITLE
Launch forms via odkcollect:// links, with entity preselection

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -121,7 +121,15 @@ the specific language governing permissions and limitations under the License.
         <activity
             android:name=".activities.FormFillingActivity"
             android:theme="@style/Theme.Collect.FormEntry"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <data android:scheme="odkcollect" android:host="form" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+            </intent-filter>
+        </activity>
         <activity
             android:name="org.odk.collect.draw.DrawActivity"
             android:screenOrientation="landscape" />


### PR DESCRIPTION
This proof of concept enables the use of a browsable link to launch the FormFillingActivity on a specific form.  A query parameter in the link can also preselect an entity in the form.

The implementation consists of three parts:

1. Add an `<intent-filter>` to the manifest entry for FormFillingActivity, which catches URLs that begin with `odkcollect://form/`

2. Add a branch in the FormLoaderTask that handles an incoming intent with this kind of URL by looking up a specific form by its Form ID (e.g. "trees_follow_up") rather than its internal id (e.g. "forms/2").

3. Add a method `preselectEntity` that pre-answers a question in the form based on a query parameter in the URL.  The parameter name should match the name of the question, and the parameter value should be the UUID of the entity.

With these changes, a webpage with a link such as the following will launch ODK Collect into the form filling flow for a specific form with an entity preselected:

```
Launch a form:
<a href="odkcollect://form/trees_follow_up?tree=71297c7d-6a22-4354-b08a-3fbee155d74e">
  trees_follow_up
</a>
```

For testing, the above HTML is available here so you can load it on a phone browser: https://zestyping.github.io/odkform