### PR TITLE
Switch to surface container colors from elevation overlay

### DIFF
--- a/collect_app/src/main/res/values-night/colors.xml
+++ b/collect_app/src/main/res/values-night/colors.xml
@@ -15,8 +15,11 @@
     <color name="colorSurfaceVariant">#40484c</color>
     <color name="colorOnSurface">#d3e5ef</color>
     <color name="colorOnSurfaceVariant">#c0c8cd</color>
+    <color name="colorSurfaceContainerLowest">#001117</color>
     <color name="colorSurfaceContainerLow">#293134</color>
-    <color name="elevationOverlayColor">#4cbcf0</color>
+    <color name="colorSurfaceContainer">#293134</color>
+    <color name="colorSurfaceContainerHigh">#293134</color>
+    <color name="colorSurfaceContainerHighest">#162f3b</color>
     <color name="colorSurfaceInverse">#BFE9FF</color>
     <color name="colorOnSurfaceInverse">#001F2A</color>
 

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -15,8 +15,11 @@
     <color name="colorSurfaceVariant">#dce3e9</color>
     <color name="colorOnSurface">#001f2a</color>
     <color name="colorOnSurfaceVariant">#40484c</color>
+    <color name="colorSurfaceContainerLowest">#ffffff</color>
     <color name="colorSurfaceContainerLow">#f7f7f7</color>
-    <color name="elevationOverlayColor">#fafcff</color>
+    <color name="colorSurfaceContainer">#f7f7f7</color>
+    <color name="colorSurfaceContainerHigh">#f7f7f7</color>
+    <color name="colorSurfaceContainerHighest">#ecf5fa</color>
     <color name="colorSurfaceInverse">#003547</color>
     <color name="colorOnSurfaceInverse">#E1F4FF</color>
 

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -59,9 +59,11 @@
         <item name="colorOutline">@color/color_on_surface_medium_emphasis</item>
         <item name="colorErrorContainer">@color/colorErrorContainer</item>
         <item name="colorOnErrorContainer">@color/colorOnErrorContainer</item>
-        <item name="elevationOverlayColor">@color/elevationOverlayColor</item>
+        <item name="colorSurfaceContainerLowest">@color/colorSurfaceContainerLowest</item>
         <item name="colorSurfaceContainerLow">@color/colorSurfaceContainerLow</item>
-        <item name="colorSurfaceContainerHighest">@color/color_primary_low_emphasis</item>
+        <item name="colorSurfaceContainer">@color/colorSurfaceContainer</item>
+        <item name="colorSurfaceContainerHigh">@color/colorSurfaceContainerHigh</item>
+        <item name="colorSurfaceContainerHighest">@color/colorSurfaceContainerHighest</item>
         <item name="textAppearanceDisplayLarge">@style/TextAppearance.Material3.DisplayLarge</item>
         <item name="textAppearanceDisplayMedium">@style/TextAppearance.Material3.DisplayMedium
         </item>


### PR DESCRIPTION
Closes #6010 

This updates the way we defined colors for Material 3 components like dialogs or bottom sheets. Older versions of Material Components would use an "elevation overlay" color for this where as Material 3 uses the new "tonal" surface container colors.