### PR TITLE
Handle non-existing layers

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
@@ -147,9 +147,14 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
             baseCategory.addPreference(pref)
         }
 
-        // Clear the reference layer if it isn't supported by the new basemap.
+        // Clear the reference layer if it does not exist or it isn't supported by the new basemap.
         val layerId = settingsProvider.getUnprotectedSettings().getString(REFERENCE_LAYER_KEY)
-        if (layerId != null && !cftor.supportsLayer(referenceLayerRepository.get(layerId)!!.file)) {
+        if (layerId != null) {
+            val layer = referenceLayerRepository.get(layerId)
+            if (layer == null || !cftor.supportsLayer(layer.file)) {
+                settingsProvider.getUnprotectedSettings().save(REFERENCE_LAYER_KEY, null)
+            }
+
             settingsProvider.getUnprotectedSettings().save(REFERENCE_LAYER_KEY, null)
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
@@ -29,6 +29,7 @@ import org.odk.collect.async.Scheduler
 import org.odk.collect.maps.MapConfigurator
 import org.odk.collect.maps.layers.OfflineMapLayersPicker
 import org.odk.collect.maps.layers.ReferenceLayerRepository
+import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.settings.keys.ProjectKeys.CATEGORY_BASEMAP
 import org.odk.collect.settings.keys.ProjectKeys.KEY_BASEMAP_SOURCE
 import org.odk.collect.strings.localization.getLocalizedString
@@ -65,8 +66,8 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
 
     override fun onSettingChanged(key: String) {
         super.onSettingChanged(key)
-        if (key == REFERENCE_LAYER_KEY) {
-            findPreference<Preference>(REFERENCE_LAYER_KEY)!!.summary = getLayerName()
+        if (key == ProjectKeys.KEY_REFERENCE_LAYER) {
+            findPreference<Preference>(ProjectKeys.KEY_REFERENCE_LAYER)!!.summary = getLayerName()
         }
     }
 
@@ -80,7 +81,7 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
     override fun onPreferenceClick(preference: Preference): Boolean {
         if (allowClick(javaClass.name)) {
             when (preference.key) {
-                REFERENCE_LAYER_KEY -> {
+                ProjectKeys.KEY_REFERENCE_LAYER -> {
                     DialogFragmentUtils.showIfNotShowing(
                         OfflineMapLayersPicker::class.java,
                         childFragmentManager
@@ -121,14 +122,14 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
     }
 
     private fun initLayersPref() {
-        findPreference<Preference>(REFERENCE_LAYER_KEY)?.apply {
+        findPreference<Preference>(ProjectKeys.KEY_REFERENCE_LAYER)?.apply {
             onPreferenceClickListener = this@MapsPreferencesFragment
             summary = getLayerName()
         }
     }
 
     private fun getLayerName(): String {
-        val layerId = settingsProvider.getUnprotectedSettings().getString(REFERENCE_LAYER_KEY)
+        val layerId = settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER)
         return if (layerId == null) {
             requireContext().getLocalizedString(org.odk.collect.strings.R.string.none)
         } else {
@@ -148,18 +149,14 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
         }
 
         // Clear the reference layer if it does not exist or it isn't supported by the new basemap.
-        val layerId = settingsProvider.getUnprotectedSettings().getString(REFERENCE_LAYER_KEY)
+        val layerId = settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER)
         if (layerId != null) {
             val layer = referenceLayerRepository.get(layerId)
             if (layer == null || !cftor.supportsLayer(layer.file)) {
-                settingsProvider.getUnprotectedSettings().save(REFERENCE_LAYER_KEY, null)
+                settingsProvider.getUnprotectedSettings().save(ProjectKeys.KEY_REFERENCE_LAYER, null)
             }
 
-            settingsProvider.getUnprotectedSettings().save(REFERENCE_LAYER_KEY, null)
+            settingsProvider.getUnprotectedSettings().save(ProjectKeys.KEY_REFERENCE_LAYER, null)
         }
-    }
-
-    companion object {
-        const val REFERENCE_LAYER_KEY = "reference_layer"
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragmentTest.kt
@@ -1,0 +1,77 @@
+package org.odk.collect.android.preferences.screens
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.gson.Gson
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.odk.collect.android.application.initialization.AnalyticsInitializer
+import org.odk.collect.android.application.initialization.MapsInitializer
+import org.odk.collect.android.injection.config.AppDependencyModule
+import org.odk.collect.android.projects.ProjectsDataService
+import org.odk.collect.android.support.CollectHelpers
+import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
+import org.odk.collect.projects.Project
+import org.odk.collect.projects.ProjectsRepository
+import org.odk.collect.settings.InMemSettingsProvider
+import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.shared.strings.UUIDGenerator
+
+@RunWith(AndroidJUnit4::class)
+class MapsPreferencesFragmentTest {
+
+    @get:Rule
+    val launcherRule = FragmentScenarioLauncherRule()
+
+    private val project = Project.DEMO_PROJECT
+    private val projectsDataService = mock<ProjectsDataService>().apply {
+        whenever(getCurrentProject()).thenReturn(project)
+    }
+    private val projectsRepository = mock<ProjectsRepository>().apply {
+        whenever(get(project.uuid)).thenReturn(project)
+    }
+    private val settingsProvider = InMemSettingsProvider()
+
+    @Before
+    fun setup() {
+        CollectHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
+            override fun providesCurrentProjectProvider(
+                settingsProvider: SettingsProvider,
+                projectsRepository: ProjectsRepository,
+                analyticsInitializer: AnalyticsInitializer,
+                context: Context,
+                mapsInitializer: MapsInitializer
+            ): ProjectsDataService {
+                return projectsDataService
+            }
+
+            override fun providesProjectsRepository(
+                uuidGenerator: UUIDGenerator,
+                gson: Gson,
+                settingsProvider: SettingsProvider
+            ): ProjectsRepository {
+                return projectsRepository
+            }
+
+            override fun providesSettingsProvider(context: Context): SettingsProvider {
+                return settingsProvider
+            }
+        })
+    }
+
+    @Test
+    fun `if saved layer does not exist it is set to 'none'`() {
+        val settings = settingsProvider.getUnprotectedSettings()
+        settings.save(MapsPreferencesFragment.REFERENCE_LAYER_KEY, "blah")
+
+        launcherRule.launch(MapsPreferencesFragment::class.java)
+
+        assertThat(settings.getString(MapsPreferencesFragment.REFERENCE_LAYER_KEY), equalTo(null))
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragmentTest.kt
@@ -21,6 +21,7 @@ import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.shared.strings.UUIDGenerator
 
 @RunWith(AndroidJUnit4::class)
@@ -68,10 +69,10 @@ class MapsPreferencesFragmentTest {
     @Test
     fun `if saved layer does not exist it is set to 'none'`() {
         val settings = settingsProvider.getUnprotectedSettings()
-        settings.save(MapsPreferencesFragment.REFERENCE_LAYER_KEY, "blah")
+        settings.save(ProjectKeys.KEY_REFERENCE_LAYER, "blah")
 
         launcherRule.launch(MapsPreferencesFragment::class.java)
 
-        assertThat(settings.getString(MapsPreferencesFragment.REFERENCE_LAYER_KEY), equalTo(null))
+        assertThat(settings.getString(ProjectKeys.KEY_REFERENCE_LAYER), equalTo(null))
     }
 }


### PR DESCRIPTION
Closes #6176 

#### Why is this the best possible solution? Were any other approaches considered?
If the selected layer does not exist anymore it should be cleared and the `none` option should be selected in offline layers.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should only fix the issue and have no side effects.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
