### PR TITLE
Tweak color and padding for Material Pill

### DIFF
--- a/material/src/main/java/org/odk/collect/material/ErrorsPill.kt
+++ b/material/src/main/java/org/odk/collect/material/ErrorsPill.kt
@@ -25,9 +25,6 @@ class ErrorsPill(context: Context, attrs: AttributeSet?) : MaterialPill(context,
             visibility = View.VISIBLE
             setIcon(org.odk.collect.icons.R.drawable.ic_baseline_check_24)
             setText(org.odk.collect.strings.R.string.draft_no_errors)
-            setPillBackgroundColor(MaterialColors.getColor(this, com.google.android.material.R.attr.colorSurfaceContainerHighest))
-            setTextColor(ContextUtils.getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
-            setIconTint(ContextUtils.getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnSurface))
         }
     }
 }

--- a/material/src/main/java/org/odk/collect/material/ErrorsPill.kt
+++ b/material/src/main/java/org/odk/collect/material/ErrorsPill.kt
@@ -25,6 +25,9 @@ class ErrorsPill(context: Context, attrs: AttributeSet?) : MaterialPill(context,
             visibility = View.VISIBLE
             setIcon(org.odk.collect.icons.R.drawable.ic_baseline_check_24)
             setText(org.odk.collect.strings.R.string.draft_no_errors)
+            setPillBackgroundColor(MaterialColors.getColor(this, com.google.android.material.R.attr.colorPrimaryContainer))
+            setTextColor(ContextUtils.getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnPrimaryContainer))
+            setIconTint(ContextUtils.getThemeAttributeValue(context, com.google.android.material.R.attr.colorOnPrimaryContainer))
         }
     }
 }

--- a/material/src/main/java/org/odk/collect/material/MaterialPill.kt
+++ b/material/src/main/java/org/odk/collect/material/MaterialPill.kt
@@ -65,7 +65,7 @@ open class MaterialPill(context: Context, attrs: AttributeSet?) :
 
     private fun getDefaultBackgroundColor(context: Context) = getThemeAttributeValue(
         context,
-        com.google.android.material.R.attr.colorPrimary
+        com.google.android.material.R.attr.colorPrimaryContainer
     )
 
     private fun createMaterialShapeDrawable(@ColorInt color: Int): MaterialShapeDrawable {

--- a/material/src/main/res/layout/pill.xml
+++ b/material/src/main/res/layout/pill.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:paddingHorizontal="@dimen/margin_extra_small"
+    android:paddingHorizontal="@dimen/margin_small"
     android:paddingVertical="@dimen/margin_extra_extra_small">
 
     <ImageView
@@ -14,7 +14,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:tint="?colorOnPrimary"
+        app:tint="?colorOnPrimaryContainer"
         tools:src="@drawable/ic_baseline_warning_24" />
 
     <com.google.android.material.textview.MaterialTextView
@@ -23,7 +23,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin_extra_small"
         android:textAppearance="?textAppearanceLabelLarge"
-        android:textColor="?colorOnPrimary"
+        android:textColor="?colorOnPrimaryContainer"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/icon"


### PR DESCRIPTION
Just changes the default color for pills to "color primary container" (meaning we don't need to override it for the "no errors" state) and adds a little more horizontal margin.