### PR TITLE
Support updating dynamic required questions in field-list

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -421,6 +421,20 @@ public class FieldListUpdateTest {
                 .assertTextDoesNotExist("Target16");
     }
 
+    @Test
+    public void changeInValueUsedToDetermineIfAQuestionIsRequired_ShouldUpdateTheRelatedRequiredQuestion() {
+        new FormEntryPage("fieldlist-updates")
+                .clickGoToArrow()
+                .clickGoUpIcon()
+                .clickOnGroup("Dynamic required question")
+                .clickOnQuestion("Source17")
+                .assertQuestion("Target17")
+                .answerQuestion(0, "blah")
+                .assertQuestion("Target17", true)
+                .answerQuestion(0, "")
+                .assertQuestion("Target17");
+    }
+
     // Scroll down until the desired group name is visible. This is needed to make the tests work
     // on devices with screens of different heights.
     private void jumpToGroupWithText(String text) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -431,8 +431,10 @@ public class FieldListUpdateTest {
                 .assertQuestion("Target17")
                 .answerQuestion(0, "blah")
                 .assertQuestion("Target17", true)
+                .swipeToNextQuestionWithConstraintViolation(org.odk.collect.strings.R.string.required_answer_error)
                 .answerQuestion(0, "")
-                .assertQuestion("Target17");
+                .assertQuestion("Target17")
+                .assertTextDoesNotExist(org.odk.collect.strings.R.string.required_answer_error);
     }
 
     // Scroll down until the desired group name is visible. This is needed to make the tests work

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -143,6 +143,13 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return new ErrorDialog().assertOnPage();
     }
 
+    public FormEntryPage swipeToNextQuestionWithConstraintViolation(int constraintText) {
+        flingLeft();
+        assertText(constraintText);
+
+        return this;
+    }
+
     public FormEntryPage swipeToNextQuestionWithConstraintViolation(String constraintText) {
         flingLeft();
         assertText(constraintText);

--- a/collect_app/src/main/java/org/odk/collect/android/logic/ImmutableDisplayableQuestion.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/ImmutableDisplayableQuestion.java
@@ -64,6 +64,11 @@ public class ImmutableDisplayableQuestion {
     private final boolean isReadOnly;
 
     /**
+     * Whether the question is required.
+     */
+    private final boolean isRequired;
+
+    /**
      * The choices displayed to a user if this question is of a type that has choices.
      */
     private List<SelectChoice> selectChoices;
@@ -78,6 +83,7 @@ public class ImmutableDisplayableQuestion {
         guidanceText = question.getSpecialFormQuestionText(question.getQuestion().getHelpTextID(), "guidance");
         answerText = question.getAnswerText();
         isReadOnly = question.isReadOnly();
+        isRequired = question.isRequired();
 
         List<SelectChoice> choices = question.getSelectChoices();
         if (choices != null) {
@@ -106,7 +112,8 @@ public class ImmutableDisplayableQuestion {
                 && (getGuidanceHintText(question) == null ? guidanceText == null : getGuidanceHintText(question).equals(guidanceText))
                 && (question.getAnswerText() == null ? answerText == null : question.getAnswerText().equals(answerText))
                 && (question.isReadOnly() == isReadOnly)
-                && selectChoiceListsEqual(question.getSelectChoices(), selectChoices);
+                && selectChoiceListsEqual(question.getSelectChoices(), selectChoices)
+                && question.isRequired() == isRequired;
     }
 
     private static boolean selectChoiceListsEqual(List<SelectChoice> selectChoiceList1, List<SelectChoice> selectChoiceList2) {

--- a/test-forms/src/main/resources/forms/fieldlist-updates.xml
+++ b/test-forms/src/main/resources/forms/fieldlist-updates.xml
@@ -186,6 +186,10 @@
             <source16/>
             <target16/>
           </audio>
+          <required>
+            <source17/>
+            <target17/>
+          </required>
           <meta>
             <instanceID/>
           </meta>
@@ -372,6 +376,8 @@
       <bind nodeset="/fieldlist-updates/long_list_of_questions/question20" type="integer"/>
       <bind nodeset="/fieldlist-updates/audio/source16" type="binary"/>
       <bind nodeset="/fieldlist-updates/audio/target16" relevant=" /fieldlist-updates/audio/source16  != ''" type="string"/>
+      <bind nodeset="/fieldlist-updates/required/source17" type="binary"/>
+      <bind nodeset="/fieldlist-updates/required/target17" required=" /fieldlist-updates/required/source17  != ''" type="string"/>
       <bind calculate="concat('uuid:', uuid())" nodeset="/fieldlist-updates/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>
@@ -727,6 +733,15 @@
       </upload>
       <input ref="/fieldlist-updates/audio/target16">
         <label>Target16</label>
+      </input>
+    </group>
+    <group appearance="field-list" ref="/fieldlist-updates/required">
+      <label>Dynamic required question</label>
+      <input ref="/fieldlist-updates/required/source17">
+        <label>Source17</label>
+      </input>
+      <input ref="/fieldlist-updates/required/target17">
+        <label>Target17</label>
       </input>
     </group>
   </h:body>


### PR DESCRIPTION
Closes #5941 

#### Why is this the best possible solution? Were any other approaches considered?
When we update questions on one screen we compare them before the changes and after (for example before answering one of the questions and after). If the same question is still exactly the same we do nothing otherwise we update it. The problem was that we didn't take into account whether a question was required while comparing the states. I've updated the logis and now everything is fine.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue. I've updated the logic responsible for updating questions on one screen that might sound dangerous but the change is rather small and safe so I don't think we need to test a lot other similar cases.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
