### PR TITLE
Fixed creating savepoints for saved forms that were started from a blank form (not the list of already saved forms)

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -225,7 +225,7 @@ class SavePointTest {
         rule.fillNewForm("two-question-audit.xml", "Two Question")
     }
 
-    @Test
+    @Test // https://github.com/getodk/collect/pull/6058
     fun whenBlankFormStartedThenSavedAndKilled_aSavepointShouldBeCreatedForASavedFormNotForTheBlankOne() {
         // Start blank form, save it and create a savepoint
         rule.setUpProjectAndCopyForm("two-question.xml")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -225,6 +225,28 @@ class SavePointTest {
         rule.fillNewForm("two-question-audit.xml", "Two Question")
     }
 
+    @Test
+    fun whenBlankFormStartedThenSavedAndKilled_aSavepointShouldBeCreatedForASavedFormNotForTheBlankOne() {
+        // Start blank form, save it and create a savepoint
+        rule.setUpProjectAndCopyForm("two-question.xml")
+            .fillNewForm("two-question.xml", "Two Question")
+            .answerQuestion("What is your name?", "Alexei")
+            .clickSave()
+            .swipeToNextQuestion("What is your age?")
+            .answerQuestion("What is your age?", "46")
+            .killApp()
+
+        // Start blank form and check save point is not loaded
+        rule.fillNewForm("two-question.xml", "Two Question")
+            .pressBackAndDiscardForm(AppClosedPage())
+
+        // Edit saved form and check save point is loaded
+        rule.editFormWithSavepoint("two-question.xml")
+            .clickRecover(FormHierarchyPage("Two Question"))
+            .assertText("Alexei")
+            .assertText("46")
+    }
+
     /**
      * Simulates a case where the process is killed without lifecycle clean up (like a phone
      * being battery dying).

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -1570,6 +1570,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                     showShortToast(this, org.odk.collect.strings.R.string.data_saved_ok);
                 }
 
+                formSessionRepository.update(sessionId, formSaveViewModel.getInstance());
                 formSaveViewModel.resumeFormEntry();
                 break;
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
@@ -19,6 +19,8 @@ interface FormSessionRepository {
     }
 
     fun set(id: String, formController: FormController, form: Form, instance: Instance?)
+
+    fun update(id: String, instance: Instance?)
 }
 
 class AppStateFormSessionRepository(application: Application) : FormSessionRepository {
@@ -35,6 +37,12 @@ class AppStateFormSessionRepository(application: Application) : FormSessionRepos
 
     override fun set(id: String, formController: FormController, form: Form, instance: Instance?) {
         getLiveData(id).value = FormSession(formController, form, instance)
+    }
+
+    override fun update(id: String, instance: Instance?) {
+        getLiveData(id).value?.let {
+            getLiveData(id).value = FormSession(it.formController, it.form, instance)
+        }
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSessionRepository.kt
@@ -40,8 +40,9 @@ class AppStateFormSessionRepository(application: Application) : FormSessionRepos
     }
 
     override fun update(id: String, instance: Instance?) {
-        getLiveData(id).value?.let {
-            getLiveData(id).value = FormSession(it.formController, it.form, instance)
+        val liveData = getLiveData(id)
+        liveData.value?.let {
+            liveData.value = it.copy(instance = instance)
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
@@ -25,6 +25,12 @@ class InMemFormSessionRepository : FormSessionRepository {
         getLiveData(id).value = FormSession(formController, form, instance)
     }
 
+    override fun update(id: String, instance: Instance?) {
+        getLiveData(id).value?.let {
+            getLiveData(id).value = FormSession(it.formController, it.form, instance)
+        }
+    }
+
     override fun clear(id: String) {
         getLiveData(id).value = null
         map.remove(id)

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/support/InMemFormSessionRepository.kt
@@ -26,8 +26,9 @@ class InMemFormSessionRepository : FormSessionRepository {
     }
 
     override fun update(id: String, instance: Instance?) {
-        getLiveData(id).value?.let {
-            getLiveData(id).value = FormSession(it.formController, it.form, instance)
+        val liveData = getLiveData(id)
+        liveData.value?.let {
+            liveData.value = it.copy(instance = instance)
         }
     }
 


### PR DESCRIPTION
Closes #6051

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that `FormSession` I used to get a form and an instance from in order to create a savepoint (https://github.com/getodk/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java#L747) was not updated. That means if it was a blank form the instance was always null even after saving such a form. It was only not null after editing such a saved form. As a result, savepoints were created for a blank form even after saving it because the instance object was null.
I don't see any reason why `FormSession` should not be updated once a form changes its state from a blank one to a saved one.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As I said in the issue once a blank form is saved by a user (by clicking the save icon and continuing filling it) it becomes a saved one and savepoints that are created during filling that form should not be loaded when we start a blank form again. This should just fix the issue and nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
