### PR TITLE
Fix potential ANR when saving form

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/data/Consumable.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/data/Consumable.kt
@@ -1,5 +1,8 @@
 package org.odk.collect.androidshared.data
 
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+
 /**
  * Useful for values that are read multiple times but only used
  * once (like an error that shows a dialog once).
@@ -14,5 +17,14 @@ data class Consumable<T>(val value: T) {
 
     fun consume() {
         consumed = true
+    }
+}
+
+fun <T> LiveData<Consumable<T>>.consume(lifecycleOwner: LifecycleOwner, consumer: (T) -> Unit) {
+    observe(lifecycleOwner) { consumable ->
+        if (!consumable.isConsumed()) {
+            consumable.consume()
+            consumer(consumable.value)
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
@@ -27,6 +27,7 @@ import org.odk.collect.android.projects.ProjectIconView
 import org.odk.collect.android.projects.ProjectSettingsDialog
 import org.odk.collect.android.utilities.ActionRegister
 import org.odk.collect.android.utilities.ApplicationConstants
+import org.odk.collect.androidshared.data.consume
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.androidshared.ui.SnackbarUtils
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
@@ -86,12 +87,8 @@ class MainMenuFragment(
             )
         }
 
-        mainMenuViewModel.savedForm.observe(viewLifecycleOwner) {
-            val value = it.value
-
-            if (value != null && !it.isConsumed()) {
-                it.consume()
-
+        mainMenuViewModel.savedForm.consume(viewLifecycleOwner) { value ->
+            if (value != null) {
                 SnackbarUtils.showLongSnackbar(
                     requireView(),
                     getString(value.second),

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
@@ -88,23 +88,21 @@ class MainMenuFragment(
         }
 
         mainMenuViewModel.savedForm.consume(viewLifecycleOwner) { value ->
-            if (value != null) {
-                SnackbarUtils.showLongSnackbar(
-                    requireView(),
-                    getString(value.second),
-                    action = value.third?.let { action ->
-                        SnackbarUtils.Action(getString(action)) {
-                            formEntryFlowLauncher.launch(
-                                FormFillingIntentFactory.editInstanceIntent(
-                                    requireContext(),
-                                    value.first
-                                )
+            SnackbarUtils.showLongSnackbar(
+                requireView(),
+                getString(value.message),
+                action = value.action?.let { action ->
+                    SnackbarUtils.Action(getString(action)) {
+                        formEntryFlowLauncher.launch(
+                            FormFillingIntentFactory.editInstanceIntent(
+                                requireContext(),
+                                value.uri
                             )
-                        }
-                    },
-                    displayDismissButton = true
-                )
-            }
+                        )
+                    }
+                },
+                displayDismissButton = true
+            )
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -61,6 +61,7 @@ class MainMenuActivityTest {
         on { sendableInstancesCount } doReturn MutableLiveData(0)
         on { sentInstancesCount } doReturn MutableLiveData(0)
         on { editableInstancesCount } doReturn MutableLiveData(0)
+        on { savedForm } doReturn MutableLiveData()
     }
 
     private val currentProjectViewModel = mock<CurrentProjectViewModel> {


### PR DESCRIPTION
Work towards #5838 

This removes UI thread DB access when showing a form saved snackbar.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here! I've moved the DB access to a background thread which results in switching a single `getX` method for a `setX` and a `Consumable<LiveData>` event.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Only thing affected here is the form saved snack bar, so some testing around that is all that is needed I'd imagine. Reproducing the ANR won't be possible (as always), so it's best just to check that nothing looks wrong with the existing feature set.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
