### PR TITLE
Maintain ranking item color when dragging

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/RankingListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/RankingListAdapter.java
@@ -16,6 +16,7 @@
 
 package org.odk.collect.android.adapters;
 
+import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.GradientDrawable;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -77,23 +78,25 @@ public class RankingListAdapter extends Adapter<ItemViewHolder> {
 
         final TextView textView;
         final ThemeUtils themeUtils;
+        private final ColorDrawable background;
 
         ItemViewHolder(View itemView) {
             super(itemView);
             textView = itemView.findViewById(R.id.rank_item_text);
             textView.setTextSize(QuestionFontSizeUtils.getQuestionFontSize());
             themeUtils = new ThemeUtils(itemView.getContext());
+            background = (ColorDrawable) itemView.getBackground();
         }
 
         public void onItemSelected() {
             GradientDrawable border = new GradientDrawable();
             border.setStroke(10, themeUtils.getAccentColor());
-            border.setColor(textView.getContext().getResources().getColor(R.color.colorSurfaceContainerLow));
+            border.setColor(background.getColor());
             itemView.setBackground(border);
         }
 
         public void onItemClear() {
-            itemView.setBackgroundColor(textView.getContext().getResources().getColor(R.color.colorSurfaceContainerLow));
+            itemView.setBackground(background);
         }
     }
 }


### PR DESCRIPTION
Closes #6180

#### Why is this the best possible solution? Were any other approaches considered?

Instead of referencing the background color multiple times, the items existing background color will now be preserved when dragging which should hopefully prevent mistakes like this in the future.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just affects the ranking widget!

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
