### PR TITLE
Prevent double taps on multi select actions

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/DoubleClickSafeMaterialButton.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/DoubleClickSafeMaterialButton.kt
@@ -1,0 +1,24 @@
+package org.odk.collect.androidshared.ui.multiclicksafe
+
+import android.content.Context
+import android.util.AttributeSet
+import com.google.android.material.button.MaterialButton
+
+class DoubleClickSafeMaterialButton @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialButton(context, attrs, defStyleAttr) {
+
+    override fun performClick(): Boolean {
+        return allowClick() && super.performClick()
+    }
+
+    /**
+     * Use [MultiClickGuard] with a scope unique to this object (class name + hash).
+     */
+    private fun allowClick(): Boolean {
+        val scope = javaClass.name + hashCode()
+        return MultiClickGuard.allowClick(scope)
+    }
+}

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
@@ -15,21 +15,21 @@ object MultiClickGuard {
     }
 
     /**
-     * Debounce multiple clicks within the same screen
+     * Debounce multiple clicks within the same scope
      *
-     * @param screenName The name of the screen. If not provided, the Java class name of the element
+     * @param scope If not provided, the Java class name of the element
      * is used. However, this approach is imperfect, as elements on the same screen might belong to
      * different classes. Consequently, clicks on these elements are treated as interactions occurring
      * on two distinct screens, not protecting from rapid clicking.
      */
     @JvmStatic
     @JvmOverloads
-    fun allowClick(screenName: String = javaClass.name, clickDebounceMs: Long = 1000): Boolean {
+    fun allowClick(scope: String = javaClass.name, clickDebounceMs: Long = 1000): Boolean {
         if (test) {
             return true
         }
         val elapsedRealtime = SystemClock.elapsedRealtime()
-        val isSameClass = screenName == lastClickName
+        val isSameClass = scope == lastClickName
         val isBeyondThreshold = elapsedRealtime - lastClickTime > clickDebounceMs
         val isBeyondTestThreshold =
             lastClickTime == 0L || lastClickTime == elapsedRealtime // just for tests
@@ -38,7 +38,7 @@ object MultiClickGuard {
 
         if (allowClick) {
             lastClickTime = elapsedRealtime
-            lastClickName = screenName
+            lastClickName = scope
         }
         return allowClick
     }

--- a/lists/src/main/res/layout/multi_select_controls_layout.xml
+++ b/lists/src/main/res/layout/multi_select_controls_layout.xml
@@ -19,7 +19,7 @@
         android:layout_weight="1"
         android:text="@string/select_all" />
 
-    <com.google.android.material.button.MaterialButton
+    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
         android:id="@+id/action"
         style="?materialButtonStyle"
         android:layout_width="0dp"

--- a/lists/src/main/res/layout/multi_select_controls_layout.xml
+++ b/lists/src/main/res/layout/multi_select_controls_layout.xml
@@ -19,7 +19,7 @@
         android:layout_weight="1"
         android:text="@string/select_all" />
 
-    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+    <org.odk.collect.androidshared.ui.multiclicksafe.DoubleClickSafeMaterialButton
         android:id="@+id/action"
         style="?materialButtonStyle"
         android:layout_width="0dp"


### PR DESCRIPTION
Closes #6159

#### Why is this the best possible solution? Were any other approaches considered?

I've just used our standard `MultiClickGuard` approach to blocking double taps here. I didn't add it to the Select All/Clear all button as it felt like that should be toggle-able, and I couldn't find a problem with it.

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
