### PR TITLE
Fix broken save point recovery translations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,5 +19,6 @@ https://github.com/getodk/collect/blob/master/docs/CONTRIBUTING.md
 - [ ] added or modified tests for any new or changed behavior
 - [ ] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
 - [ ] added a comment above any new strings describing it for translators
+- [ ] added any new strings with date formatting to `DateFormatsTest`
 - [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
 - [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -1041,7 +1041,6 @@
   <!--Title displayed in a dialog before starting a form if there is a work to recover-->
   <string name="savepoint_recovery_dialog_title">Ihre Arbeit Wiederherstellen?</string>
   <!--Message displayed in a dialog before starting a form if there is a work to recover-->
-  <string name="savepoint_recovery_dialog_message">Collect wurde am \'EEE, MMM dd, yyyy \'um\' HH:mm\' unerwartet beendet und hat ihre Arbeit gespeichert.\n\nWollen Sie die gespeicherte Arbeit wiederherstellen oder verwerfen?</string>
   <!--Text for the button that accepts the recovery of the work-->
   <string name="recover">Wiederherstellen</string>
   <!--Text for the button that declines the recovery of the work-->

--- a/strings/src/main/res/values-fr/strings.xml
+++ b/strings/src/main/res/values-fr/strings.xml
@@ -1068,7 +1068,6 @@
   <!--Title displayed in a dialog before starting a form if there is a work to recover-->
   <string name="savepoint_recovery_dialog_title">Récupérer votre travail ?</string>
   <!--Message displayed in a dialog before starting a form if there is a work to recover-->
-  <string name="savepoint_recovery_dialog_message">\'Collect s\'est arrété de manière inattendue le \'EEE dd MMM yyyy à HH:mm\' et a sauvegardé votre travail.\n\nVoulez vous le récupérer ou l\'ignorer ?\'</string>
   <!--Text for the button that accepts the recovery of the work-->
   <string name="recover">Récupérer ?</string>
   <!--Text for the button that declines the recovery of the work-->

--- a/strings/src/test/java/org/odk/collect/strings/format/DateFormatsTest.kt
+++ b/strings/src/test/java/org/odk/collect/strings/format/DateFormatsTest.kt
@@ -42,5 +42,6 @@ private val formats = setOf(
     R.string.sent_on_date_at_time,
     R.string.sending_failed_on_date_at_time,
     R.string.deleted_on_date_at_time,
-    R.string.modified_on_date_at_time
+    R.string.modified_on_date_at_time,
+    R.string.savepoint_recovery_dialog_message
 )


### PR DESCRIPTION
This removes broken French and German translations for strings with date formatting.

#### Why is this the best possible solution? Were any other approaches considered?

I've just removed the strings for now as it's easier than me to trying to guess what they should look like.

I've added a PR Template todo to hopefully remind us to catch this in future, other than that we'd probably need to look at something like a custom lint.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should prevent crashes when the save point discovery dialog is shown on French or German devices.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
