### PR TITLE
Fix flaky `FieldListUpdateTest` test

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -57,7 +57,6 @@ import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.espresso.matcher.ViewMatchers;
 
 import org.hamcrest.Matcher;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -393,7 +392,6 @@ public class FieldListUpdateTest {
     }
 
     @Test
-    @Ignore("https://github.com/getodk/collect/issues/5996")
     public void listOfQuestionsShouldNotBeScrolledToTheLastEditedQuestionAfterClickingOnAQuestion() {
         new FormEntryPage("fieldlist-updates")
                 .clickGoToArrow()
@@ -401,8 +399,8 @@ public class FieldListUpdateTest {
                 .clickOnGroup("Long list of questions")
                 .clickOnQuestion("Question1")
                 .answerQuestion(0, "X")
-                .activateTextQuestion(19)
-                .checkIsTranslationDisplayed("Question20");
+                .selectTextField("Question20", 19)
+                .assertText("Question20");
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -302,12 +302,6 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
-    public FormEntryPage activateTextQuestion(int index) {
-        onView(withIndex(withClassName(endsWith("EditText")), index)).perform(scrollTo());
-        onView(withIndex(withClassName(endsWith("EditText")), index)).perform(click());
-        return this;
-    }
-
     public FormEntryPage assertQuestion(String text) {
         return assertQuestion(text, false);
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -557,6 +557,17 @@ abstract class Page<T : Page<T>> {
         return destination
     }
 
+    fun selectTextField(label: String, index: Int = 0): T {
+        closeSoftKeyboard()
+
+        onView(withIndex(withClassName(endsWith("EditText")), index)).perform(scrollTo())
+
+        assertText(label)
+        onView(withIndex(withClassName(endsWith("EditText")), index)).perform(click())
+
+        return this as T
+    }
+
     companion object {
         private fun rotateToLandscape(): ViewAction {
             return RotateAction(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE)


### PR DESCRIPTION
Closes #5996

This test actually failed locally using API 34 which made it much easer to find the problem (trying to scroll while the keyboard is up). The test still passes running in API 30.
