### PR TITLE
Fixed icon colors used in AudioVideoImageTextLabel

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioButton.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioButton.java
@@ -15,7 +15,6 @@
 package org.odk.collect.android.audio;
 
 import android.content.Context;
-import android.content.res.ColorStateList;
 import android.util.AttributeSet;
 import android.view.View;
 
@@ -31,8 +30,6 @@ public class AudioButton extends MultiClickSafeMaterialButton implements View.On
     private Listener listener;
 
     private Boolean playing = false;
-    private Integer playingColor;
-    private Integer idleColor;
 
     public AudioButton(Context context) {
         super(context, null);
@@ -46,12 +43,6 @@ public class AudioButton extends MultiClickSafeMaterialButton implements View.On
 
     public Boolean isPlaying() {
         return playing;
-    }
-
-    public void setColors(Integer idleColor, Integer playingColor) {
-        this.idleColor = idleColor;
-        this.playingColor = playingColor;
-        render();
     }
 
     public void setPlaying(Boolean isPlaying) {
@@ -80,16 +71,8 @@ public class AudioButton extends MultiClickSafeMaterialButton implements View.On
     private void render() {
         if (playing) {
             setIconResource(R.drawable.ic_stop_black_24dp);
-
-            if (playingColor != null) {
-                setIconTint(ColorStateList.valueOf(playingColor));
-            }
         } else {
             setIconResource(R.drawable.ic_volume_up_black_24dp);
-
-            if (idleColor != null) {
-                setIconTint(ColorStateList.valueOf(idleColor));
-            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -38,7 +38,6 @@ import org.odk.collect.android.listeners.SelectItemClickListener;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.ScreenContext;
-import org.odk.collect.android.utilities.ThemeUtils;
 import org.odk.collect.audioclips.Clip;
 import org.odk.collect.imageloader.ImageLoader;
 
@@ -133,7 +132,6 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
 
     public void setPlayTextColor(int textColor) {
         playTextColor = textColor;
-        binding.audioButton.setColors(new ThemeUtils(getContext()).getColorOnSurface(), playTextColor);
     }
 
     public void setMediaUtils(MediaUtils mediaUtils) {


### PR DESCRIPTION
Closes #6048 

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that we tried to set the color of the audio button programmatically using `colorOnSurface`. It was a wrong color obviously but it looks like we don't need to set it at all. It works well as the audio button uses the proper style.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This can only affect the way the audio button looks like. Please make sure it has the proper color no matter if the audio is playing or not.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue is ok.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
