### PR TITLE
Make sure instances show in the correct project

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModel.kt
@@ -39,7 +39,7 @@ class SavedFormListViewModel(
             _filterText.value = value
         }
 
-    val formsToDisplay: LiveData<List<Instance>> = instancesDataService.instances
+    val formsToDisplay: LiveData<List<Instance>> = instancesDataService.getInstances(projectId)
         .map { instances -> instances.filter { instance -> instance.deletedDate == null } }
         .combine(_sortOrder) { instances, order ->
             when (order) {

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -32,7 +32,10 @@ class InstancesDataService(
     val editableCount: LiveData<Int> = appState.getLive(EDITABLE_COUNT_KEY, 0)
     val sendableCount: LiveData<Int> = appState.getLive(SENDABLE_COUNT_KEY, 0)
     val sentCount: LiveData<Int> = appState.getLive(SENT_COUNT_KEY, 0)
-    val instances: Flow<List<Instance>> = appState.getFlow("instances", emptyList())
+
+    fun getInstances(projectId: String): Flow<List<Instance>> {
+        return appState.getFlow("instances", emptyList())
+    }
 
     fun update(projectId: String) {
         val projectDependencyProvider = projectDependencyProviderFactory.create(projectId)

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -34,7 +34,7 @@ class InstancesDataService(
     val sentCount: LiveData<Int> = appState.getLive(SENT_COUNT_KEY, 0)
 
     fun getInstances(projectId: String): Flow<List<Instance>> {
-        return appState.getFlow("instances", emptyList())
+        return appState.getFlow("instances:$projectId", emptyList())
     }
 
     fun update(projectId: String) {
@@ -58,7 +58,7 @@ class InstancesDataService(
         appState.setLive(EDITABLE_COUNT_KEY, editableInstances)
         appState.setLive(SENDABLE_COUNT_KEY, sendableInstances)
         appState.setLive(SENT_COUNT_KEY, sentInstances)
-        appState.setFlow("instances", instancesRepository.all)
+        appState.setFlow("instances:$projectId", instancesRepository.all)
 
         onUpdate()
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModelTest.kt
@@ -31,14 +31,14 @@ class SavedFormListViewModelTest {
     private val settings = InMemSettings()
 
     private val instancesDataService: InstancesDataService = mock {
-        on { instances } doReturn MutableStateFlow(emptyList())
+        on { getInstances(any()) } doReturn MutableStateFlow(emptyList())
     }
 
     @Test
     fun `formsToDisplay should not include deleted forms`() {
         val myForm = InstanceFixtures.instance(displayName = "My form", deletedDate = 1)
         val yourForm = InstanceFixtures.instance(displayName = "Your form")
-        saveForms(listOf(myForm, yourForm))
+        saveForms("projectId", listOf(myForm, yourForm))
 
         val viewModel = SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
 
@@ -52,7 +52,7 @@ class SavedFormListViewModelTest {
     fun `setting filterText filters forms on display name`() {
         val myForm = InstanceFixtures.instance(displayName = "My form")
         val yourForm = InstanceFixtures.instance(displayName = "Your form")
-        saveForms(listOf(myForm, yourForm))
+        saveForms("projectId", listOf(myForm, yourForm),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -74,7 +74,7 @@ class SavedFormListViewModelTest {
     fun `clearing filterText does not filter forms`() {
         val myForm = InstanceFixtures.instance(displayName = "My form")
         val yourForm = InstanceFixtures.instance(displayName = "Your form")
-        saveForms(listOf(myForm, yourForm))
+        saveForms("projectId", listOf(myForm, yourForm),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -96,7 +96,7 @@ class SavedFormListViewModelTest {
     fun `filtering forms is not case sensitive`() {
         val myForm = InstanceFixtures.instance(displayName = "My form")
         val yourForm = InstanceFixtures.instance(displayName = "Your form")
-        saveForms(listOf(myForm, yourForm))
+        saveForms("projectId", listOf(myForm, yourForm),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -112,7 +112,7 @@ class SavedFormListViewModelTest {
     fun `can sort forms by ascending name`() {
         val a = InstanceFixtures.instance(displayName = "A")
         val b = InstanceFixtures.instance(displayName = "B")
-        saveForms(listOf(b, a))
+        saveForms("projectId", listOf(b, a),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -128,7 +128,7 @@ class SavedFormListViewModelTest {
     fun `can sort forms by descending name`() {
         val a = InstanceFixtures.instance(displayName = "A")
         val b = InstanceFixtures.instance(displayName = "B")
-        saveForms(listOf(a, b))
+        saveForms("projectId", listOf(a, b),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -144,7 +144,7 @@ class SavedFormListViewModelTest {
     fun `can sort forms by descending date`() {
         val a = InstanceFixtures.instance(displayName = "A", lastStatusChangeDate = 0)
         val b = InstanceFixtures.instance(displayName = "B", lastStatusChangeDate = 1)
-        saveForms(listOf(a, b))
+        saveForms("projectId", listOf(a, b),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -160,7 +160,7 @@ class SavedFormListViewModelTest {
     fun `can sort forms by ascending date`() {
         val a = InstanceFixtures.instance(displayName = "A", lastStatusChangeDate = 0)
         val b = InstanceFixtures.instance(displayName = "B", lastStatusChangeDate = 1)
-        saveForms(listOf(b, a))
+        saveForms("projectId", listOf(b, a),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -176,7 +176,7 @@ class SavedFormListViewModelTest {
     fun `sort order is retained between view models`() {
         val a = InstanceFixtures.instance(displayName = "A", lastStatusChangeDate = 0)
         val b = InstanceFixtures.instance(displayName = "B", lastStatusChangeDate = 1)
-        saveForms(listOf(b, a))
+        saveForms("projectId", listOf(b, a),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -224,7 +224,7 @@ class SavedFormListViewModelTest {
         assertThat(result.getOrAwaitValue(scheduler)!!.value, equalTo(1))
     }
 
-    private fun saveForms(instances: List<Instance>) {
-        whenever(instancesDataService.instances).doReturn(MutableStateFlow(instances))
+    private fun saveForms(projectId: String, instances: List<Instance>) {
+        whenever(instancesDataService.getInstances(projectId)).doReturn(MutableStateFlow(instances))
     }
 }


### PR DESCRIPTION
Closes #6124

#### Why is this the best possible solution? Were any other approaches considered?

The instances just needed qualified by project in the data service so they don't end up in the wrong place. 

We probably also want to do the same rework for the counts in `InstancesDataService`, but we get away with them being non project specific right now because we always update them when viewing the Main Menu. I'd also like to get #6158 merged before making changes like that as it should introduce better structuring for data services and make them easier to test.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The code changed really only affects the saved form delete page so that's the main thing to concentrate on when testing.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
