### PR TITLE
Update command used to install local JavaRosa

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ JavaRosa is the form engine that powers Collect. If you want to debug or change 
 1. Build and install your changes of JavaRosa (into your local Maven repo):
 
 ```bash
-./gradlew installLocal
+./gradlew publishToMavenLocal
 ```
 
 1. Change `const val javarosa = javarosa_online` in `Dependencies.kt` to `const val javarosa = javarosa_local`


### PR DESCRIPTION
~Blocked by https://github.com/getodk/javarosa/pull/766~

We now use the official Gradle maven plugin so no longer need the custom command.