### PR TITLE
Fixed using navigation buttons in tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormNavigationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormNavigationTest.kt
@@ -15,7 +15,6 @@
  */
 package org.odk.collect.android.feature.formentry
 
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -99,7 +98,6 @@ class FormNavigationTest {
     }
 
     @Test
-    @Ignore("https://github.com/getodk/collect/issues/6044")
     fun whenNavigationSettingsChangeChangesShouldBeReflectedInFormFilling() {
         rule.startAtMainMenu()
             .copyForm("two-question.xml")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -198,16 +198,19 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public FormEntryPage clickForwardButton() {
+        closeSoftKeyboard();
         onView(withText(getTranslatedString(org.odk.collect.strings.R.string.form_forward))).perform(click());
         return this;
     }
 
     public FormEndPage clickForwardButtonToEndScreen() {
+        closeSoftKeyboard();
         onView(withText(getTranslatedString(org.odk.collect.strings.R.string.form_forward))).perform(click());
         return new FormEndPage(formName).assertOnPage();
     }
 
     public FormEntryPage clickBackwardButton() {
+        closeSoftKeyboard();
         onView(withText(getTranslatedString(org.odk.collect.strings.R.string.form_backward))).perform(click());
         return this;
     }


### PR DESCRIPTION
Closes #6044 

#### Why is this the best possible solution? Were any other approaches considered?
It looks like the issue here is caused by the keyboard. The form we use in that test has two questions (one text and one number question). When we navigate between them, the keyboard is automatically displayed but it changes its type (text to number and the other way around). Those two types of keyboards have different sizes and as a result, the navigation buttons that are displayed above the keyboard jump slightly. If that move takes place when in tests we try to click one of those buttons it can fail.

To test that it works well I've copied the test 50 times and run it on firebase.
 
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
