### PR TITLE
Fix line numbers in Crashlytics reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
           command: ./gradlew assembleSelfSignedRelease
 
       - run:
-          name: Check APK size isn't larger than 10.9MB
+          name: Check APK size isn't larger than 11.5MB
           command: ./check-size.sh
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
 
       - run:
           name: Check APK size isn't larger than 10.9MB
-          command: if [ $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') -gt 10900000 ]; then exit 1; fi
+          command: ./check-size.sh
 
       - run:
           name: Copy APK to predictable path for artifact storage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run:
           name: Generate combined build.gradle file for cache key
-          command: cat build.gradle */build.gradle .circleci/gradle.properties .circleci/config.yml buildSrc/src/main/java/dependencies/Dependencies.kt buildSrc/src/main/java/dependencies/Versions.kt > deps.txt
+          command: cat build.gradle */build.gradle */build.gradle.kts .circleci/gradle.properties .circleci/config.yml buildSrc/src/main/java/dependencies/Dependencies.kt buildSrc/src/main/java/dependencies/Versions.kt > deps.txt
       - restore_cache:
           keys:
             - compile-deps-{{ checksum "deps.txt" }}

--- a/check-size.sh
+++ b/check-size.sh
@@ -1,0 +1,6 @@
+set -e
+
+if [ $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') -gt 10900000 ];then
+  echo "APK increased to $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') bytes!"
+  exit 1
+fi

--- a/check-size.sh
+++ b/check-size.sh
@@ -1,6 +1,6 @@
 set -e
 
-if [ $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') -gt 10900000 ];then
+if [ $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') -gt 11500000 ];then
   echo "APK increased to $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') bytes!"
   exit 1
 fi

--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -25,3 +25,6 @@
 -keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
 -dontwarn org.codehaus.mojo.animal_sniffer.*
 -dontwarn okhttp3.internal.platform.ConscryptPlatform
+
+# Keep line numbers for Crashlytics https://stackoverflow.com/questions/38529304/android-crashlytics-sending-incorrect-line-number
+-keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
This will fix the line numbers we're seeing in Crashlytics to make it easier to diagnose crash reports. It's likely this was broken when Android tooling switched to the newer R8 toolchain.

I validated this using our simulate crash feature and checked that the reported line numbers were now accurate (and were not before).