### PR TITLE
Reset reference manager on quitting a form

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/FormUpdateTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/FormUpdateTest.kt
@@ -5,6 +5,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import org.odk.collect.android.support.StubOpenRosaServer
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.MainMenuPage
@@ -148,5 +149,33 @@ class FormUpdateTest {
             .clickOKOnDialog(MainMenuPage())
             .startBlankForm("One Question Last Saved")
             .assertText("32")
+    }
+
+    @Test
+    fun itIsPossibleToDownloadAnUpdate_afterDownloadingAndOpeningAFormWithBrokenExternalDataset() {
+        testDependencies.server.addForm(
+            "external_select_csv.xml",
+            listOf(StubOpenRosaServer.MediaFileItem("external_data.csv", "external_data_broken.csv"))
+        )
+
+        val mainMenuPage = rule.withProject(testDependencies.server.url)
+            .clickGetBlankForm()
+            .clickGetSelected()
+            .clickOKOnDialog(MainMenuPage())
+            .startBlankFormWithError("external select")
+            .assertText(org.odk.collect.strings.R.string.error_occured)
+            .clickOKOnDialog(MainMenuPage())
+
+        testDependencies.server.addForm(
+            "external_select_csv.xml",
+            listOf(StubOpenRosaServer.MediaFileItem("external_data.csv"))
+        )
+
+        mainMenuPage.clickGetBlankForm()
+            .clickGetSelected()
+            .clickOKOnDialog(MainMenuPage())
+            .startBlankForm("external select")
+            .assertTextDoesNotExist("Error Occurred")
+            .assertTexts("One", "Two", "Three")
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/FormUpdateTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/FormUpdateTest.kt
@@ -151,7 +151,7 @@ class FormUpdateTest {
             .assertText("32")
     }
 
-    @Test
+    @Test // https://github.com/getodk/collect/issues/6097
     fun itIsPossibleToDownloadAnUpdate_afterDownloadingAndOpeningAFormWithBrokenExternalDataset() {
         testDependencies.server.addForm(
             "external_select_csv.xml",

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -74,7 +74,6 @@ import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -2110,7 +2109,6 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
     }
 
     private void exit() {
-        ReferenceManager.instance().reset();
         backgroundLocationViewModel.activityHidden();
         formEntryViewModel.exit();
         finish();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -74,6 +74,7 @@ import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -2109,6 +2110,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
     }
 
     private void exit() {
+        ReferenceManager.instance().reset();
         backgroundLocationViewModel.activityHidden();
         formEntryViewModel.exit();
         finish();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -15,6 +15,7 @@ import org.javarosa.core.model.GroupDef;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.actions.recordaudio.RecordAudioActionHandler;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.xpath.parser.XPathSyntaxException;
@@ -356,6 +357,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
     public void exit() {
         formSessionRepository.clear(sessionId);
+        ReferenceManager.instance().reset();
     }
 
     public void validate() {

--- a/test-forms/src/main/resources/media/external_data_broken.csv
+++ b/test-forms/src/main/resources/media/external_data_broken.csv
@@ -1,0 +1,4 @@
+name,label
+one,"One
+two,Two
+three,Three


### PR DESCRIPTION
Closes #6097 

#### Why is this the best possible solution? Were any other approaches considered?
In https://github.com/getodk/collect/issues/6097#issuecomment-2091609975 I've described three options:
- changes in Central
- changes in Javarosa
- changes in Collect

we have agreed that the easiest solution for now is to handle this in Collect and improvements in Javarosa/Central are something we might want to have either way.

I've only made one mistake regarding what we can do to fix the issue in Collect saying that it would be enough to download media files before parsing a form. I don't know why I thought so but it's not doable as we need to read form metadata (parse the form) to download and copy media files.
Fortunately, I was able to come up with another (even better solution) which is resetting the reference manager on quitting a form. Thanks to that during parsing a form we don't have references to the old (and maybe even outdated) attachments and the problem does not take place. We don't need them during reading metadata so it's safe to get rid of them. When we open anew form the new references are populated and everything works fine.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue without any side effects. I can't think of any risk here or any particular feature that should be tested more.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
