### PR TITLE
Fixed updating index

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -559,8 +559,15 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         formEntryViewModel = viewModelProvider.get(FormEntryViewModel.class);
         printerWidgetViewModel = viewModelProvider.get(PrinterWidgetViewModel.class);
 
-        formEntryViewModel.getCurrentIndex().observe(this, index -> {
-            formIndexAnimationHandler.handle(index);
+        formEntryViewModel.getCurrentIndex().observe(this, indexAndValidationResult -> {
+            if (indexAndValidationResult != null) {
+                FormIndex formIndex = indexAndValidationResult.component1();
+                ValidationResult validationResult = indexAndValidationResult.component2();
+                formIndexAnimationHandler.handle(formIndex);
+                if (validationResult != null) {
+                    handleValidationResult(validationResult);
+                }
+            }
         });
 
         formEntryViewModel.isLoading().observe(this, isLoading -> {
@@ -581,16 +588,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 return;
             }
             ValidationResult validationResult = consumable.getValue();
-            if (validationResult instanceof FailedValidationResult failedValidationResult) {
-                String errorMessage = failedValidationResult.getCustomErrorMessage();
-                if (errorMessage == null) {
-                    errorMessage = getString(failedValidationResult.getDefaultErrorMessage());
-                }
-                getCurrentViewIfODKView().setErrorForQuestionWithIndex(failedValidationResult.getIndex(), errorMessage);
-                swipeHandler.setBeenSwiped(false);
-            } else if (validationResult instanceof SuccessValidationResult) {
-                SnackbarUtils.showLongSnackbar(findViewById(R.id.llParent), getString(org.odk.collect.strings.R.string.success_form_validation), findViewById(R.id.buttonholder));
-            }
+            handleValidationResult(validationResult);
             consumable.consume();
         });
 
@@ -642,6 +640,19 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         audioClipViewModel.isLoading().observe(this, (isLoading) -> {
             findViewById(R.id.loading_screen).setVisibility(isLoading ? View.VISIBLE : View.GONE);
         });
+    }
+
+    private void handleValidationResult(ValidationResult validationResult) {
+        if (validationResult instanceof FailedValidationResult failedValidationResult) {
+            String errorMessage = failedValidationResult.getCustomErrorMessage();
+            if (errorMessage == null) {
+                errorMessage = getString(failedValidationResult.getDefaultErrorMessage());
+            }
+            getCurrentViewIfODKView().setErrorForQuestionWithIndex(failedValidationResult.getIndex(), errorMessage);
+            swipeHandler.setBeenSwiped(false);
+        } else if (validationResult instanceof SuccessValidationResult) {
+            SnackbarUtils.showLongSnackbar(findViewById(R.id.llParent), getString(org.odk.collect.strings.R.string.success_form_validation), findViewById(R.id.buttonholder));
+        }
     }
 
     private void formControllerAvailable(@NonNull FormController formController, @NonNull Form form, @Nullable Instance instance) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormIndexAnimationHandler.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormIndexAnimationHandler.kt
@@ -14,11 +14,7 @@ class FormIndexAnimationHandler(private val listener: Listener) {
 
     private var lastIndex: FormIndex? = null
 
-    fun handle(index: FormIndex?) {
-        if (index == null) {
-            return
-        }
-
+    fun handle(index: FormIndex) {
         if (lastIndex == null) {
             listener.onScreenRefresh()
         } else {


### PR DESCRIPTION
Closes #5939 

#### Why is this the best possible solution? Were any other approaches considered?
It was a race condition. The problem was that we always updated the index after validating answers which caused building a new widget. As a result, sometimes errors were displayed before creating a new widget and not displayed again after rebuilding the widget.

My first implementation was different: https://github.com/getodk/collect/pull/6005 but we have discussed it and decided that reworking the way errors are propagated would be better (see the conversation https://github.com/getodk/collect/pull/6005#discussion_r1522963425) to make sure questions are first created (if needed) and only then we display errors (also if needed).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
These changes should only fix the issue without bringing any additional changes. However, the way we display errors (the red outline) changed (it looks the same but the code changed) so please verify there is no regression when triggering errors in different ways:
- navigating between questions
- finalizing a form with errors
- validating forms

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with required questions or constraints.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
