### PR TITLE
Ignore expired savepoints

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConstants.java
@@ -5,7 +5,7 @@ public final class DatabaseConstants {
     public static final String FORMS_DATABASE_NAME = "forms.db";
     public static final String FORMS_TABLE_NAME = "forms";
     // Please always test upgrades manually when you change this value
-    public static final int FORMS_DATABASE_VERSION = 12;
+    public static final int FORMS_DATABASE_VERSION = 13;
 
     public static final String INSTANCES_DATABASE_NAME = "instances.db";
     public static final String INSTANCES_TABLE_NAME = "instances";

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConstants.java
@@ -10,7 +10,7 @@ public final class DatabaseConstants {
     public static final String INSTANCES_DATABASE_NAME = "instances.db";
     public static final String INSTANCES_TABLE_NAME = "instances";
     // Please always test upgrades manually when you change this value
-    public static final int INSTANCES_DATABASE_VERSION = 6;
+    public static final int INSTANCES_DATABASE_VERSION = 7;
 
     public static final String SAVEPOINTS_DATABASE_NAME = "savepoints.db";
     public static final String SAVEPOINTS_TABLE_NAME = "savepoints";

--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/FormDatabaseMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/FormDatabaseMigrator.java
@@ -383,6 +383,28 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
                 + DELETED_DATE + " integer);");
     }
 
+    public void createFormsTableV12(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS " + FORMS_TABLE_NAME + " ("
+                + _ID + " integer primary key, "
+                + DISPLAY_NAME + " text not null, "
+                + DESCRIPTION + " text, "
+                + JR_FORM_ID + " text not null, "
+                + JR_VERSION + " text, "
+                + MD5_HASH + " text not null UNIQUE ON CONFLICT IGNORE, "
+                + DATE + " integer not null, " // milliseconds
+                + FORM_MEDIA_PATH + " text not null, "
+                + FORM_FILE_PATH + " text not null, "
+                + LANGUAGE + " text, "
+                + SUBMISSION_URI + " text, "
+                + BASE64_RSA_PUBLIC_KEY + " text, "
+                + JRCACHE_FILE_PATH + " text not null, "
+                + AUTO_SEND + " text, "
+                + AUTO_DELETE + " text, "
+                + GEOMETRY_XPATH + " text, "
+                + DELETED_DATE + " integer, "
+                + LAST_DETECTED_ATTACHMENTS_UPDATE_DATE + " integer);"); // milliseconds
+    }
+
     private void createFormsTableV13(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE IF NOT EXISTS " + FORMS_TABLE_NAME + " ("
                 + _ID + " integer primary key autoincrement, "

--- a/collect_app/src/main/java/org/odk/collect/android/database/instances/InstanceDatabaseMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/instances/InstanceDatabaseMigrator.java
@@ -36,8 +36,7 @@ public class InstanceDatabaseMigrator implements DatabaseMigrator {
     public static final String[] CURRENT_VERSION_COLUMN_NAMES = COLUMN_NAMES_V6;
 
     public void onCreate(SQLiteDatabase db) {
-        createInstancesTableV5(db, INSTANCES_TABLE_NAME);
-        upgradeToVersion6(db, INSTANCES_TABLE_NAME);
+        createInstancesTableV7(db);
     }
 
     @SuppressWarnings({"checkstyle:FallThrough"})
@@ -56,19 +55,19 @@ public class InstanceDatabaseMigrator implements DatabaseMigrator {
                 upgradeToVersion6(db, INSTANCES_TABLE_NAME);
                 break;
             case 6:
+                upgradeToVersion7(db);
+                break;
+            case 7:
                 // Remember to bump the database version number in {@link org.odk.collect.android.database.DatabaseConstants}
-                // upgradeToVersion7(db);
+                // upgradeToVersion8(db);
             default:
                 Timber.i("Unknown version %d", oldVersion);
         }
     }
 
     public void onDowngrade(SQLiteDatabase db) {
-        String temporaryTableName = INSTANCES_TABLE_NAME + "_tmp";
-        createInstancesTableV5(db, temporaryTableName);
-        upgradeToVersion6(db, temporaryTableName);
-
-        dropObsoleteColumns(db, CURRENT_VERSION_COLUMN_NAMES, temporaryTableName);
+        SQLiteUtils.dropTable(db, INSTANCES_TABLE_NAME);
+        createInstancesTableV7(db);
     }
 
     private void upgradeToVersion2(SQLiteDatabase db) {
@@ -137,6 +136,14 @@ public class InstanceDatabaseMigrator implements DatabaseMigrator {
         SQLiteUtils.addColumn(db, name, GEOMETRY_TYPE, "text");
     }
 
+    private void upgradeToVersion7(SQLiteDatabase db) {
+        String temporaryTable = INSTANCES_TABLE_NAME + "_tmp";
+        SQLiteUtils.renameTable(db, INSTANCES_TABLE_NAME, temporaryTable);
+        createInstancesTableV7(db);
+        SQLiteUtils.copyRows(db, temporaryTable, CURRENT_VERSION_COLUMN_NAMES, INSTANCES_TABLE_NAME);
+        SQLiteUtils.dropTable(db, temporaryTable);
+    }
+
     private void createInstancesTableV5(SQLiteDatabase db, String name) {
         db.execSQL("CREATE TABLE IF NOT EXISTS " + name + " ("
                 + _ID + " integer primary key, "
@@ -149,5 +156,21 @@ public class InstanceDatabaseMigrator implements DatabaseMigrator {
                 + STATUS + " text not null, "
                 + LAST_STATUS_CHANGE_DATE + " date not null, "
                 + DELETED_DATE + " date );");
+    }
+
+    private void createInstancesTableV7(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS " + INSTANCES_TABLE_NAME + " ("
+                + _ID + " integer primary key autoincrement, "
+                + DISPLAY_NAME + " text not null, "
+                + SUBMISSION_URI + " text, "
+                + CAN_EDIT_WHEN_COMPLETE + " text, "
+                + INSTANCE_FILE_PATH + " text not null, "
+                + JR_FORM_ID + " text not null, "
+                + JR_VERSION + " text, "
+                + STATUS + " text not null, "
+                + LAST_STATUS_CHANGE_DATE + " date not null, "
+                + DELETED_DATE + " date, "
+                + GEOMETRY + " text, "
+                + GEOMETRY_TYPE + " text);");
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/database/instances/InstanceDatabaseMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/instances/InstanceDatabaseMigrator.java
@@ -158,6 +158,22 @@ public class InstanceDatabaseMigrator implements DatabaseMigrator {
                 + DELETED_DATE + " date );");
     }
 
+    public void createInstancesTableV6(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS " + INSTANCES_TABLE_NAME + " ("
+                + _ID + " integer primary key, "
+                + DISPLAY_NAME + " text not null, "
+                + SUBMISSION_URI + " text, "
+                + CAN_EDIT_WHEN_COMPLETE + " text, "
+                + INSTANCE_FILE_PATH + " text not null, "
+                + JR_FORM_ID + " text not null, "
+                + JR_VERSION + " text, "
+                + STATUS + " text not null, "
+                + LAST_STATUS_CHANGE_DATE + " date not null, "
+                + DELETED_DATE + " date, "
+                + GEOMETRY + " text, "
+                + GEOMETRY_TYPE + " text);");
+    }
+
     private void createInstancesTableV7(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE IF NOT EXISTS " + INSTANCES_TABLE_NAME + " ("
                 + _ID + " integer primary key autoincrement, "

--- a/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
@@ -53,13 +53,50 @@ public class FormDatabaseMigratorTest {
 
     @Before
     public void setup() {
-        assertThat("Test expects different Forms DB version", DatabaseConstants.FORMS_DATABASE_VERSION, is(12));
+        assertThat("Test expects different Forms DB version", DatabaseConstants.FORMS_DATABASE_VERSION, is(13));
         database = SQLiteDatabase.create(null);
     }
 
     @After
     public void teardown() {
         database.close();
+    }
+
+    @Test
+    public void onUpgrade_fromVersion12() {
+        int oldVersion = 12;
+        database.setVersion(oldVersion);
+        FormDatabaseMigrator formDatabaseMigrator = new FormDatabaseMigrator();
+
+        formDatabaseMigrator.createFormsTableV12(database);
+        ContentValues contentValues = createVersion12Form();
+        database.insert(FORMS_TABLE_NAME, null, contentValues);
+
+        formDatabaseMigrator.onUpgrade(database, oldVersion);
+
+        try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
+            assertThat(cursor.getColumnCount(), is(18));
+            assertThat(cursor.getCount(), is(1));
+
+            cursor.moveToFirst();
+            assertThat(cursor.getString(cursor.getColumnIndex(DISPLAY_NAME)), is(contentValues.getAsString(DISPLAY_NAME)));
+            assertThat(cursor.getString(cursor.getColumnIndex(DESCRIPTION)), is(contentValues.getAsString(DESCRIPTION)));
+            assertThat(cursor.getString(cursor.getColumnIndex(JR_FORM_ID)), is(contentValues.getAsString(JR_FORM_ID)));
+            assertThat(cursor.getString(cursor.getColumnIndex(JR_VERSION)), is(contentValues.getAsString(JR_VERSION)));
+            assertThat(cursor.getString(cursor.getColumnIndex(MD5_HASH)), is(contentValues.getAsString(MD5_HASH)));
+            assertThat(cursor.getInt(cursor.getColumnIndex(DATE)), is(contentValues.getAsInteger(DATE)));
+            assertThat(cursor.getString(cursor.getColumnIndex(FORM_MEDIA_PATH)), is(contentValues.getAsString(FORM_MEDIA_PATH)));
+            assertThat(cursor.getString(cursor.getColumnIndex(FORM_FILE_PATH)), is(contentValues.getAsString(FORM_FILE_PATH)));
+            assertThat(cursor.getString(cursor.getColumnIndex(LANGUAGE)), is(contentValues.getAsString(LANGUAGE)));
+            assertThat(cursor.getString(cursor.getColumnIndex(SUBMISSION_URI)), is(contentValues.getAsString(SUBMISSION_URI)));
+            assertThat(cursor.getString(cursor.getColumnIndex(BASE64_RSA_PUBLIC_KEY)), is(contentValues.getAsString(BASE64_RSA_PUBLIC_KEY)));
+            assertThat(cursor.getString(cursor.getColumnIndex(JRCACHE_FILE_PATH)), is(contentValues.getAsString(JRCACHE_FILE_PATH)));
+            assertThat(cursor.getString(cursor.getColumnIndex(AUTO_SEND)), is(contentValues.getAsString(AUTO_SEND)));
+            assertThat(cursor.getString(cursor.getColumnIndex(AUTO_DELETE)), is(contentValues.getAsString(AUTO_DELETE)));
+            assertThat(cursor.getString(cursor.getColumnIndex(GEOMETRY_XPATH)), is(contentValues.getAsString(GEOMETRY_XPATH)));
+            assertThat(cursor.getInt(cursor.getColumnIndex(DELETED_DATE)), is(contentValues.getAsInteger(DELETED_DATE)));
+            assertThat(cursor.getInt(cursor.getColumnIndex(LAST_DETECTED_ATTACHMENTS_UPDATE_DATE)), is(contentValues.getAsInteger(LAST_DETECTED_ATTACHMENTS_UPDATE_DATE)));
+        }
     }
 
     @Test
@@ -402,6 +439,28 @@ public class FormDatabaseMigratorTest {
         contentValues.put(AUTO_DELETE, "AutoDelete");
         contentValues.put(GEOMETRY_XPATH, "GeometryXPath");
         contentValues.put(DELETED_DATE, 0);
+        return contentValues;
+    }
+
+    private ContentValues createVersion12Form() {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(DISPLAY_NAME, "DisplayName");
+        contentValues.put(DESCRIPTION, "Description");
+        contentValues.put(JR_FORM_ID, "FormId");
+        contentValues.put(JR_VERSION, "FormVersion");
+        contentValues.put(MD5_HASH, "Md5Hash");
+        contentValues.put(DATE, 0);
+        contentValues.put(FORM_MEDIA_PATH, "Form/Media/Path");
+        contentValues.put(FORM_FILE_PATH, "Form/File/Path");
+        contentValues.put(LANGUAGE, "Language");
+        contentValues.put(SUBMISSION_URI, "submission.uri");
+        contentValues.put(BASE64_RSA_PUBLIC_KEY, "Base64RsaPublicKey");
+        contentValues.put(JRCACHE_FILE_PATH, "Jr/Cache/File/Path");
+        contentValues.put(AUTO_SEND, "AutoSend");
+        contentValues.put(AUTO_DELETE, "AutoDelete");
+        contentValues.put(GEOMETRY_XPATH, "GeometryXPath");
+        contentValues.put(DELETED_DATE, 0);
+        contentValues.put(LAST_DETECTED_ATTACHMENTS_UPDATE_DATE, 0);
         return contentValues;
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/database/InstanceDatabaseMigratorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/database/InstanceDatabaseMigratorTest.kt
@@ -1,0 +1,80 @@
+package org.odk.collect.android.database
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.CAN_EDIT_WHEN_COMPLETE
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.DELETED_DATE
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.DISPLAY_NAME
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.GEOMETRY
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.GEOMETRY_TYPE
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.INSTANCE_FILE_PATH
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.JR_FORM_ID
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.JR_VERSION
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.LAST_STATUS_CHANGE_DATE
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.STATUS
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns.SUBMISSION_URI
+import org.odk.collect.android.database.instances.InstanceDatabaseMigrator
+
+@RunWith(AndroidJUnit4::class)
+class InstanceDatabaseMigratorTest {
+
+    private var database = SQLiteDatabase.create(null)
+    private var instancesDatabaseMigrator = InstanceDatabaseMigrator()
+
+    @Before
+    fun setup() {
+        assertThat("Test expects different Instances DB version", DatabaseConstants.INSTANCES_DATABASE_VERSION, equalTo(7))
+    }
+
+    @Test
+    fun onUpgrade_fromVersion12() {
+        val oldVersion = 6
+        database.version = oldVersion
+        instancesDatabaseMigrator.createInstancesTableV6(database)
+
+        val contentValues = createInstanceV6()
+
+        database.insert(DatabaseConstants.INSTANCES_TABLE_NAME, null, contentValues)
+        instancesDatabaseMigrator.onUpgrade(database, oldVersion)
+        database.rawQuery("SELECT * FROM " + DatabaseConstants.INSTANCES_TABLE_NAME + ";", arrayOf<String>()).use { cursor ->
+            assertThat(cursor.columnCount, equalTo(12))
+            assertThat(cursor.count, equalTo(1))
+
+            cursor.moveToFirst()
+
+            assertThat(cursor.getString(cursor.getColumnIndex(DISPLAY_NAME)), equalTo(contentValues.getAsString(DISPLAY_NAME)))
+            assertThat(cursor.getString(cursor.getColumnIndex(SUBMISSION_URI)), equalTo(contentValues.getAsString(SUBMISSION_URI)))
+            assertThat(cursor.getString(cursor.getColumnIndex(CAN_EDIT_WHEN_COMPLETE)), equalTo(contentValues.getAsString(CAN_EDIT_WHEN_COMPLETE)))
+            assertThat(cursor.getString(cursor.getColumnIndex(INSTANCE_FILE_PATH)), equalTo(contentValues.getAsString(INSTANCE_FILE_PATH)))
+            assertThat(cursor.getString(cursor.getColumnIndex(JR_FORM_ID)), equalTo(contentValues.getAsString(JR_FORM_ID)))
+            assertThat(cursor.getString(cursor.getColumnIndex(JR_VERSION)), equalTo(contentValues.getAsString(JR_VERSION)))
+            assertThat(cursor.getString(cursor.getColumnIndex(STATUS)), equalTo(contentValues.getAsString(STATUS)))
+            assertThat(cursor.getInt(cursor.getColumnIndex(LAST_STATUS_CHANGE_DATE)), equalTo(contentValues.getAsInteger(LAST_STATUS_CHANGE_DATE)))
+            assertThat(cursor.getInt(cursor.getColumnIndex(DELETED_DATE)), equalTo(contentValues.getAsInteger(DELETED_DATE)))
+            assertThat(cursor.getString(cursor.getColumnIndex(GEOMETRY)), equalTo(contentValues.getAsString(GEOMETRY)))
+            assertThat(cursor.getString(cursor.getColumnIndex(GEOMETRY_TYPE)), equalTo(contentValues.getAsString(GEOMETRY_TYPE)))
+        }
+    }
+
+    private fun createInstanceV6(): ContentValues {
+        return ContentValues().apply {
+            put(DISPLAY_NAME, "DisplayName")
+            put(SUBMISSION_URI, "SubmissionUri")
+            put(CAN_EDIT_WHEN_COMPLETE, "True")
+            put(INSTANCE_FILE_PATH, "InstanceFilePath")
+            put(JR_FORM_ID, "JrFormId")
+            put(JR_VERSION, "JrVersion")
+            put(STATUS, "Status")
+            put(LAST_STATUS_CHANGE_DATE, 0)
+            put(DELETED_DATE, 0)
+            put(GEOMETRY, "Geometry")
+            put(GEOMETRY_TYPE, "GeometryType")
+        }
+    }
+}


### PR DESCRIPTION
Closes #6038 

#### Why is this the best possible solution? Were any other approaches considered?
The problem here is that the `savepoints` db uses db ids from the `forms` db and the `savepoints` db to refer to the forms they belong to. If we download a form (let's say it's our first form) in sqlite its db id will be 1. Once we create a savepoint for this form it will be keeping that value (1) as a reference in the database. However, sqlite works in the way that it can reuse ids that are no longer used, so if we remove such a form and redownload it (or download any other form) it will be saved into the forms database with 1 as a db id. As a result after opening the new form, the old savepoints will be found and loaded.
I thought that maybe we would need to rework the `savepoints` db but it would require a lot of work (and would not be perfect too). ~~Instead, I think a better solution is to do what we already do for saved forms (comparing the time of the last modification of a savepoint and a form) https://github.com/getodk/collect/pull/6049/files#diff-8ec04b331c791ac6110c2bb601e45c92aafffcc7e7eedfd7b43b78bd9af3c34fL40 so I've added a similar check for blank forms here https://github.com/getodk/collect/pull/6049/files#diff-8ec04b331c791ac6110c2bb601e45c92aafffcc7e7eedfd7b43b78bd9af3c34fR29~~

~~Another solution (than editing `SavepointUseCases.findValidSavepoint()`) would be to remove savepoints when forms they refer to are being removed but that would require handling this in a few different places (or adding `SavepointsRepository` as a dependency to `FormsRepository`) what I don't like so doing that in `SavepointUseCases.findValidSavepoint()` seems to be better.~~

After discussing potential solutions with @seadowg we have decided that changing the way our databases work (avoiding resuing db ids) is the best solution here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As described in the issue, savepoints that were created before downloading a form should not be loaded even if they were created for exactly the same form (it's a scenario when we remove and download again the same form, not a different one as described in the issue). The fix contains changes in the databases (forms and instances dbs) which has always been tricky so please test upgrading the app from v2023.1.3 to make sure those dbs work well.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
