### PR TITLE
Migrate old savepoints

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/SavepointsImporter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/SavepointsImporter.kt
@@ -58,7 +58,8 @@ class SavepointsImporter(
                     match != null
                 }?.forEach { savepointFile ->
                     if (savepointFile.lastModified() > form.date) {
-                        savepointsRepository.save(Savepoint(form.dbId, null, savepointFile.absolutePath, File(instancesDir, "$formFileName/$formFileName.xml").absolutePath))
+                        val instanceFileName = savepointFile.name.substringBefore(".xml.save")
+                        savepointsRepository.save(Savepoint(form.dbId, null, savepointFile.absolutePath, File(instancesDir, "$instanceFileName/$instanceFileName.xml").absolutePath))
                     }
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/SavepointsImporter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/SavepointsImporter.kt
@@ -39,10 +39,9 @@ class SavepointsImporter(
             if (instance.deletedDate == null) {
                 val savepointFile = File(cacheDir, File(instance.instanceFilePath).name.plus(".save"))
                 if (savepointFile.exists() && savepointFile.lastModified() > instance.lastStatusChangeDate) {
-                    formsRepository.getAllByFormIdAndVersion(instance.formId, instance.formVersion).firstOrNull()?.let { form ->
-                        if (!form.isDeleted) {
-                            savepointsRepository.save(Savepoint(form.dbId, instance.dbId, savepointFile.absolutePath, instance.instanceFilePath))
-                        }
+                    val form = formsRepository.getAllByFormIdAndVersion(instance.formId, instance.formVersion).firstOrNull()
+                    if (form != null && !form.isDeleted) {
+                        savepointsRepository.save(Savepoint(form.dbId, instance.dbId, savepointFile.absolutePath, instance.instanceFilePath))
                     }
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/SavepointsImporter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/SavepointsImporter.kt
@@ -1,0 +1,75 @@
+package org.odk.collect.android.application.initialization
+
+import org.odk.collect.android.storage.StoragePathProvider
+import org.odk.collect.android.storage.StorageSubdirectory
+import org.odk.collect.android.utilities.FormsRepositoryProvider
+import org.odk.collect.android.utilities.InstancesRepositoryProvider
+import org.odk.collect.android.utilities.SavepointsRepositoryProvider
+import org.odk.collect.forms.FormsRepository
+import org.odk.collect.forms.instances.InstancesRepository
+import org.odk.collect.forms.savepoints.Savepoint
+import org.odk.collect.forms.savepoints.SavepointsRepository
+import org.odk.collect.projects.ProjectsRepository
+import org.odk.collect.settings.keys.MetaKeys
+import org.odk.collect.upgrade.Upgrade
+import java.io.File
+
+class SavepointsImporter(
+    private val projectsRepository: ProjectsRepository,
+    private val instancesRepositoryProvider: InstancesRepositoryProvider,
+    private val formsRepositoryProvider: FormsRepositoryProvider,
+    private val savepointsRepositoryProvider: SavepointsRepositoryProvider,
+    private val storagePathProvider: StoragePathProvider
+) : Upgrade {
+    override fun key(): String {
+        return MetaKeys.OLD_SAVEPOINTS_IMPORTED
+    }
+
+    override fun run() {
+        projectsRepository.getAll().forEach { project ->
+            val instancesRepository = instancesRepositoryProvider.get(project.uuid)
+            val formsRepository = formsRepositoryProvider.get(project.uuid)
+            val savepointsRepository = savepointsRepositoryProvider.get(project.uuid)
+            val cacheDir = File(storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE, project.uuid))
+            val instancesDir = File(storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid))
+
+            importSavepointsThatBelongToSavedForms(instancesRepository, formsRepository, savepointsRepository, cacheDir)
+
+            importSavepointsThatBelongToBlankForms(formsRepository, savepointsRepository, cacheDir, instancesDir)
+        }
+    }
+
+    private fun importSavepointsThatBelongToSavedForms(instancesRepository: InstancesRepository, formsRepository: FormsRepository, savepointsRepository: SavepointsRepository, cacheDir: File) {
+        instancesRepository.all.forEach { instance ->
+            if (instance.deletedDate == null) {
+                val savepointFile = File(cacheDir, File(instance.instanceFilePath).name.plus(".save"))
+                if (savepointFile.exists() && savepointFile.lastModified() > instance.lastStatusChangeDate) {
+                    formsRepository.getAllByFormIdAndVersion(instance.formId, instance.formVersion).firstOrNull()?.let { form ->
+                        if (!form.isDeleted) {
+                            savepointsRepository.save(Savepoint(form.dbId, instance.dbId, savepointFile.absolutePath, instance.instanceFilePath))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun importSavepointsThatBelongToBlankForms(formsRepository: FormsRepository, savepointsRepository: SavepointsRepository, cacheDir: File, instancesDir: File) {
+        formsRepository.all.sortedByDescending { form -> form.date }.forEach { form ->
+            if (!form.isDeleted) {
+                val formFileName = File(form.formFilePath).name.substringBeforeLast(".xml")
+
+                cacheDir.listFiles { file ->
+                    file.name.startsWith("${formFileName}_") && file.name.endsWith(".xml.save")
+                }?.forEach { savepointFile ->
+                    if (savepointFile.lastModified() > form.date) {
+                        val alreadyUsed = savepointsRepository.getAll().any { savepoint -> savepoint.savepointFilePath == savepointFile.absolutePath }
+                        if (!alreadyUsed) {
+                            savepointsRepository.save(Savepoint(form.dbId, null, savepointFile.absolutePath, File(instancesDir, "$formFileName/$formFileName.xml").absolutePath))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/upgrade/UpgradeInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/upgrade/UpgradeInitializer.kt
@@ -6,6 +6,7 @@ import org.odk.collect.android.application.initialization.ExistingProjectMigrato
 import org.odk.collect.android.application.initialization.ExistingSettingsMigrator
 import org.odk.collect.android.application.initialization.FormUpdatesUpgrade
 import org.odk.collect.android.application.initialization.GoogleDriveProjectsDeleter
+import org.odk.collect.android.application.initialization.SavepointsImporter
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.MetaKeys
 import org.odk.collect.upgrade.AppUpgrader
@@ -16,7 +17,8 @@ class UpgradeInitializer(
     private val existingProjectMigrator: ExistingProjectMigrator,
     private val existingSettingsMigrator: ExistingSettingsMigrator,
     private val formUpdatesUpgrade: FormUpdatesUpgrade,
-    private val googleDriveProjectsDeleter: GoogleDriveProjectsDeleter
+    private val googleDriveProjectsDeleter: GoogleDriveProjectsDeleter,
+    private val savepointsImporter: SavepointsImporter
 ) {
 
     fun initialize() {
@@ -29,7 +31,8 @@ class UpgradeInitializer(
                 existingProjectMigrator,
                 existingSettingsMigrator,
                 formUpdatesUpgrade,
-                googleDriveProjectsDeleter
+                googleDriveProjectsDeleter,
+                savepointsImporter
             )
         ).upgradeIfNeeded()
     }

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseObjectMapper.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseObjectMapper.kt
@@ -31,6 +31,7 @@ object DatabaseObjectMapper {
         values.put(DatabaseFormColumns.FORM_MEDIA_PATH, formMediaPath)
         values.put(DatabaseFormColumns.LANGUAGE, form.language)
         values.put(DatabaseFormColumns.AUTO_SEND, form.autoSend)
+        values.put(DatabaseFormColumns.DATE, form.date)
         values.put(DatabaseFormColumns.AUTO_DELETE, form.autoDelete)
         values.put(DatabaseFormColumns.GEOMETRY_XPATH, form.geometryXpath)
         values.put(DatabaseFormColumns.LAST_DETECTED_ATTACHMENTS_UPDATE_DATE, form.lastDetectedAttachmentsUpdateDate)

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -63,6 +63,7 @@ import org.odk.collect.android.preferences.screens.ProjectPreferencesFragment;
 import org.odk.collect.android.preferences.screens.ServerPreferencesFragment;
 import org.odk.collect.android.preferences.screens.UserInterfacePreferencesFragment;
 import org.odk.collect.android.projects.ManualProjectCreatorDialog;
+import org.odk.collect.android.projects.ProjectDependencyProviderFactory;
 import org.odk.collect.android.projects.ProjectResetter;
 import org.odk.collect.android.projects.ProjectSettingsDialog;
 import org.odk.collect.android.projects.ProjectsDataService;
@@ -307,4 +308,6 @@ public interface AppDependencyComponent {
     EntitiesRepositoryProvider entitiesRepositoryProvider();
 
     FormsDataService formsDataService();
+
+    ProjectDependencyProviderFactory projectDependencyProviderFactory();
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -32,6 +32,7 @@ import org.odk.collect.android.application.initialization.ExistingSettingsMigrat
 import org.odk.collect.android.application.initialization.FormUpdatesUpgrade;
 import org.odk.collect.android.application.initialization.GoogleDriveProjectsDeleter;
 import org.odk.collect.android.application.initialization.MapsInitializer;
+import org.odk.collect.android.application.initialization.SavepointsImporter;
 import org.odk.collect.android.application.initialization.upgrade.UpgradeInitializer;
 import org.odk.collect.android.backgroundwork.FormUpdateAndInstanceSubmitScheduler;
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler;
@@ -535,14 +536,20 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public UpgradeInitializer providesUpgradeInitializer(Context context, SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator, ExistingSettingsMigrator existingSettingsMigrator, FormUpdatesUpgrade formUpdatesUpgrade, GoogleDriveProjectsDeleter googleDriveProjectsDeleter) {
+    public SavepointsImporter providesSavepointsMigrator(ProjectsRepository projectsRepository, InstancesRepositoryProvider instancesRepositoryProvider, FormsRepositoryProvider formsRepositoryProvider, SavepointsRepositoryProvider savepointsRepositoryProvider, StoragePathProvider storagePathProvider) {
+        return new SavepointsImporter(projectsRepository, instancesRepositoryProvider, formsRepositoryProvider, savepointsRepositoryProvider, storagePathProvider);
+    }
+
+    @Provides
+    public UpgradeInitializer providesUpgradeInitializer(Context context, SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator, ExistingSettingsMigrator existingSettingsMigrator, FormUpdatesUpgrade formUpdatesUpgrade, GoogleDriveProjectsDeleter googleDriveProjectsDeleter, SavepointsImporter savepointsImporter) {
         return new UpgradeInitializer(
                 context,
                 settingsProvider,
                 existingProjectMigrator,
                 existingSettingsMigrator,
                 formUpdatesUpgrade,
-                googleDriveProjectsDeleter
+                googleDriveProjectsDeleter,
+                savepointsImporter
         );
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -536,12 +536,7 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public SavepointsImporter providesSavepointsMigrator(ProjectsRepository projectsRepository, ProjectDependencyProviderFactory projectDependencyProviderFactory) {
-        return new SavepointsImporter(projectsRepository, projectDependencyProviderFactory);
-    }
-
-    @Provides
-    public UpgradeInitializer providesUpgradeInitializer(Context context, SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator, ExistingSettingsMigrator existingSettingsMigrator, FormUpdatesUpgrade formUpdatesUpgrade, GoogleDriveProjectsDeleter googleDriveProjectsDeleter, SavepointsImporter savepointsImporter) {
+    public UpgradeInitializer providesUpgradeInitializer(Context context, SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator, ExistingSettingsMigrator existingSettingsMigrator, FormUpdatesUpgrade formUpdatesUpgrade, GoogleDriveProjectsDeleter googleDriveProjectsDeleter, ProjectsRepository projectsRepository, ProjectDependencyProviderFactory projectDependencyProviderFactory) {
         return new UpgradeInitializer(
                 context,
                 settingsProvider,
@@ -549,7 +544,7 @@ public class AppDependencyModule {
                 existingSettingsMigrator,
                 formUpdatesUpgrade,
                 googleDriveProjectsDeleter,
-                savepointsImporter
+                new SavepointsImporter(projectsRepository, projectDependencyProviderFactory)
         );
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -536,8 +536,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public SavepointsImporter providesSavepointsMigrator(ProjectsRepository projectsRepository, InstancesRepositoryProvider instancesRepositoryProvider, FormsRepositoryProvider formsRepositoryProvider, SavepointsRepositoryProvider savepointsRepositoryProvider, StoragePathProvider storagePathProvider) {
-        return new SavepointsImporter(projectsRepository, instancesRepositoryProvider, formsRepositoryProvider, savepointsRepositoryProvider, storagePathProvider);
+    public SavepointsImporter providesSavepointsMigrator(ProjectsRepository projectsRepository, ProjectDependencyProviderFactory projectDependencyProviderFactory) {
+        return new SavepointsImporter(projectsRepository, projectDependencyProviderFactory);
     }
 
     @Provides

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
@@ -53,7 +53,7 @@ class SavepointsImporterTest {
         createBlankForm(project, "sampleForm", "1", date = System.currentTimeMillis() + TimeInMs.ONE_HOUR)
 
         // create savepoints
-        createSavepointFile(project, "sampleForm_${System.currentTimeMillis()}.xml")
+        createSavepointFile(project, "sampleForm_2024-04-10_01-35-41.xml.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -69,7 +69,7 @@ class SavepointsImporterTest {
         createBlankForm(project, "sampleForm", "1", deleted = true)
 
         // create savepoints
-        createSavepointFile(project, "sampleForm_${System.currentTimeMillis()}.xml")
+        createSavepointFile(project, "sampleForm_2024-04-10_01-35-41.xml.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -89,8 +89,8 @@ class SavepointsImporterTest {
         val blankForm2 = createBlankForm(project, form2Name, "2")
 
         // create savepoints
-        val savepointFile1 = createSavepointFile(project, "${form1Name}_${System.currentTimeMillis()}.xml")
-        val savepointFile2 = createSavepointFile(project, "${form2Name}_${System.currentTimeMillis()}.xml")
+        val savepointFile1 = createSavepointFile(project, "${form1Name}_2024-04-10_01-35-41.xml.save")
+        val savepointFile2 = createSavepointFile(project, "${form2Name}_2024-04-10_01-35-42.xml.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -114,8 +114,8 @@ class SavepointsImporterTest {
         val blankForm2 = createBlankForm(project, form2Name, "1", "2", date = 2)
 
         // create savepoints
-        val savepointFile1 = createSavepointFile(project, "${form1Name}_${System.currentTimeMillis()}.xml")
-        val savepointFile2 = createSavepointFile(project, "${form2Name}_${System.currentTimeMillis()}.xml")
+        val savepointFile1 = createSavepointFile(project, "${form1Name}_2024-04-10_01-35-41.xml.save")
+        val savepointFile2 = createSavepointFile(project, "${form2Name}_2024-04-10_01-35-42.xml.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -126,7 +126,7 @@ class SavepointsImporterTest {
             Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form1Name/$form1Name.xml")
         val expectedSavepoint2 =
             Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form2Name/$form2Name.xml")
-        assertThat(savepoints, contains(expectedSavepoint2, expectedSavepoint1))
+        assertThat(savepoints, contains(expectedSavepoint1, expectedSavepoint2))
     }
 
     @Test
@@ -154,7 +154,7 @@ class SavepointsImporterTest {
         val savedForm = createSavedForm("sampleForm", form, lastStatusChangeDate = System.currentTimeMillis() + TimeInMs.ONE_HOUR)
 
         // create savepoints
-        createSavepointFile(project, File(savedForm.instanceFilePath).name)
+        createSavepointFile(project, "${File(savedForm.instanceFilePath).name}.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -173,7 +173,7 @@ class SavepointsImporterTest {
         val savedForm = createSavedForm("sampleForm", form)
 
         // create savepoints
-        createSavepointFile(project, File(savedForm.instanceFilePath).name)
+        createSavepointFile(project, "${File(savedForm.instanceFilePath).name}.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -189,7 +189,7 @@ class SavepointsImporterTest {
         val savedForm = createSavedForm("sampleForm", FormFixtures.form("1"))
 
         // create savepoints
-        createSavepointFile(project, File(savedForm.instanceFilePath).name)
+        createSavepointFile(project, "${File(savedForm.instanceFilePath).name}.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -208,7 +208,7 @@ class SavepointsImporterTest {
         val savedForm = createSavedForm("sampleForm", form, deletedDate = System.currentTimeMillis())
 
         // create savepoints
-        createSavepointFile(project, File(savedForm.instanceFilePath).name)
+        createSavepointFile(project, "${File(savedForm.instanceFilePath).name}.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -232,8 +232,8 @@ class SavepointsImporterTest {
         val savedForm2 = createSavedForm(form2Name, form2)
 
         // create savepoints
-        val savepointFile1 = createSavepointFile(project, File(savedForm1.instanceFilePath).name)
-        val savepointFile2 = createSavepointFile(project, File(savedForm2.instanceFilePath).name)
+        val savepointFile1 = createSavepointFile(project, "${File(savedForm1.instanceFilePath).name}.save")
+        val savepointFile2 = createSavepointFile(project, "${File(savedForm2.instanceFilePath).name}.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -257,9 +257,9 @@ class SavepointsImporterTest {
         return projectDependencyProvider.instancesRepository.save(InstanceFixtures.instance(displayName = formName, form = form, lastStatusChangeDate = lastStatusChangeDate, deletedDate = deletedDate))
     }
 
-    private fun createSavepointFile(project: Project.Saved, instanceName: String): File {
+    private fun createSavepointFile(project: Project.Saved, fileName: String): File {
         val cacheDir = File(projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE, project.uuid))
-        return File(cacheDir, "$instanceName.save").also {
+        return File(cacheDir, fileName).also {
             it.writeText(RandomString.randomString(10))
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
@@ -120,9 +120,9 @@ class SavepointsImporterTest {
         // verify import
         val savepoints = savepointsRepository.getAll()
         val expectedSavepoint1 =
-            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form1Name/$form1Name.xml")
+            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/${form1Name}_2024-04-10_01-35-41/${form1Name}_2024-04-10_01-35-41.xml")
         val expectedSavepoint2 =
-            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form2Name/$form2Name.xml")
+            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/${form2Name}_2024-04-10_01-35-42/${form2Name}_2024-04-10_01-35-42.xml")
         assertThat(savepoints, contains(expectedSavepoint1, expectedSavepoint2))
     }
 
@@ -145,9 +145,9 @@ class SavepointsImporterTest {
         // verify import
         val savepoints = savepointsRepository.getAll()
         val expectedSavepoint1 =
-            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form1Name/$form1Name.xml")
+            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/${form1Name}_2024-04-10_01-35-41/${form1Name}_2024-04-10_01-35-41.xml")
         val expectedSavepoint2 =
-            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form2Name/$form2Name.xml")
+            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/${form2Name}_2024-04-10_01-35-42/${form2Name}_2024-04-10_01-35-42.xml")
         assertThat(savepoints, contains(expectedSavepoint1, expectedSavepoint2))
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
@@ -53,7 +53,7 @@ class SavepointsImporterTest {
         createBlankForm(project, "sampleForm", "1", date = System.currentTimeMillis() + TimeInMs.ONE_HOUR)
 
         // create savepoints
-        createSavepointFile(project, "sampleForm_2024-04-10_01-35-41.xml.save")
+        createFileInCache(project, "sampleForm_2024-04-10_01-35-41.xml.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -69,7 +69,25 @@ class SavepointsImporterTest {
         createBlankForm(project, "sampleForm", "1", deleted = true)
 
         // create savepoints
-        createSavepointFile(project, "sampleForm_2024-04-10_01-35-41.xml.save")
+        createFileInCache(project, "sampleForm_2024-04-10_01-35-41.xml.save")
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifInCacheThereIsAFileThatLooksLikeASavepointForBlankFormButDoesNotContainTheCorrectSuffixThatIdentifiesSavepoints_nothingShouldBeImported() {
+        val formName = "sampleForm"
+
+        // create blank forms
+        createBlankForm(project, formName, "1", "1")
+
+        // create savepoints
+        createFileInCache(project, "${formName}_2024-04-10_01-35-41.xml")
 
         // trigger importing
         savepointsImporter.run()
@@ -89,8 +107,8 @@ class SavepointsImporterTest {
         val blankForm2 = createBlankForm(project, form2Name, "2")
 
         // create savepoints
-        val savepointFile1 = createSavepointFile(project, "${form1Name}_2024-04-10_01-35-41.xml.save")
-        val savepointFile2 = createSavepointFile(project, "${form2Name}_2024-04-10_01-35-42.xml.save")
+        val savepointFile1 = createFileInCache(project, "${form1Name}_2024-04-10_01-35-41.xml.save")
+        val savepointFile2 = createFileInCache(project, "${form2Name}_2024-04-10_01-35-42.xml.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -114,8 +132,8 @@ class SavepointsImporterTest {
         val blankForm2 = createBlankForm(project, form2Name, "1", "2", date = 2)
 
         // create savepoints
-        val savepointFile1 = createSavepointFile(project, "${form1Name}_2024-04-10_01-35-41.xml.save")
-        val savepointFile2 = createSavepointFile(project, "${form2Name}_2024-04-10_01-35-42.xml.save")
+        val savepointFile1 = createFileInCache(project, "${form1Name}_2024-04-10_01-35-41.xml.save")
+        val savepointFile2 = createFileInCache(project, "${form2Name}_2024-04-10_01-35-42.xml.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -154,7 +172,7 @@ class SavepointsImporterTest {
         val savedForm = createSavedForm("sampleForm", form, lastStatusChangeDate = System.currentTimeMillis() + TimeInMs.ONE_HOUR)
 
         // create savepoints
-        createSavepointFile(project, "${File(savedForm.instanceFilePath).name}.save")
+        createFileInCache(project, "${File(savedForm.instanceFilePath).name}.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -173,7 +191,7 @@ class SavepointsImporterTest {
         val savedForm = createSavedForm("sampleForm", form)
 
         // create savepoints
-        createSavepointFile(project, "${File(savedForm.instanceFilePath).name}.save")
+        createFileInCache(project, "${File(savedForm.instanceFilePath).name}.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -189,7 +207,7 @@ class SavepointsImporterTest {
         val savedForm = createSavedForm("sampleForm", FormFixtures.form("1"))
 
         // create savepoints
-        createSavepointFile(project, "${File(savedForm.instanceFilePath).name}.save")
+        createFileInCache(project, "${File(savedForm.instanceFilePath).name}.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -208,7 +226,28 @@ class SavepointsImporterTest {
         val savedForm = createSavedForm("sampleForm", form, deletedDate = System.currentTimeMillis())
 
         // create savepoints
-        createSavepointFile(project, "${File(savedForm.instanceFilePath).name}.save")
+        createFileInCache(project, "${File(savedForm.instanceFilePath).name}.save")
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifInCacheThereIsAFileThatLooksLikeASavepointForSavedFormButDoesNotContainTheCorrectSuffixThatIdentifiesSavepoints_nothingShouldBeImported() {
+        val formName = "sampleForm"
+
+        // create blank forms
+        val form = createBlankForm(project, formName, "1")
+
+        // create saved forms
+        val savedForm = createSavedForm(formName, form)
+
+        // create savepoints
+        createFileInCache(project, File(savedForm.instanceFilePath).name)
 
         // trigger importing
         savepointsImporter.run()
@@ -232,8 +271,8 @@ class SavepointsImporterTest {
         val savedForm2 = createSavedForm(form2Name, form2)
 
         // create savepoints
-        val savepointFile1 = createSavepointFile(project, "${File(savedForm1.instanceFilePath).name}.save")
-        val savepointFile2 = createSavepointFile(project, "${File(savedForm2.instanceFilePath).name}.save")
+        val savepointFile1 = createFileInCache(project, "${File(savedForm1.instanceFilePath).name}.save")
+        val savepointFile2 = createFileInCache(project, "${File(savedForm2.instanceFilePath).name}.save")
 
         // trigger importing
         savepointsImporter.run()
@@ -257,7 +296,7 @@ class SavepointsImporterTest {
         return projectDependencyProvider.instancesRepository.save(InstanceFixtures.instance(displayName = formName, form = form, lastStatusChangeDate = lastStatusChangeDate, deletedDate = deletedDate))
     }
 
-    private fun createSavepointFile(project: Project.Saved, fileName: String): File {
+    private fun createFileInCache(project: Project.Saved, fileName: String): File {
         val cacheDir = File(projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE, project.uuid))
         return File(cacheDir, fileName).also {
             it.writeText(RandomString.randomString(10))

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
@@ -33,6 +33,10 @@ class SavepointsImporterTest {
 
     private val project = projectsRepository.save(Project.DEMO_PROJECT)
     private val projectDependencyProvider = projectDependencyProviderFactory.create(project.uuid)
+    private val savepointsRepository = projectDependencyProvider.savepointsRepository
+    private val storagePathProvider = projectDependencyProvider.storagePathProvider
+    private val formsRepository = projectDependencyProvider.formsRepository
+    private val instancesRepository = projectDependencyProvider.instancesRepository
 
     @Test
     fun ifABlankFormHasNoSavepoint_nothingShouldBeImported() {
@@ -43,7 +47,7 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
@@ -59,7 +63,7 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
@@ -75,12 +79,12 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
     @Test
-    fun ifInCacheThereIsAFileThatLooksLikeASavepointForBlankFormButDoesNotContainTheCorrectSuffixThatIdentifiesSavepoints_nothingShouldBeImported() {
+    fun ifAFileForABlankFormExistsWithMatchingName_butIncorrectSuffix_nothingShouldBeImported() {
         val formName = "sampleForm"
 
         // create blank forms
@@ -93,7 +97,7 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
@@ -114,11 +118,11 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         val expectedSavepoint1 =
-            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form1Name/$form1Name.xml")
+            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form1Name/$form1Name.xml")
         val expectedSavepoint2 =
-            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form2Name/$form2Name.xml")
+            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form2Name/$form2Name.xml")
         assertThat(savepoints, contains(expectedSavepoint1, expectedSavepoint2))
     }
 
@@ -139,11 +143,11 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         val expectedSavepoint1 =
-            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form1Name/$form1Name.xml")
+            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form1Name/$form1Name.xml")
         val expectedSavepoint2 =
-            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form2Name/$form2Name.xml")
+            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form2Name/$form2Name.xml")
         assertThat(savepoints, contains(expectedSavepoint1, expectedSavepoint2))
     }
 
@@ -159,7 +163,7 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
@@ -178,7 +182,7 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
@@ -197,7 +201,7 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
@@ -213,7 +217,7 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
@@ -232,12 +236,12 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
     @Test
-    fun ifInCacheThereIsAFileThatLooksLikeASavepointForSavedFormButDoesNotContainTheCorrectSuffixThatIdentifiesSavepoints_nothingShouldBeImported() {
+    fun ifAFileForASavedFormExistsWithMatchingName_butIncorrectSuffix_nothingShouldBeImported() {
         val formName = "sampleForm"
 
         // create blank forms
@@ -253,7 +257,7 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         assertThat(savepoints.isEmpty(), equalTo(true))
     }
 
@@ -278,26 +282,26 @@ class SavepointsImporterTest {
         savepointsImporter.run()
 
         // verify import
-        val savepoints = projectDependencyProvider.savepointsRepository.getAll()
+        val savepoints = savepointsRepository.getAll()
         val expectedSavepoint1 = Savepoint(1, 1, savepointFile1.absolutePath, savedForm1.instanceFilePath)
         val expectedSavepoint2 = Savepoint(2, 2, savepointFile2.absolutePath, savedForm2.instanceFilePath)
         assertThat(savepoints, contains(expectedSavepoint1, expectedSavepoint2))
     }
 
     private fun createBlankForm(project: Project.Saved, formName: String, formId: String, formVersion: String = "1", date: Long = 0, deleted: Boolean = false): Form {
-        val formFile = File(projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS, project.uuid), "$formName.xml").also {
+        val formFile = File(storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS, project.uuid), "$formName.xml").also {
             it.writeText(RandomString.randomString(10))
         }
-        val blankForm = projectDependencyProvider.formsRepository.save(FormFixtures.form(formId, formVersion, formFile.absolutePath))
-        return projectDependencyProvider.formsRepository.save(Form.Builder(blankForm).date(date).deleted(deleted).build())
+        val blankForm = formsRepository.save(FormFixtures.form(formId, formVersion, formFile.absolutePath))
+        return formsRepository.save(Form.Builder(blankForm).date(date).deleted(deleted).build())
     }
 
     private fun createSavedForm(formName: String, form: Form, lastStatusChangeDate: Long = System.currentTimeMillis() - TimeInMs.ONE_HOUR, deletedDate: Long? = null): Instance {
-        return projectDependencyProvider.instancesRepository.save(InstanceFixtures.instance(displayName = formName, form = form, lastStatusChangeDate = lastStatusChangeDate, deletedDate = deletedDate))
+        return instancesRepository.save(InstanceFixtures.instance(displayName = formName, form = form, lastStatusChangeDate = lastStatusChangeDate, deletedDate = deletedDate))
     }
 
     private fun createFileInCache(project: Project.Saved, fileName: String): File {
-        val cacheDir = File(projectDependencyProvider.storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE, project.uuid))
+        val cacheDir = File(storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE, project.uuid))
         return File(cacheDir, fileName).also {
             it.writeText(RandomString.randomString(10))
         }

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
@@ -1,0 +1,268 @@
+package org.odk.collect.android.application.initialization
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.android.injection.DaggerUtils
+import org.odk.collect.android.storage.StorageSubdirectory
+import org.odk.collect.forms.Form
+import org.odk.collect.forms.instances.Instance
+import org.odk.collect.forms.savepoints.Savepoint
+import org.odk.collect.formstest.FormFixtures
+import org.odk.collect.formstest.InstanceFixtures
+import org.odk.collect.projects.Project
+import org.odk.collect.shared.TimeInMs
+import org.odk.collect.shared.strings.RandomString
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class SavepointsImporterTest {
+    private val component = DaggerUtils.getComponent(ApplicationProvider.getApplicationContext<Context>() as Application)
+
+    private val projectsRepository = component.projectsRepository()
+    private val instancesRepositoryProvider = component.instancesRepositoryProvider()
+    private val formsRepositoryProvider = component.formsRepositoryProvider()
+    private val savepointsRepositoryProvider = component.savepointsRepositoryProvider()
+    private val storagePathProvider = component.storagePathProvider()
+
+    private val savepointsImporter =
+        SavepointsImporter(projectsRepository, instancesRepositoryProvider, formsRepositoryProvider, savepointsRepositoryProvider, storagePathProvider)
+
+    private val project = projectsRepository.save(Project.DEMO_PROJECT)
+
+    @Test
+    fun ifABlankFormHasNoSavepoint_nothingShouldBeImported() {
+        // create blank forms
+        createBlankForm(project, "sampleForm", "1")
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifABlankFormHasASavepointCreatedEarlierThanTheForm_nothingShouldBeImported() {
+        // create blank forms
+        createBlankForm(project, "sampleForm", "1", date = System.currentTimeMillis() + TimeInMs.ONE_HOUR)
+
+        // create savepoints
+        createSavepointFile(project, "sampleForm_${System.currentTimeMillis()}.xml")
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifABlankFormHasASavepointButTheFormIsSoftDeleted_nothingShouldBeImported() {
+        // create blank forms
+        createBlankForm(project, "sampleForm", "1", deleted = true)
+
+        // create savepoints
+        createSavepointFile(project, "sampleForm_${System.currentTimeMillis()}.xml")
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifThereAreMultipleDifferentBlankFormsWithSavepoints_allSavepointsShouldBeImported() {
+        val form1Name = "sampleForm1"
+        val form2Name = "sampleForm2"
+
+        // create blank forms
+        val blankForm1 = createBlankForm(project, form1Name, "1")
+        val blankForm2 = createBlankForm(project, form2Name, "2")
+
+        // create savepoints
+        val savepointFile1 = createSavepointFile(project, "${form1Name}_${System.currentTimeMillis()}.xml")
+        val savepointFile2 = createSavepointFile(project, "${form2Name}_${System.currentTimeMillis()}.xml")
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        val expectedSavepoint1 =
+            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form1Name/$form1Name.xml")
+        val expectedSavepoint2 =
+            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form2Name/$form2Name.xml")
+        assertThat(savepoints, contains(expectedSavepoint1, expectedSavepoint2))
+    }
+
+    @Test
+    fun ifThereAreMultipleVersionsOfTheSameBlankFormWithSavepoints_allSavepointsShouldBeImported() {
+        val form1Name = "sampleForm"
+        val form2Name = "sampleForm_1"
+
+        // create blank forms
+        val blankForm1 = createBlankForm(project, form1Name, "1", "1", date = 1)
+        val blankForm2 = createBlankForm(project, form2Name, "1", "2", date = 2)
+
+        // create savepoints
+        val savepointFile1 = createSavepointFile(project, "${form1Name}_${System.currentTimeMillis()}.xml")
+        val savepointFile2 = createSavepointFile(project, "${form2Name}_${System.currentTimeMillis()}.xml")
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        val expectedSavepoint1 =
+            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form1Name/$form1Name.xml")
+        val expectedSavepoint2 =
+            Savepoint(blankForm2.dbId, null, savepointFile2.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/$form2Name/$form2Name.xml")
+        assertThat(savepoints, contains(expectedSavepoint2, expectedSavepoint1))
+    }
+
+    @Test
+    fun ifASavedFormHasNoSavepoint_nothingShouldBeImported() {
+        // create blank forms
+        val form = createBlankForm(project, "sampleForm", "1")
+
+        // create saved forms
+        createSavedForm(project, "sampleForm", form)
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifASavedFormHasASavepointCreatedEarlierThanTheForm_nothingShouldBeImported() {
+        // create blank forms
+        val form = createBlankForm(project, "sampleForm", "1")
+
+        // create saved forms
+        val savedForm = createSavedForm(project, "sampleForm", form, lastStatusChangeDate = System.currentTimeMillis() + TimeInMs.ONE_HOUR)
+
+        // create savepoints
+        createSavepointFile(project, File(savedForm.instanceFilePath).name)
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifASavedFormHasASavepointButItsBlankFormIsSoftDeleted_nothingShouldBeImported() {
+        // create blank forms
+        val form = createBlankForm(project, "sampleForm", "1", deleted = true)
+
+        // create saved forms
+        val savedForm = createSavedForm(project, "sampleForm", form)
+
+        // create savepoints
+        createSavepointFile(project, File(savedForm.instanceFilePath).name)
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifASavedFormHasASavepointButItsBlankFormDoesNotExist_nothingShouldBeImported() {
+        // create saved forms
+        val savedForm = createSavedForm(project, "sampleForm", FormFixtures.form("1"))
+
+        // create savepoints
+        createSavepointFile(project, File(savedForm.instanceFilePath).name)
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifASavedFormHasASavepointButTheFormIsSoftDeleted_nothingShouldBeImported() {
+        // create blank forms
+        val form = createBlankForm(project, "sampleForm", "1")
+
+        // create saved forms
+        val savedForm = createSavedForm(project, "sampleForm", form, deletedDate = System.currentTimeMillis())
+
+        // create savepoints
+        createSavepointFile(project, File(savedForm.instanceFilePath).name)
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        assertThat(savepoints.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun ifThereAreMultipleDifferentSavedFormsWithSavepoints_allSavepointsShouldBeImported() {
+        val form1Name = "sampleForm1"
+        val form2Name = "sampleForm2"
+
+        // create blank forms
+        val form1 = createBlankForm(project, form1Name, "1")
+        val form2 = createBlankForm(project, form2Name, "2")
+
+        // create saved forms
+        val savedForm1 = createSavedForm(project, form1Name, form1)
+        val savedForm2 = createSavedForm(project, form2Name, form2)
+
+        // create savepoints
+        val savepointFile1 = createSavepointFile(project, File(savedForm1.instanceFilePath).name)
+        val savepointFile2 = createSavepointFile(project, File(savedForm2.instanceFilePath).name)
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepositoryProvider.get(project.uuid).getAll()
+        val expectedSavepoint1 = Savepoint(1, 1, savepointFile1.absolutePath, savedForm1.instanceFilePath)
+        val expectedSavepoint2 = Savepoint(2, 2, savepointFile2.absolutePath, savedForm2.instanceFilePath)
+        assertThat(savepoints, contains(expectedSavepoint1, expectedSavepoint2))
+    }
+
+    private fun createBlankForm(project: Project.Saved, formName: String, formId: String, formVersion: String = "1", date: Long = 0, deleted: Boolean = false): Form {
+        val formFile = File(storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS, project.uuid), "$formName.xml").also {
+            it.writeText(RandomString.randomString(10))
+        }
+        val blankForm = formsRepositoryProvider.get(project.uuid).save(FormFixtures.form(formId, formVersion, formFile.absolutePath))
+        return formsRepositoryProvider.get(project.uuid).save(Form.Builder(blankForm).date(date).deleted(deleted).build())
+    }
+
+    private fun createSavedForm(project: Project.Saved, formName: String, form: Form, lastStatusChangeDate: Long = System.currentTimeMillis() - TimeInMs.ONE_HOUR, deletedDate: Long? = null): Instance {
+        return instancesRepositoryProvider.get(project.uuid).save(InstanceFixtures.instance(displayName = formName, form = form, lastStatusChangeDate = lastStatusChangeDate, deletedDate = deletedDate))
+    }
+
+    private fun createSavepointFile(project: Project.Saved, instanceName: String): File {
+        val cacheDir = File(storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE, project.uuid))
+        return File(cacheDir, "$instanceName.save").also {
+            it.writeText(RandomString.randomString(10))
+        }
+    }
+}

--- a/forms-test/src/main/java/org/odk/collect/formstest/InstanceUtils.kt
+++ b/forms-test/src/main/java/org/odk/collect/formstest/InstanceUtils.kt
@@ -43,6 +43,6 @@ object InstanceUtils {
         val instanceDir = File(instancesDir + File.separator + System.currentTimeMillis() + Math.random())
         instanceDir.mkdir()
 
-        return createTempFile(instanceDir, "intance_${System.currentTimeMillis()}", ".xml")
+        return createTempFile(instanceDir, "intance", ".xml")
     }
 }

--- a/forms-test/src/main/java/org/odk/collect/formstest/InstanceUtils.kt
+++ b/forms-test/src/main/java/org/odk/collect/formstest/InstanceUtils.kt
@@ -43,6 +43,6 @@ object InstanceUtils {
         val instanceDir = File(instancesDir + File.separator + System.currentTimeMillis() + Math.random())
         instanceDir.mkdir()
 
-        return createTempFile(instanceDir, "intance", ".xml")
+        return createTempFile(instanceDir, "intance_${System.currentTimeMillis()}", ".xml")
     }
 }

--- a/settings/src/main/java/org/odk/collect/settings/keys/MetaKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/MetaKeys.kt
@@ -8,6 +8,7 @@ object MetaKeys {
     const val CURRENT_PROJECT_ID = "current_project_id"
     const val KEY_PROJECTS = "projects"
     const val EXISTING_PROJECT_IMPORTED = "existing_project_imported"
+    const val OLD_SAVEPOINTS_IMPORTED = "old_savepoints_imported"
     const val LAST_LAUNCHED = "last_launched"
     const val LAST_USED_PEN_COLOR = "last_used_pen_color"
     const val PERMISSIONS_REQUESTED = "permissions_requested"


### PR DESCRIPTION
Closes #5997 
~~Blocked by #6049~~

#### Why is this the best possible solution? Were any other approaches considered?
https://github.com/getodk/collect/pull/5951 has introduced a new way of handling savepoints that relies on a database. In the older version savepoints were created as files and detected by file names. Now they are still saved as files in the same way but the mechanism of finding savepoints has been improved using the database mentioned above. Because of that, we needed to import old savepoints to our new database.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
To make sure importing old savepoints works well you need to:
- Install an APK with the old savepoints implementation eg v2024.1.3 
- Create some savepoints for blank and saved forms
- Upgrade your app to the version with these changes
- Make sure the old correct savepoints are available when you open the forms (blank and saved ones)

This might be tricky so please be careful. Reading the tests I have added (at least the titles) should help you understand the complexity: https://github.com/getodk/collect/pull/6068/files#diff-88b7def45e9dbbc62a204360e82832c2704e8b542d114ad5c1fba08ac145754aR25

Please also make sure that newly created savepoints (those created with the app after upgrading) work well too.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
