### PR TITLE
Only auto send forms when auto send is enabled

### DIFF
--- a/async/src/main/java/org/odk/collect/async/CoroutineAndWorkManagerScheduler.kt
+++ b/async/src/main/java/org/odk/collect/async/CoroutineAndWorkManagerScheduler.kt
@@ -37,7 +37,7 @@ class CoroutineAndWorkManagerScheduler(foregroundContext: CoroutineContext, back
             .setInputData(workManagerInputData)
             .build()
 
-        workManager.beginUniqueWork(tag, ExistingWorkPolicy.APPEND_OR_REPLACE, workRequest).enqueue()
+        workManager.beginUniqueWork(tag, ExistingWorkPolicy.REPLACE, workRequest).enqueue()
     }
 
     override fun networkDeferredRepeat(tag: String, spec: TaskSpec, repeatPeriod: Long, inputData: Map<String, String>) {

--- a/async/src/main/java/org/odk/collect/async/Scheduler.kt
+++ b/async/src/main/java/org/odk/collect/async/Scheduler.kt
@@ -32,7 +32,7 @@ interface Scheduler {
      * will only be run when the network is available.
      *
      * @param tag used to identify this task in future. If there is a previously scheduled task
-     * with the same tag then that task then this will replace that
+     * with the same tag then that task will be cancelled and this will replace it
      * @param spec defines the task to be run
      * @param inputData a map of input data that can be accessed by the task
      * @param networkConstraint the specific kind of network required

--- a/async/src/main/java/org/odk/collect/async/Scheduler.kt
+++ b/async/src/main/java/org/odk/collect/async/Scheduler.kt
@@ -32,9 +32,10 @@ interface Scheduler {
      * will only be run when the network is available.
      *
      * @param tag used to identify this task in future. If there is a previously scheduled task
-     * with the same tag then that task then nothing new will be scheduled (this becomes  no-op)
+     * with the same tag then that task then this will replace that
      * @param spec defines the task to be run
      * @param inputData a map of input data that can be accessed by the task
+     * @param networkConstraint the specific kind of network required
      */
     fun networkDeferred(tag: String, spec: TaskSpec, inputData: Map<String, String>, networkConstraint: NetworkType? = null)
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
@@ -7,6 +7,7 @@ import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.ErrorPage
+import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.ViewSentFormPage
 import org.odk.collect.android.support.rules.CollectTestRule
@@ -132,5 +133,18 @@ class AutoSendTest {
                 "Show details",
                 ErrorPage()
             )
+    }
+
+    @Test
+    fun whenAutoSendDisabled_fillingAndFinalizingForm_doesNotSendFormAutomatically() {
+        val mainMenuPage = rule.startAtMainMenu()
+            .setServer(testDependencies.server.url)
+            .copyForm("one-question.xml")
+            .startBlankForm("One Question")
+            .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("what is your age", "31"))
+
+        testDependencies.scheduler.runDeferredTasks()
+
+        mainMenuPage.assertNumberOfFinalizedForms(1)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -449,7 +449,7 @@ public class AppDependencyModule {
             return null;
         };
 
-        return new InstancesDataService(getState(application), instanceSubmitScheduler, projectsDependencyProviderFactory, notifier, propertyManager, httpInterface, onUpdate);
+        return new InstancesDataService(application, instanceSubmitScheduler, projectsDependencyProviderFactory, notifier, propertyManager, httpInterface, onUpdate);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.android.instancemanagement
 
+import android.app.Application
 import androidx.lifecycle.LiveData
 import kotlinx.coroutines.flow.Flow
 import org.odk.collect.analytics.Analytics
@@ -14,13 +15,13 @@ import org.odk.collect.android.openrosa.OpenRosaHttpInterface
 import org.odk.collect.android.projects.ProjectDependencyProviderFactory
 import org.odk.collect.android.utilities.ExternalizableFormDefCache
 import org.odk.collect.android.utilities.FormsUploadResultInterpreter
-import org.odk.collect.androidshared.data.AppState
+import org.odk.collect.androidshared.data.getState
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.metadata.PropertyManager
 import java.io.File
 
 class InstancesDataService(
-    private val appState: AppState,
+    private val application: Application,
     private val instanceSubmitScheduler: InstanceSubmitScheduler,
     private val projectDependencyProviderFactory: ProjectDependencyProviderFactory,
     private val notifier: Notifier,
@@ -28,6 +29,7 @@ class InstancesDataService(
     private val httpInterface: OpenRosaHttpInterface,
     private val onUpdate: () -> Unit
 ) {
+    private val appState = application.getState()
     val editableCount: LiveData<Int> = appState.getLive(EDITABLE_COUNT_KEY, 0)
     val sendableCount: LiveData<Int> = appState.getLive(SENDABLE_COUNT_KEY, 0)
     val sentCount: LiveData<Int> = appState.getLive(SENT_COUNT_KEY, 0)
@@ -193,6 +195,7 @@ class InstancesDataService(
         ).withLock { acquiredLock: Boolean ->
             if (acquiredLock) {
                 val toUpload = InstanceAutoSendFetcher.getInstancesToAutoSend(
+                    application,
                     projectDependencyProvider.instancesRepository,
                     projectDependencyProvider.formsRepository,
                     projectDependencyProvider.settingsProvider

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -194,7 +194,8 @@ class InstancesDataService(
             if (acquiredLock) {
                 val toUpload = InstanceAutoSendFetcher.getInstancesToAutoSend(
                     projectDependencyProvider.instancesRepository,
-                    projectDependencyProvider.formsRepository
+                    projectDependencyProvider.formsRepository,
+                    projectDependencyProvider.settingsProvider
                 )
 
                 if (toUpload.isNotEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcher.kt
@@ -1,14 +1,17 @@
 package org.odk.collect.android.instancemanagement.autosend
 
+import android.app.Application
 import org.odk.collect.forms.FormsRepository
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.forms.instances.InstancesRepository
 import org.odk.collect.settings.SettingsProvider
-import org.odk.collect.settings.keys.ProjectKeys
+import org.odk.collect.settings.enums.AutoSend
+import org.odk.collect.settings.enums.StringIdEnumUtils.getAutoSend
 
 object InstanceAutoSendFetcher {
 
     fun getInstancesToAutoSend(
+        application: Application,
         instancesRepository: InstancesRepository,
         formsRepository: FormsRepository,
         settingsProvider: SettingsProvider
@@ -19,11 +22,11 @@ object InstanceAutoSendFetcher {
         )
 
         val autoSendSetting =
-            settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_AUTOSEND)
+            settingsProvider.getUnprotectedSettings().getAutoSend(application)
 
         return allFinalizedForms.filter {
             formsRepository.getLatestByFormIdAndVersion(it.formId, it.formVersion)?.let { form ->
-                form.shouldFormBeSentAutomatically(autoSendSetting != "off")
+                form.shouldFormBeSentAutomatically(autoSendSetting != AutoSend.OFF)
             } ?: false
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcher.kt
@@ -3,21 +3,27 @@ package org.odk.collect.android.instancemanagement.autosend
 import org.odk.collect.forms.FormsRepository
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.forms.instances.InstancesRepository
+import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.keys.ProjectKeys
 
 object InstanceAutoSendFetcher {
 
     fun getInstancesToAutoSend(
         instancesRepository: InstancesRepository,
-        formsRepository: FormsRepository
+        formsRepository: FormsRepository,
+        settingsProvider: SettingsProvider
     ): List<Instance> {
         val allFinalizedForms = instancesRepository.getAllByStatus(
             Instance.STATUS_COMPLETE,
             Instance.STATUS_SUBMISSION_FAILED
         )
 
+        val autoSendSetting =
+            settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_AUTOSEND)
+
         return allFinalizedForms.filter {
             formsRepository.getLatestByFormIdAndVersion(it.formId, it.formVersion)?.let { form ->
-                form.shouldFormBeSentAutomatically(true)
+                form.shouldFormBeSentAutomatically(autoSendSetting != "off")
             } ?: false
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstancesDataServiceTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstancesDataServiceTest.kt
@@ -1,5 +1,7 @@
 package org.odk.collect.android.instancemanagement
 
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -24,11 +26,15 @@ import org.odk.collect.formstest.InMemInstancesRepository
 import org.odk.collect.formstest.InstanceFixtures
 import org.odk.collect.projects.Project
 import org.odk.collect.settings.InMemSettingsProvider
+import org.odk.collect.settings.enums.AutoSend
 import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.testshared.BooleanChangeLock
 
 @RunWith(AndroidJUnit4::class)
 class InstancesDataServiceTest {
+
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+
     val project = Project.Saved("1", "Test", "T", "#000000")
 
     private val formsRepositoryProvider = mock<FormsRepositoryProvider>().apply {
@@ -44,6 +50,8 @@ class InstancesDataServiceTest {
     val settingsProvider = InMemSettingsProvider().also {
         it.getUnprotectedSettings(project.uuid)
             .save(ProjectKeys.KEY_SERVER_URL, "http://example.com")
+        it.getUnprotectedSettings()
+            .save(ProjectKeys.KEY_AUTOSEND, AutoSend.WIFI_ONLY.getValue(application))
     }
 
     private val projectsDependencyProviderFactory = ProjectDependencyProviderFactory(
@@ -63,7 +71,7 @@ class InstancesDataServiceTest {
 
     private val instancesDataService =
         InstancesDataService(
-            mock(),
+            application,
             mock(),
             projectsDependencyProviderFactory,
             notifier,

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcherTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcherTest.kt
@@ -8,6 +8,7 @@ import org.odk.collect.formstest.FormUtils.buildForm
 import org.odk.collect.formstest.InMemFormsRepository
 import org.odk.collect.formstest.InMemInstancesRepository
 import org.odk.collect.formstest.InstanceUtils.buildInstance
+import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.shared.TempFiles.createTempDir
 
 class InstanceAutoSendFetcherTest {
@@ -74,7 +75,8 @@ class InstanceAutoSendFetcherTest {
 
         val instancesToSend = InstanceAutoSendFetcher.getInstancesToAutoSend(
             instancesRepository,
-            formsRepository
+            formsRepository,
+            InMemSettingsProvider()
         )
         assertThat(
             instancesToSend.map { it.instanceFilePath },
@@ -107,7 +109,8 @@ class InstanceAutoSendFetcherTest {
 
         val instancesToSend = InstanceAutoSendFetcher.getInstancesToAutoSend(
             instancesRepository,
-            formsRepository
+            formsRepository,
+            InMemSettingsProvider()
         )
         assertThat(
             instancesToSend.map { it.instanceFilePath },

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcherTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcherTest.kt
@@ -1,8 +1,12 @@
 package org.odk.collect.android.instancemanagement.autosend
 
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.formstest.FormUtils.buildForm
 import org.odk.collect.formstest.InMemFormsRepository
@@ -11,6 +15,7 @@ import org.odk.collect.formstest.InstanceUtils.buildInstance
 import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.shared.TempFiles.createTempDir
 
+@RunWith(AndroidJUnit4::class)
 class InstanceAutoSendFetcherTest {
 
     private val instancesRepository = InMemInstancesRepository()
@@ -44,6 +49,8 @@ class InstanceAutoSendFetcherTest {
     private val instanceOfFormWithCustomAutoSendSubmissionFailed = buildInstance("4", "1", "instance 3", Instance.STATUS_SUBMISSION_FAILED, null, createTempDir().absolutePath).build()
     private val instanceOfFormWithCustomAutoSendSubmitted = buildInstance("4", "1", "instance 4", Instance.STATUS_SUBMITTED, null, createTempDir().absolutePath).build()
 
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+
     @Test
     fun `return all finalized instances of forms that do not have auto send disabled on a form level`() {
         formsRepository.save(formWithEnabledAutoSend)
@@ -74,10 +81,12 @@ class InstanceAutoSendFetcherTest {
         }
 
         val instancesToSend = InstanceAutoSendFetcher.getInstancesToAutoSend(
+            application,
             instancesRepository,
             formsRepository,
             InMemSettingsProvider()
         )
+
         assertThat(
             instancesToSend.map { it.instanceFilePath },
             contains(
@@ -108,6 +117,7 @@ class InstanceAutoSendFetcherTest {
         }
 
         val instancesToSend = InstanceAutoSendFetcher.getInstancesToAutoSend(
+            application,
             instancesRepository,
             formsRepository,
             InMemSettingsProvider()

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcherTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcherTest.kt
@@ -13,6 +13,8 @@ import org.odk.collect.formstest.InMemFormsRepository
 import org.odk.collect.formstest.InMemInstancesRepository
 import org.odk.collect.formstest.InstanceUtils.buildInstance
 import org.odk.collect.settings.InMemSettingsProvider
+import org.odk.collect.settings.enums.AutoSend
+import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.shared.TempFiles.createTempDir
 
 @RunWith(AndroidJUnit4::class)
@@ -80,11 +82,16 @@ class InstanceAutoSendFetcherTest {
             save(instanceOfFormWithCustomAutoSendSubmitted)
         }
 
+        val settingsProvider = InMemSettingsProvider().also {
+            it.getUnprotectedSettings()
+                .save(ProjectKeys.KEY_AUTOSEND, AutoSend.WIFI_ONLY.getValue(application))
+        }
+
         val instancesToSend = InstanceAutoSendFetcher.getInstancesToAutoSend(
             application,
             instancesRepository,
             formsRepository,
-            InMemSettingsProvider()
+            settingsProvider
         )
 
         assertThat(
@@ -116,11 +123,16 @@ class InstanceAutoSendFetcherTest {
             save(instanceOfFormWithEnabledAutoSendCompleteV2)
         }
 
+        val settingsProvider = InMemSettingsProvider().also {
+            it.getUnprotectedSettings()
+                .save(ProjectKeys.KEY_AUTOSEND, AutoSend.WIFI_ONLY.getValue(application))
+        }
+
         val instancesToSend = InstanceAutoSendFetcher.getInstancesToAutoSend(
             application,
             instancesRepository,
             formsRepository,
-            InMemSettingsProvider()
+            settingsProvider
         )
         assertThat(
             instancesToSend.map { it.instanceFilePath },


### PR DESCRIPTION
Closes #6112
Closes #6113

This corrects the logic to check if auto send is enabled or not, and fixes how we schedule deferred work so we're able to change network constraints for an existing task.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There's definitely a bunch of risk here again as it's hard to reason about and test all the different scenarios you can get into with background work. The only thing affected here is auto send though thankfully so other background tasks don't need to be verified.

#### Do we need any specific form for testing your changes? If so, please attach one.

The only thing to keep in mind is that forms can have auto send enabled/disabled themselves which massively complicates the workflows here.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
