### PR TITLE
Disable maxWidth attribute in the bottom sheet

### DIFF
--- a/geo/src/main/res/layout/selection_map_layout.xml
+++ b/geo/src/main/res/layout/selection_map_layout.xml
@@ -103,6 +103,7 @@
         android:layout_height="match_parent"
         android:background="?colorSurface"
         app:behavior_hideable="true"
+        android:maxWidth="@null"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
         style="@style/Widget.Material3.BottomSheet"
         tools:visibility="gone" />


### PR DESCRIPTION
Closes #6066 

#### Why is this the best possible solution? Were any other approaches considered?
By default the max width of the bottom sheet was 640px. I think there is no way to disable that attribute other than setting its value to big enough to make the sheet full-width.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just make sure that the bottom sheet is full-width.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
