### PR TITLE
Update robolectric install script to work with alternative CI

### DIFF
--- a/download-robolectric-deps.sh
+++ b/download-robolectric-deps.sh
@@ -11,16 +11,17 @@ wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/13-robolectric-9030017-i4/android-all-instrumented-13-robolectric-9030017-i4.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/14-robolectric-10818077-i4/android-all-instrumented-14-robolectric-10818077-i4.jar -P robolectric-deps
 
-mkdir -p collect_app/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p audiorecorder/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p projects/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p location/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p androidshared/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p geo/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p permissions/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p settings/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p maps/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p errors/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p selfie-camera/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p qr-code/src/test/resources && cp robolectric-deps.properties "$_"
-mkdir -p draw/src/test/resources && cp robolectric-deps.properties "$_"
+dest_dir="src/test/resources"
+mkdir -p collect_app/$dest_dir && cp robolectric-deps.properties collect_app/$dest_dir
+mkdir -p audiorecorder/$dest_dir && cp robolectric-deps.properties audiorecorder/$dest_dir
+mkdir -p projects/$dest_dir && cp robolectric-deps.properties projects/$dest_dir
+mkdir -p location/$dest_dir && cp robolectric-deps.properties location/$dest_dir
+mkdir -p androidshared/$dest_dir && cp robolectric-deps.properties androidshared/$dest_dir
+mkdir -p geo/$dest_dir && cp robolectric-deps.properties geo/$dest_dir
+mkdir -p permissions/$dest_dir && cp robolectric-deps.properties permissions/$dest_dir
+mkdir -p settings/$dest_dir && cp robolectric-deps.properties settings/$dest_dir
+mkdir -p maps/$dest_dir && cp robolectric-deps.properties maps/$dest_dir
+mkdir -p errors/$dest_dir && cp robolectric-deps.properties errors/$dest_dir
+mkdir -p selfie-camera/$dest_dir && cp robolectric-deps.properties selfie-camera/$dest_dir
+mkdir -p qr-code/$dest_dir && cp robolectric-deps.properties qr-code/$dest_dir
+mkdir -p draw/$dest_dir && cp robolectric-deps.properties draw/$dest_dir


### PR DESCRIPTION
#### Issue Solved

- The `download-robolectric-deps.sh` script uses the `_` environment variable in the shell.
- Usage of `$_` clearly works fine in CircleCI.
- However, it does not work within Github Workflows.
- I wasn't able to pin down the exact cause, as `$_` should work in most shells.

#### Solution Provided

- I replaced usage of `$_` with a simple variable `dest_dir="src/test/resources"`
- This variable is used to specify the path to copy to, instead of `$_`.
- The script now works for Github Workflows.

#### Why is this the best possible solution? Were any other approaches considered?

- Original script was not working for Github Workflows.
- When the CircleCI workflow runs in this PR, it will test the script still works with CircleCI.
- This change improves the script robustness, in case environments do not support `$_` and facilitates a change of CI tool in the future.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- No change.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

- None.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
