### PR TITLE
Use highest surface container color for rank items

### DIFF
--- a/collect_app/src/main/res/layout/ranking_item.xml
+++ b/collect_app/src/main/res/layout/ranking_item.xml
@@ -18,7 +18,7 @@ limitations under the License.
     android:layout_height="wrap_content"
     android:padding="10dp"
     android:layout_marginTop="5dp"
-    android:background="@color/colorSurfaceContainerLow">
+    android:background="?colorSurfaceContainerHighest">
 
     <TextView
         android:id="@+id/rank_item_text"


### PR DESCRIPTION
Closes #6047

#### Why is this the best possible solution? Were any other approaches considered?

As discussed in #6047, this is just a temporary fix. In the next release, we'll be introducing new colors (#6156) and will be revising the ranking UI (#6171).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just make the ranking items slightly more visible! Nothing else has changed here.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
