### PR TITLE
Delete savepoints when deleting blank forms they belong to

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormsRepository.java
@@ -29,6 +29,7 @@ import org.odk.collect.android.database.DatabaseConstants;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormsRepository;
+import org.odk.collect.forms.savepoints.SavepointsRepository;
 import org.odk.collect.shared.files.DirectoryUtils;
 import org.odk.collect.shared.strings.Md5;
 
@@ -50,8 +51,9 @@ public class DatabaseFormsRepository implements FormsRepository {
     private final String formsPath;
     private final String cachePath;
     private final Supplier<Long> clock;
+    private final SavepointsRepository savepointsRepository;
 
-    public DatabaseFormsRepository(Context context, String dbPath, String formsPath, String cachePath, Supplier<Long> clock) {
+    public DatabaseFormsRepository(Context context, String dbPath, String formsPath, String cachePath, Supplier<Long> clock, SavepointsRepository savepointsRepository) {
         this.formsPath = formsPath;
         this.cachePath = cachePath;
         this.clock = clock;
@@ -62,6 +64,7 @@ public class DatabaseFormsRepository implements FormsRepository {
                 new FormDatabaseMigrator(),
                 DatabaseConstants.FORMS_DATABASE_VERSION
         );
+        this.savepointsRepository = savepointsRepository;
     }
 
     @Nullable
@@ -182,6 +185,7 @@ public class DatabaseFormsRepository implements FormsRepository {
         ContentValues values = new ContentValues();
         values.put(DELETED_DATE, System.currentTimeMillis());
         updateForm(id, values);
+        savepointsRepository.delete(id, null);
     }
 
     @Override
@@ -303,5 +307,7 @@ public class DatabaseFormsRepository implements FormsRepository {
                 mediaDir.delete();
             }
         }
+
+        savepointsRepository.delete(form.getDbId(), null);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormsRepositoryProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormsRepositoryProvider.kt
@@ -8,7 +8,8 @@ import org.odk.collect.forms.FormsRepository
 
 class FormsRepositoryProvider @JvmOverloads constructor(
     private val context: Context,
-    private val storagePathProvider: StoragePathProvider = StoragePathProvider()
+    private val storagePathProvider: StoragePathProvider = StoragePathProvider(),
+    private val savepointsRepositoryProvider: SavepointsRepositoryProvider = SavepointsRepositoryProvider(context, storagePathProvider)
 ) {
 
     private val clock = { System.currentTimeMillis() }
@@ -18,6 +19,8 @@ class FormsRepositoryProvider @JvmOverloads constructor(
         val dbPath = storagePathProvider.getOdkDirPath(StorageSubdirectory.METADATA, projectId)
         val formsPath = storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS, projectId)
         val cachePath = storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE, projectId)
-        return DatabaseFormsRepository(context, dbPath, formsPath, cachePath, clock)
+        val savepointsRepository = savepointsRepositoryProvider.get(projectId)
+
+        return DatabaseFormsRepository(context, dbPath, formsPath, cachePath, clock, savepointsRepository)
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/database/DatabaseFormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/database/DatabaseFormsRepositoryTest.java
@@ -21,12 +21,12 @@ public class DatabaseFormsRepositoryTest extends FormsRepositoryTest {
 
     @Override
     public FormsRepository buildSubject() {
-        return new DatabaseFormsRepository(ApplicationProvider.getApplicationContext(), dbDir.getAbsolutePath(), formsDir.getAbsolutePath(), cacheDir.getAbsolutePath(), System::currentTimeMillis);
+        return new DatabaseFormsRepository(ApplicationProvider.getApplicationContext(), dbDir.getAbsolutePath(), formsDir.getAbsolutePath(), cacheDir.getAbsolutePath(), System::currentTimeMillis, savepointsRepository);
     }
 
     @Override
     public FormsRepository buildSubject(Supplier<Long> clock) {
-        return new DatabaseFormsRepository(ApplicationProvider.getApplicationContext(), dbDir.getAbsolutePath(), formsDir.getAbsolutePath(), cacheDir.getAbsolutePath(), clock);
+        return new DatabaseFormsRepository(ApplicationProvider.getApplicationContext(), dbDir.getAbsolutePath(), formsDir.getAbsolutePath(), cacheDir.getAbsolutePath(), clock, savepointsRepository);
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FormsRepositoryProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FormsRepositoryProviderTest.kt
@@ -34,7 +34,7 @@ class FormsRepositoryProviderTest {
             on { getOdkDirPath(CACHE, projectId) } doReturn cacheDir.absolutePath
         }
 
-        val formsRepositoryProvider = FormsRepositoryProvider(context, storagePathProvider)
+        val formsRepositoryProvider = FormsRepositoryProvider(context, storagePathProvider, mock())
         val repository = formsRepositoryProvider.get(projectId)
 
         val form = repository.save(buildForm("id", "version", formsDir.absolutePath).build())

--- a/forms-test/src/main/java/org/odk/collect/formstest/FormsRepositoryTest.java
+++ b/forms-test/src/main/java/org/odk/collect/formstest/FormsRepositoryTest.java
@@ -138,15 +138,16 @@ public abstract class FormsRepositoryTest {
     @Test
     public void softDelete_deletesTheSavepointThatBelongsToTheFormThatShouldBeDeleted() {
         FormsRepository formsRepository = buildSubject();
-        Form form = formsRepository.save(FormUtils.buildForm("1", null, getFormFilesPath())
-                .build());
-        Savepoint savepoint1 = new Savepoint(form.getDbId(), null, "", "");
-        Savepoint savepoint2 = new Savepoint(form.getDbId() + 1, null, "", "");
+        Form form1 = formsRepository.save(FormUtils.buildForm("id1", "version", getFormFilesPath()).build());
+        Form form2 = formsRepository.save(FormUtils.buildForm("id2", "version", getFormFilesPath()).build());
+
+        Savepoint savepoint1 = new Savepoint(form1.getDbId(), null, "", "");
+        Savepoint savepoint2 = new Savepoint(form2.getDbId(), null, "", "");
         savepointsRepository.save(savepoint1);
         savepointsRepository.save(savepoint2);
 
-        formsRepository.softDelete(form.getDbId());
-        assertThat(formsRepository.get(form.getDbId()).isDeleted(), is(true));
+        formsRepository.softDelete(form1.getDbId());
+
         assertThat(savepointsRepository.getAll(), contains(savepoint2));
     }
 
@@ -275,14 +276,16 @@ public abstract class FormsRepositoryTest {
     @Test
     public void delete_deletesTheSavepointThatBelongsToTheFormThatShouldBeDeleted() {
         FormsRepository formsRepository = buildSubject();
-        Form form = formsRepository.save(FormUtils.buildForm("id", "version", getFormFilesPath()).build());
+        Form form1 = formsRepository.save(FormUtils.buildForm("id1", "version", getFormFilesPath()).build());
+        Form form2 = formsRepository.save(FormUtils.buildForm("id2", "version", getFormFilesPath()).build());
 
-        Savepoint savepoint1 = new Savepoint(form.getDbId(), null, "", "");
-        Savepoint savepoint2 = new Savepoint(form.getDbId() + 1, null, "", "");
+        Savepoint savepoint1 = new Savepoint(form1.getDbId(), null, "", "");
+        Savepoint savepoint2 = new Savepoint(form2.getDbId(), null, "", "");
         savepointsRepository.save(savepoint1);
         savepointsRepository.save(savepoint2);
 
-        formsRepository.delete(form.getDbId());
+        formsRepository.delete(form1.getDbId());
+
         assertThat(savepointsRepository.getAll(), contains(savepoint2));
     }
 
@@ -330,14 +333,12 @@ public abstract class FormsRepositoryTest {
 
         Savepoint savepoint1 = new Savepoint(form1.getDbId(), null, "", "");
         Savepoint savepoint2 = new Savepoint(form2.getDbId(), null, "", "");
-        Savepoint savepoint3 = new Savepoint(form2.getDbId() + 1, null, "", "");
         savepointsRepository.save(savepoint1);
         savepointsRepository.save(savepoint2);
-        savepointsRepository.save(savepoint3);
 
         formsRepository.deleteAll();
 
-        assertThat(savepointsRepository.getAll(), contains(savepoint3));
+        assertThat(savepointsRepository.getAll().isEmpty(), equalTo(true));
     }
 
     @Test

--- a/forms-test/src/main/java/org/odk/collect/formstest/FormsRepositoryTest.java
+++ b/forms-test/src/main/java/org/odk/collect/formstest/FormsRepositoryTest.java
@@ -4,6 +4,8 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormsRepository;
+import org.odk.collect.forms.savepoints.Savepoint;
+import org.odk.collect.forms.savepoints.SavepointsRepository;
 import org.odk.collect.shared.strings.Md5;
 
 import java.io.File;
@@ -24,6 +26,7 @@ import static org.mockito.Mockito.when;
 import static org.odk.collect.formstest.FormUtils.createXFormBody;
 
 public abstract class FormsRepositoryTest {
+    protected final SavepointsRepository savepointsRepository = new InMemSavepointsRepository();
 
     public abstract FormsRepository buildSubject();
 
@@ -130,6 +133,21 @@ public abstract class FormsRepositoryTest {
 
         formsRepository.softDelete(1L);
         assertThat(formsRepository.get(1L).isDeleted(), is(true));
+    }
+
+    @Test
+    public void softDelete_deletesTheSavepointThatBelongsToTheFormThatShouldBeDeleted() {
+        FormsRepository formsRepository = buildSubject();
+        Form form = formsRepository.save(FormUtils.buildForm("1", null, getFormFilesPath())
+                .build());
+        Savepoint savepoint1 = new Savepoint(form.getDbId(), null, "", "");
+        Savepoint savepoint2 = new Savepoint(form.getDbId() + 1, null, "", "");
+        savepointsRepository.save(savepoint1);
+        savepointsRepository.save(savepoint2);
+
+        formsRepository.softDelete(form.getDbId());
+        assertThat(formsRepository.get(form.getDbId()).isDeleted(), is(true));
+        assertThat(savepointsRepository.getAll(), contains(savepoint2));
     }
 
     @Test
@@ -255,6 +273,20 @@ public abstract class FormsRepositoryTest {
     }
 
     @Test
+    public void delete_deletesTheSavepointThatBelongsToTheFormThatShouldBeDeleted() {
+        FormsRepository formsRepository = buildSubject();
+        Form form = formsRepository.save(FormUtils.buildForm("id", "version", getFormFilesPath()).build());
+
+        Savepoint savepoint1 = new Savepoint(form.getDbId(), null, "", "");
+        Savepoint savepoint2 = new Savepoint(form.getDbId() + 1, null, "", "");
+        savepointsRepository.save(savepoint1);
+        savepointsRepository.save(savepoint2);
+
+        formsRepository.delete(form.getDbId());
+        assertThat(savepointsRepository.getAll(), contains(savepoint2));
+    }
+
+    @Test
     public void delete_whenMediaPathIsFile_deletesFiles() throws Exception {
         FormsRepository formsRepository = buildSubject();
         Form form = formsRepository.save(FormUtils.buildForm("id", "version", getFormFilesPath()).build());
@@ -291,6 +323,24 @@ public abstract class FormsRepositoryTest {
     }
 
     @Test
+    public void deleteAll_deletesAllSavepointsThatBelongToFormsThatShouldBeDeleted() {
+        FormsRepository formsRepository = buildSubject();
+        Form form1 = formsRepository.save(FormUtils.buildForm("id1", "version", getFormFilesPath()).build());
+        Form form2 = formsRepository.save(FormUtils.buildForm("id2", "version", getFormFilesPath()).build());
+
+        Savepoint savepoint1 = new Savepoint(form1.getDbId(), null, "", "");
+        Savepoint savepoint2 = new Savepoint(form2.getDbId(), null, "", "");
+        Savepoint savepoint3 = new Savepoint(form2.getDbId() + 1, null, "", "");
+        savepointsRepository.save(savepoint1);
+        savepointsRepository.save(savepoint2);
+        savepointsRepository.save(savepoint3);
+
+        formsRepository.deleteAll();
+
+        assertThat(savepointsRepository.getAll(), contains(savepoint3));
+    }
+
+    @Test
     public void deleteByMd5Hash_deletesFormsWithMatchingHash() {
         FormsRepository formsRepository = buildSubject();
         formsRepository.save(FormUtils.buildForm("id1", "version", getFormFilesPath(), createXFormBody("id1", "version", "Form1")).build());
@@ -301,6 +351,23 @@ public abstract class FormsRepositoryTest {
 
         assertThat(formsRepository.getAll().size(), is(1));
         assertThat(formsRepository.getAll().get(0).getFormId(), is("id2"));
+    }
+
+    @Test
+    public void deleteByMd5Hash_deletesTheSavepointThatBelongsToTheFormThatShouldBeDeleted() {
+        FormsRepository formsRepository = buildSubject();
+        Form form1 = formsRepository.save(FormUtils.buildForm("id1", "version", getFormFilesPath(), createXFormBody("id1", "version", "Form1")).build());
+        Form form2 = formsRepository.save(FormUtils.buildForm("id2", "version", getFormFilesPath(), createXFormBody("id2", "version", "Form2")).build());
+
+        Savepoint savepoint1 = new Savepoint(form1.getDbId(), null, "", "");
+        Savepoint savepoint2 = new Savepoint(form2.getDbId(), null, "", "");
+        savepointsRepository.save(savepoint1);
+        savepointsRepository.save(savepoint2);
+
+        List<Form> id1Forms = formsRepository.getAllByFormIdAndVersion("id1", "version");
+        formsRepository.deleteByMd5Hash(id1Forms.get(0).getMD5Hash());
+
+        assertThat(savepointsRepository.getAll(), contains(savepoint2));
     }
 
     @Test(expected = Exception.class)

--- a/forms-test/src/test/java/org/odk/collect/formstest/InMemFormsRepositoryTest.java
+++ b/forms-test/src/test/java/org/odk/collect/formstest/InMemFormsRepositoryTest.java
@@ -17,12 +17,12 @@ public class InMemFormsRepositoryTest extends FormsRepositoryTest {
 
     @Override
     public FormsRepository buildSubject() {
-        return new InMemFormsRepository();
+        return new InMemFormsRepository(savepointsRepository);
     }
 
     @Override
     public FormsRepository buildSubject(Supplier<Long> clock) {
-        return new InMemFormsRepository(clock);
+        return new InMemFormsRepository(clock, savepointsRepository);
     }
 
     @Override


### PR DESCRIPTION
Closes #6131 

#### Why is this the best possible solution? Were any other approaches considered?
Removing savepoints when forms they belong to are being deleted seems to be the best solution that not only fixes the issue but also protects us from having orphaned savepoints. Another solution could be for example comparing dates of creation to avoid using savepoints that were created earlier than the form itself but those savepoints would still be present in the database and in the cache dir so I think getting rid of them is the proper approach.

I've implemented this only for blank forms as this turned out to be an issue but we should do the same for saved forms too in order to avoid keeping orphaned savepoints. I will file a separate issue for that.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The main change is that during deleting blank forms their savepoints should also be deleted to avoid keeping orphaned savepoints. This will happen not only if a blank form is completely deleted but also in the case of soft deletion. Thanks to that issue #6131 will be fixed.
So far it didn't work like that so if a blank form was deleted but had a savepoint that savepoint remained in the database and in the cache dir (savepoints were only removed when igorered in the form view). Such a savepoint would be useless and would only clutter the cache dir. This is something we probably haven't tested that much so now it's a good time to do that.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
