### PR TITLE
Fixed issues caused by the new 'masked' appearance

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
@@ -170,7 +170,7 @@ object Appearances {
 
     @JvmStatic
     fun useThousandSeparator(prompt: FormEntryPrompt): Boolean {
-        return getSanitizedAppearanceHint(prompt).contains(THOUSANDS_SEP)
+        return getSanitizedAppearanceHint(prompt).contains(THOUSANDS_SEP) && !isMasked(prompt)
     }
 
     @JvmStatic

--- a/collect_app/src/main/java/org/odk/collect/android/views/WidgetAnswerText.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/views/WidgetAnswerText.kt
@@ -33,8 +33,6 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
 
     val binding = WidgetAnswerTextBinding.inflate(LayoutInflater.from(context), this, true)
 
-    private var isMasked: Boolean = false
-
     fun init(fontSize: Float, readOnly: Boolean, numberOfRows: Int?, isMasked: Boolean, afterTextChanged: Runnable) {
         binding.editText.id = generateViewId()
         binding.textView.id = generateViewId()
@@ -61,9 +59,11 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
             }
         })
         if (isMasked) {
-            this.isMasked = isMasked
+            binding.editText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
             binding.editText.transformationMethod = PasswordTransformationMethod.getInstance()
             binding.textView.transformationMethod = PasswordTransformationMethod.getInstance()
+        } else {
+            binding.editText.inputType = InputType.TYPE_CLASS_TEXT
         }
     }
 
@@ -83,7 +83,6 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
             binding.editText.addTextChangedListener(ThousandsSeparatorTextWatcher(binding.editText))
         }
 
-        binding.editText.inputType = InputType.TYPE_NUMBER_FLAG_SIGNED
         binding.editText.keyListener = DigitsKeyListener(true, false) // only allows numbers and no periods
 
         // ints can only hold 2,147,483,648. we allow 999,999,999
@@ -98,11 +97,6 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
         if (answer != null) {
             setAnswer(String.format(Locale.US, "%d", answer))
         }
-
-        if (isMasked) {
-            binding.editText.transformationMethod = PasswordTransformationMethod.getInstance()
-            binding.textView.transformationMethod = PasswordTransformationMethod.getInstance()
-        }
     }
 
     fun setStringNumberType(useThousandSeparator: Boolean, answer: String?) {
@@ -110,7 +104,6 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
             binding.editText.addTextChangedListener(ThousandsSeparatorTextWatcher(binding.editText))
         }
 
-        binding.editText.inputType = InputType.TYPE_NUMBER_FLAG_SIGNED
         binding.editText.keyListener = object : DigitsKeyListener() {
             override fun getAcceptedChars(): CharArray {
                 return charArrayOf(
@@ -122,11 +115,6 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
         if (answer != null) {
             setAnswer(answer)
         }
-
-        if (isMasked) {
-            binding.editText.transformationMethod = PasswordTransformationMethod.getInstance()
-            binding.textView.transformationMethod = PasswordTransformationMethod.getInstance()
-        }
     }
 
     fun setDecimalType(useThousandSeparator: Boolean, answer: Double?) {
@@ -134,7 +122,6 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
             binding.editText.addTextChangedListener(ThousandsSeparatorTextWatcher(binding.editText))
         }
 
-        binding.editText.inputType = InputType.TYPE_NUMBER_FLAG_DECIMAL
         binding.editText.keyListener = DigitsKeyListener(true, true) // only numbers are allowed
 
         // only 15 characters allowed
@@ -153,11 +140,6 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
             nf.isGroupingUsed = false
             val formattedValue: String = nf.format(answer)
             setAnswer(formattedValue)
-        }
-
-        if (isMasked) {
-            binding.editText.transformationMethod = PasswordTransformationMethod.getInstance()
-            binding.textView.transformationMethod = PasswordTransformationMethod.getInstance()
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/AppearancesTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/AppearancesTest.kt
@@ -233,6 +233,12 @@ class AppearancesTest {
     }
 
     @Test
+    fun `useThousandSeparator returns false when 'thousands-sep' appearance is found but mixed with 'masked'`() {
+        whenever(formEntryPrompt.appearanceHint).thenReturn("thousands-sep masked")
+        assertFalse(Appearances.useThousandSeparator(formEntryPrompt))
+    }
+
+    @Test
     fun `useThousandSeparator returns true when 'thousands-sep' appearance is found`() {
         whenever(formEntryPrompt.appearanceHint).thenReturn("THOUSANDS-SEP")
         assertTrue(Appearances.useThousandSeparator(formEntryPrompt))

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
@@ -20,7 +20,12 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
+
+import android.text.InputType;
+import android.text.method.PasswordTransformationMethod;
+import android.text.method.SingleLineTransformationMethod;
 
 public class DecimalWidgetTest extends GeneralStringWidgetTest<DecimalWidget, DecimalData> {
 
@@ -204,5 +209,22 @@ public class DecimalWidgetTest extends GeneralStringWidgetTest<DecimalWidget, De
         assertEquals("123,456,789.54", getWidget().widgetAnswerText.getAnswer());
         assertEquals("123,456,789.54", getWidget().widgetAnswerText.getBinding().editText.getText().toString());
         assertEquals("123,456,789.54", getWidget().widgetAnswerText.getBinding().textView.getText().toString());
+    }
+
+    @Override
+    @Test
+    public void verifyInputType() {
+        DecimalWidget widget = getWidget();
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+    }
+
+    @Override
+    @Test
+    public void verifyInputTypeWithMaskedAppearance() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
+        DecimalWidget widget = getWidget();
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
@@ -20,7 +20,12 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
+
+import android.text.InputType;
+import android.text.method.PasswordTransformationMethod;
+import android.text.method.SingleLineTransformationMethod;
 
 /**
  * @author James Knight
@@ -87,5 +92,24 @@ public class ExDecimalWidgetTest extends GeneralExStringWidgetTest<ExDecimalWidg
         assertEquals("123,456,789.54", getWidget().binding.widgetAnswerText.getAnswer());
         assertEquals("123,456,789.54", getWidget().binding.widgetAnswerText.getBinding().editText.getText().toString());
         assertEquals("123,456,789.54", getWidget().binding.widgetAnswerText.getBinding().textView.getText().toString());
+    }
+
+    @Override
+    @Test
+    public void verifyInputType() {
+        ExDecimalWidget widget = getWidget();
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+        assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
+    }
+
+    @Override
+    @Test
+    public void verifyInputTypeWithMaskedAppearance() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
+        ExDecimalWidget widget = getWidget();
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+        assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
@@ -11,8 +11,15 @@ import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 import org.odk.collect.android.widgets.utilities.StringRequester;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
+
+import android.text.InputType;
+import android.text.method.PasswordTransformationMethod;
+import android.text.method.SingleLineTransformationMethod;
 
 /**
  * @author James Knight
@@ -59,5 +66,24 @@ public class ExIntegerWidgetTest extends GeneralExStringWidgetTest<ExIntegerWidg
         assertEquals("123,456,789", getWidget().binding.widgetAnswerText.getAnswer());
         assertEquals("123,456,789", getWidget().binding.widgetAnswerText.getBinding().editText.getText().toString());
         assertEquals("123,456,789", getWidget().binding.widgetAnswerText.getBinding().textView.getText().toString());
+    }
+
+    @Override
+    @Test
+    public void verifyInputType() {
+        ExIntegerWidget widget = getWidget();
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+        assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
+    }
+
+    @Override
+    @Test
+    public void verifyInputTypeWithMaskedAppearance() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
+        ExIntegerWidget widget = getWidget();
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+        assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
@@ -5,13 +5,21 @@ import androidx.annotation.NonNull;
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 import org.odk.collect.android.widgets.utilities.StringRequester;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.utilities.Appearances.MASKED;
+
+import android.text.InputType;
+import android.text.method.PasswordTransformationMethod;
+import android.text.method.SingleLineTransformationMethod;
 
 /**
  * @author James Knight
@@ -38,5 +46,24 @@ public class ExStringWidgetTest extends GeneralExStringWidgetTest<ExStringWidget
     public void setUp() throws Exception {
         super.setUp();
         when(formEntryPrompt.getAppearanceHint()).thenReturn("");
+    }
+
+    @Override
+    @Test
+    public void verifyInputType() {
+        ExStringWidget widget = getWidget();
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+        assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
+    }
+
+    @Override
+    @Test
+    public void verifyInputTypeWithMaskedAppearance() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
+        ExStringWidget widget = getWidget();
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+        assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
@@ -8,8 +8,15 @@ import org.junit.Test;
 import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
+
+import android.text.InputType;
+import android.text.method.PasswordTransformationMethod;
+import android.text.method.SingleLineTransformationMethod;
 
 /**
  * @author James Knight
@@ -46,5 +53,22 @@ public class IntegerWidgetTest extends GeneralStringWidgetTest<IntegerWidget, In
         assertEquals("123,456,789", getWidget().widgetAnswerText.getAnswer());
         assertEquals("123,456,789", getWidget().widgetAnswerText.getBinding().editText.getText().toString());
         assertEquals("123,456,789", getWidget().widgetAnswerText.getBinding().textView.getText().toString());
+    }
+
+    @Override
+    @Test
+    public void verifyInputType() {
+        IntegerWidget widget = getWidget();
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+    }
+
+    @Override
+    @Test
+    public void verifyInputTypeWithMaskedAppearance() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
+        IntegerWidget widget = getWidget();
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
@@ -10,8 +10,15 @@ import org.junit.Test;
 import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
+
+import android.text.InputType;
+import android.text.method.PasswordTransformationMethod;
+import android.text.method.SingleLineTransformationMethod;
 
 /**
  * @author James Knight
@@ -44,5 +51,22 @@ public class StringNumberWidgetTest extends GeneralStringWidgetTest<StringNumber
         assertEquals("123,456,789,123,456,789,123,456,789,123,456,789", getWidget().widgetAnswerText.getAnswer());
         assertEquals("123,456,789,123,456,789,123,456,789,123,456,789", getWidget().widgetAnswerText.getBinding().editText.getText().toString());
         assertEquals("123,456,789,123,456,789,123,456,789,123,456,789", getWidget().widgetAnswerText.getBinding().textView.getText().toString());
+    }
+
+    @Override
+    @Test
+    public void verifyInputType() {
+        StringNumberWidget widget = getWidget();
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+    }
+
+    @Override
+    @Test
+    public void verifyInputTypeWithMaskedAppearance() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
+        StringNumberWidget widget = getWidget();
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringWidgetTest.java
@@ -1,10 +1,20 @@
 package org.odk.collect.android.widgets;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+import static org.odk.collect.android.utilities.Appearances.MASKED;
+
+import android.text.InputType;
+import android.text.method.PasswordTransformationMethod;
+import android.text.method.SingleLineTransformationMethod;
+
 import androidx.annotation.NonNull;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
+import org.junit.Test;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
@@ -23,5 +33,23 @@ public class StringWidgetTest extends GeneralStringWidgetTest<StringWidget, Stri
     @Override
     public StringData getNextAnswer() {
         return new StringData(RandomString.make());
+    }
+
+    @Override
+    @Test
+    public void verifyInputType() {
+        StringWidget widget = getWidget();
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+        assertThat(widget.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
+    }
+
+    @Override
+    @Test
+    public void verifyInputTypeWithMaskedAppearance() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
+        StringWidget widget = getWidget();
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
@@ -81,4 +81,10 @@ public abstract class GeneralExStringWidgetTest<W extends ExStringWidget, A exte
         assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
         assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
     }
+
+    @Test
+    public abstract void verifyInputType();
+
+    @Test
+    public abstract void verifyInputTypeWithMaskedAppearance();
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
@@ -120,4 +120,10 @@ public abstract class GeneralStringWidgetTest<W extends StringWidget, A extends 
         assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
         assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
     }
+
+    @Test
+    public abstract void verifyInputType();
+
+    @Test
+    public abstract void verifyInputTypeWithMaskedAppearance();
 }


### PR DESCRIPTION
Closes #6072
Closes #6073 
Closes #6075
Closes #6080 

#### Why is this the best possible solution? Were any other approaches considered?
#6073  has been fixed in https://github.com/getodk/collect/pull/6088/commits/24d2b99f1fd401064ca77b7679e93002774c1eec - as we have discussed it doesn't make sense to mix `thousands-sep` with `masked` (`masked` should win).
#6072 and #6075 have been fixed in https://github.com/getodk/collect/pull/6088/commits/66281862ac8120adda91f0acc96c741054a64872 by fixing setting inputtypes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should fix the issues we had with `text` and `number` questions with the new `masked` appearance. Please test the form attached below but also the `All question types` one to make sure `text` and `number` questions without the `masked` appearance work well.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to https://github.com/getodk/collect/pull/6008

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
