### PR TITLE
Updated icons used by external question types

### DIFF
--- a/collect_app/src/main/res/layout/ex_arbitrary_file_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_arbitrary_file_widget_answer.xml
@@ -11,7 +11,7 @@
         android:text="@string/launch_app"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:icon="@drawable/ic_baseline_attach_file_white_24" />
+        app:icon="@drawable/ic_baseline_open_in_new_white_24" />
 
     <com.google.android.material.textview.MaterialTextView
         android:layout_width="wrap_content"

--- a/collect_app/src/main/res/layout/ex_audio_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_audio_widget_answer.xml
@@ -11,7 +11,7 @@
         android:text="@string/launch_app"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:icon="@drawable/ic_baseline_mic_white_24" />
+        app:icon="@drawable/ic_baseline_open_in_new_white_24" />
 
     <include
         android:id="@+id/audio_player"

--- a/collect_app/src/main/res/layout/ex_image_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_image_widget_answer.xml
@@ -11,7 +11,7 @@
         android:text="@string/launch_app"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:icon="@drawable/ic_baseline_photo_camera_white_24" />
+        app:icon="@drawable/ic_baseline_open_in_new_white_24" />
 
     <ImageView
         android:id="@+id/image_view"

--- a/collect_app/src/main/res/layout/ex_video_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_video_widget_answer.xml
@@ -11,7 +11,7 @@
         android:text="@string/launch_app"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:icon="@drawable/ic_baseline_videocam_white_24" />
+        app:icon="@drawable/ic_baseline_open_in_new_white_24" />
 
     <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
         android:id="@+id/play_video_button"


### PR DESCRIPTION
Closes #6055 

#### Why is this the best possible solution? Were any other approaches considered?
We have decided that all external questions should use the same icon.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It only updates the icons used by external question types.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
