### PR TITLE
Add support for styling lines and shapes in Select One from Map questions

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/ColorUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/ColorUtils.kt
@@ -1,0 +1,30 @@
+package org.odk.collect.androidshared.utils
+
+import android.graphics.Color
+import androidx.annotation.ColorInt
+
+@ColorInt
+fun String.toColorInt() = try {
+    var sanitizedColor = if (this.startsWith("#")) {
+        this
+    } else {
+        "#$this"
+    }
+
+    if (sanitizedColor.length == 4) {
+        sanitizedColor = shorthandToLonghandHexColor(sanitizedColor)
+    }
+
+    Color.parseColor(sanitizedColor)
+} catch (e: Throwable) {
+    null
+}
+
+private fun shorthandToLonghandHexColor(shorthandColor: String): String {
+    var longHandColor = ""
+    shorthandColor.substring(1).map {
+        longHandColor += it.toString() + it.toString()
+    }
+
+    return "#$longHandColor"
+}

--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/ColorUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/ColorUtils.kt
@@ -21,10 +21,7 @@ fun String.toColorInt() = try {
 }
 
 private fun shorthandToLonghandHexColor(shorthandColor: String): String {
-    var longHandColor = ""
-    shorthandColor.substring(1).map {
-        longHandColor += it.toString() + it.toString()
+    return shorthandColor.substring(1).fold("#") { accum, char ->
+        "$accum$char$char"
     }
-
-    return "#$longHandColor"
 }

--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/ColorUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/ColorUtils.kt
@@ -16,7 +16,7 @@ fun String.toColorInt() = try {
     }
 
     Color.parseColor(sanitizedColor)
-} catch (e: Throwable) {
+} catch (e: IllegalArgumentException) {
     null
 }
 

--- a/androidshared/src/test/java/org/odk/collect/androidshared/utils/ColorUtilsTest.kt
+++ b/androidshared/src/test/java/org/odk/collect/androidshared/utils/ColorUtilsTest.kt
@@ -1,0 +1,45 @@
+package org.odk.collect.androidshared.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ColorUtilsTest {
+    @Test
+    fun `return null when color is empty`() {
+        assertThat("".toColorInt(), equalTo(null))
+    }
+
+    @Test
+    fun `return null when color is blank`() {
+        assertThat(" ".toColorInt(), equalTo(null))
+    }
+
+    @Test
+    fun `return null when color is invalid`() {
+        assertThat("qwerty".toColorInt(), equalTo(null))
+    }
+
+    @Test
+    fun `return color int for valid hex color with # prefix`() {
+        assertThat("#aaccee".toColorInt(), equalTo(-5583634))
+    }
+
+    @Test
+    fun `return color int for valid hex color without # prefix`() {
+        assertThat("aaccee".toColorInt(), equalTo(-5583634))
+    }
+
+    @Test
+    fun `return color int for valid shorthand hex color with # prefix`() {
+        assertThat("#ace".toColorInt(), equalTo(-5583634))
+    }
+
+    @Test
+    fun `return color int for valid shorthand hex color without # prefix`() {
+        assertThat("ace".toColorInt(), equalTo(-5583634))
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.support
 import android.os.Handler
 import android.os.Looper
 import androidx.fragment.app.Fragment
+import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.PolygonDescription
@@ -58,11 +59,7 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         return MapPoint(0.0, 0.0)
     }
 
-    override fun addPolyLine(
-        points: MutableIterable<MapPoint>,
-        closed: Boolean,
-        draggable: Boolean
-    ): Int {
+    override fun addPolyLine(lineDescription: LineDescription): Int {
         return -1
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -5,6 +5,7 @@ import android.os.Looper
 import androidx.fragment.app.Fragment
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
+import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.maps.markers.MarkerDescription
 import org.odk.collect.maps.markers.MarkerIconDescription
 
@@ -65,8 +66,8 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         return -1
     }
 
-    override fun addPolygon(points: MutableIterable<MapPoint>): Int {
-        return addPolyLine(points, closed = true, draggable = false)
+    override fun addPolygon(polygonDescription: PolygonDescription): Int {
+        return -1
     }
 
     override fun appendPointToPolyLine(featureId: Int, point: MapPoint) {}

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
@@ -115,12 +115,12 @@ class FormMapViewModel(
             )
 
             val info = "$instanceLastStatusChangeDate\n${dateFormat.format(instance.deletedDate)}"
-            MappableSelectItem(
+            MappableSelectItem.MappableSelectPoint(
                 instance.dbId,
-                listOf(MapPoint(latitude, longitude)),
-                getDrawableIdForStatus(instance.status, false),
-                getDrawableIdForStatus(instance.status, true),
                 instance.displayName,
+                point = MapPoint(latitude, longitude),
+                smallIcon = getDrawableIdForStatus(instance.status, false),
+                largeIcon = getDrawableIdForStatus(instance.status, true),
                 info = info
             )
         } else if (!instance.canEditWhenComplete() && listOf(
@@ -130,12 +130,12 @@ class FormMapViewModel(
             ).contains(instance.status)
         ) {
             val info = "$instanceLastStatusChangeDate\n${resources.getString(org.odk.collect.strings.R.string.cannot_edit_completed_form)}"
-            MappableSelectItem(
+            MappableSelectItem.MappableSelectPoint(
                 instance.dbId,
-                listOf(MapPoint(latitude, longitude)),
-                getDrawableIdForStatus(instance.status, false),
-                getDrawableIdForStatus(instance.status, true),
                 instance.displayName,
+                point = MapPoint(latitude, longitude),
+                smallIcon = getDrawableIdForStatus(instance.status, false),
+                largeIcon = getDrawableIdForStatus(instance.status, true),
                 info = info
             )
         } else {
@@ -146,12 +146,12 @@ class FormMapViewModel(
                     createViewAction()
                 }
 
-            MappableSelectItem(
+            MappableSelectItem.MappableSelectPoint(
                 instance.dbId,
-                listOf(MapPoint(latitude, longitude)),
-                getDrawableIdForStatus(instance.status, false),
-                getDrawableIdForStatus(instance.status, true),
                 instance.displayName,
+                point = MapPoint(latitude, longitude),
+                smallIcon = getDrawableIdForStatus(instance.status, false),
+                largeIcon = getDrawableIdForStatus(instance.status, true),
                 info = instanceLastStatusChangeDate,
                 action = action,
                 status = instanceStatusToMappableSelectionItemStatus(instance)

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -198,6 +198,7 @@ internal class SelectChoicesMapData(
                                         org.odk.collect.icons.R.drawable.ic_save,
                                         resources.getString(org.odk.collect.strings.R.string.select_item)
                                     ),
+                                    strokeColor = selectChoice.additionalChildren.firstOrNull { it.first == "stroke" }?.second,
                                     fillColor = selectChoice.additionalChildren.firstOrNull { it.first == "fill" }?.second
                                 )
                             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -136,7 +136,7 @@ internal class SelectChoicesMapData(
         prompt: FormEntryPrompt
     ): List<MappableSelectItem> {
         return selectChoices.foldIndexed(emptyList()) { index, list, selectChoice ->
-            val geometry = selectChoice.getChild("geometry")
+            val geometry = selectChoice.getChild(GEOMETRY)
 
             if (geometry != null) {
                 try {
@@ -155,9 +155,9 @@ internal class SelectChoicesMapData(
 
                             if (points.size == 1) {
                                 val markerColor =
-                                    getPropertyValue(selectChoice, "marker-color")
+                                    getPropertyValue(selectChoice, MARKER_COLOR)
                                 val markerSymbol =
-                                    getPropertyValue(selectChoice, "marker-symbol")
+                                    getPropertyValue(selectChoice, MARKER_SYMBOL)
 
                                 list + MappableSelectItem.MappableSelectPoint(
                                     index.toLong(),
@@ -185,8 +185,8 @@ internal class SelectChoicesMapData(
                                         org.odk.collect.icons.R.drawable.ic_save,
                                         resources.getString(org.odk.collect.strings.R.string.select_item)
                                     ),
-                                    strokeWidth = getPropertyValue(selectChoice, "stroke-width"),
-                                    strokeColor = getPropertyValue(selectChoice, "stroke")
+                                    strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
+                                    strokeColor = getPropertyValue(selectChoice, STROKE)
                                 )
                             } else {
                                 list + MappableSelectItem.MappableSelectPolygon(
@@ -199,9 +199,9 @@ internal class SelectChoicesMapData(
                                         org.odk.collect.icons.R.drawable.ic_save,
                                         resources.getString(org.odk.collect.strings.R.string.select_item)
                                     ),
-                                    strokeWidth = getPropertyValue(selectChoice, "stroke-width"),
-                                    strokeColor = getPropertyValue(selectChoice, "stroke"),
-                                    fillColor = getPropertyValue(selectChoice, "fill")
+                                    strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
+                                    strokeColor = getPropertyValue(selectChoice, STROKE),
+                                    fillColor = getPropertyValue(selectChoice, FILL)
                                 )
                             }
                         } else {
@@ -241,5 +241,14 @@ internal class SelectChoicesMapData(
 
     override fun getMappableItems(): LiveData<List<MappableSelectItem>?> {
         return items
+    }
+
+    companion object PropertyNames {
+        const val GEOMETRY = "geometry"
+        const val MARKER_COLOR = "marker-color"
+        const val MARKER_SYMBOL = "marker-symbol"
+        const val STROKE = "stroke"
+        const val STROKE_WIDTH = "stroke-width"
+        const val FILL = "fill"
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -185,6 +185,7 @@ internal class SelectChoicesMapData(
                                         org.odk.collect.icons.R.drawable.ic_save,
                                         resources.getString(org.odk.collect.strings.R.string.select_item)
                                     ),
+                                    strokeWidth = selectChoice.additionalChildren.firstOrNull { it.first == "stroke-width" }?.second,
                                     strokeColor = selectChoice.additionalChildren.firstOrNull { it.first == "stroke" }?.second
                                 )
                             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -155,9 +155,9 @@ internal class SelectChoicesMapData(
 
                             if (points.size == 1) {
                                 val markerColor =
-                                    selectChoice.additionalChildren.firstOrNull { it.first == "marker-color" }?.second
+                                    getPropertyValue(selectChoice, "marker-color")
                                 val markerSymbol =
-                                    selectChoice.additionalChildren.firstOrNull { it.first == "marker-symbol" }?.second
+                                    getPropertyValue(selectChoice, "marker-symbol")
 
                                 list + MappableSelectItem.MappableSelectPoint(
                                     index.toLong(),
@@ -185,8 +185,8 @@ internal class SelectChoicesMapData(
                                         org.odk.collect.icons.R.drawable.ic_save,
                                         resources.getString(org.odk.collect.strings.R.string.select_item)
                                     ),
-                                    strokeWidth = selectChoice.additionalChildren.firstOrNull { it.first == "stroke-width" }?.second,
-                                    strokeColor = selectChoice.additionalChildren.firstOrNull { it.first == "stroke" }?.second
+                                    strokeWidth = getPropertyValue(selectChoice, "stroke-width"),
+                                    strokeColor = getPropertyValue(selectChoice, "stroke")
                                 )
                             } else {
                                 list + MappableSelectItem.MappableSelectPolygon(
@@ -199,9 +199,9 @@ internal class SelectChoicesMapData(
                                         org.odk.collect.icons.R.drawable.ic_save,
                                         resources.getString(org.odk.collect.strings.R.string.select_item)
                                     ),
-                                    strokeWidth = selectChoice.additionalChildren.firstOrNull { it.first == "stroke-width" }?.second,
-                                    strokeColor = selectChoice.additionalChildren.firstOrNull { it.first == "stroke" }?.second,
-                                    fillColor = selectChoice.additionalChildren.firstOrNull { it.first == "fill" }?.second
+                                    strokeWidth = getPropertyValue(selectChoice, "stroke-width"),
+                                    strokeColor = getPropertyValue(selectChoice, "stroke"),
+                                    fillColor = getPropertyValue(selectChoice, "fill")
                                 )
                             }
                         } else {
@@ -217,6 +217,10 @@ internal class SelectChoicesMapData(
                 list
             }
         }
+    }
+
+    private fun getPropertyValue(selectChoice: SelectChoice, propertyName: String): String? {
+        return selectChoice.additionalChildren.firstOrNull { it.first == propertyName }?.second
     }
 
     override fun isLoading(): NonNullLiveData<Boolean> {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -153,26 +153,52 @@ internal class SelectChoicesMapData(
                                 IconifiedText(null, "${it.first}: ${it.second}")
                             }
 
-                            val markerColor =
-                                selectChoice.additionalChildren.firstOrNull { it.first == "marker-color" }?.second
-                            val markerSymbol =
-                                selectChoice.additionalChildren.firstOrNull { it.first == "marker-symbol" }?.second
+                            if (points.size == 1) {
+                                val markerColor =
+                                    selectChoice.additionalChildren.firstOrNull { it.first == "marker-color" }?.second
+                                val markerSymbol =
+                                    selectChoice.additionalChildren.firstOrNull { it.first == "marker-symbol" }?.second
 
-                            list + MappableSelectItem(
-                                index.toLong(),
-                                points,
-                                if (markerSymbol == null) org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small else org.odk.collect.icons.R.drawable.ic_map_marker_small,
-                                if (markerSymbol == null) org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big else org.odk.collect.icons.R.drawable.ic_map_marker_big,
-                                prompt.getSelectChoiceText(selectChoice),
-                                properties,
-                                selectChoice.index == selectedIndex,
-                                markerColor,
-                                markerSymbol,
-                                action = IconifiedText(
-                                    org.odk.collect.icons.R.drawable.ic_save,
-                                    resources.getString(org.odk.collect.strings.R.string.select_item)
+                                list + MappableSelectItem.MappableSelectPoint(
+                                    index.toLong(),
+                                    prompt.getSelectChoiceText(selectChoice),
+                                    properties,
+                                    selectChoice.index == selectedIndex,
+                                    point = points[0],
+                                    smallIcon = if (markerSymbol == null) org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small else org.odk.collect.icons.R.drawable.ic_map_marker_small,
+                                    largeIcon = if (markerSymbol == null) org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big else org.odk.collect.icons.R.drawable.ic_map_marker_big,
+                                    color = markerColor,
+                                    symbol = markerSymbol,
+                                    action = IconifiedText(
+                                        org.odk.collect.icons.R.drawable.ic_save,
+                                        resources.getString(org.odk.collect.strings.R.string.select_item)
+                                    )
                                 )
-                            )
+                            } else if (points.first() != points.last()) {
+                                list + MappableSelectItem.MappableSelectLine(
+                                    index.toLong(),
+                                    prompt.getSelectChoiceText(selectChoice),
+                                    properties,
+                                    selectChoice.index == selectedIndex,
+                                    points = points,
+                                    action = IconifiedText(
+                                        org.odk.collect.icons.R.drawable.ic_save,
+                                        resources.getString(org.odk.collect.strings.R.string.select_item)
+                                    )
+                                )
+                            } else {
+                                list + MappableSelectItem.MappableSelectPolygon(
+                                    index.toLong(),
+                                    prompt.getSelectChoiceText(selectChoice),
+                                    properties,
+                                    selectChoice.index == selectedIndex,
+                                    points = points,
+                                    action = IconifiedText(
+                                        org.odk.collect.icons.R.drawable.ic_save,
+                                        resources.getString(org.odk.collect.strings.R.string.select_item)
+                                    )
+                                )
+                            }
                         } else {
                             list
                         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -196,7 +196,8 @@ internal class SelectChoicesMapData(
                                     action = IconifiedText(
                                         org.odk.collect.icons.R.drawable.ic_save,
                                         resources.getString(org.odk.collect.strings.R.string.select_item)
-                                    )
+                                    ),
+                                    fillColor = selectChoice.additionalChildren.firstOrNull { it.first == "fill" }?.second
                                 )
                             }
                         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -184,7 +184,8 @@ internal class SelectChoicesMapData(
                                     action = IconifiedText(
                                         org.odk.collect.icons.R.drawable.ic_save,
                                         resources.getString(org.odk.collect.strings.R.string.select_item)
-                                    )
+                                    ),
+                                    strokeColor = selectChoice.additionalChildren.firstOrNull { it.first == "stroke" }?.second
                                 )
                             } else {
                                 list + MappableSelectItem.MappableSelectPolygon(

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -198,6 +198,7 @@ internal class SelectChoicesMapData(
                                         org.odk.collect.icons.R.drawable.ic_save,
                                         resources.getString(org.odk.collect.strings.R.string.select_item)
                                     ),
+                                    strokeWidth = selectChoice.additionalChildren.firstOrNull { it.first == "stroke-width" }?.second,
                                     strokeColor = selectChoice.additionalChildren.firstOrNull { it.first == "stroke" }?.second,
                                     fillColor = selectChoice.additionalChildren.firstOrNull { it.first == "fill" }?.second
                                 )

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
@@ -106,12 +106,12 @@ class FormMapViewModelTest {
         val viewModel = createAndLoadViewModel(form)
         assertThat(viewModel.getMappableItems().value!!.size, equalTo(1))
 
-        val expectedItem = MappableSelectItem(
+        val expectedItem = MappableSelectItem.MappableSelectPoint(
             instanceWithPoint.dbId,
-            listOf(MapPoint(2.0, 1.0)),
-            R.drawable.ic_room_form_state_incomplete_24dp,
-            R.drawable.ic_room_form_state_incomplete_48dp,
             instanceWithPoint.displayName,
+            point = MapPoint(2.0, 1.0),
+            smallIcon = R.drawable.ic_room_form_state_incomplete_24dp,
+            largeIcon = R.drawable.ic_room_form_state_incomplete_48dp,
             action = IconifiedText(
                 R.drawable.ic_edit,
                 application.getString(org.odk.collect.strings.R.string.edit_data)
@@ -145,12 +145,12 @@ class FormMapViewModelTest {
         )
 
         val viewModel = createAndLoadViewModel(form)
-        val expectedItem = MappableSelectItem(
+        val expectedItem = MappableSelectItem.MappableSelectPoint(
             instance.dbId,
-            listOf(MapPoint(2.0, 1.0)),
-            R.drawable.ic_room_form_state_incomplete_24dp,
-            R.drawable.ic_room_form_state_incomplete_48dp,
             instance.displayName,
+            point = MapPoint(2.0, 1.0),
+            smallIcon = R.drawable.ic_room_form_state_incomplete_24dp,
+            largeIcon = R.drawable.ic_room_form_state_incomplete_48dp,
             action = IconifiedText(
                 R.drawable.ic_edit,
                 application.getString(org.odk.collect.strings.R.string.edit_data)
@@ -184,12 +184,12 @@ class FormMapViewModelTest {
         )
 
         val viewModel = createAndLoadViewModel(form)
-        val expectedItem = MappableSelectItem(
+        val expectedItem = MappableSelectItem.MappableSelectPoint(
             instance.dbId,
-            listOf(MapPoint(2.0, 1.0)),
-            R.drawable.ic_room_form_state_incomplete_24dp,
-            R.drawable.ic_room_form_state_incomplete_48dp,
             instance.displayName,
+            point = MapPoint(2.0, 1.0),
+            smallIcon = R.drawable.ic_room_form_state_incomplete_24dp,
+            largeIcon = R.drawable.ic_room_form_state_incomplete_48dp,
             action = IconifiedText(
                 R.drawable.ic_edit,
                 application.getString(org.odk.collect.strings.R.string.edit_data)
@@ -223,12 +223,12 @@ class FormMapViewModelTest {
         )
 
         val viewModel = createAndLoadViewModel(form)
-        val expectedItem = MappableSelectItem(
+        val expectedItem = MappableSelectItem.MappableSelectPoint(
             instance.dbId,
-            listOf(MapPoint(2.0, 1.0)),
-            R.drawable.ic_room_form_state_complete_24dp,
-            R.drawable.ic_room_form_state_complete_48dp,
             instance.displayName,
+            point = MapPoint(2.0, 1.0),
+            smallIcon = R.drawable.ic_room_form_state_complete_24dp,
+            largeIcon = R.drawable.ic_room_form_state_complete_48dp,
             action = IconifiedText(
                 R.drawable.ic_visibility,
                 application.getString(org.odk.collect.strings.R.string.view_data)
@@ -263,12 +263,12 @@ class FormMapViewModelTest {
         settingsProvider.getProtectedSettings().save(ProtectedProjectKeys.KEY_EDIT_SAVED, false)
 
         val viewModel = createAndLoadViewModel(form)
-        val expectedItem = MappableSelectItem(
+        val expectedItem = MappableSelectItem.MappableSelectPoint(
             instance.dbId,
-            listOf(MapPoint(2.0, 1.0)),
-            R.drawable.ic_room_form_state_complete_24dp,
-            R.drawable.ic_room_form_state_complete_48dp,
             instance.displayName,
+            point = MapPoint(2.0, 1.0),
+            smallIcon = R.drawable.ic_room_form_state_complete_24dp,
+            largeIcon = R.drawable.ic_room_form_state_complete_48dp,
             action = IconifiedText(
                 R.drawable.ic_visibility,
                 application.getString(org.odk.collect.strings.R.string.view_data)
@@ -301,12 +301,12 @@ class FormMapViewModelTest {
         )
 
         val viewModel = createAndLoadViewModel(form)
-        val expectedItem = MappableSelectItem(
+        val expectedItem = MappableSelectItem.MappableSelectPoint(
             instance.dbId,
-            listOf(MapPoint(2.0, 1.0)),
-            R.drawable.ic_room_form_state_incomplete_24dp,
-            R.drawable.ic_room_form_state_incomplete_48dp,
             instance.displayName,
+            point = MapPoint(2.0, 1.0),
+            smallIcon = R.drawable.ic_room_form_state_incomplete_24dp,
+            largeIcon = R.drawable.ic_room_form_state_incomplete_48dp,
             info = formatDate(
                 org.odk.collect.strings.R.string.saved_on_date_at_time,
                 instance.lastStatusChangeDate
@@ -339,12 +339,12 @@ class FormMapViewModelTest {
         )
 
         val viewModel = createAndLoadViewModel(form)
-        val expectedItem = MappableSelectItem(
+        val expectedItem = MappableSelectItem.MappableSelectPoint(
             instance.dbId,
-            listOf(MapPoint(2.0, 1.0)),
-            R.drawable.ic_room_form_state_submitted_24dp,
-            R.drawable.ic_room_form_state_submitted_48dp,
             instance.displayName,
+            point = MapPoint(2.0, 1.0),
+            smallIcon = R.drawable.ic_room_form_state_submitted_24dp,
+            largeIcon = R.drawable.ic_room_form_state_submitted_48dp,
             action = IconifiedText(
                 R.drawable.ic_visibility,
                 application.getString(org.odk.collect.strings.R.string.view_data)
@@ -377,12 +377,12 @@ class FormMapViewModelTest {
         )
 
         val viewModel = createAndLoadViewModel(form)
-        val expectedItem = MappableSelectItem(
+        val expectedItem = MappableSelectItem.MappableSelectPoint(
             instance.dbId,
-            listOf(MapPoint(2.0, 1.0)),
-            R.drawable.ic_room_form_state_submission_failed_24dp,
-            R.drawable.ic_room_form_state_submission_failed_48dp,
             instance.displayName,
+            point = MapPoint(2.0, 1.0),
+            smallIcon = R.drawable.ic_room_form_state_submission_failed_24dp,
+            largeIcon = R.drawable.ic_room_form_state_submission_failed_48dp,
             action = IconifiedText(
                 R.drawable.ic_visibility,
                 application.getString(org.odk.collect.strings.R.string.view_data)

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -273,13 +273,14 @@ class SelectChoicesMapDataTest {
      * https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0.
      */
     @Test
-    fun `polygon fill color is pulled from simple style attributes`() {
+    fun `polygon stroke and fill color are pulled from simple style attributes`() {
         val choices = listOf(
             selectChoice(
                 value = "a",
                 item = treeElement(
                     children = listOf(
                         treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4; 12.0 -1.0 3 4"),
+                        treeElement("stroke", "#000000"),
                         treeElement("fill", "#ffffff")
                     )
                 )
@@ -294,6 +295,7 @@ class SelectChoicesMapDataTest {
 
         val data = loadDataForPrompt(prompt)
         val item = data.getMappableItems().getOrAwaitValue()!![0] as MappableSelectItem.MappableSelectPolygon
+        assertThat(item.strokeColor, equalTo("#000000"))
         assertThat(item.fillColor, equalTo("#ffffff"))
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -239,6 +239,35 @@ class SelectChoicesMapDataTest {
         assertThat(item.color, equalTo("#ffffff"))
     }
 
+    /**
+     * Attributes names come from properties defined at
+     * https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0.
+     */
+    @Test
+    fun `polygon fill color is pulled from simple style attributes`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(
+                        treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4; 12.0 -1.0 3 4"),
+                        treeElement("fill", "#ffffff")
+                    )
+                )
+            )
+        )
+
+        val prompt = MockFormEntryPromptBuilder()
+            .withLongText("Which is your favourite place?")
+            .withSelectChoices(choices)
+            .withSelectChoiceText(mapOf(choices[0] to "A"))
+            .build()
+
+        val data = loadDataForPrompt(prompt)
+        val item = data.getMappableItems().getOrAwaitValue()!![0] as MappableSelectItem.MappableSelectPolygon
+        assertThat(item.fillColor, equalTo("#ffffff"))
+    }
+
     @Test
     fun `uses different icon if marker-symbol is defined`() {
         val choices = listOf(

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -16,6 +16,7 @@ import org.odk.collect.android.widgets.support.FormElementFixtures.selectChoice
 import org.odk.collect.android.widgets.support.FormElementFixtures.treeElement
 import org.odk.collect.androidtest.getOrAwaitValue
 import org.odk.collect.geo.selection.IconifiedText
+import org.odk.collect.geo.selection.MappableSelectItem
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.testshared.FakeScheduler
 
@@ -50,7 +51,7 @@ class SelectChoicesMapDataTest {
         val mappableItems = data.getMappableItems().getOrAwaitValue()!!
         assertThat(mappableItems.size, equalTo(1))
 
-        val points = mappableItems[0].points
+        val points = (mappableItems[0] as MappableSelectItem.MappableSelectLine).points
         assertThat(
             points,
             equalTo(listOf(MapPoint(12.0, -1.0, 3.0, 4.0), MapPoint(12.1, -1.0, 3.0, 4.0)))
@@ -80,7 +81,7 @@ class SelectChoicesMapDataTest {
         val mappableItems = data.getMappableItems().getOrAwaitValue()!!
         assertThat(mappableItems.size, equalTo(1))
 
-        val points = mappableItems[0].points
+        val points = (mappableItems[0] as MappableSelectItem.MappableSelectPolygon).points
         assertThat(
             points,
             equalTo(listOf(MapPoint(12.0, -1.0, 3.0, 4.0), MapPoint(12.1, -1.0, 3.0, 4.0), MapPoint(12.0, -1.0, 3.0, 4.0)))
@@ -233,7 +234,7 @@ class SelectChoicesMapDataTest {
             .build()
 
         val data = loadDataForPrompt(prompt)
-        val item = data.getMappableItems().getOrAwaitValue()!![0]
+        val item = data.getMappableItems().getOrAwaitValue()!![0] as MappableSelectItem.MappableSelectPoint
         assertThat(item.symbol, equalTo("A"))
         assertThat(item.color, equalTo("#ffffff"))
     }
@@ -259,7 +260,7 @@ class SelectChoicesMapDataTest {
             .build()
 
         val data = loadDataForPrompt(prompt)
-        val item = data.getMappableItems().getOrAwaitValue()!![0]
+        val item = data.getMappableItems().getOrAwaitValue()!![0] as MappableSelectItem.MappableSelectPoint
         assertThat(item.smallIcon, equalTo(org.odk.collect.icons.R.drawable.ic_map_marker_small))
         assertThat(item.largeIcon, equalTo(org.odk.collect.icons.R.drawable.ic_map_marker_big))
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -34,7 +34,7 @@ class SelectChoicesMapDataTest {
             selectChoice(
                 value = "a",
                 item = treeElement(
-                    children = listOf(treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4"))
+                    children = listOf(treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 3 4; 12.1 -1.0 3 4"))
                 )
             )
         )
@@ -64,7 +64,7 @@ class SelectChoicesMapDataTest {
             selectChoice(
                 value = "a",
                 item = treeElement(
-                    children = listOf(treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4; 12.0 -1.0 3 4"))
+                    children = listOf(treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 3 4; 12.1 -1.0 3 4; 12.0 -1.0 3 4"))
                 )
             )
         )
@@ -93,7 +93,7 @@ class SelectChoicesMapDataTest {
         val choices = listOf(
             selectChoice(
                 value = "a",
-                item = treeElement(children = listOf(treeElement("geometry", "12.0 -1.0 305 0")))
+                item = treeElement(children = listOf(treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 305 0")))
             ),
             selectChoice(
                 value = "b",
@@ -120,7 +120,7 @@ class SelectChoicesMapDataTest {
                 value = "a",
                 item = treeElement(
                     children = listOf(
-                        treeElement("geometry", "12.0 -1.0 305 0"),
+                        treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 305 0"),
                         treeElement("property", "blah")
                     )
                 )
@@ -165,7 +165,7 @@ class SelectChoicesMapDataTest {
                 value = "a",
                 item = treeElement(
                     children = listOf(
-                        treeElement("geometry", "0 170.00 0 0")
+                        treeElement(SelectChoicesMapData.GEOMETRY, "0 170.00 0 0")
                     )
                 )
             ),
@@ -174,7 +174,7 @@ class SelectChoicesMapDataTest {
                 value = "b",
                 item = treeElement(
                     children = listOf(
-                        treeElement("geometry", "blah")
+                        treeElement(SelectChoicesMapData.GEOMETRY, "blah")
                     )
                 )
             ),
@@ -183,7 +183,7 @@ class SelectChoicesMapDataTest {
                 value = "c",
                 item = treeElement(
                     children = listOf(
-                        treeElement("geometry", "0 180.1 0 0")
+                        treeElement(SelectChoicesMapData.GEOMETRY, "0 180.1 0 0")
                     )
                 )
             ),
@@ -192,7 +192,7 @@ class SelectChoicesMapDataTest {
                 value = "c",
                 item = treeElement(
                     children = listOf(
-                        treeElement("geometry", "0 180 0 0; 0 180.1 0 0")
+                        treeElement(SelectChoicesMapData.GEOMETRY, "0 180 0 0; 0 180.1 0 0")
                     )
                 )
             )
@@ -219,9 +219,9 @@ class SelectChoicesMapDataTest {
                 value = "a",
                 item = treeElement(
                     children = listOf(
-                        treeElement("geometry", "12.0 -1.0 305 0"),
-                        treeElement("marker-symbol", "A"),
-                        treeElement("marker-color", "#ffffff")
+                        treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 305 0"),
+                        treeElement(SelectChoicesMapData.MARKER_SYMBOL, "A"),
+                        treeElement(SelectChoicesMapData.MARKER_COLOR, "#ffffff")
                     )
                 )
             )
@@ -250,9 +250,9 @@ class SelectChoicesMapDataTest {
                 value = "a",
                 item = treeElement(
                     children = listOf(
-                        treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4"),
-                        treeElement("stroke-width", "10"),
-                        treeElement("stroke", "#ffffff")
+                        treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 3 4; 12.1 -1.0 3 4"),
+                        treeElement(SelectChoicesMapData.STROKE_WIDTH, "10"),
+                        treeElement(SelectChoicesMapData.STROKE, "#ffffff")
                     )
                 )
             )
@@ -281,10 +281,10 @@ class SelectChoicesMapDataTest {
                 value = "a",
                 item = treeElement(
                     children = listOf(
-                        treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4; 12.0 -1.0 3 4"),
-                        treeElement("stroke-width", "10"),
-                        treeElement("stroke", "#000000"),
-                        treeElement("fill", "#ffffff")
+                        treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 3 4; 12.1 -1.0 3 4; 12.0 -1.0 3 4"),
+                        treeElement(SelectChoicesMapData.STROKE_WIDTH, "10"),
+                        treeElement(SelectChoicesMapData.STROKE, "#000000"),
+                        treeElement(SelectChoicesMapData.FILL, "#ffffff")
                     )
                 )
             )
@@ -310,8 +310,8 @@ class SelectChoicesMapDataTest {
                 value = "a",
                 item = treeElement(
                     children = listOf(
-                        treeElement("geometry", "12.0 -1.0 305 0"),
-                        treeElement("marker-symbol", "A")
+                        treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 305 0"),
+                        treeElement(SelectChoicesMapData.MARKER_SYMBOL, "A")
                     )
                 )
             )

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -273,13 +273,14 @@ class SelectChoicesMapDataTest {
      * https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0.
      */
     @Test
-    fun `polygon stroke and fill color are pulled from simple style attributes`() {
+    fun `polygon stroke width, stroke color and fill color are pulled from simple style attributes`() {
         val choices = listOf(
             selectChoice(
                 value = "a",
                 item = treeElement(
                     children = listOf(
                         treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4; 12.0 -1.0 3 4"),
+                        treeElement("stroke-width", "10"),
                         treeElement("stroke", "#000000"),
                         treeElement("fill", "#ffffff")
                     )
@@ -295,6 +296,7 @@ class SelectChoicesMapDataTest {
 
         val data = loadDataForPrompt(prompt)
         val item = data.getMappableItems().getOrAwaitValue()!![0] as MappableSelectItem.MappableSelectPolygon
+        assertThat(item.strokeWidth, equalTo("10"))
         assertThat(item.strokeColor, equalTo("#000000"))
         assertThat(item.fillColor, equalTo("#ffffff"))
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -244,6 +244,35 @@ class SelectChoicesMapDataTest {
      * https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0.
      */
     @Test
+    fun `line stroke color is pulled from simple style attributes`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(
+                        treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4"),
+                        treeElement("stroke", "#ffffff")
+                    )
+                )
+            )
+        )
+
+        val prompt = MockFormEntryPromptBuilder()
+            .withLongText("Which is your favourite place?")
+            .withSelectChoices(choices)
+            .withSelectChoiceText(mapOf(choices[0] to "A"))
+            .build()
+
+        val data = loadDataForPrompt(prompt)
+        val item = data.getMappableItems().getOrAwaitValue()!![0] as MappableSelectItem.MappableSelectLine
+        assertThat(item.strokeColor, equalTo("#ffffff"))
+    }
+
+    /**
+     * Attributes names come from properties defined at
+     * https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0.
+     */
+    @Test
     fun `polygon fill color is pulled from simple style attributes`() {
         val choices = listOf(
             selectChoice(

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -251,6 +251,7 @@ class SelectChoicesMapDataTest {
                 item = treeElement(
                     children = listOf(
                         treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4"),
+                        treeElement("stroke-width", "10"),
                         treeElement("stroke", "#ffffff")
                     )
                 )
@@ -265,6 +266,7 @@ class SelectChoicesMapDataTest {
 
         val data = loadDataForPrompt(prompt)
         val item = data.getMappableItems().getOrAwaitValue()!![0] as MappableSelectItem.MappableSelectLine
+        assertThat(item.strokeWidth, equalTo("10"))
         assertThat(item.strokeColor, equalTo("#ffffff"))
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
@@ -53,11 +53,11 @@ class SelectOneFromMapDialogFragmentTest {
     private val selectChoices = listOf(
         selectChoice(
             value = "a",
-            item = treeElement(children = listOf(treeElement("geometry", "12.0 -1.0 305 0")))
+            item = treeElement(children = listOf(treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 305 0")))
         ),
         selectChoice(
             value = "b",
-            item = treeElement(children = listOf(treeElement("geometry", "13.0 -1.0 305 0")))
+            item = treeElement(children = listOf(treeElement(SelectChoicesMapData.GEOMETRY, "13.0 -1.0 305 0")))
         )
     )
 
@@ -170,8 +170,8 @@ class SelectOneFromMapDialogFragmentTest {
 
             assertThat(data.getMapTitle().value, equalTo(prompt.longText))
             assertThat(data.getItemCount().value, equalTo(prompt.selectChoices.size))
-            val firstFeatureGeometry = selectChoices[0].getChild("geometry")!!.split(" ")
-            val secondFeatureGeometry = selectChoices[1].getChild("geometry")!!.split(" ")
+            val firstFeatureGeometry = selectChoices[0].getChild(SelectChoicesMapData.GEOMETRY)!!.split(" ")
+            val secondFeatureGeometry = selectChoices[1].getChild(SelectChoicesMapData.GEOMETRY)!!.split(" ")
             assertThat(
                 data.getMappableItems().value,
                 equalTo(

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
@@ -176,37 +176,33 @@ class SelectOneFromMapDialogFragmentTest {
                 data.getMappableItems().value,
                 equalTo(
                     listOf(
-                        MappableSelectItem(
+                        MappableSelectItem.MappableSelectPoint(
                             0,
-                            listOf(
-                                MapPoint(
-                                    firstFeatureGeometry[0].toDouble(),
-                                    firstFeatureGeometry[1].toDouble(),
-                                    firstFeatureGeometry[2].toDouble(),
-                                    firstFeatureGeometry[3].toDouble()
-                                )
-                            ),
-                            org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small,
-                            org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big,
                             "A",
+                            point = MapPoint(
+                                firstFeatureGeometry[0].toDouble(),
+                                firstFeatureGeometry[1].toDouble(),
+                                firstFeatureGeometry[2].toDouble(),
+                                firstFeatureGeometry[3].toDouble()
+                            ),
+                            smallIcon = org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small,
+                            largeIcon = org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big,
                             action = IconifiedText(
                                 org.odk.collect.icons.R.drawable.ic_save,
                                 application.getString(org.odk.collect.strings.R.string.select_item)
                             )
                         ),
-                        MappableSelectItem(
+                        MappableSelectItem.MappableSelectPoint(
                             1,
-                            listOf(
-                                MapPoint(
-                                    secondFeatureGeometry[0].toDouble(),
-                                    secondFeatureGeometry[1].toDouble(),
-                                    secondFeatureGeometry[2].toDouble(),
-                                    secondFeatureGeometry[3].toDouble()
-                                )
-                            ),
-                            org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small,
-                            org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big,
                             "B",
+                            point = MapPoint(
+                                secondFeatureGeometry[0].toDouble(),
+                                secondFeatureGeometry[1].toDouble(),
+                                secondFeatureGeometry[2].toDouble(),
+                                secondFeatureGeometry[3].toDouble()
+                            ),
+                            smallIcon = org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small,
+                            largeIcon = org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big,
                             action = IconifiedText(
                                 org.odk.collect.icons.R.drawable.ic_save,
                                 application.getString(org.odk.collect.strings.R.string.select_item)

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.android.widgets.support
 
 import androidx.fragment.app.Fragment
+import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.PolygonDescription
@@ -54,11 +55,7 @@ class NoOpMapFragment : Fragment(), MapFragment {
         TODO("Not yet implemented")
     }
 
-    override fun addPolyLine(
-        points: MutableIterable<MapPoint>,
-        closed: Boolean,
-        draggable: Boolean
-    ): Int {
+    override fun addPolyLine(lineDescription: LineDescription): Int {
         TODO("Not yet implemented")
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.widgets.support
 import androidx.fragment.app.Fragment
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
+import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.maps.markers.MarkerDescription
 import org.odk.collect.maps.markers.MarkerIconDescription
 
@@ -61,7 +62,7 @@ class NoOpMapFragment : Fragment(), MapFragment {
         TODO("Not yet implemented")
     }
 
-    override fun addPolygon(points: MutableIterable<MapPoint>): Int {
+    override fun addPolygon(polygonDescription: PolygonDescription): Int {
         TODO("Not yet implemented")
     }
 

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
@@ -276,7 +276,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
         if (restoredPoints != null) {
             points = restoredPoints;
         }
-        featureId = map.addPolyLine(new LineDescription(points, String.valueOf(MapConsts.POLYLINE_STROKE_WIDTH), null, true, outputMode == OutputMode.GEOSHAPE));
+        featureId = map.addPolyLine(new LineDescription(points, String.valueOf(MapConsts.DEFAULT_STROKE_WIDTH), null, true, outputMode == OutputMode.GEOSHAPE));
 
         if (inputActive && !intentReadOnly) {
             startInput();
@@ -444,7 +444,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
 
     private void clear() {
         map.clearFeatures();
-        featureId = map.addPolyLine(new LineDescription(new ArrayList<>(), String.valueOf(MapConsts.POLYLINE_STROKE_WIDTH), null, true, outputMode == OutputMode.GEOSHAPE));
+        featureId = map.addPolyLine(new LineDescription(new ArrayList<>(), String.valueOf(MapConsts.DEFAULT_STROKE_WIDTH), null, true, outputMode == OutputMode.GEOSHAPE));
         inputActive = false;
         updateUi();
     }

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
@@ -43,6 +43,7 @@ import org.odk.collect.geo.R;
 import org.odk.collect.geo.ReferenceLayerSettingsNavigator;
 import org.odk.collect.location.Location;
 import org.odk.collect.location.tracker.LocationTracker;
+import org.odk.collect.maps.LineDescription;
 import org.odk.collect.maps.MapFragment;
 import org.odk.collect.maps.MapFragmentFactory;
 import org.odk.collect.maps.MapPoint;
@@ -274,7 +275,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
         if (restoredPoints != null) {
             points = restoredPoints;
         }
-        featureId = map.addPolyLine(points, outputMode == OutputMode.GEOSHAPE, true);
+        featureId = map.addPolyLine(new LineDescription(points, null, outputMode == OutputMode.GEOSHAPE, true));
 
         if (inputActive && !intentReadOnly) {
             startInput();
@@ -442,7 +443,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
 
     private void clear() {
         map.clearFeatures();
-        featureId = map.addPolyLine(new ArrayList<>(), outputMode == OutputMode.GEOSHAPE, true);
+        featureId = map.addPolyLine(new LineDescription(new ArrayList<>(), null, outputMode == OutputMode.GEOSHAPE, true));
         inputActive = false;
         updateUi();
     }

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
@@ -44,6 +44,7 @@ import org.odk.collect.geo.ReferenceLayerSettingsNavigator;
 import org.odk.collect.location.Location;
 import org.odk.collect.location.tracker.LocationTracker;
 import org.odk.collect.maps.LineDescription;
+import org.odk.collect.maps.MapConsts;
 import org.odk.collect.maps.MapFragment;
 import org.odk.collect.maps.MapFragmentFactory;
 import org.odk.collect.maps.MapPoint;
@@ -275,7 +276,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
         if (restoredPoints != null) {
             points = restoredPoints;
         }
-        featureId = map.addPolyLine(new LineDescription(points, null, outputMode == OutputMode.GEOSHAPE, true));
+        featureId = map.addPolyLine(new LineDescription(points, String.valueOf(MapConsts.POLYLINE_STROKE_WIDTH), null, true, outputMode == OutputMode.GEOSHAPE));
 
         if (inputActive && !intentReadOnly) {
             startInput();
@@ -443,7 +444,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
 
     private void clear() {
         map.clearFeatures();
-        featureId = map.addPolyLine(new LineDescription(new ArrayList<>(), null, outputMode == OutputMode.GEOSHAPE, true));
+        featureId = map.addPolyLine(new LineDescription(new ArrayList<>(), String.valueOf(MapConsts.POLYLINE_STROKE_WIDTH), null, true, outputMode == OutputMode.GEOSHAPE));
         inputActive = false;
         updateUi();
     }

--- a/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
@@ -47,6 +47,7 @@ sealed class MappableSelectItem {
         override val action: IconifiedText? = null,
         override val status: Status? = null,
         val points: List<MapPoint>,
+        val strokeColor: String? = null,
         val fillColor: String? = null
     ) : MappableSelectItem()
 }

--- a/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
@@ -34,7 +34,8 @@ sealed class MappableSelectItem {
         override val info: String? = null,
         override val action: IconifiedText? = null,
         override val status: Status? = null,
-        val points: List<MapPoint>
+        val points: List<MapPoint>,
+        val strokeColor: String? = null
     ) : MappableSelectItem()
 
     data class MappableSelectPolygon(

--- a/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
@@ -2,20 +2,52 @@ package org.odk.collect.geo.selection
 
 import org.odk.collect.maps.MapPoint
 
-data class MappableSelectItem(
-    val id: Long,
-    val points: List<MapPoint>,
-    val smallIcon: Int,
-    val largeIcon: Int,
-    val name: String,
-    val properties: List<IconifiedText> = emptyList(),
-    val selected: Boolean = false,
-    val color: String? = null,
-    val symbol: String? = null,
-    val info: String? = null,
-    val action: IconifiedText? = null,
-    val status: Status? = null
-)
+sealed class MappableSelectItem {
+    abstract val id: Long
+    abstract val name: String
+    abstract val properties: List<IconifiedText>
+    abstract val selected: Boolean
+    abstract val info: String?
+    abstract val action: IconifiedText?
+    abstract val status: Status?
+
+    data class MappableSelectPoint(
+        override val id: Long,
+        override val name: String,
+        override val properties: List<IconifiedText> = emptyList(),
+        override val selected: Boolean = false,
+        override val info: String? = null,
+        override val action: IconifiedText? = null,
+        override val status: Status? = null,
+        val point: MapPoint,
+        val smallIcon: Int,
+        val largeIcon: Int,
+        val color: String? = null,
+        val symbol: String? = null
+    ) : MappableSelectItem()
+
+    data class MappableSelectLine(
+        override val id: Long,
+        override val name: String,
+        override val properties: List<IconifiedText> = emptyList(),
+        override val selected: Boolean = false,
+        override val info: String? = null,
+        override val action: IconifiedText? = null,
+        override val status: Status? = null,
+        val points: List<MapPoint>
+    ) : MappableSelectItem()
+
+    data class MappableSelectPolygon(
+        override val id: Long,
+        override val name: String,
+        override val properties: List<IconifiedText> = emptyList(),
+        override val selected: Boolean = false,
+        override val info: String? = null,
+        override val action: IconifiedText? = null,
+        override val status: Status? = null,
+        val points: List<MapPoint>
+    ) : MappableSelectItem()
+}
 
 data class IconifiedText(val icon: Int?, val text: String)
 

--- a/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
@@ -47,6 +47,7 @@ sealed class MappableSelectItem {
         override val action: IconifiedText? = null,
         override val status: Status? = null,
         val points: List<MapPoint>,
+        val strokeWidth: String? = null,
         val strokeColor: String? = null,
         val fillColor: String? = null
     ) : MappableSelectItem()

--- a/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
@@ -45,7 +45,8 @@ sealed class MappableSelectItem {
         override val info: String? = null,
         override val action: IconifiedText? = null,
         override val status: Status? = null,
-        val points: List<MapPoint>
+        val points: List<MapPoint>,
+        val fillColor: String? = null
     ) : MappableSelectItem()
 }
 

--- a/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/MappableSelectItem.kt
@@ -35,6 +35,7 @@ sealed class MappableSelectItem {
         override val action: IconifiedText? = null,
         override val status: Status? = null,
         val points: List<MapPoint>,
+        val strokeWidth: String? = null,
         val strokeColor: String? = null
     ) : MappableSelectItem()
 

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -391,7 +391,7 @@ class SelectionMapFragment(
             ids + map.addPolyLine(LineDescription(item.points, item.strokeColor, false, false))
         }
         val polygonIds = polygons.fold(listOf<Int>()) { ids, item ->
-            ids + map.addPolygon(PolygonDescription(item.points, item.strokeColor, item.fillColor))
+            ids + map.addPolygon(PolygonDescription(item.points, item.strokeWidth, item.strokeColor, item.fillColor))
         }
 
         (singlePoints + lines + polygons).zip(pointIds + lineIds + polygonIds).forEach { (item, featureId) ->

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -27,6 +27,7 @@ import org.odk.collect.geo.databinding.SelectionMapLayoutBinding
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragmentFactory
 import org.odk.collect.maps.MapPoint
+import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.maps.markers.MarkerDescription
 import org.odk.collect.maps.markers.MarkerIconDescription
 import org.odk.collect.material.BottomSheetBehavior
@@ -389,7 +390,7 @@ class SelectionMapFragment(
             ids + map.addPolyLine(item.points, false, false)
         }
         val polygonIds = polygons.fold(listOf<Int>()) { ids, item ->
-            ids + map.addPolygon(item.points)
+            ids + map.addPolygon(PolygonDescription(item.points, item.fillColor))
         }
 
         (singlePoints + lines + polygons).zip(pointIds + lineIds + polygonIds).forEach { (item, featureId) ->

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -388,7 +388,7 @@ class SelectionMapFragment(
 
         val pointIds = map.addMarkers(markerDescriptions)
         val lineIds = lines.fold(listOf<Int>()) { ids, item ->
-            ids + map.addPolyLine(LineDescription(item.points, item.strokeWidth, item.strokeColor, false, false))
+            ids + map.addPolyLine(LineDescription(item.points, item.strokeWidth, item.strokeColor))
         }
         val polygonIds = polygons.fold(listOf<Int>()) { ids, item ->
             ids + map.addPolygon(PolygonDescription(item.points, item.strokeWidth, item.strokeColor, item.fillColor))

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -391,7 +391,7 @@ class SelectionMapFragment(
             ids + map.addPolyLine(LineDescription(item.points, item.strokeColor, false, false))
         }
         val polygonIds = polygons.fold(listOf<Int>()) { ids, item ->
-            ids + map.addPolygon(PolygonDescription(item.points, item.fillColor))
+            ids + map.addPolygon(PolygonDescription(item.points, item.strokeColor, item.fillColor))
         }
 
         (singlePoints + lines + polygons).zip(pointIds + lineIds + polygonIds).forEach { (item, featureId) ->

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -237,7 +237,9 @@ class SelectionMapFragment(
                 val selectedItem = selectedItemViewModel.getSelectedItem()
                 if (newState == STATE_HIDDEN && selectedItem != null) {
                     selectedItemViewModel.setSelectedItem(null)
-                    resetIcon(selectedItem)
+                    if (selectedItem is MappableSelectItem.MappableSelectPoint) {
+                        resetIcon(selectedItem)
+                    }
 
                     closeSummarySheet.isEnabled = false
                 } else {
@@ -269,7 +271,7 @@ class SelectionMapFragment(
         val selectedItem = selectedItemViewModel.getSelectedItem()
 
         if (item != null) {
-            if (selectedItem != null && selectedItem.id != item.id) {
+            if (selectedItem != null && selectedItem.id != item.id && selectedItem is MappableSelectItem.MappableSelectPoint) {
                 resetIcon(selectedItem)
             }
 
@@ -281,22 +283,24 @@ class SelectionMapFragment(
                     }
                 )
             } else {
-                if (item.points.size > 1) {
-                    map.zoomToBoundingBox(item.points, 0.8, true)
-                } else {
-                    val point = item.points[0]
+                when (item) {
+                    is MappableSelectItem.MappableSelectLine -> map.zoomToBoundingBox(item.points, 0.8, true)
+                    is MappableSelectItem.MappableSelectPolygon -> map.zoomToBoundingBox(item.points, 0.8, true)
+                    is MappableSelectItem.MappableSelectPoint -> {
+                        val point = item.point
 
-                    if (maintainZoom) {
-                        map.zoomToPoint(MapPoint(point.latitude, point.longitude), map.zoom, true)
-                    } else {
-                        map.zoomToPoint(MapPoint(point.latitude, point.longitude), true)
+                        if (maintainZoom) {
+                            map.zoomToPoint(MapPoint(point.latitude, point.longitude), map.zoom, true)
+                        } else {
+                            map.zoomToPoint(MapPoint(point.latitude, point.longitude), true)
+                        }
+
+                        map.setMarkerIcon(
+                            featureId,
+                            MarkerIconDescription(item.largeIcon, item.color, item.symbol)
+                        )
                     }
                 }
-
-                map.setMarkerIcon(
-                    featureId,
-                    MarkerIconDescription(item.largeIcon, item.color, item.symbol)
-                )
 
                 summarySheet.setItem(item)
 
@@ -349,7 +353,7 @@ class SelectionMapFragment(
         }
     }
 
-    private fun resetIcon(selectedItem: MappableSelectItem) {
+    private fun resetIcon(selectedItem: MappableSelectItem.MappableSelectPoint) {
         val featureId = featureIdsByItemId[selectedItem.id]
         if (featureId != null) {
             map.setMarkerIcon(
@@ -367,14 +371,13 @@ class SelectionMapFragment(
         map.clearFeatures()
         itemsByFeatureId.clear()
 
-        val singlePoints = items.filter { it.points.size == 1 }
-        val polys = items.filter { it.points.size != 1 }
+        val singlePoints = items.filterIsInstance<MappableSelectItem.MappableSelectPoint>()
+        val lines = items.filterIsInstance<MappableSelectItem.MappableSelectLine>()
+        val polygons = items.filterIsInstance<MappableSelectItem.MappableSelectPolygon>()
 
         val markerDescriptions = singlePoints.map {
-            val point = it.points[0]
-
             MarkerDescription(
-                MapPoint(point.latitude, point.longitude),
+                MapPoint(it.point.latitude, it.point.longitude),
                 false,
                 MapFragment.BOTTOM,
                 MarkerIconDescription(it.smallIcon, it.color, it.symbol)
@@ -382,18 +385,21 @@ class SelectionMapFragment(
         }
 
         val pointIds = map.addMarkers(markerDescriptions)
-        val polyIds = polys.fold(listOf<Int>()) { ids, item ->
-            if (item.points.first() == item.points.last()) {
-                ids + map.addPolygon(item.points)
-            } else {
-                ids + map.addPolyLine(item.points, false, false)
-            }
+        val lineIds = lines.fold(listOf<Int>()) { ids, item ->
+            ids + map.addPolyLine(item.points, false, false)
+        }
+        val polygonIds = polygons.fold(listOf<Int>()) { ids, item ->
+            ids + map.addPolygon(item.points)
         }
 
-        (singlePoints + polys).zip(pointIds + polyIds).forEach { (item, featureId) ->
+        (singlePoints + lines + polygons).zip(pointIds + lineIds + polygonIds).forEach { (item, featureId) ->
             itemsByFeatureId[featureId] = item
             featureIdsByItemId[item.id] = featureId
-            points.addAll(item.points)
+            when (item) {
+                is MappableSelectItem.MappableSelectPoint -> points.add(item.point)
+                is MappableSelectItem.MappableSelectLine -> points.addAll(item.points)
+                is MappableSelectItem.MappableSelectPolygon -> points.addAll(item.points)
+            }
         }
 
         featureCount = items.size

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -388,7 +388,7 @@ class SelectionMapFragment(
 
         val pointIds = map.addMarkers(markerDescriptions)
         val lineIds = lines.fold(listOf<Int>()) { ids, item ->
-            ids + map.addPolyLine(LineDescription(item.points, item.strokeColor, false, false))
+            ids + map.addPolyLine(LineDescription(item.points, item.strokeWidth, item.strokeColor, false, false))
         }
         val polygonIds = polygons.fold(listOf<Int>()) { ids, item ->
             ids + map.addPolygon(PolygonDescription(item.points, item.strokeWidth, item.strokeColor, item.fillColor))

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -24,6 +24,7 @@ import org.odk.collect.androidshared.ui.multiclicksafe.setMultiClickSafeOnClickL
 import org.odk.collect.geo.GeoDependencyComponentProvider
 import org.odk.collect.geo.ReferenceLayerSettingsNavigator
 import org.odk.collect.geo.databinding.SelectionMapLayoutBinding
+import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragmentFactory
 import org.odk.collect.maps.MapPoint
@@ -387,7 +388,7 @@ class SelectionMapFragment(
 
         val pointIds = map.addMarkers(markerDescriptions)
         val lineIds = lines.fold(listOf<Int>()) { ids, item ->
-            ids + map.addPolyLine(item.points, false, false)
+            ids + map.addPolyLine(LineDescription(item.points, item.strokeColor, false, false))
         }
         val polygonIds = polygons.fold(listOf<Int>()) { ids, item ->
             ids + map.addPolygon(PolygonDescription(item.points, item.fillColor))

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionSummarySheet.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionSummarySheet.kt
@@ -73,10 +73,10 @@ internal class SelectionSummarySheet(context: Context, attrs: AttributeSet?) :
         }
 
         item.action?.let {
-            binding.action.text = item.action!!.text
+            binding.action.text = it.text
 
-            if (item.action!!.icon != null) {
-                binding.action.icon = ContextCompat.getDrawable(context, item.action!!.icon!!)
+            if (it.icon != null) {
+                binding.action.icon = ContextCompat.getDrawable(context, it.icon)
             }
 
             binding.action.visibility = View.VISIBLE

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionSummarySheet.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionSummarySheet.kt
@@ -73,10 +73,10 @@ internal class SelectionSummarySheet(context: Context, attrs: AttributeSet?) :
         }
 
         item.action?.let {
-            binding.action.text = item.action.text
+            binding.action.text = item.action!!.text
 
-            if (item.action.icon != null) {
-                binding.action.icon = ContextCompat.getDrawable(context, item.action.icon)
+            if (item.action!!.icon != null) {
+                binding.action.icon = ContextCompat.getDrawable(context, item.action!!.icon!!)
             }
 
             binding.action.visibility = View.VISIBLE

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.java
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.java
@@ -51,6 +51,7 @@ import org.odk.collect.geo.ReferenceLayerSettingsNavigator;
 import org.odk.collect.geo.support.FakeMapFragment;
 import org.odk.collect.geo.support.RobolectricApplication;
 import org.odk.collect.location.tracker.LocationTracker;
+import org.odk.collect.maps.LineDescription;
 import org.odk.collect.maps.MapFragmentFactory;
 import org.odk.collect.maps.MapPoint;
 import org.robolectric.shadows.ShadowApplication;
@@ -138,9 +139,9 @@ public class GeoPolyActivityTest {
 
         mapFragment.ready();
 
-        List<List<MapPoint>> polys = mapFragment.getPolyLines();
+        List<LineDescription> polys = mapFragment.getPolyLines();
         assertThat(polys.size(), equalTo(1));
-        assertThat(polys.get(0), equalTo(polygon));
+        assertThat(polys.get(0).getPoints(), equalTo(polygon));
     }
 
     @Test
@@ -157,13 +158,13 @@ public class GeoPolyActivityTest {
 
         mapFragment.ready();
 
-        List<List<MapPoint>> polys = mapFragment.getPolyLines();
+        List<LineDescription> polys = mapFragment.getPolyLines();
         assertThat(polys.size(), equalTo(1));
 
         ArrayList<MapPoint> expectedPolygon = new ArrayList<>();
         expectedPolygon.add(new MapPoint(1.0, 2.0, 3, 4));
         expectedPolygon.add(new MapPoint(2.0, 3.0, 3, 4));
-        assertThat(polys.get(0), equalTo(expectedPolygon));
+        assertThat(polys.get(0).getPoints(), equalTo(expectedPolygon));
         assertThat(mapFragment.isPolyClosed(0), equalTo(true));
     }
 
@@ -178,9 +179,9 @@ public class GeoPolyActivityTest {
 
         mapFragment.ready();
 
-        List<List<MapPoint>> polys = mapFragment.getPolyLines();
+        List<LineDescription> polys = mapFragment.getPolyLines();
         assertThat(polys.size(), equalTo(1));
-        assertThat(polys.get(0).isEmpty(), equalTo(true));
+        assertThat(polys.get(0).getPoints().isEmpty(), equalTo(true));
     }
 
     @Test
@@ -231,7 +232,7 @@ public class GeoPolyActivityTest {
         mapFragment.setLocation(new MapPoint(1, 1));
         onView(withId(R.id.record_button)).perform(click());
         onView(withId(R.id.record_button)).perform(click());
-        assertThat(mapFragment.getPolyLines().get(0).size(), equalTo(1));
+        assertThat(mapFragment.getPolyLines().get(0).getPoints().size(), equalTo(1));
     }
 
     @Test
@@ -243,7 +244,7 @@ public class GeoPolyActivityTest {
 
         mapFragment.click(new MapPoint(1, 1));
         mapFragment.click(new MapPoint(1, 1));
-        assertThat(mapFragment.getPolyLines().get(0).size(), equalTo(1));
+        assertThat(mapFragment.getPolyLines().get(0).getPoints().size(), equalTo(1));
     }
 
     private void startInput(int mode) {

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -198,6 +198,7 @@ class SelectionMapFragmentTest {
                     MapPoint(41.0, 0.0),
                     MapPoint(40.0, 0.0)
                 ),
+                strokeWidth = "10",
                 strokeColor = "#aaccee",
                 fillColor = "#ffffff"
             )
@@ -210,6 +211,7 @@ class SelectionMapFragmentTest {
         map.ready()
 
         assertThat(map.getPolygons()[0].points, equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectPolygon).points }?.first()))
+        assertThat(map.getPolygons()[0].getStrokeWidth(), equalTo(10f))
         assertThat(map.getPolygons()[0].getStrokeColor(), equalTo(-5583634))
         assertThat(map.getPolygons()[0].getFillColor(), equalTo(1157627903))
         onView(withText(application.getString(org.odk.collect.strings.R.string.select_item_count, "Things", 0, 1)))

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -173,6 +173,7 @@ class SelectionMapFragmentTest {
                     MapPoint(40.0, 0.0),
                     MapPoint(41.0, 0.0)
                 ),
+                strokeWidth = "10",
                 strokeColor = "#ffffff"
             )
         )
@@ -183,6 +184,7 @@ class SelectionMapFragmentTest {
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
         assertThat(map.getPolyLines()[0].points, equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectLine).points }?.first()))
+        assertThat(map.getPolyLines()[0].getStrokeWidth(), equalTo(10f))
         assertThat(map.getPolyLines()[0].getStrokeColor(), equalTo(-1))
         onView(withText(application.getString(org.odk.collect.strings.R.string.select_item_count, "Things", 0, 1)))
             .check(matches(isDisplayed()))

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -172,7 +172,8 @@ class SelectionMapFragmentTest {
                 points = listOf(
                     MapPoint(40.0, 0.0),
                     MapPoint(41.0, 0.0)
-                )
+                ),
+                strokeColor = "#ffffff"
             )
         )
 
@@ -181,9 +182,8 @@ class SelectionMapFragmentTest {
 
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
-
-        assertThat(map.getPolyLines(), equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectLine).points }))
-        assertThat(map.isPolyDraggable(0), equalTo(false))
+        assertThat(map.getPolyLines()[0].points, equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectLine).points }?.first()))
+        assertThat(map.getPolyLines()[0].getStrokeColor(), equalTo(-1))
         onView(withText(application.getString(org.odk.collect.strings.R.string.select_item_count, "Things", 0, 1)))
             .check(matches(isDisplayed()))
     }

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -128,8 +128,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `updates markers when items update`() {
         val items: List<MappableSelectItem> = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)))
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0))
         )
         val itemsLiveData = MutableLiveData(items)
         whenever(data.getMappableItems()).thenReturn(itemsLiveData)
@@ -137,7 +137,7 @@ class SelectionMapFragmentTest {
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
 
-        assertThat(map.getMarkers(), equalTo(itemsLiveData.value?.map { it.toMapPoint() }))
+        assertThat(map.getMarkers(), equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectPoint).toMapPoint() }))
 
         itemsLiveData.value = emptyList()
         assertThat(map.getMarkers(), equalTo(emptyList()))
@@ -146,8 +146,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `updates item count when items update`() {
         val items: List<MappableSelectItem> = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0),
-            Fixtures.actionMappableSelectItem().copy(id = 1)
+            Fixtures.actionMappableSelectPoint().copy(id = 0),
+            Fixtures.actionMappableSelectPoint().copy(id = 1)
         )
 
         val itemsLiveData = MutableLiveData(items)
@@ -167,7 +167,7 @@ class SelectionMapFragmentTest {
     @Test
     fun `shows polyline when item has multiple points`() {
         val items: List<MappableSelectItem> = listOf(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectLine().copy(
                 id = 0,
                 points = listOf(
                     MapPoint(40.0, 0.0),
@@ -182,7 +182,7 @@ class SelectionMapFragmentTest {
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
 
-        assertThat(map.getPolyLines(), equalTo(itemsLiveData.value?.map { it.points }))
+        assertThat(map.getPolyLines(), equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectLine).points }))
         assertThat(map.isPolyDraggable(0), equalTo(false))
         onView(withText(application.getString(org.odk.collect.strings.R.string.select_item_count, "Things", 0, 1)))
             .check(matches(isDisplayed()))
@@ -191,7 +191,7 @@ class SelectionMapFragmentTest {
     @Test
     fun `shows polygon when item has multiple closed points`() {
         val items: List<MappableSelectItem> = listOf(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPolygon().copy(
                 id = 0,
                 points = listOf(
                     MapPoint(40.0, 0.0),
@@ -207,7 +207,7 @@ class SelectionMapFragmentTest {
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
 
-        assertThat(map.getPolygons(), equalTo(itemsLiveData.value?.map { it.points }))
+        assertThat(map.getPolygons(), equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectPolygon).points }))
         onView(withText(application.getString(org.odk.collect.strings.R.string.select_item_count, "Things", 0, 1)))
             .check(matches(isDisplayed()))
     }
@@ -215,8 +215,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `zooms to fit all items`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)))
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0))
         )
 
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
@@ -232,7 +232,7 @@ class SelectionMapFragmentTest {
     fun `zooms to fit all points in for item with multiple points`() {
         val points = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))
         val items: List<MappableSelectItem> = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = points)
+            Fixtures.actionMappableSelectLine().copy(id = 0, points = points)
         )
 
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
@@ -246,7 +246,7 @@ class SelectionMapFragmentTest {
     @Test
     fun `does not zoom to fit all items again when they change`() {
         val originalItems =
-            listOf(Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))))
+            listOf(Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)))
         val itemsLiveData: MutableLiveData<List<MappableSelectItem>?> =
             MutableLiveData(originalItems)
         whenever(data.getMappableItems()).thenReturn(itemsLiveData)
@@ -255,7 +255,7 @@ class SelectionMapFragmentTest {
         map.ready()
 
         itemsLiveData.value =
-            listOf(Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(52.0, 0.0))))
+            listOf(Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(52.0, 0.0)))
 
         val points = originalItems.map { it.toMapPoint() }
         assertThat(map.getZoomBoundingBox(), equalTo(Pair(points, 0.8)))
@@ -263,7 +263,7 @@ class SelectionMapFragmentTest {
 
     @Test
     fun `does not zoom to fit all items if map already has center`() {
-        val items = listOf(Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))))
+        val items = listOf(Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)))
         val itemsLiveData: MutableLiveData<List<MappableSelectItem>?> =
             MutableLiveData(items)
         whenever(data.getMappableItems()).thenReturn(itemsLiveData)
@@ -278,8 +278,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `zooms to current location when zoomToFitItems is false`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)))
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0))
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -335,7 +335,7 @@ class SelectionMapFragmentTest {
     @Test
     fun `does not zoom to current location when items change`() {
         val originalItems =
-            listOf(Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))))
+            listOf(Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)))
         val itemsLiveData: MutableLiveData<List<MappableSelectItem>?> =
             MutableLiveData(originalItems)
         whenever(data.getMappableItems()).thenReturn(itemsLiveData)
@@ -345,7 +345,7 @@ class SelectionMapFragmentTest {
         map.setLocation(MapPoint(67.0, 48.0))
 
         itemsLiveData.value =
-            listOf(Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(52.0, 0.0))))
+            listOf(Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(52.0, 0.0)))
 
         val points = originalItems.map { it.toMapPoint() }
         assertThat(map.getZoomBoundingBox(), equalTo(Pair(points, 0.8)))
@@ -366,8 +366,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `clicking zoom to fit button zooms to fit all items`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)))
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0))
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -384,7 +384,7 @@ class SelectionMapFragmentTest {
     fun `clicking zoom to fit button zooms to fit all polys`() {
         val points = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))
         val items: List<MappableSelectItem> = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = points)
+            Fixtures.actionMappableSelectLine().copy(id = 0, points = points)
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -410,8 +410,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `clicking on item centers on that item with current zoom level`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)))
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0))
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -429,8 +429,8 @@ class SelectionMapFragmentTest {
     fun `clicking on item with multiple points zooms to fit all item points`() {
         val itemPoints = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = itemPoints)
+            Fixtures.actionMappableSelectLine().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
+            Fixtures.actionMappableSelectLine().copy(id = 1, points = itemPoints)
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -448,29 +448,29 @@ class SelectionMapFragmentTest {
     @Test
     fun `clicking on item always selects correct item`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(45.0, 0.0)))
+            Fixtures.actionMappableSelectLine().copy(id = 0, points = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(45.0, 0.0))
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
 
-        map.clickOnFeatureId(map.getFeatureId(items[1].points))
-        assertThat(map.center, equalTo(items[1].points[0]))
+        map.clickOnFeatureId(map.getFeatureId(listOf((items[1] as MappableSelectItem.MappableSelectPoint).point)))
+        assertThat(map.center, equalTo((items[1] as MappableSelectItem.MappableSelectPoint).point))
     }
 
     @Test
     fun `clicking on item switches item marker to large icon`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 id = 0,
                 smallIcon = android.R.drawable.ic_lock_idle_charging,
                 largeIcon = android.R.drawable.ic_lock_idle_alarm,
                 symbol = "A",
                 color = "#ffffff"
             ),
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 id = 1,
                 smallIcon = android.R.drawable.ic_lock_idle_charging,
                 largeIcon = android.R.drawable.ic_lock_idle_alarm,
@@ -499,14 +499,14 @@ class SelectionMapFragmentTest {
     @Test
     fun `clicking on item when another has been tapped switches the first one back to its small icon`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 id = 0,
                 smallIcon = android.R.drawable.ic_lock_idle_charging,
                 largeIcon = android.R.drawable.ic_lock_idle_alarm,
                 symbol = "A",
                 color = "#ffffff"
             ),
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 id = 1,
                 smallIcon = android.R.drawable.ic_lock_idle_charging,
                 largeIcon = android.R.drawable.ic_lock_idle_alarm,
@@ -536,8 +536,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `clicking on item sets item on summary sheet`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, name = "Blah1"),
-            Fixtures.actionMappableSelectItem().copy(id = 1, name = "Blah2")
+            Fixtures.actionMappableSelectPoint().copy(id = 0, name = "Blah1"),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, name = "Blah2")
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -552,8 +552,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `clicking on item returns item ID as result when skipSummary is true`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0),
-            Fixtures.actionMappableSelectItem().copy(id = 1)
+            Fixtures.actionMappableSelectPoint().copy(id = 0),
+            Fixtures.actionMappableSelectPoint().copy(id = 1)
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -589,7 +589,7 @@ class SelectionMapFragmentTest {
 
     @Test
     fun `clicking map with an item selected deselects it`() {
-        val item = Fixtures.actionMappableSelectItem().copy(id = 0, name = "Blah1")
+        val item = Fixtures.actionMappableSelectPoint().copy(id = 0, name = "Blah1")
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(listOf(item)))
 
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
@@ -605,7 +605,7 @@ class SelectionMapFragmentTest {
 
     @Test
     fun `pressing back with an item selected deselects it`() {
-        val item = Fixtures.actionMappableSelectItem()
+        val item = Fixtures.actionMappableSelectPoint()
             .copy(id = 0, name = "Blah1", symbol = "A", color = "#ffffff")
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(listOf(item)))
 
@@ -627,7 +627,7 @@ class SelectionMapFragmentTest {
 
     @Test
     fun `pressing back after deselecting item disables back callbacks`() {
-        val item = Fixtures.actionMappableSelectItem().copy(id = 0, name = "Blah1")
+        val item = Fixtures.actionMappableSelectPoint().copy(id = 0, name = "Blah1")
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(listOf(item)))
 
         val scenario = launcherRule.launchInContainer(SelectionMapFragment::class.java)
@@ -642,7 +642,7 @@ class SelectionMapFragmentTest {
 
     @Test
     fun `recreating after deselecting item has no item selected`() {
-        val items = listOf(Fixtures.actionMappableSelectItem().copy(id = 0, name = "Point1"))
+        val items = listOf(Fixtures.actionMappableSelectPoint().copy(id = 0, name = "Point1"))
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
         val scenario = launcherRule.launchInContainer(SelectionMapFragment::class.java)
@@ -663,7 +663,7 @@ class SelectionMapFragmentTest {
     @Test
     fun `clicking action hides summary sheet`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 id = 0,
                 name = "Item",
                 action = IconifiedText(null, "Action")
@@ -682,8 +682,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `centers on already selected item`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(40.1, 0.0)), selected = true)
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(40.1, 0.0), selected = true)
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -697,8 +697,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `does not move when location changes when centered on already selected item`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)), selected = true)
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0), selected = true)
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -739,8 +739,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `recreating maintains selection`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0)), name = "Point1"),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)), name = "Point2")
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0), name = "Point1"),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0), name = "Point2")
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -759,9 +759,9 @@ class SelectionMapFragmentTest {
     @Test
     fun `recreating with initial selection maintains new selection`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem()
-                .copy(id = 0, points = listOf(MapPoint(40.0, 0.0)), name = "Point1", selected = true),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)), name = "Point2")
+            Fixtures.actionMappableSelectPoint()
+                .copy(id = 0, point = MapPoint(40.0, 0.0), name = "Point1", selected = true),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0), name = "Point2")
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -807,8 +807,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `opening the map with already selected item when skipSummary is true does not close the map`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)), selected = true)
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0), selected = true)
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -841,8 +841,8 @@ class SelectionMapFragmentTest {
     @Test
     fun `recreating the map with already selected item when skipSummary is true does not close the map`() {
         val items = listOf(
-            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
-            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)), selected = true)
+            Fixtures.actionMappableSelectPoint().copy(id = 0, point = MapPoint(40.0, 0.0)),
+            Fixtures.actionMappableSelectPoint().copy(id = 1, point = MapPoint(41.0, 0.0), selected = true)
         )
         whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
 
@@ -873,7 +873,7 @@ class SelectionMapFragmentTest {
         assertThat(actualResult, equalTo(null))
     }
 
-    private fun MappableSelectItem.toMapPoint(): MapPoint {
-        return MapPoint(this.points[0].latitude, this.points[0].longitude)
+    private fun MappableSelectItem.MappableSelectPoint.toMapPoint(): MapPoint {
+        return MapPoint(this.point.latitude, this.point.longitude)
     }
 }

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -198,6 +198,7 @@ class SelectionMapFragmentTest {
                     MapPoint(41.0, 0.0),
                     MapPoint(40.0, 0.0)
                 ),
+                strokeColor = "#aaccee",
                 fillColor = "#ffffff"
             )
         )
@@ -209,6 +210,7 @@ class SelectionMapFragmentTest {
         map.ready()
 
         assertThat(map.getPolygons()[0].points, equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectPolygon).points }?.first()))
+        assertThat(map.getPolygons()[0].getStrokeColor(), equalTo(-5583634))
         assertThat(map.getPolygons()[0].getFillColor(), equalTo(1157627903))
         onView(withText(application.getString(org.odk.collect.strings.R.string.select_item_count, "Things", 0, 1)))
             .check(matches(isDisplayed()))

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -197,7 +197,8 @@ class SelectionMapFragmentTest {
                     MapPoint(40.0, 0.0),
                     MapPoint(41.0, 0.0),
                     MapPoint(40.0, 0.0)
-                )
+                ),
+                fillColor = "#ffffff"
             )
         )
 
@@ -207,7 +208,8 @@ class SelectionMapFragmentTest {
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
 
-        assertThat(map.getPolygons(), equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectPolygon).points }))
+        assertThat(map.getPolygons()[0].points, equalTo(itemsLiveData.value?.map { (it as MappableSelectItem.MappableSelectPolygon).points }?.first()))
+        assertThat(map.getPolygons()[0].getFillColor(), equalTo(1157627903))
         onView(withText(application.getString(org.odk.collect.strings.R.string.select_item_count, "Things", 0, 1)))
             .check(matches(isDisplayed()))
     }

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionSummarySheetTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionSummarySheetTest.kt
@@ -23,7 +23,7 @@ class SelectionSummarySheetTest {
     fun `setItem shows an error chip when the status is ERRORS`() {
         val selectionSummarySheet = SelectionSummarySheet(application)
         selectionSummarySheet.setItem(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 status = Status.ERRORS
             )
         )
@@ -36,7 +36,7 @@ class SelectionSummarySheetTest {
     fun `setItem shows a no-error chip when the status is NO_ERRORS`() {
         val selectionSummarySheet = SelectionSummarySheet(application)
         selectionSummarySheet.setItem(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 status = Status.NO_ERRORS
             )
         )
@@ -48,7 +48,7 @@ class SelectionSummarySheetTest {
     @Test
     fun `setItem does not show a chip if the status is null`() {
         val selectionSummarySheet = SelectionSummarySheet(application)
-        selectionSummarySheet.setItem(Fixtures.actionMappableSelectItem())
+        selectionSummarySheet.setItem(Fixtures.actionMappableSelectPoint())
 
         assertThat(selectionSummarySheet.binding.statusChip.visibility, equalTo(View.GONE))
     }
@@ -57,7 +57,7 @@ class SelectionSummarySheetTest {
     fun `setItem shows name`() {
         val selectionSummarySheet = SelectionSummarySheet(application)
         selectionSummarySheet.setItem(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 name = "Cosmic Dread"
             )
         )
@@ -69,7 +69,7 @@ class SelectionSummarySheetTest {
     fun `setItem shows properties`() {
         val selectionSummarySheet = SelectionSummarySheet(application)
         selectionSummarySheet.setItem(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 properties = listOf(
                     IconifiedText(
                         android.R.drawable.ic_btn_speak_now,
@@ -100,7 +100,7 @@ class SelectionSummarySheetTest {
     fun `properties without icons have hidden icon view`() {
         val selectionSummarySheet = SelectionSummarySheet(application)
         selectionSummarySheet.setItem(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 properties = listOf(
                     IconifiedText(
                         null,
@@ -119,7 +119,7 @@ class SelectionSummarySheetTest {
     fun `properties reset between items`() {
         val selectionSummarySheet = SelectionSummarySheet(application)
         selectionSummarySheet.setItem(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 properties = listOf(
                     IconifiedText(
                         android.R.drawable.ic_btn_speak_now,
@@ -130,7 +130,7 @@ class SelectionSummarySheetTest {
         )
 
         selectionSummarySheet.setItem(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 properties = listOf(
                     IconifiedText(
                         android.R.drawable.ic_dialog_info,
@@ -153,7 +153,7 @@ class SelectionSummarySheetTest {
     fun `setItem shows info and hides action when it is non-null`() {
         val selectionSummarySheet = SelectionSummarySheet(application)
         selectionSummarySheet.setItem(
-            Fixtures.infoMappableSelectItem().copy(
+            Fixtures.infoMappableSelectPoint().copy(
                 info = "Don't even bother looking"
             )
         )
@@ -167,7 +167,7 @@ class SelectionSummarySheetTest {
     fun `setItem shows action and hides info when it is non-null`() {
         val selectionSummarySheet = SelectionSummarySheet(application)
         selectionSummarySheet.setItem(
-            Fixtures.actionMappableSelectItem().copy(
+            Fixtures.actionMappableSelectPoint().copy(
                 action = IconifiedText(
                     android.R.drawable.ic_btn_speak_now,
                     "Come on in"

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.geo.support
 
 import androidx.fragment.app.Fragment
+import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragment.FeatureListener
 import org.odk.collect.maps.MapFragment.PointListener
@@ -108,16 +109,12 @@ class FakeMapFragment : Fragment(), MapFragment {
         return markers[featureId]!!
     }
 
-    override fun addPolyLine(
-        points: Iterable<MapPoint>,
-        closed: Boolean,
-        draggable: Boolean
-    ): Int {
+    override fun addPolyLine(lineDescription: LineDescription): Int {
         val featureId = generateFeatureId()
 
-        polyLines[featureId] = points.toList()
-        polyClosed.add(closed)
-        polyDraggable.add(draggable)
+        polyLines[featureId] = lineDescription.points
+        polyClosed.add(lineDescription.closed)
+        polyDraggable.add(lineDescription.draggable)
 
         featureIds.add(featureId)
         return featureId

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -6,6 +6,7 @@ import org.odk.collect.maps.MapFragment.FeatureListener
 import org.odk.collect.maps.MapFragment.PointListener
 import org.odk.collect.maps.MapFragment.ReadyListener
 import org.odk.collect.maps.MapPoint
+import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.maps.markers.MarkerDescription
 import org.odk.collect.maps.markers.MarkerIconDescription
 import kotlin.random.Random
@@ -122,9 +123,9 @@ class FakeMapFragment : Fragment(), MapFragment {
         return featureId
     }
 
-    override fun addPolygon(points: MutableIterable<MapPoint>): Int {
+    override fun addPolygon(polygonDescription: PolygonDescription): Int {
         val featureId = generateFeatureId()
-        polygons[featureId] = points.toList()
+        polygons[featureId] = polygonDescription.points
         featureIds.add(featureId)
         return featureId
     }

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -28,7 +28,7 @@ class FakeMapFragment : Fragment(), MapFragment {
     private val polyLines = mutableMapOf<Int, List<MapPoint>>()
     private val polyClosed: MutableList<Boolean> = ArrayList()
     private val polyDraggable: MutableList<Boolean> = ArrayList()
-    private val polygons = mutableMapOf<Int, List<MapPoint>>()
+    private val polygons = mutableMapOf<Int, PolygonDescription>()
     private var hasCenter = false
     private val featureIds = mutableListOf<Int>()
 
@@ -125,7 +125,7 @@ class FakeMapFragment : Fragment(), MapFragment {
 
     override fun addPolygon(polygonDescription: PolygonDescription): Int {
         val featureId = generateFeatureId()
-        polygons[featureId] = polygonDescription.points
+        polygons[featureId] = polygonDescription
         featureIds.add(featureId)
         return featureId
     }
@@ -257,7 +257,7 @@ class FakeMapFragment : Fragment(), MapFragment {
         return featureId
     }
 
-    fun getPolygons(): List<List<MapPoint>> {
+    fun getPolygons(): List<PolygonDescription> {
         return polygons.values.toList()
     }
 

--- a/geo/src/test/java/org/odk/collect/geo/support/Fixtures.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/Fixtures.kt
@@ -6,27 +6,47 @@ import org.odk.collect.geo.selection.MappableSelectItem
 import org.odk.collect.maps.MapPoint
 
 object Fixtures {
-    fun actionMappableSelectItem(): MappableSelectItem {
-        return MappableSelectItem(
+    fun actionMappableSelectPoint(): MappableSelectItem.MappableSelectPoint {
+        return MappableSelectItem.MappableSelectPoint(
             0,
-            listOf(MapPoint(0.0, 0.0)),
-            R.drawable.ic_lock_power_off,
-            R.drawable.ic_lock_idle_charging,
             "0",
             listOf(IconifiedText(R.drawable.ic_lock_idle_charging, "An item")),
+            point = MapPoint(0.0, 0.0),
+            smallIcon = R.drawable.ic_lock_power_off,
+            largeIcon = R.drawable.ic_lock_idle_charging,
             action = IconifiedText(R.drawable.ic_delete, "Action")
         )
     }
 
-    fun infoMappableSelectItem(): MappableSelectItem {
-        return MappableSelectItem(
+    fun infoMappableSelectPoint(): MappableSelectItem.MappableSelectPoint {
+        return MappableSelectItem.MappableSelectPoint(
             0,
-            listOf(MapPoint(0.0, 0.0)),
-            R.drawable.ic_lock_power_off,
-            R.drawable.ic_lock_idle_charging,
             "0",
             listOf(IconifiedText(R.drawable.ic_lock_idle_charging, "An item")),
+            point = MapPoint(0.0, 0.0),
+            smallIcon = R.drawable.ic_lock_power_off,
+            largeIcon = R.drawable.ic_lock_idle_charging,
             info = "Info"
+        )
+    }
+
+    fun actionMappableSelectLine(): MappableSelectItem.MappableSelectLine {
+        return MappableSelectItem.MappableSelectLine(
+            0,
+            "0",
+            listOf(IconifiedText(R.drawable.ic_lock_idle_charging, "An item")),
+            points = listOf(MapPoint(0.0, 0.0), MapPoint(1.0, 1.0)),
+            action = IconifiedText(R.drawable.ic_delete, "Action")
+        )
+    }
+
+    fun actionMappableSelectPolygon(): MappableSelectItem.MappableSelectPolygon {
+        return MappableSelectItem.MappableSelectPolygon(
+            0,
+            "0",
+            listOf(IconifiedText(R.drawable.ic_lock_idle_charging, "An item")),
+            points = listOf(MapPoint(0.0, 0.0), MapPoint(1.0, 1.0)),
+            action = IconifiedText(R.drawable.ic_delete, "Action")
         )
     }
 }

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -947,7 +947,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
             polygon = map.addPolygon(new PolygonOptions()
                     .addAll(StreamSupport.stream(polygonDescription.getPoints().spliterator(), false).map(mapPoint -> new LatLng(mapPoint.latitude, mapPoint.longitude)).collect(Collectors.toList()))
                     .strokeColor(polygonDescription.getStrokeColor())
-                    .strokeWidth(POLYLINE_STROKE_WIDTH)
+                    .strokeWidth(polygonDescription.getStrokeWidth())
                     .fillColor(polygonDescription.getFillColor())
                     .clickable(true)
             );

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -14,8 +14,6 @@
 
 package org.odk.collect.googlemaps;
 
-import static org.odk.collect.maps.MapConsts.POLYLINE_STROKE_WIDTH;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.location.Location;
@@ -793,7 +791,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
                 polyline = map.addPolyline(new PolylineOptions()
                         .color(lineDescription.getStrokeColor())
                         .zIndex(1)
-                        .width(POLYLINE_STROKE_WIDTH)
+                        .width(lineDescription.getStrokeWidth())
                         .addAll(latLngs)
                         .clickable(true)
                 );
@@ -889,7 +887,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
                 polyline = map.addPolyline(new PolylineOptions()
                     .color(lineDescription.getStrokeColor())
                     .zIndex(1)
-                    .width(POLYLINE_STROKE_WIDTH)
+                    .width(lineDescription.getStrokeWidth())
                     .addAll(latLngs)
                     .clickable(true)
                 );

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -319,7 +319,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     @Override
     public int addPolygon(PolygonDescription polygonDescription) {
         int featureId = nextFeatureId++;
-        features.put(featureId, new StaticPolygonFeature(map, polygonDescription.getPoints(), requireContext().getResources().getColor(org.odk.collect.icons.R.color.mapLineColor), polygonDescription.getFillColor()));
+        features.put(featureId, new StaticPolygonFeature(map, polygonDescription));
         return featureId;
     }
 
@@ -943,12 +943,12 @@ public class GoogleMapFragment extends SupportMapFragment implements
     private static class StaticPolygonFeature implements MapFeature {
         private Polygon polygon;
 
-        StaticPolygonFeature(GoogleMap map, Iterable<MapPoint> points, int strokeLineColor, int fillColor) {
+        StaticPolygonFeature(GoogleMap map, PolygonDescription polygonDescription) {
             polygon = map.addPolygon(new PolygonOptions()
-                    .addAll(StreamSupport.stream(points.spliterator(), false).map(mapPoint -> new LatLng(mapPoint.latitude, mapPoint.longitude)).collect(Collectors.toList()))
-                    .strokeColor(strokeLineColor)
+                    .addAll(StreamSupport.stream(polygonDescription.getPoints().spliterator(), false).map(mapPoint -> new LatLng(mapPoint.latitude, mapPoint.longitude)).collect(Collectors.toList()))
+                    .strokeColor(polygonDescription.getStrokeColor())
                     .strokeWidth(POLYLINE_STROKE_WIDTH)
-                    .fillColor(fillColor)
+                    .fillColor(polygonDescription.getFillColor())
                     .clickable(true)
             );
         }

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -14,7 +14,6 @@
 
 package org.odk.collect.googlemaps;
 
-import static org.odk.collect.maps.MapConsts.POLYGON_FILL_COLOR_OPACITY;
 import static org.odk.collect.maps.MapConsts.POLYLINE_STROKE_WIDTH;
 
 import android.annotation.SuppressLint;
@@ -25,7 +24,6 @@ import android.os.Handler;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.graphics.ColorUtils;
 
 import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.maps.CameraUpdate;
@@ -55,6 +53,7 @@ import org.odk.collect.maps.MapConfigurator;
 import org.odk.collect.maps.MapFragment;
 import org.odk.collect.maps.MapFragmentDelegate;
 import org.odk.collect.maps.MapPoint;
+import org.odk.collect.maps.PolygonDescription;
 import org.odk.collect.maps.layers.MapFragmentReferenceLayerUtils;
 import org.odk.collect.maps.layers.ReferenceLayerRepository;
 import org.odk.collect.maps.markers.MarkerDescription;
@@ -317,9 +316,9 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     @Override
-    public int addPolygon(@NonNull Iterable<MapPoint> points) {
+    public int addPolygon(PolygonDescription polygonDescription) {
         int featureId = nextFeatureId++;
-        features.put(featureId, new StaticPolygonFeature(map, points, requireContext().getResources().getColor(org.odk.collect.icons.R.color.mapLineColor)));
+        features.put(featureId, new StaticPolygonFeature(map, polygonDescription.getPoints(), requireContext().getResources().getColor(org.odk.collect.icons.R.color.mapLineColor), polygonDescription.getFillColor()));
         return featureId;
     }
 
@@ -943,12 +942,12 @@ public class GoogleMapFragment extends SupportMapFragment implements
     private static class StaticPolygonFeature implements MapFeature {
         private Polygon polygon;
 
-        StaticPolygonFeature(GoogleMap map, Iterable<MapPoint> points, int strokeLineColor) {
+        StaticPolygonFeature(GoogleMap map, Iterable<MapPoint> points, int strokeLineColor, int fillColor) {
             polygon = map.addPolygon(new PolygonOptions()
                     .addAll(StreamSupport.stream(points.spliterator(), false).map(mapPoint -> new LatLng(mapPoint.latitude, mapPoint.longitude)).collect(Collectors.toList()))
                     .strokeColor(strokeLineColor)
                     .strokeWidth(POLYLINE_STROKE_WIDTH)
-                    .fillColor(ColorUtils.setAlphaComponent(strokeLineColor, POLYGON_FILL_COLOR_OPACITY))
+                    .fillColor(fillColor)
                     .clickable(true)
             );
         }

--- a/icons/src/main/res/drawable/ic_map_point.xml
+++ b/icons/src/main/res/drawable/ic_map_point.xml
@@ -3,6 +3,6 @@
         android:height="36dp"
         android:viewportWidth="36"
         android:viewportHeight="36">
-    <path android:fillColor="@color/mapLineColor" android:pathData="M18,13c-2.77,0 -5,2.24 -5,5s2.24,5 5,5s5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
+    <path android:fillColor="#ffff0000" android:pathData="M18,13c-2.77,0 -5,2.24 -5,5s2.24,5 5,5s5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
     <path android:fillColor="#ffffff" android:pathData="M18,21.33c-1.84,0 -3.33,-1.5 -3.33,-3.33s1.5,-3.33 3.33,-3.33s3.33,1.5 3.33,3.33s-1.5,3.33 -3.33,3.33z"/>
 </vector>

--- a/icons/src/main/res/values/map_colors.xml
+++ b/icons/src/main/res/values/map_colors.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<!-- Colors used on map views -->
-
-<resources>
-    <color name="mapLineColor">#ffff0000</color>
-</resources>

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -120,7 +120,7 @@ internal class DynamicPolyLineFeature(
                 PolylineAnnotationOptions()
                     .withPoints(points)
                     .withLineColor(lineDescription.getStrokeColor())
-                    .withLineWidth((lineDescription.getStrokeWidth() / 2).toDouble())
+                    .withLineWidth((lineDescription.getStrokeWidth() / 3).toDouble())
             ).also {
                 polylineAnnotationManager.update(it)
             }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -10,7 +10,6 @@ import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions
 import org.odk.collect.maps.LineDescription
-import org.odk.collect.maps.MapConsts.MAPBOX_POLYLINE_STROKE_WIDTH
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
 
@@ -121,7 +120,7 @@ internal class DynamicPolyLineFeature(
                 PolylineAnnotationOptions()
                     .withPoints(points)
                     .withLineColor(lineDescription.getStrokeColor())
-                    .withLineWidth(MAPBOX_POLYLINE_STROKE_WIDTH.toDouble())
+                    .withLineWidth((lineDescription.getStrokeWidth() / 2).toDouble())
             ).also {
                 polylineAnnotationManager.update(it)
             }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -120,7 +120,7 @@ internal class DynamicPolyLineFeature(
                 PolylineAnnotationOptions()
                     .withPoints(points)
                     .withLineColor(lineDescription.getStrokeColor())
-                    .withLineWidth((lineDescription.getStrokeWidth() / 3).toDouble())
+                    .withLineWidth(MapUtils.convertStrokeWidth(lineDescription))
             ).also {
                 polylineAnnotationManager.update(it)
             }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -2,7 +2,6 @@ package org.odk.collect.mapbox
 
 import android.content.Context
 import com.mapbox.geojson.Point
-import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationDragListener
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
@@ -10,6 +9,7 @@ import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions
+import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapConsts.MAPBOX_POLYLINE_STROKE_WIDTH
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
@@ -22,8 +22,7 @@ internal class DynamicPolyLineFeature(
     private val featureId: Int,
     private val featureClickListener: MapFragment.FeatureListener?,
     private val featureDragEndListener: MapFragment.FeatureListener?,
-    private val closedPolygon: Boolean,
-    initMapPoints: Iterable<MapPoint>
+    private val lineDescription: LineDescription
 ) : MapFeature {
     val mapPoints = mutableListOf<MapPoint>()
     private val pointAnnotations = mutableListOf<PointAnnotation>()
@@ -32,7 +31,7 @@ internal class DynamicPolyLineFeature(
     private var polylineAnnotation: PolylineAnnotation? = null
 
     init {
-        initMapPoints.forEach {
+        lineDescription.points.forEach {
             mapPoints.add(it)
             pointAnnotations.add(
                 MapUtils.createPointAnnotation(
@@ -108,7 +107,7 @@ internal class DynamicPolyLineFeature(
             }
             .toMutableList()
             .also {
-                if (closedPolygon && it.isNotEmpty()) {
+                if (lineDescription.closed && it.isNotEmpty()) {
                     it.add(it.first())
                 }
             }
@@ -121,7 +120,7 @@ internal class DynamicPolyLineFeature(
             polylineAnnotation = polylineAnnotationManager.create(
                 PolylineAnnotationOptions()
                     .withPoints(points)
-                    .withLineColor(ColorUtils.colorToRgbaString(context.resources.getColor(org.odk.collect.icons.R.color.mapLineColor)))
+                    .withLineColor(lineDescription.getStrokeColor())
                     .withLineWidth(MAPBOX_POLYLINE_STROKE_WIDTH.toDouble())
             ).also {
                 polylineAnnotationManager.update(it)

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapUtils.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapUtils.kt
@@ -6,6 +6,7 @@ import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
+import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.markers.MarkerDescription
@@ -64,5 +65,11 @@ object MapUtils {
         // obtained from a GPS reading, so the altitude and standard
         // deviation fields are no longer meaningful; reset them to zero.
         return MapPoint(pointAnnotation.point.latitude(), pointAnnotation.point.longitude(), 0.0, 0.0)
+    }
+
+    // To ensure consistent stroke width across map platforms like Mapbox, Google, and OSM,
+    // the value for Mapbox needs to be divided by 3.
+    fun convertStrokeWidth(lineDescription: LineDescription): Double {
+        return (lineDescription.getStrokeWidth() / 3).toDouble()
     }
 }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.launch
 import org.odk.collect.androidshared.utils.ScreenUtils
 import org.odk.collect.location.LocationClient
 import org.odk.collect.location.LocationClient.LocationClientListener
+import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragment.ErrorListener
 import org.odk.collect.maps.MapFragment.FeatureListener
@@ -337,9 +338,9 @@ class MapboxMapFragment :
         }
     }
 
-    override fun addPolyLine(points: MutableIterable<MapPoint>, closed: Boolean, draggable: Boolean): Int {
+    override fun addPolyLine(lineDescription: LineDescription): Int {
         val featureId = nextFeatureId++
-        if (draggable) {
+        if (lineDescription.draggable) {
             features[featureId] = DynamicPolyLineFeature(
                 requireContext(),
                 pointAnnotationManager,
@@ -347,8 +348,7 @@ class MapboxMapFragment :
                 featureId,
                 featureClickListener,
                 featureDragEndListener,
-                closed,
-                points
+                lineDescription
             )
         } else {
             features[featureId] = StaticPolyLineFeature(
@@ -356,8 +356,7 @@ class MapboxMapFragment :
                 polylineAnnotationManager,
                 featureId,
                 featureClickListener,
-                closed,
-                points
+                lineDescription
             )
         }
         return featureId

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -352,7 +352,6 @@ class MapboxMapFragment :
             )
         } else {
             features[featureId] = StaticPolyLineFeature(
-                requireContext(),
                 polylineAnnotationManager,
                 featureId,
                 featureClickListener,

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -365,12 +365,10 @@ class MapboxMapFragment :
     override fun addPolygon(polygonDescription: PolygonDescription): Int {
         val featureId = nextFeatureId++
         features[featureId] = StaticPolygonFeature(
-            requireContext(),
             mapView.annotations.createPolygonAnnotationManager(),
-            polygonDescription.points,
+            polygonDescription,
             featureClickListener,
-            featureId,
-            polygonDescription.getFillColor()
+            featureId
         )
 
         return featureId

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -57,6 +57,7 @@ import org.odk.collect.maps.MapFragment.PointListener
 import org.odk.collect.maps.MapFragment.ReadyListener
 import org.odk.collect.maps.MapFragmentDelegate
 import org.odk.collect.maps.MapPoint
+import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.maps.layers.MapFragmentReferenceLayerUtils.getReferenceLayerFile
 import org.odk.collect.maps.layers.MbtilesFile
 import org.odk.collect.maps.layers.ReferenceLayerRepository
@@ -362,14 +363,15 @@ class MapboxMapFragment :
         return featureId
     }
 
-    override fun addPolygon(points: MutableIterable<MapPoint>): Int {
+    override fun addPolygon(polygonDescription: PolygonDescription): Int {
         val featureId = nextFeatureId++
         features[featureId] = StaticPolygonFeature(
             requireContext(),
             mapView.annotations.createPolygonAnnotationManager(),
-            points,
+            polygonDescription.points,
             featureClickListener,
-            featureId
+            featureId,
+            polygonDescription.getFillColor()
         )
 
         return featureId

--- a/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
@@ -43,7 +43,7 @@ internal class StaticPolyLineFeature(
                 PolylineAnnotationOptions()
                     .withPoints(points)
                     .withLineColor(lineDescription.getStrokeColor())
-                    .withLineWidth((lineDescription.getStrokeWidth() / 2).toDouble())
+                    .withLineWidth((lineDescription.getStrokeWidth() / 3).toDouble())
             ).also {
                 polylineAnnotationManager.update(it)
             }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
@@ -6,7 +6,6 @@ import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions
 import org.odk.collect.maps.LineDescription
-import org.odk.collect.maps.MapConsts.MAPBOX_POLYLINE_STROKE_WIDTH
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
 
@@ -46,7 +45,7 @@ internal class StaticPolyLineFeature(
                 PolylineAnnotationOptions()
                     .withPoints(points)
                     .withLineColor(lineDescription.getStrokeColor())
-                    .withLineWidth(MAPBOX_POLYLINE_STROKE_WIDTH.toDouble())
+                    .withLineWidth((lineDescription.getStrokeWidth() / 2).toDouble())
             ).also {
                 polylineAnnotationManager.update(it)
             }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
@@ -2,10 +2,10 @@ package org.odk.collect.mapbox
 
 import android.content.Context
 import com.mapbox.geojson.Point
-import com.mapbox.maps.extension.style.utils.ColorUtils
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions
+import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapConsts.MAPBOX_POLYLINE_STROKE_WIDTH
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
@@ -16,14 +16,13 @@ internal class StaticPolyLineFeature(
     private val polylineAnnotationManager: PolylineAnnotationManager,
     private val featureId: Int,
     private val featureClickListener: MapFragment.FeatureListener?,
-    private val closedPolygon: Boolean,
-    initMapPoints: Iterable<MapPoint>
+    private val lineDescription: LineDescription
 ) : MapFeature {
     private val mapPoints = mutableListOf<MapPoint>()
     private var polylineAnnotation: PolylineAnnotation? = null
 
     init {
-        initMapPoints.forEach {
+        lineDescription.points.forEach {
             mapPoints.add(it)
         }
 
@@ -33,7 +32,7 @@ internal class StaticPolyLineFeature(
             }
             .toMutableList()
             .also {
-                if (closedPolygon && it.isNotEmpty()) {
+                if (lineDescription.closed && it.isNotEmpty()) {
                     it.add(it.first())
                 }
             }
@@ -46,7 +45,7 @@ internal class StaticPolyLineFeature(
             polylineAnnotation = polylineAnnotationManager.create(
                 PolylineAnnotationOptions()
                     .withPoints(points)
-                    .withLineColor(ColorUtils.colorToRgbaString(context.resources.getColor(org.odk.collect.icons.R.color.mapLineColor)))
+                    .withLineColor(lineDescription.getStrokeColor())
                     .withLineWidth(MAPBOX_POLYLINE_STROKE_WIDTH.toDouble())
             ).also {
                 polylineAnnotationManager.update(it)

--- a/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.mapbox
 
-import android.content.Context
 import com.mapbox.geojson.Point
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager
@@ -11,7 +10,6 @@ import org.odk.collect.maps.MapPoint
 
 /** A polyline that can not be manipulated by dragging Symbols at its vertices. */
 internal class StaticPolyLineFeature(
-    context: Context,
     private val polylineAnnotationManager: PolylineAnnotationManager,
     private val featureId: Int,
     private val featureClickListener: MapFragment.FeatureListener?,

--- a/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
@@ -43,7 +43,7 @@ internal class StaticPolyLineFeature(
                 PolylineAnnotationOptions()
                     .withPoints(points)
                     .withLineColor(lineDescription.getStrokeColor())
-                    .withLineWidth((lineDescription.getStrokeWidth() / 3).toDouble())
+                    .withLineWidth(MapUtils.convertStrokeWidth(lineDescription))
             ).also {
                 polylineAnnotationManager.update(it)
             }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolygonFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolygonFeature.kt
@@ -1,13 +1,11 @@
 package org.odk.collect.mapbox
 
 import android.content.Context
-import androidx.core.graphics.ColorUtils
 import com.mapbox.geojson.Point
 import com.mapbox.maps.plugin.annotation.generated.OnPolygonAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
-import org.odk.collect.maps.MapConsts.POLYGON_FILL_COLOR_OPACITY
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
 
@@ -16,19 +14,15 @@ class StaticPolygonFeature(
     private val polygonAnnotationManager: PolygonAnnotationManager,
     points: Iterable<MapPoint>,
     featureClickListener: MapFragment.FeatureListener?,
-    featureId: Int
+    featureId: Int,
+    fillColor: Int
 ) : MapFeature {
 
     private val polygonAnnotation: PolygonAnnotation = polygonAnnotationManager.create(
         PolygonAnnotationOptions()
             .withPoints(listOf(points.map { Point.fromLngLat(it.longitude, it.latitude) }))
             .withFillOutlineColor(context.resources.getColor(org.odk.collect.icons.R.color.mapLineColor))
-            .withFillColor(
-                ColorUtils.setAlphaComponent(
-                    context.resources.getColor(org.odk.collect.icons.R.color.mapLineColor),
-                    POLYGON_FILL_COLOR_OPACITY
-                )
-            )
+            .withFillColor(fillColor)
     )
 
     private val polygonClickListener =

--- a/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolygonFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolygonFeature.kt
@@ -1,28 +1,25 @@
 package org.odk.collect.mapbox
 
-import android.content.Context
 import com.mapbox.geojson.Point
 import com.mapbox.maps.plugin.annotation.generated.OnPolygonAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import org.odk.collect.maps.MapFragment
-import org.odk.collect.maps.MapPoint
+import org.odk.collect.maps.PolygonDescription
 
 class StaticPolygonFeature(
-    context: Context,
     private val polygonAnnotationManager: PolygonAnnotationManager,
-    points: Iterable<MapPoint>,
+    polygonDescription: PolygonDescription,
     featureClickListener: MapFragment.FeatureListener?,
-    featureId: Int,
-    fillColor: Int
+    featureId: Int
 ) : MapFeature {
 
     private val polygonAnnotation: PolygonAnnotation = polygonAnnotationManager.create(
         PolygonAnnotationOptions()
-            .withPoints(listOf(points.map { Point.fromLngLat(it.longitude, it.latitude) }))
-            .withFillOutlineColor(context.resources.getColor(org.odk.collect.icons.R.color.mapLineColor))
-            .withFillColor(fillColor)
+            .withPoints(listOf(polygonDescription.points.map { Point.fromLngLat(it.longitude, it.latitude) }))
+            .withFillOutlineColor(polygonDescription.getStrokeColor())
+            .withFillColor(polygonDescription.getFillColor())
     )
 
     private val polygonClickListener =

--- a/maps/build.gradle.kts
+++ b/maps/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     coreLibraryDesugaring(Dependencies.desugar)
 
     implementation(project(":shared"))
+    implementation(project(":androidshared"))
     implementation(Dependencies.kotlin_stdlib)
     implementation(Dependencies.androidx_fragment_ktx)
     implementation(Dependencies.androidx_preference_ktx)

--- a/maps/build.gradle.kts
+++ b/maps/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
 
     implementation(project(":shared"))
     implementation(project(":androidshared"))
+    implementation(project(":icons"))
     implementation(Dependencies.kotlin_stdlib)
     implementation(Dependencies.androidx_fragment_ktx)
     implementation(Dependencies.androidx_preference_ktx)

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -18,7 +18,7 @@ data class LineDescription(
                     MapConsts.DEFAULT_STROKE_WIDTH
                 }
             } ?: MapConsts.DEFAULT_STROKE_WIDTH
-        } catch (e: Throwable) {
+        } catch (e: NumberFormatException) {
             MapConsts.DEFAULT_STROKE_WIDTH
         }
     }

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -25,6 +25,6 @@ data class LineDescription(
 
     fun getStrokeColor(): Int {
         val customColor = strokeColor?.toColorInt()
-        return customColor ?: MapConsts.DEFAULT_STROKE_COLOR.toColorInt()!!
+        return customColor ?: MapConsts.DEFAULT_STROKE_COLOR
     }
 }

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -1,0 +1,15 @@
+package org.odk.collect.maps
+
+import org.odk.collect.androidshared.utils.toColorInt
+
+data class LineDescription(
+    val points: List<MapPoint>,
+    private val strokeColor: String?,
+    val draggable: Boolean,
+    val closed: Boolean
+) {
+    fun getStrokeColor(): Int {
+        val customColor = strokeColor?.toColorInt()
+        return customColor ?: "#ffff0000".toColorInt()!!
+    }
+}

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -15,16 +15,16 @@ data class LineDescription(
                 if (it >= 0) {
                     it
                 } else {
-                    MapConsts.POLYLINE_STROKE_WIDTH
+                    MapConsts.DEFAULT_STROKE_WIDTH
                 }
-            } ?: MapConsts.POLYLINE_STROKE_WIDTH
+            } ?: MapConsts.DEFAULT_STROKE_WIDTH
         } catch (e: Throwable) {
-            MapConsts.POLYLINE_STROKE_WIDTH
+            MapConsts.DEFAULT_STROKE_WIDTH
         }
     }
 
     fun getStrokeColor(): Int {
         val customColor = strokeColor?.toColorInt()
-        return customColor ?: "#ffff0000".toColorInt()!!
+        return customColor ?: MapConsts.DEFAULT_STROKE_COLOR.toColorInt()!!
     }
 }

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -3,11 +3,11 @@ package org.odk.collect.maps
 import org.odk.collect.androidshared.utils.toColorInt
 
 data class LineDescription(
-    val points: List<MapPoint>,
-    private val strokeWidth: String?,
-    private val strokeColor: String?,
-    val draggable: Boolean,
-    val closed: Boolean
+    val points: List<MapPoint> = emptyList(),
+    private val strokeWidth: String? = null,
+    private val strokeColor: String? = null,
+    val draggable: Boolean = false,
+    val closed: Boolean = false
 ) {
     fun getStrokeWidth(): Float {
         return try {

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -4,10 +4,25 @@ import org.odk.collect.androidshared.utils.toColorInt
 
 data class LineDescription(
     val points: List<MapPoint>,
+    private val strokeWidth: String?,
     private val strokeColor: String?,
     val draggable: Boolean,
     val closed: Boolean
 ) {
+    fun getStrokeWidth(): Float {
+        return try {
+            strokeWidth?.toFloat()?.let {
+                if (it >= 0) {
+                    it
+                } else {
+                    MapConsts.POLYLINE_STROKE_WIDTH
+                }
+            } ?: MapConsts.POLYLINE_STROKE_WIDTH
+        } catch (e: Throwable) {
+            MapConsts.POLYLINE_STROKE_WIDTH
+        }
+    }
+
     fun getStrokeColor(): Int {
         val customColor = strokeColor?.toColorInt()
         return customColor ?: "#ffff0000".toColorInt()!!

--- a/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
@@ -2,6 +2,5 @@ package org.odk.collect.maps
 
 object MapConsts {
     const val POLYLINE_STROKE_WIDTH = 8f
-    const val MAPBOX_POLYLINE_STROKE_WIDTH = 4
     const val POLYGON_FILL_COLOR_OPACITY = 68
 }

--- a/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.maps
 
 object MapConsts {
-    const val POLYLINE_STROKE_WIDTH = 8f
-    const val POLYGON_FILL_COLOR_OPACITY = 68
+    const val DEFAULT_STROKE_COLOR = "#ffff0000"
+    const val DEFAULT_STROKE_WIDTH = 8f
+    const val DEFAULT_FILL_COLOR_OPACITY = 68
 }

--- a/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
@@ -1,7 +1,7 @@
 package org.odk.collect.maps
 
 object MapConsts {
-    const val DEFAULT_STROKE_COLOR = "#ffff0000"
+    const val DEFAULT_STROKE_COLOR = -65536 // color-int representation of #ffff0000
     const val DEFAULT_STROKE_WIDTH = 8f
     const val DEFAULT_FILL_COLOR_OPACITY = 68
 }

--- a/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
@@ -1,7 +1,7 @@
 package org.odk.collect.maps
 
 object MapConsts {
-    const val POLYLINE_STROKE_WIDTH = 8
+    const val POLYLINE_STROKE_WIDTH = 8f
     const val MAPBOX_POLYLINE_STROKE_WIDTH = 4
     const val POLYGON_FILL_COLOR_OPACITY = 68
 }

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.java
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.java
@@ -124,7 +124,7 @@ public interface MapFragment {
      * Adds a polygon to the map with given sequence of vertices. * Returns a positive integer,
      * the featureId for the newly added shape.
      */
-    int addPolygon(@NonNull Iterable<MapPoint> points);
+    int addPolygon(PolygonDescription polygonDescription);
 
     /** Appends a vertex to the polyline or polygon specified by featureId. */
     void appendPointToPolyLine(int featureId, @NonNull MapPoint point);

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.java
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.java
@@ -118,7 +118,7 @@ public interface MapFragment {
      * The vertices will have handles that can be dragged by the user.
      * Returns a positive integer, the featureId for the newly added shape.
      */
-    int addPolyLine(@NonNull Iterable<MapPoint> points, boolean closed, boolean draggable);
+    int addPolyLine(LineDescription lineDescription);
 
     /**
      * Adds a polygon to the map with given sequence of vertices. * Returns a positive integer,

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -4,10 +4,10 @@ import androidx.core.graphics.ColorUtils
 import org.odk.collect.androidshared.utils.toColorInt
 
 data class PolygonDescription(
-    val points: List<MapPoint>,
-    private val strokeWidth: String?,
-    private val strokeColor: String?,
-    private val fillColor: String?
+    val points: List<MapPoint> = emptyList(),
+    private val strokeWidth: String? = null,
+    private val strokeColor: String? = null,
+    private val fillColor: String? = null
 ) {
     fun getStrokeWidth(): Float {
         return try {

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -15,31 +15,31 @@ data class PolygonDescription(
                 if (it >= 0) {
                     it
                 } else {
-                    MapConsts.POLYLINE_STROKE_WIDTH
+                    MapConsts.DEFAULT_STROKE_WIDTH
                 }
-            } ?: MapConsts.POLYLINE_STROKE_WIDTH
+            } ?: MapConsts.DEFAULT_STROKE_WIDTH
         } catch (e: Throwable) {
-            MapConsts.POLYLINE_STROKE_WIDTH
+            MapConsts.DEFAULT_STROKE_WIDTH
         }
     }
 
     fun getStrokeColor(): Int {
         val customColor = strokeColor?.toColorInt()
-        return customColor ?: "#ffff0000".toColorInt()!!
+        return customColor ?: MapConsts.DEFAULT_STROKE_COLOR.toColorInt()!!
     }
 
     fun getFillColor(): Int {
         val customColor = fillColor?.toColorInt()?.let {
             ColorUtils.setAlphaComponent(
                 it,
-                MapConsts.POLYGON_FILL_COLOR_OPACITY
+                MapConsts.DEFAULT_FILL_COLOR_OPACITY
             )
         }
 
         return customColor
             ?: ColorUtils.setAlphaComponent(
-                "#ffff0000".toColorInt()!!,
-                MapConsts.POLYGON_FILL_COLOR_OPACITY
+                MapConsts.DEFAULT_STROKE_COLOR.toColorInt()!!,
+                MapConsts.DEFAULT_FILL_COLOR_OPACITY
             )
     }
 }

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -18,7 +18,7 @@ data class PolygonDescription(
                     MapConsts.DEFAULT_STROKE_WIDTH
                 }
             } ?: MapConsts.DEFAULT_STROKE_WIDTH
-        } catch (e: Throwable) {
+        } catch (e: NumberFormatException) {
             MapConsts.DEFAULT_STROKE_WIDTH
         }
     }

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -25,7 +25,7 @@ data class PolygonDescription(
 
     fun getStrokeColor(): Int {
         val customColor = strokeColor?.toColorInt()
-        return customColor ?: MapConsts.DEFAULT_STROKE_COLOR.toColorInt()!!
+        return customColor ?: MapConsts.DEFAULT_STROKE_COLOR
     }
 
     fun getFillColor(): Int {
@@ -38,7 +38,7 @@ data class PolygonDescription(
 
         return customColor
             ?: ColorUtils.setAlphaComponent(
-                MapConsts.DEFAULT_STROKE_COLOR.toColorInt()!!,
+                MapConsts.DEFAULT_STROKE_COLOR,
                 MapConsts.DEFAULT_FILL_COLOR_OPACITY
             )
     }

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -5,8 +5,14 @@ import org.odk.collect.androidshared.utils.toColorInt
 
 data class PolygonDescription(
     val points: List<MapPoint>,
+    private val strokeColor: String?,
     private val fillColor: String?
 ) {
+    fun getStrokeColor(): Int {
+        val customColor = strokeColor?.toColorInt()
+        return customColor ?: "#ffff0000".toColorInt()!!
+    }
+
     fun getFillColor(): Int {
         val customColor = fillColor?.toColorInt()?.let {
             ColorUtils.setAlphaComponent(

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -1,0 +1,24 @@
+package org.odk.collect.maps
+
+import androidx.core.graphics.ColorUtils
+import org.odk.collect.androidshared.utils.toColorInt
+
+data class PolygonDescription(
+    val points: List<MapPoint>,
+    private val fillColor: String?
+) {
+    fun getFillColor(): Int {
+        val customColor = fillColor?.toColorInt()?.let {
+            ColorUtils.setAlphaComponent(
+                it,
+                MapConsts.POLYGON_FILL_COLOR_OPACITY
+            )
+        }
+
+        return customColor
+            ?: ColorUtils.setAlphaComponent(
+                "#ffff0000".toColorInt()!!,
+                MapConsts.POLYGON_FILL_COLOR_OPACITY
+            )
+    }
+}

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -5,9 +5,24 @@ import org.odk.collect.androidshared.utils.toColorInt
 
 data class PolygonDescription(
     val points: List<MapPoint>,
+    private val strokeWidth: String?,
     private val strokeColor: String?,
     private val fillColor: String?
 ) {
+    fun getStrokeWidth(): Float {
+        return try {
+            strokeWidth?.toFloat()?.let {
+                if (it >= 0) {
+                    it
+                } else {
+                    MapConsts.POLYLINE_STROKE_WIDTH
+                }
+            } ?: MapConsts.POLYLINE_STROKE_WIDTH
+        } catch (e: Throwable) {
+            MapConsts.POLYLINE_STROKE_WIDTH
+        }
+    }
+
     fun getStrokeColor(): Int {
         val customColor = strokeColor?.toColorInt()
         return customColor ?: "#ffff0000".toColorInt()!!

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
@@ -1,6 +1,6 @@
 package org.odk.collect.maps.markers
 
-import android.graphics.Color
+import org.odk.collect.androidshared.utils.toColorInt
 import org.odk.collect.shared.strings.StringUtils
 import java.util.Locale
 
@@ -9,23 +9,7 @@ class MarkerIconDescription @JvmOverloads constructor(
     private val color: String? = null,
     private val symbol: String? = null
 ) {
-    fun getColor(): Int? = try {
-        color?.let {
-            var sanitizedColor = if (color.startsWith("#")) {
-                color
-            } else {
-                "#$color"
-            }
-
-            if (sanitizedColor.length == 4) {
-                sanitizedColor = shorthandToLonghandHexColor(sanitizedColor)
-            }
-
-            Color.parseColor(sanitizedColor)
-        }
-    } catch (e: Throwable) {
-        null
-    }
+    fun getColor(): Int? = color?.toColorInt()
 
     fun getSymbol(): String? = symbol?.let {
         if (it.isBlank()) {
@@ -33,14 +17,5 @@ class MarkerIconDescription @JvmOverloads constructor(
         } else {
             StringUtils.firstCharacterOrEmoji(it).uppercase(Locale.US)
         }
-    }
-
-    private fun shorthandToLonghandHexColor(shorthandColor: String): String {
-        var longHandColor = ""
-        shorthandColor.substring(1).map {
-            longHandColor += it.toString() + it.toString()
-        }
-
-        return "#$longHandColor"
     }
 }

--- a/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
@@ -41,13 +41,13 @@ class LineDescriptionTest {
     @Test
     fun `getStrokeColor returns the default color when the passed one is null`() {
         val lineDescription = LineDescription(emptyList(), null, null, false, false)
-        assertThat(lineDescription.getStrokeColor(), equalTo(-65536))
+        assertThat(lineDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
     }
 
     @Test
     fun `getStrokeColor returns the default color when the passed one is invalid`() {
         val lineDescription = LineDescription(emptyList(), null, "blah", false, false)
-        assertThat(lineDescription.getStrokeColor(), equalTo(-65536))
+        assertThat(lineDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
     }
 
     @Test

--- a/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
@@ -9,20 +9,50 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class LineDescriptionTest {
     @Test
+    fun `getStrokeWidth returns the default value when the passed one is null`() {
+        val lineDescription = LineDescription(emptyList(), null, null, false, false)
+        assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+    }
+
+    @Test
+    fun `getStrokeWidth returns the default value when the passed one is invalid`() {
+        val lineDescription = LineDescription(emptyList(), "blah", null, false, false)
+        assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+    }
+
+    @Test
+    fun `getStrokeWidth returns the default value when the passed one is not greater than or equal to zero`() {
+        val lineDescription = LineDescription(emptyList(), "-1", null, false, false)
+        assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+    }
+
+    @Test
+    fun `getStrokeWidth returns custom value when the passed one is a valid int number`() {
+        val lineDescription = LineDescription(emptyList(), "10", null, false, false)
+        assertThat(lineDescription.getStrokeWidth(), equalTo(10f))
+    }
+
+    @Test
+    fun `getStrokeWidth returns custom value when the passed one is a valid float number`() {
+        val lineDescription = LineDescription(emptyList(), "10.5", null, false, false)
+        assertThat(lineDescription.getStrokeWidth(), equalTo(10.5f))
+    }
+
+    @Test
     fun `getStrokeColor returns the default color when the passed one is null`() {
-        val lineDescription = LineDescription(emptyList(), null, false, false)
+        val lineDescription = LineDescription(emptyList(), null, null, false, false)
         assertThat(lineDescription.getStrokeColor(), equalTo(-65536))
     }
 
     @Test
     fun `getStrokeColor returns the default color when the passed one is invalid`() {
-        val lineDescription = LineDescription(emptyList(), "blah", false, false)
+        val lineDescription = LineDescription(emptyList(), null, "blah", false, false)
         assertThat(lineDescription.getStrokeColor(), equalTo(-65536))
     }
 
     @Test
     fun `getStrokeColor returns custom color when it is valid`() {
-        val lineDescription = LineDescription(emptyList(), "#aaccee", false, false)
+        val lineDescription = LineDescription(emptyList(), null, "#aaccee", false, false)
         assertThat(lineDescription.getStrokeColor(), equalTo(-5583634))
     }
 }

--- a/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
@@ -11,19 +11,19 @@ class LineDescriptionTest {
     @Test
     fun `getStrokeWidth returns the default value when the passed one is null`() {
         val lineDescription = LineDescription(emptyList(), null, null, false, false)
-        assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+        assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns the default value when the passed one is invalid`() {
         val lineDescription = LineDescription(emptyList(), "blah", null, false, false)
-        assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+        assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns the default value when the passed one is not greater than or equal to zero`() {
         val lineDescription = LineDescription(emptyList(), "-1", null, false, false)
-        assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+        assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test

--- a/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
@@ -1,0 +1,28 @@
+package org.odk.collect.maps
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LineDescriptionTest {
+    @Test
+    fun `getStrokeColor returns the default color when the passed one is null`() {
+        val lineDescription = LineDescription(emptyList(), null, false, false)
+        assertThat(lineDescription.getStrokeColor(), equalTo(-65536))
+    }
+
+    @Test
+    fun `getStrokeColor returns the default color when the passed one is invalid`() {
+        val lineDescription = LineDescription(emptyList(), "blah", false, false)
+        assertThat(lineDescription.getStrokeColor(), equalTo(-65536))
+    }
+
+    @Test
+    fun `getStrokeColor returns custom color when it is valid`() {
+        val lineDescription = LineDescription(emptyList(), "#aaccee", false, false)
+        assertThat(lineDescription.getStrokeColor(), equalTo(-5583634))
+    }
+}

--- a/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
@@ -10,49 +10,49 @@ import org.junit.runner.RunWith
 class LineDescriptionTest {
     @Test
     fun `getStrokeWidth returns the default value when the passed one is null`() {
-        val lineDescription = LineDescription(emptyList(), null, null, false, false)
+        val lineDescription = LineDescription(strokeWidth = null)
         assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns the default value when the passed one is invalid`() {
-        val lineDescription = LineDescription(emptyList(), "blah", null, false, false)
+        val lineDescription = LineDescription(strokeWidth = "blah")
         assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns the default value when the passed one is not greater than or equal to zero`() {
-        val lineDescription = LineDescription(emptyList(), "-1", null, false, false)
+        val lineDescription = LineDescription(strokeWidth = "-1")
         assertThat(lineDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns custom value when the passed one is a valid int number`() {
-        val lineDescription = LineDescription(emptyList(), "10", null, false, false)
+        val lineDescription = LineDescription(strokeWidth = "10")
         assertThat(lineDescription.getStrokeWidth(), equalTo(10f))
     }
 
     @Test
     fun `getStrokeWidth returns custom value when the passed one is a valid float number`() {
-        val lineDescription = LineDescription(emptyList(), "10.5", null, false, false)
+        val lineDescription = LineDescription(strokeWidth = "10.5")
         assertThat(lineDescription.getStrokeWidth(), equalTo(10.5f))
     }
 
     @Test
     fun `getStrokeColor returns the default color when the passed one is null`() {
-        val lineDescription = LineDescription(emptyList(), null, null, false, false)
+        val lineDescription = LineDescription(strokeColor = null)
         assertThat(lineDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
     }
 
     @Test
     fun `getStrokeColor returns the default color when the passed one is invalid`() {
-        val lineDescription = LineDescription(emptyList(), null, "blah", false, false)
+        val lineDescription = LineDescription(strokeColor = "blah")
         assertThat(lineDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
     }
 
     @Test
     fun `getStrokeColor returns custom color when it is valid`() {
-        val lineDescription = LineDescription(emptyList(), null, "#aaccee", false, false)
+        val lineDescription = LineDescription(strokeColor = "#aaccee")
         assertThat(lineDescription.getStrokeColor(), equalTo(-5583634))
     }
 }

--- a/maps/src/test/java/org/odk/collect/maps/MarkerIconDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/MarkerIconDescriptionTest.kt
@@ -10,47 +10,10 @@ import org.odk.collect.maps.markers.MarkerIconDescription
 
 @RunWith(AndroidJUnit4::class)
 class MarkerIconDescriptionTest {
-
     @Test
     fun `return null when color is null`() {
         val markerIconDescription = MarkerIconDescription(0, null)
         assertThat(markerIconDescription.getColor(), `is`(nullValue()))
-    }
-
-    @Test
-    fun `return null when color is empty`() {
-        val markerIconDescription = MarkerIconDescription(0, "")
-        assertThat(markerIconDescription.getColor(), `is`(nullValue()))
-    }
-
-    @Test
-    fun `return null when color is invalid`() {
-        val markerIconDescription = MarkerIconDescription(0, "qwerty")
-        assertThat(markerIconDescription.getColor(), `is`(nullValue()))
-    }
-
-    @Test
-    fun `return color int for valid hex color with # prefix`() {
-        val markerIconDescription = MarkerIconDescription(0, "#aaccee")
-        assertThat(markerIconDescription.getColor(), `is`(-5583634))
-    }
-
-    @Test
-    fun `return color int for valid hex color without # prefix`() {
-        val markerIconDescription = MarkerIconDescription(0, "aaccee")
-        assertThat(markerIconDescription.getColor(), `is`(-5583634))
-    }
-
-    @Test
-    fun `return color int for valid shorthand hex color with # prefix`() {
-        val markerIconDescription = MarkerIconDescription(0, "#ace")
-        assertThat(markerIconDescription.getColor(), `is`(-5583634))
-    }
-
-    @Test
-    fun `return color int for valid shorthand hex color without # prefix`() {
-        val markerIconDescription = MarkerIconDescription(0, "ace")
-        assertThat(markerIconDescription.getColor(), `is`(-5583634))
     }
 
     @Test

--- a/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
@@ -9,20 +9,38 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class PolygonDescriptionTest {
     @Test
+    fun `getStrokeColor returns the default color when the passed one is null`() {
+        val polygonDescription = PolygonDescription(emptyList(), null, null)
+        assertThat(polygonDescription.getStrokeColor(), equalTo(-65536))
+    }
+
+    @Test
+    fun `getStrokeColor returns the default color when the passed one is invalid`() {
+        val polygonDescription = PolygonDescription(emptyList(), "blah", null)
+        assertThat(polygonDescription.getStrokeColor(), equalTo(-65536))
+    }
+
+    @Test
+    fun `getStrokeColor returns custom color when it is valid`() {
+        val polygonDescription = PolygonDescription(emptyList(), "#aaccee", null)
+        assertThat(polygonDescription.getStrokeColor(), equalTo(-5583634))
+    }
+
+    @Test
     fun `getFillColor returns the default color when the passed one is null`() {
-        val polygonDescription = PolygonDescription(emptyList(), null)
+        val polygonDescription = PolygonDescription(emptyList(), null, null)
         assertThat(polygonDescription.getFillColor(), equalTo(1157562368))
     }
 
     @Test
     fun `getFillColor returns the default color when the passed one is invalid`() {
-        val polygonDescription = PolygonDescription(emptyList(), "blah")
+        val polygonDescription = PolygonDescription(emptyList(), null, "blah")
         assertThat(polygonDescription.getFillColor(), equalTo(1157562368))
     }
 
     @Test
     fun `getFillColor returns custom color when it is valid`() {
-        val polygonDescription = PolygonDescription(emptyList(), "#aaccee")
+        val polygonDescription = PolygonDescription(emptyList(), null, "#aaccee")
         assertThat(polygonDescription.getFillColor(), equalTo(1152044270))
     }
 }

--- a/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
@@ -9,38 +9,68 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class PolygonDescriptionTest {
     @Test
+    fun `getStrokeWidth returns the default value when the passed one is null`() {
+        val polygonDescription = PolygonDescription(emptyList(), null, null, null)
+        assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+    }
+
+    @Test
+    fun `getStrokeWidth returns the default value when the passed one is invalid`() {
+        val polygonDescription = PolygonDescription(emptyList(), "blah", null, null)
+        assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+    }
+
+    @Test
+    fun `getStrokeWidth returns the default value when the passed one is not greater than or equal to zero`() {
+        val polygonDescription = PolygonDescription(emptyList(), "-1", null, null)
+        assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+    }
+
+    @Test
+    fun `getStrokeWidth returns custom value when the passed one is a valid int number`() {
+        val polygonDescription = PolygonDescription(emptyList(), "10", null, null)
+        assertThat(polygonDescription.getStrokeWidth(), equalTo(10f))
+    }
+
+    @Test
+    fun `getStrokeWidth returns custom value when the passed one is a valid float number`() {
+        val polygonDescription = PolygonDescription(emptyList(), "10.5", null, null)
+        assertThat(polygonDescription.getStrokeWidth(), equalTo(10.5f))
+    }
+
+    @Test
     fun `getStrokeColor returns the default color when the passed one is null`() {
-        val polygonDescription = PolygonDescription(emptyList(), null, null)
+        val polygonDescription = PolygonDescription(emptyList(), "0", null, null)
         assertThat(polygonDescription.getStrokeColor(), equalTo(-65536))
     }
 
     @Test
     fun `getStrokeColor returns the default color when the passed one is invalid`() {
-        val polygonDescription = PolygonDescription(emptyList(), "blah", null)
+        val polygonDescription = PolygonDescription(emptyList(), "0", "blah", null)
         assertThat(polygonDescription.getStrokeColor(), equalTo(-65536))
     }
 
     @Test
     fun `getStrokeColor returns custom color when it is valid`() {
-        val polygonDescription = PolygonDescription(emptyList(), "#aaccee", null)
+        val polygonDescription = PolygonDescription(emptyList(), "0", "#aaccee", null)
         assertThat(polygonDescription.getStrokeColor(), equalTo(-5583634))
     }
 
     @Test
     fun `getFillColor returns the default color when the passed one is null`() {
-        val polygonDescription = PolygonDescription(emptyList(), null, null)
+        val polygonDescription = PolygonDescription(emptyList(), "0", null, null)
         assertThat(polygonDescription.getFillColor(), equalTo(1157562368))
     }
 
     @Test
     fun `getFillColor returns the default color when the passed one is invalid`() {
-        val polygonDescription = PolygonDescription(emptyList(), null, "blah")
+        val polygonDescription = PolygonDescription(emptyList(), "0", null, "blah")
         assertThat(polygonDescription.getFillColor(), equalTo(1157562368))
     }
 
     @Test
     fun `getFillColor returns custom color when it is valid`() {
-        val polygonDescription = PolygonDescription(emptyList(), null, "#aaccee")
+        val polygonDescription = PolygonDescription(emptyList(), "0", null, "#aaccee")
         assertThat(polygonDescription.getFillColor(), equalTo(1152044270))
     }
 }

--- a/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
@@ -41,13 +41,13 @@ class PolygonDescriptionTest {
     @Test
     fun `getStrokeColor returns the default color when the passed one is null`() {
         val polygonDescription = PolygonDescription(emptyList(), "0", null, null)
-        assertThat(polygonDescription.getStrokeColor(), equalTo(-65536))
+        assertThat(polygonDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
     }
 
     @Test
     fun `getStrokeColor returns the default color when the passed one is invalid`() {
         val polygonDescription = PolygonDescription(emptyList(), "0", "blah", null)
-        assertThat(polygonDescription.getStrokeColor(), equalTo(-65536))
+        assertThat(polygonDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
     }
 
     @Test

--- a/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
@@ -11,19 +11,19 @@ class PolygonDescriptionTest {
     @Test
     fun `getStrokeWidth returns the default value when the passed one is null`() {
         val polygonDescription = PolygonDescription(emptyList(), null, null, null)
-        assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+        assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns the default value when the passed one is invalid`() {
         val polygonDescription = PolygonDescription(emptyList(), "blah", null, null)
-        assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+        assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns the default value when the passed one is not greater than or equal to zero`() {
         val polygonDescription = PolygonDescription(emptyList(), "-1", null, null)
-        assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.POLYLINE_STROKE_WIDTH))
+        assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test

--- a/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
@@ -1,0 +1,28 @@
+package org.odk.collect.maps
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PolygonDescriptionTest {
+    @Test
+    fun `getFillColor returns the default color when the passed one is null`() {
+        val polygonDescription = PolygonDescription(emptyList(), null)
+        assertThat(polygonDescription.getFillColor(), equalTo(1157562368))
+    }
+
+    @Test
+    fun `getFillColor returns the default color when the passed one is invalid`() {
+        val polygonDescription = PolygonDescription(emptyList(), "blah")
+        assertThat(polygonDescription.getFillColor(), equalTo(1157562368))
+    }
+
+    @Test
+    fun `getFillColor returns custom color when it is valid`() {
+        val polygonDescription = PolygonDescription(emptyList(), "#aaccee")
+        assertThat(polygonDescription.getFillColor(), equalTo(1152044270))
+    }
+}

--- a/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
@@ -10,67 +10,67 @@ import org.junit.runner.RunWith
 class PolygonDescriptionTest {
     @Test
     fun `getStrokeWidth returns the default value when the passed one is null`() {
-        val polygonDescription = PolygonDescription(emptyList(), null, null, null)
+        val polygonDescription = PolygonDescription(strokeWidth = null)
         assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns the default value when the passed one is invalid`() {
-        val polygonDescription = PolygonDescription(emptyList(), "blah", null, null)
+        val polygonDescription = PolygonDescription(strokeWidth = "blah")
         assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns the default value when the passed one is not greater than or equal to zero`() {
-        val polygonDescription = PolygonDescription(emptyList(), "-1", null, null)
+        val polygonDescription = PolygonDescription(strokeWidth = "-1")
         assertThat(polygonDescription.getStrokeWidth(), equalTo(MapConsts.DEFAULT_STROKE_WIDTH))
     }
 
     @Test
     fun `getStrokeWidth returns custom value when the passed one is a valid int number`() {
-        val polygonDescription = PolygonDescription(emptyList(), "10", null, null)
+        val polygonDescription = PolygonDescription(strokeWidth = "10")
         assertThat(polygonDescription.getStrokeWidth(), equalTo(10f))
     }
 
     @Test
     fun `getStrokeWidth returns custom value when the passed one is a valid float number`() {
-        val polygonDescription = PolygonDescription(emptyList(), "10.5", null, null)
+        val polygonDescription = PolygonDescription(strokeWidth = "10.5")
         assertThat(polygonDescription.getStrokeWidth(), equalTo(10.5f))
     }
 
     @Test
     fun `getStrokeColor returns the default color when the passed one is null`() {
-        val polygonDescription = PolygonDescription(emptyList(), "0", null, null)
+        val polygonDescription = PolygonDescription(strokeColor = null)
         assertThat(polygonDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
     }
 
     @Test
     fun `getStrokeColor returns the default color when the passed one is invalid`() {
-        val polygonDescription = PolygonDescription(emptyList(), "0", "blah", null)
+        val polygonDescription = PolygonDescription(strokeColor = "blah")
         assertThat(polygonDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
     }
 
     @Test
     fun `getStrokeColor returns custom color when it is valid`() {
-        val polygonDescription = PolygonDescription(emptyList(), "0", "#aaccee", null)
+        val polygonDescription = PolygonDescription(strokeColor = "#aaccee")
         assertThat(polygonDescription.getStrokeColor(), equalTo(-5583634))
     }
 
     @Test
     fun `getFillColor returns the default color when the passed one is null`() {
-        val polygonDescription = PolygonDescription(emptyList(), "0", null, null)
+        val polygonDescription = PolygonDescription(fillColor = null)
         assertThat(polygonDescription.getFillColor(), equalTo(1157562368))
     }
 
     @Test
     fun `getFillColor returns the default color when the passed one is invalid`() {
-        val polygonDescription = PolygonDescription(emptyList(), "0", null, "blah")
+        val polygonDescription = PolygonDescription(fillColor = "blah")
         assertThat(polygonDescription.getFillColor(), equalTo(1157562368))
     }
 
     @Test
     fun `getFillColor returns custom color when it is valid`() {
-        val polygonDescription = PolygonDescription(emptyList(), "0", null, "#aaccee")
+        val polygonDescription = PolygonDescription(fillColor = "#aaccee")
         assertThat(polygonDescription.getFillColor(), equalTo(1152044270))
     }
 }

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -346,7 +346,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     @Override
     public int addPolygon(PolygonDescription polygonDescription) {
         int featureId = nextFeatureId++;
-        features.put(featureId, new StaticPolygonFeature(map, polygonDescription.getPoints(), polygonDescription.getFillColor()));
+        features.put(featureId, new StaticPolygonFeature(map, polygonDescription));
         return featureId;
     }
 
@@ -946,15 +946,14 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         private final MapView map;
         private final Polygon polygon = new Polygon();
 
-        StaticPolygonFeature(MapView map, Iterable<MapPoint> points, int fillColor) {
+        StaticPolygonFeature(MapView map, PolygonDescription polygonDescription) {
             this.map = map;
 
             map.getOverlays().add(polygon);
-            int strokeColor = map.getContext().getResources().getColor(org.odk.collect.icons.R.color.mapLineColor);
-            polygon.getOutlinePaint().setColor(strokeColor);
+            polygon.getOutlinePaint().setColor(polygonDescription.getStrokeColor());
             polygon.setStrokeWidth(POLYLINE_STROKE_WIDTH);
-            polygon.getFillPaint().setColor(fillColor);
-            polygon.setPoints(StreamSupport.stream(points.spliterator(), false).map(point -> new GeoPoint(point.latitude, point.longitude)).collect(Collectors.toList()));
+            polygon.getFillPaint().setColor(polygonDescription.getFillColor());
+            polygon.setPoints(StreamSupport.stream(polygonDescription.getPoints().spliterator(), false).map(point -> new GeoPoint(point.latitude, point.longitude)).collect(Collectors.toList()));
             polygon.setOnClickListener((polygon, mapView, eventPos) -> {
                 int featureId = findFeature(polygon);
                 if (featureClickListener != null && featureId != -1) {

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -16,8 +16,6 @@ package org.odk.collect.osmdroid;
 
 import static androidx.core.graphics.drawable.DrawableKt.toBitmap;
 
-import static org.odk.collect.maps.MapConsts.POLYLINE_STROKE_WIDTH;
-
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -815,7 +813,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
                 return false;
             });
             Paint paint = polyline.getPaint();
-            paint.setStrokeWidth(POLYLINE_STROKE_WIDTH);
+            paint.setStrokeWidth(lineDescription.getStrokeWidth());
             map.getOverlays().add(polyline);
 
             List<GeoPoint> geoPoints = StreamSupport.stream(lineDescription.getPoints().spliterator(), false).map(mapPoint -> new GeoPoint(mapPoint.latitude, mapPoint.longitude, mapPoint.altitude)).collect(Collectors.toList());
@@ -874,7 +872,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
                 return false;
             });
             Paint paint = polyline.getPaint();
-            paint.setStrokeWidth(POLYLINE_STROKE_WIDTH);
+            paint.setStrokeWidth(lineDescription.getStrokeWidth());
             map.getOverlays().add(polyline);
             for (MapPoint point : lineDescription.getPoints()) {
                 markers.add(createMarker(map, new MarkerDescription(point, true, CENTER, new MarkerIconDescription(org.odk.collect.icons.R.drawable.ic_map_point))));

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -951,7 +951,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
 
             map.getOverlays().add(polygon);
             polygon.getOutlinePaint().setColor(polygonDescription.getStrokeColor());
-            polygon.setStrokeWidth(POLYLINE_STROKE_WIDTH);
+            polygon.setStrokeWidth(polygonDescription.getStrokeWidth());
             polygon.getFillPaint().setColor(polygonDescription.getFillColor());
             polygon.setPoints(StreamSupport.stream(polygonDescription.getPoints().spliterator(), false).map(point -> new GeoPoint(point.latitude, point.longitude)).collect(Collectors.toList()));
             polygon.setOnClickListener((polygon, mapView, eventPos) -> {

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -16,7 +16,6 @@ package org.odk.collect.osmdroid;
 
 import static androidx.core.graphics.drawable.DrawableKt.toBitmap;
 
-import static org.odk.collect.maps.MapConsts.POLYGON_FILL_COLOR_OPACITY;
 import static org.odk.collect.maps.MapConsts.POLYLINE_STROKE_WIDTH;
 
 import android.content.BroadcastReceiver;
@@ -38,7 +37,6 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
-import androidx.core.graphics.ColorUtils;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.gms.location.LocationListener;
@@ -49,6 +47,7 @@ import org.odk.collect.maps.MapConfigurator;
 import org.odk.collect.maps.MapFragment;
 import org.odk.collect.maps.MapFragmentDelegate;
 import org.odk.collect.maps.MapPoint;
+import org.odk.collect.maps.PolygonDescription;
 import org.odk.collect.maps.layers.MapFragmentReferenceLayerUtils;
 import org.odk.collect.maps.layers.ReferenceLayerRepository;
 import org.odk.collect.maps.markers.MarkerDescription;
@@ -344,9 +343,9 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     }
 
     @Override
-    public int addPolygon(@NonNull Iterable<MapPoint> points) {
+    public int addPolygon(PolygonDescription polygonDescription) {
         int featureId = nextFeatureId++;
-        features.put(featureId, new StaticPolygonFeature(map, points));
+        features.put(featureId, new StaticPolygonFeature(map, polygonDescription.getPoints(), polygonDescription.getFillColor()));
         return featureId;
     }
 
@@ -946,14 +945,14 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         private final MapView map;
         private final Polygon polygon = new Polygon();
 
-        StaticPolygonFeature(MapView map, Iterable<MapPoint> points) {
+        StaticPolygonFeature(MapView map, Iterable<MapPoint> points, int fillColor) {
             this.map = map;
 
             map.getOverlays().add(polygon);
             int strokeColor = map.getContext().getResources().getColor(org.odk.collect.icons.R.color.mapLineColor);
             polygon.getOutlinePaint().setColor(strokeColor);
             polygon.setStrokeWidth(POLYLINE_STROKE_WIDTH);
-            polygon.getFillPaint().setColor(ColorUtils.setAlphaComponent(strokeColor, POLYGON_FILL_COLOR_OPACITY));
+            polygon.getFillPaint().setColor(fillColor);
             polygon.setPoints(StreamSupport.stream(points.spliterator(), false).map(point -> new GeoPoint(point.latitude, point.longitude)).collect(Collectors.toList()));
             polygon.setOnClickListener((polygon, mapView, eventPos) -> {
                 int featureId = findFeature(polygon);


### PR DESCRIPTION
Closes #5945

#### Why is this the best possible solution? Were any other approaches considered?
This is a continuation of https://github.com/getodk/collect/issues/5278 and the approach is also the same so there is nothing important to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As described in the issue we are introducing new ways of styling map elements (lines and polygons). Everything that's map-related needs to be tested with all three providers google, mapbox, and osm.
The only problem is that there is no way to set the width of a line in polygons in Mapbox. It's just not supported at this moment. We could have tried to deal with it somehow by drowning additional lines on top of the borders of a polygon but I don't think it's necessary. Let's wait for Mapbox to add this option.

#### Do we need any specific form for testing your changes? If so, please attach one.
I've used: 
[s1FromMap.xlsx](https://github.com/getodk/collect/files/14952199/s1FromMap.xlsx)
[items.geojson.txt](https://github.com/getodk/collect/files/15021773/items.geojson.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Yes https://github.com/getodk/docs/issues/1780

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
