### PR TITLE
Fixed cleaning instance dirs that are not needed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -332,6 +332,9 @@ private class FormUriViewModel(
     fun deleteSavepoint(savepoint: Savepoint) {
         scheduler.immediate(
             background = {
+                if (savepoint.instanceDbId == null) {
+                    File(savepoint.instanceFilePath).parentFile?.deleteRecursively()
+                }
                 savepointsRepositoryProvider.get().delete(savepoint.formDbId, savepoint.instanceDbId)
             },
             foreground = {

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -976,7 +976,9 @@ class FormUriActivityTest {
             ).build()
         )
         val savepointFile = TempFiles.createTempFile()
-        val savepoint = Savepoint(form.dbId, null, savepointFile.absolutePath, TempFiles.createTempFile().absolutePath)
+        val instanceDirFile = TempFiles.createTempDir()
+        val instanceFile = TempFiles.createTempFile(instanceDirFile)
+        val savepoint = Savepoint(form.dbId, null, savepointFile.absolutePath, instanceFile.absolutePath)
         savepointsRepository.save(savepoint)
 
         launcherRule.launch<FormUriActivity>(getBlankFormIntent(project.uuid, form.dbId))
@@ -986,6 +988,8 @@ class FormUriActivityTest {
         onView(withText(org.odk.collect.strings.R.string.do_not_recover)).perform(click())
         fakeScheduler.flush()
         assertThat(savepointsRepository.getAll().isEmpty(), equalTo(true))
+        assertThat(instanceDirFile.exists(), equalTo(false))
+        assertThat(instanceFile.exists(), equalTo(false))
     }
 
     @Test
@@ -1011,7 +1015,9 @@ class FormUriActivityTest {
         )
 
         val savepointFile = TempFiles.createTempFile()
-        val savepoint = Savepoint(form.dbId, instance.dbId, savepointFile.absolutePath, TempFiles.createTempFile().absolutePath)
+        val instanceDirFile = TempFiles.createTempDir()
+        val instanceFile = TempFiles.createTempFile(instanceDirFile)
+        val savepoint = Savepoint(form.dbId, instance.dbId, savepointFile.absolutePath, instanceFile.absolutePath)
         savepointsRepository.save(savepoint)
 
         launcherRule.launch<FormUriActivity>(getSavedIntent(project.uuid, instance.dbId))
@@ -1021,6 +1027,8 @@ class FormUriActivityTest {
         onView(withText(org.odk.collect.strings.R.string.do_not_recover)).perform(click())
         fakeScheduler.flush()
         assertThat(savepointsRepository.getAll().isEmpty(), equalTo(true))
+        assertThat(instanceDirFile.exists(), equalTo(true))
+        assertThat(instanceFile.exists(), equalTo(true))
     }
 
     private fun getBlankFormIntent(projectId: String?, dbId: Long) =


### PR DESCRIPTION
Closes #6057 

#### Why is this the best possible solution? Were any other approaches considered?
It brings back the behavior we had with the old savepoints back. When a user rejects a savepoint (that belongs to a blank form) we should get rid of an instance dir created for that form as it's not needed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
When a user does not want to load a savepoint for a blank form the instance dir should be removed. That's the only change. Please make sure it only happens for savepoints that belong to blank forms. Otherwise, we don't want to remove the instance dir as it contains an instance file.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
