### PR TITLE
Fixed displaying saved forms to delete

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import org.odk.collect.android.instancemanagement.InstancesDataService
 import org.odk.collect.androidshared.async.TrackableWorker
 import org.odk.collect.androidshared.data.Consumable
@@ -39,6 +40,7 @@ class SavedFormListViewModel(
         }
 
     val formsToDisplay: LiveData<List<Instance>> = instancesDataService.instances
+        .map { instances -> instances.filter { instance -> instance.deletedDate == null } }
         .combine(_sortOrder) { instances, order ->
             when (order) {
                 SortOrder.NAME_DESC -> {

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModelTest.kt
@@ -35,6 +35,20 @@ class SavedFormListViewModelTest {
     }
 
     @Test
+    fun `formsToDisplay should not include deleted forms`() {
+        val myForm = InstanceFixtures.instance(displayName = "My form", deletedDate = 1)
+        val yourForm = InstanceFixtures.instance(displayName = "Your form")
+        saveForms(listOf(myForm, yourForm))
+
+        val viewModel = SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
+
+        assertThat(
+            viewModel.formsToDisplay.getOrAwaitValue(scheduler),
+            contains(yourForm)
+        )
+    }
+
+    @Test
     fun `setting filterText filters forms on display name`() {
         val myForm = InstanceFixtures.instance(displayName = "My form")
         val yourForm = InstanceFixtures.instance(displayName = "Your form")

--- a/forms-test/src/main/java/org/odk/collect/formstest/InstanceFixtures.kt
+++ b/forms-test/src/main/java/org/odk/collect/formstest/InstanceFixtures.kt
@@ -11,7 +11,8 @@ object InstanceFixtures {
         lastStatusChangeDate: Long = 0,
         displayName: String? = null,
         dbId: Long? = null,
-        form: Form? = null
+        form: Form? = null,
+        deletedDate: Long? = null
     ): Instance {
         val instancesDir = TempFiles.createTempDir()
         return InstanceUtils.buildInstance("formId", "version", instancesDir.absolutePath)
@@ -24,6 +25,7 @@ object InstanceFixtures {
                     it.formVersion(form.version)
                 }
             }
+            .deletedDate(deletedDate)
             .build()
     }
 }


### PR DESCRIPTION
Closes #6017 

#### Why is this the best possible solution? Were any other approaches considered?
I could have edited `InstancesDataService` by adding a new flow specifically for undelete instances (and read them from the repository) but:
1. This would make testing more difficult than what I did because I would need to rework the view model test completely so that it tests a real `InstancesDataService` object.
2. I'm not sure if exposing different flows for different scenarios (all instances, undelete instances, etc) is what we want to have in our data service. Maybe exposing just one like now is clearer.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should fix filtering forms to delete so that the soft-deleted ones (forms that have already been deleted but still exist in the database so that we can keep track of sent forms for example). are not displayed on the list.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
