### PR TITLE
Don't update entity if it doesn't exist in the list

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
@@ -109,25 +109,6 @@ class EntityFormTest {
     }
 
     @Test
-    fun fillingEntityUpdateForm_withoutSelectingEntity_doesNothing() {
-        testDependencies.server.addForm(
-            "one-question-entity-update.xml",
-            listOf(EntityListItem("people.csv"))
-        )
-
-        rule.withMatchExactlyProject(testDependencies.server.url)
-            .setupEntities("people")
-
-            .startBlankForm("One Question Entity Update")
-            .swipeToNextQuestion("Name")
-            .swipeToEndScreen()
-            .clickFinalize()
-
-            .startBlankForm("One Question Entity Update")
-            .assertText("Roman Roy")
-    }
-
-    @Test
     fun entityListSecondaryInstancesAreConsistentBetweenFollowUpForms() {
         testDependencies.server.apply {
             addForm(

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
@@ -109,6 +109,25 @@ class EntityFormTest {
     }
 
     @Test
+    fun fillingEntityUpdateForm_withoutSelectingEntity_doesNothing() {
+        testDependencies.server.addForm(
+            "one-question-entity-update.xml",
+            listOf(EntityListItem("people.csv"))
+        )
+
+        rule.withMatchExactlyProject(testDependencies.server.url)
+            .setupEntities("people")
+
+            .startBlankForm("One Question Entity Update")
+            .swipeToNextQuestion("Name")
+            .swipeToEndScreen()
+            .clickFinalize()
+
+            .startBlankForm("One Question Entity Update")
+            .assertText("Roman Roy")
+    }
+
+    @Test
     fun entityListSecondaryInstancesAreConsistentBetweenFollowUpForms() {
         testDependencies.server.apply {
             addForm(

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryUseCases.kt
@@ -16,6 +16,7 @@ import org.odk.collect.android.javarosawrapper.JavaRosaFormController
 import org.odk.collect.android.utilities.FileUtils
 import org.odk.collect.android.utilities.FormUtils
 import org.odk.collect.entities.EntitiesRepository
+import org.odk.collect.entities.LocalEntityUseCases
 import org.odk.collect.forms.Form
 import org.odk.collect.forms.FormsRepository
 import org.odk.collect.forms.instances.Instance
@@ -31,7 +32,8 @@ object FormEntryUseCases {
         formDefCache: FormDefCache
     ): Pair<FormDef, Form>? {
         val form =
-            formsRepository.getAllByFormIdAndVersion(instance.formId, instance.formVersion).firstOrNull()
+            formsRepository.getAllByFormIdAndVersion(instance.formId, instance.formVersion)
+                .firstOrNull()
         return if (form == null) {
             null
         } else {
@@ -159,11 +161,10 @@ object FormEntryUseCases {
         entitiesRepository: EntitiesRepository
     ) {
         formController.finalizeForm()
-        formController.getEntities().forEach { entity ->
-            if (entitiesRepository.getLists().contains(entity.list)) {
-                entitiesRepository.save(entity)
-            }
-        }
+        LocalEntityUseCases.updateLocalEntitiesFromForm(
+            formController.getEntities(),
+            entitiesRepository
+        )
     }
 
     private fun getInstanceFromFormController(

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -112,7 +112,7 @@ object ServerFormUseCases {
 
             val dataset = mediaFile.filename.substringBefore(".csv")
             if (entitiesRepository.getLists().contains(dataset)) {
-                LocalEntityUseCases.updateLocalEntities(dataset, tempMediaFile, entitiesRepository)
+                LocalEntityUseCases.updateLocalEntitiesFromServer(dataset, tempMediaFile, entitiesRepository)
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.kt
@@ -5,14 +5,13 @@ import org.javarosa.core.model.FormIndex
 import org.javarosa.core.model.data.IAnswerData
 import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.core.services.transport.payload.ByteArrayPayload
+import org.javarosa.entities.internal.Entities
 import org.javarosa.form.api.FormEntryCaption
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.exception.JavaRosaException
 import org.odk.collect.android.formentry.audit.AuditEventLogger
-import org.odk.collect.entities.Entity
 import java.io.File
 import java.io.IOException
-import java.util.stream.Stream
 
 interface FormController {
     fun getFormDef(): FormDef?
@@ -335,5 +334,5 @@ interface FormController {
 
     fun getAnswer(treeReference: TreeReference?): IAnswerData?
 
-    fun getEntities(): Stream<Entity>
+    fun getEntities(): Entities?
 }

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
@@ -47,14 +47,13 @@ import org.javarosa.model.xform.XPathReference;
 import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.XPathExpression;
-import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.dynamicpreload.ExternalDataUtil;
+import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.formentry.audit.AsyncTaskAuditEventWriter;
 import org.odk.collect.android.formentry.audit.AuditConfig;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.FileUtils;
-import org.odk.collect.entities.Entity;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,7 +61,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Stream;
 
 import timber.log.Timber;
 
@@ -1111,12 +1109,7 @@ public class JavaRosaFormController implements FormController {
         return getFormDef().getMainInstance().resolveReference(treeReference).getValue();
     }
 
-    public Stream<Entity> getEntities() {
-        Entities extra = formEntryController.getModel().getExtras().get(Entities.class);
-        if (extra != null) {
-            return extra.getEntities().stream().map(entity -> new Entity(entity.dataset, entity.id, entity.label, entity.version, entity.properties));
-        } else {
-            return Stream.empty();
-        }
+    public Entities getEntities() {
+        return formEntryController.getModel().getExtras().get(Entities.class);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/StubFormController.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/StubFormController.kt
@@ -5,6 +5,7 @@ import org.javarosa.core.model.FormIndex
 import org.javarosa.core.model.data.IAnswerData
 import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.core.services.transport.payload.ByteArrayPayload
+import org.javarosa.entities.internal.Entities
 import org.javarosa.form.api.FormEntryCaption
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.exception.JavaRosaException
@@ -13,9 +14,7 @@ import org.odk.collect.android.javarosawrapper.FormController
 import org.odk.collect.android.javarosawrapper.InstanceMetadata
 import org.odk.collect.android.javarosawrapper.SuccessValidationResult
 import org.odk.collect.android.javarosawrapper.ValidationResult
-import org.odk.collect.entities.Entity
 import java.io.File
-import java.util.stream.Stream
 
 open class StubFormController : FormController {
     override fun getFormDef(): FormDef? = null
@@ -157,5 +156,5 @@ open class StubFormController : FormController {
 
     override fun getAnswer(treeReference: TreeReference?): IAnswerData? = null
 
-    override fun getEntities(): Stream<Entity> = Stream.empty()
+    override fun getEntities(): Entities? = null
 }

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -2,17 +2,29 @@ package org.odk.collect.entities
 
 import org.javarosa.core.model.instance.CsvExternalInstance
 import org.javarosa.core.model.instance.TreeElement
+import org.javarosa.entities.internal.Entities
 import java.io.File
 
 object LocalEntityUseCases {
 
-    fun updateLocalEntities(
+    @JvmStatic
+    fun updateLocalEntitiesFromForm(entities: Entities?, entitiesRepository: EntitiesRepository) {
+        entities?.entities?.forEach {
+            val id = it.id
+            if (id != null && entitiesRepository.getLists().contains(it.dataset)) {
+                val entity = Entity(it.dataset, id, it.label, it.version, it.properties)
+                entitiesRepository.save(entity)
+            }
+        }
+    }
+
+    fun updateLocalEntitiesFromServer(
         list: String,
-        onlineList: File,
+        serverList: File,
         entitiesRepository: EntitiesRepository
     ) {
         val root = try {
-            CsvExternalInstance().parse(list, onlineList.absolutePath)
+            CsvExternalInstance().parse(list, serverList.absolutePath)
         } catch (e: Exception) {
             return
         }

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -2,18 +2,31 @@ package org.odk.collect.entities
 
 import org.javarosa.core.model.instance.CsvExternalInstance
 import org.javarosa.core.model.instance.TreeElement
+import org.javarosa.entities.EntityAction
 import org.javarosa.entities.internal.Entities
 import java.io.File
 
 object LocalEntityUseCases {
 
     @JvmStatic
-    fun updateLocalEntitiesFromForm(entities: Entities?, entitiesRepository: EntitiesRepository) {
-        entities?.entities?.forEach {
-            val id = it.id
-            if (id != null && entitiesRepository.getLists().contains(it.dataset)) {
-                val entity = Entity(it.dataset, id, it.label, it.version, it.properties)
-                entitiesRepository.save(entity)
+    fun updateLocalEntitiesFromForm(
+        formEntities: Entities?,
+        entitiesRepository: EntitiesRepository
+    ) {
+        formEntities?.entities?.forEach { formEntity ->
+            val id = formEntity.id
+            if (id != null && entitiesRepository.getLists().contains(formEntity.dataset)) {
+                if (formEntity.action != EntityAction.UPDATE || entitiesRepository.getEntities(formEntity.dataset).any { it.id == id }) {
+                    val entity = Entity(
+                        formEntity.dataset,
+                        id,
+                        formEntity.label,
+                        formEntity.version,
+                        formEntity.properties
+                    )
+
+                    entitiesRepository.save(entity)
+                }
             }
         }
     }

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -5,6 +5,8 @@ import org.apache.commons.csv.CSVPrinter
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
+import org.javarosa.entities.EntityAction
+import org.javarosa.entities.internal.Entities
 import org.junit.Test
 import org.odk.collect.entities.Entity.State.ONLINE
 import org.odk.collect.shared.TempFiles
@@ -13,6 +15,17 @@ import java.io.File
 class LocalEntityUseCasesTest {
 
     private val entitiesRepository = InMemEntitiesRepository()
+
+    @Test
+    fun `updateLocalEntitiesFromForm does not save updated entity that doesn't already exist`() {
+        val entity =
+            org.javarosa.entities.Entity(EntityAction.UPDATE, "things", "1", "1", 1, emptyList())
+        val formEntities = Entities(listOf(entity))
+        entitiesRepository.addList("things")
+
+        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
+        assertThat(entitiesRepository.getEntities("things").size, equalTo(0))
+    }
 
     @Test
     fun `updateLocalEntitiesFromServer overrides offline version if the online version is newer`() {

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -28,6 +28,17 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
+    fun `updateLocalEntitiesFromForm does not save entity that doesn't have an ID`() {
+        val entity =
+            org.javarosa.entities.Entity(EntityAction.CREATE, "things", null, "1", 1, emptyList())
+        val formEntities = Entities(listOf(entity))
+        entitiesRepository.addList("things")
+
+        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
+        assertThat(entitiesRepository.getEntities("things").size, equalTo(0))
+    }
+
+    @Test
     fun `updateLocalEntitiesFromServer overrides offline version if the online version is newer`() {
         entitiesRepository.save(Entity("songs", "noah", "Noa", 1))
         val csv = createEntityList(Entity("songs", "noah", "Noah", 2))

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -19,7 +19,7 @@ class LocalEntityUseCasesTest {
         entitiesRepository.save(Entity("songs", "noah", "Noa", 1))
         val csv = createEntityList(Entity("songs", "noah", "Noah", 2))
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
         assertThat(songs, containsInAnyOrder(Entity("songs", "noah", "Noah", 2, state = ONLINE)))
     }
@@ -29,7 +29,7 @@ class LocalEntityUseCasesTest {
         entitiesRepository.save(Entity("songs", "noah", "Noah", 2))
         val csv = createEntityList(Entity("songs", "noah", "Noa", 1))
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
         assertThat(songs, containsInAnyOrder(Entity("songs", "noah", "Noah", 2, state = ONLINE)))
     }
@@ -39,7 +39,7 @@ class LocalEntityUseCasesTest {
         entitiesRepository.save(Entity("songs", "noah", "Noah", 2))
         val csv = createEntityList(Entity("songs", "noah", "Noa", 2))
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
         assertThat(songs, containsInAnyOrder(Entity("songs", "noah", "Noah", 2, state = ONLINE)))
     }
@@ -50,7 +50,7 @@ class LocalEntityUseCasesTest {
         val csv =
             createEntityList(Entity("songs", "noah", "Noah", 2, listOf(Pair("length", "6:38"))))
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
         assertThat(
             songs,
@@ -64,7 +64,7 @@ class LocalEntityUseCasesTest {
         val csv =
             createEntityList(Entity("songs", "noah", "Noah", 2, listOf(Pair("length", "4:58"))))
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
         assertThat(
             songs,
@@ -89,7 +89,7 @@ class LocalEntityUseCasesTest {
                 listOf("grisaille", "Grisaille")
             )
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         assertThat(entitiesRepository.getLists().size, equalTo(0))
     }
 
@@ -101,7 +101,7 @@ class LocalEntityUseCasesTest {
                 listOf("Grisaille", "2")
             )
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         assertThat(entitiesRepository.getLists().size, equalTo(0))
     }
 
@@ -113,7 +113,7 @@ class LocalEntityUseCasesTest {
                 listOf("grisaille", "2")
             )
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         assertThat(entitiesRepository.getLists().size, equalTo(0))
     }
 
@@ -121,7 +121,7 @@ class LocalEntityUseCasesTest {
     fun `updateLocalEntities adds online entity when its label is blank`() {
         val csv = createEntityList(Entity("songs", "cathedrals", label = ""))
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
         assertThat(
             songs,
@@ -133,7 +133,7 @@ class LocalEntityUseCasesTest {
     fun `updateLocalEntities does nothing if passed a non-CSV file`() {
         val file = TempFiles.createTempFile(".xml")
 
-        LocalEntityUseCases.updateLocalEntities("songs", file, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", file, entitiesRepository)
         assertThat(entitiesRepository.getLists().size, equalTo(0))
     }
 
@@ -145,7 +145,7 @@ class LocalEntityUseCasesTest {
         )
 
         val entitiesRepository = MeasurableEntitiesRepository(entitiesRepository)
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         assertThat(entitiesRepository.accesses, equalTo(2))
     }
 
@@ -154,7 +154,7 @@ class LocalEntityUseCasesTest {
         entitiesRepository.save(Entity("songs", "noah", "Noah"))
         val csv = createEntityList(Entity("songs", "cathedrals", "Cathedrals"))
 
-        LocalEntityUseCases.updateLocalEntities("songs", csv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
         assertThat(
             songs,
@@ -170,10 +170,10 @@ class LocalEntityUseCasesTest {
         entitiesRepository.save(Entity("songs", "cathedrals", "Cathedrals"))
 
         val firstCsv = createEntityList(Entity("songs", "cathedrals", "Cathedrals"))
-        LocalEntityUseCases.updateLocalEntities("songs", firstCsv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", firstCsv, entitiesRepository)
 
         val secondCsv = createEntityList(Entity("songs", "noah", "Noah"))
-        LocalEntityUseCases.updateLocalEntities("songs", secondCsv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", secondCsv, entitiesRepository)
 
         val songs = entitiesRepository.getEntities("songs")
         assertThat(songs, containsInAnyOrder(Entity("songs", "noah", "Noah", state = ONLINE)))
@@ -185,10 +185,10 @@ class LocalEntityUseCasesTest {
 
         val firstCsv =
             createEntityList(Entity("songs", "cathedrals", "Cathedrals (A Song)", version = 2))
-        LocalEntityUseCases.updateLocalEntities("songs", firstCsv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", firstCsv, entitiesRepository)
 
         val secondCsv = createEntityList()
-        LocalEntityUseCases.updateLocalEntities("songs", secondCsv, entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", secondCsv, entitiesRepository)
 
         val songs = entitiesRepository.getEntities("songs")
         assertThat(songs.isEmpty(), equalTo(true))

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -15,7 +15,7 @@ class LocalEntityUseCasesTest {
     private val entitiesRepository = InMemEntitiesRepository()
 
     @Test
-    fun `updateLocalEntities overrides offline version if the online version is newer`() {
+    fun `updateLocalEntitiesFromServer overrides offline version if the online version is newer`() {
         entitiesRepository.save(Entity("songs", "noah", "Noa", 1))
         val csv = createEntityList(Entity("songs", "noah", "Noah", 2))
 
@@ -25,7 +25,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities does not override offline version if the online version is older`() {
+    fun `updateLocalEntitiesFromServer does not override offline version if the online version is older`() {
         entitiesRepository.save(Entity("songs", "noah", "Noah", 2))
         val csv = createEntityList(Entity("songs", "noah", "Noa", 1))
 
@@ -35,7 +35,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities does not override offline version if the online version is the same`() {
+    fun `updateLocalEntitiesFromServer does not override offline version if the online version is the same`() {
         entitiesRepository.save(Entity("songs", "noah", "Noah", 2))
         val csv = createEntityList(Entity("songs", "noah", "Noa", 2))
 
@@ -45,7 +45,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities ignores properties not in offline version from older online version`() {
+    fun `updateLocalEntitiesFromServer ignores properties not in offline version from older online version`() {
         entitiesRepository.save(Entity("songs", "noah", "Noah", 3))
         val csv =
             createEntityList(Entity("songs", "noah", "Noah", 2, listOf(Pair("length", "6:38"))))
@@ -59,7 +59,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities overrides properties in offline version from newer list version`() {
+    fun `updateLocalEntitiesFromServer overrides properties in offline version from newer list version`() {
         entitiesRepository.save(Entity("songs", "noah", "Noah", 1, listOf(Pair("length", "6:38"))))
         val csv =
             createEntityList(Entity("songs", "noah", "Noah", 2, listOf(Pair("length", "4:58"))))
@@ -82,7 +82,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities does nothing if version does not exist in online entities`() {
+    fun `updateLocalEntitiesFromServer does nothing if version does not exist in online entities`() {
         val csv =
             createCsv(
                 listOf("name", "label"),
@@ -94,7 +94,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities does nothing if name does not exist in online entities`() {
+    fun `updateLocalEntitiesFromServer does nothing if name does not exist in online entities`() {
         val csv =
             createCsv(
                 listOf("label", "__version"),
@@ -106,7 +106,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities does nothing if label does not exist in online entities`() {
+    fun `updateLocalEntitiesFromServer does nothing if label does not exist in online entities`() {
         val csv =
             createCsv(
                 listOf("name", "__version"),
@@ -118,7 +118,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities adds online entity when its label is blank`() {
+    fun `updateLocalEntitiesFromServer adds online entity when its label is blank`() {
         val csv = createEntityList(Entity("songs", "cathedrals", label = ""))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
@@ -130,7 +130,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities does nothing if passed a non-CSV file`() {
+    fun `updateLocalEntitiesFromServer does nothing if passed a non-CSV file`() {
         val file = TempFiles.createTempFile(".xml")
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", file, entitiesRepository)
@@ -138,7 +138,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities accesses entities repo only twice when saving multiple entities`() {
+    fun `updateLocalEntitiesFromServer accesses entities repo only twice when saving multiple entities`() {
         val csv = createEntityList(
             Entity("songs", "noah", "Noah"),
             Entity("songs", "seven-trumpets", "Seven Trumpets")
@@ -150,7 +150,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities does not remove offline entities that are not in online entities`() {
+    fun `updateLocalEntitiesFromServer does not remove offline entities that are not in online entities`() {
         entitiesRepository.save(Entity("songs", "noah", "Noah"))
         val csv = createEntityList(Entity("songs", "cathedrals", "Cathedrals"))
 
@@ -166,7 +166,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities removes offline entity that was in online list, but isn't any longer`() {
+    fun `updateLocalEntitiesFromServer removes offline entity that was in online list, but isn't any longer`() {
         entitiesRepository.save(Entity("songs", "cathedrals", "Cathedrals"))
 
         val firstCsv = createEntityList(Entity("songs", "cathedrals", "Cathedrals"))
@@ -180,7 +180,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntities removes offline entity that was updated in online list, but isn't any longer`() {
+    fun `updateLocalEntitiesFromServer removes offline entity that was updated in online list, but isn't any longer`() {
         entitiesRepository.save(Entity("songs", "cathedrals", "Cathedrals", version = 1))
 
         val firstCsv =


### PR DESCRIPTION
Closes #6031
Closes #6109
~~Blocked by https://github.com/getodk/javarosa/pull/763~~

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here! We'd previously exposed the entity "action" from JavaRosa, but weren't using it yet. The big change here is that we detect if the entity doesn't exist if the action is "update" and skip saving.

Additionally, we ignore saving entities that don't have an ID to fix #6109.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This a fairly small set of change, so just testing the issues are fixed is probably enough here.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
