### PR TITLE
Do not support the masked appearance in numeric questions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/QuestionAnswerProcessor.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/QuestionAnswerProcessor.kt
@@ -27,11 +27,8 @@ object QuestionAnswerProcessor {
 
         if (!fep.answerText.isNullOrBlank() &&
             Appearances.isMasked(fep) &&
-            fep.controlType == Constants.CONTROL_INPUT && (
-                fep.dataType == Constants.DATATYPE_TEXT ||
-                    fep.dataType == Constants.DATATYPE_INTEGER ||
-                    fep.dataType == Constants.DATATYPE_DECIMAL
-            )
+            fep.controlType == Constants.CONTROL_INPUT &&
+            fep.dataType == Constants.DATATYPE_TEXT
         ) {
             return "••••••••••"
         }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
@@ -16,6 +16,7 @@
 package org.odk.collect.android.utilities
 
 import android.content.res.Configuration
+import org.javarosa.core.model.Constants
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.dynamicpreload.ExternalDataUtil
 import org.odk.collect.androidshared.utils.ScreenUtils
@@ -195,6 +196,6 @@ object Appearances {
     @JvmStatic
     fun isMasked(prompt: FormEntryPrompt): Boolean {
         val appearance = getSanitizedAppearanceHint(prompt)
-        return appearance.contains(MASKED)
+        return appearance.contains(MASKED) && prompt.dataType == Constants.DATATYPE_TEXT
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formhierarchy/QuestionAnswerProcessorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formhierarchy/QuestionAnswerProcessorTest.kt
@@ -27,73 +27,57 @@ class QuestionAnswerProcessorTest {
     }
 
     @Test
-    fun noAnswerShouldBeDisplayedIfItDoesNotExistAndMaskedAppearanceIsUsedForTextAndNumberDataTypes() {
-        listOf(
-            Constants.DATATYPE_TEXT,
-            Constants.DATATYPE_INTEGER,
-            Constants.DATATYPE_DECIMAL
-        ).forEach {
-            val question = mock<QuestionDef>()
-            val prompt = MockFormEntryPromptBuilder()
-                .withQuestion(question)
-                .withDataType(it)
-                .withControlType(Constants.CONTROL_INPUT)
-                .withAppearance(Appearances.MASKED)
-                .build()
+    fun noAnswerShouldBeDisplayedIfItDoesNotExistAndMaskedAppearanceIsUsedForTextDataTypes() {
+        val question = mock<QuestionDef>()
+        val prompt = MockFormEntryPromptBuilder()
+            .withQuestion(question)
+            .withDataType(Constants.DATATYPE_TEXT)
+            .withControlType(Constants.CONTROL_INPUT)
+            .withAppearance(Appearances.MASKED)
+            .build()
 
-            val answer = QuestionAnswerProcessor.getQuestionAnswer(prompt, mock(), mock())
+        val answer = QuestionAnswerProcessor.getQuestionAnswer(prompt, mock(), mock())
 
-            assertThat(answer, equalTo(""))
-        }
+        assertThat(answer, equalTo(""))
     }
 
     @Test
-    fun noAnswerShouldBeDisplayedIfItIsEmptyAndMaskedAppearanceIsUsedForTextAndNumberDataTypes() {
-        listOf(
-            Constants.DATATYPE_TEXT,
-            Constants.DATATYPE_INTEGER,
-            Constants.DATATYPE_DECIMAL
-        ).forEach {
-            val question = mock<QuestionDef>()
-            val prompt = MockFormEntryPromptBuilder()
-                .withQuestion(question)
-                .withAnswerDisplayText("")
-                .withAppearance(Appearances.MASKED)
-                .withControlType(Constants.CONTROL_INPUT)
-                .withDataType(it)
-                .build()
+    fun noAnswerShouldBeDisplayedIfItIsEmptyAndMaskedAppearanceIsUsedForTextDataTypes() {
+        val question = mock<QuestionDef>()
+        val prompt = MockFormEntryPromptBuilder()
+            .withQuestion(question)
+            .withAnswerDisplayText("")
+            .withAppearance(Appearances.MASKED)
+            .withControlType(Constants.CONTROL_INPUT)
+            .withDataType(Constants.DATATYPE_TEXT)
+            .build()
 
-            val answer = QuestionAnswerProcessor.getQuestionAnswer(prompt, mock(), mock())
+        val answer = QuestionAnswerProcessor.getQuestionAnswer(prompt, mock(), mock())
 
-            assertThat(answer, equalTo(""))
-        }
+        assertThat(answer, equalTo(""))
     }
 
     @Test
-    fun maskedAnswerShouldBeDisplayedIfItExistAndMaskedAppearanceIsUsedForTextAndNumberDataTypes() {
-        listOf(
-            Constants.DATATYPE_TEXT,
-            Constants.DATATYPE_INTEGER,
-            Constants.DATATYPE_DECIMAL
-        ).forEach {
-            val question = mock<QuestionDef>()
-            val prompt = MockFormEntryPromptBuilder()
-                .withQuestion(question)
-                .withAnswerDisplayText("blah")
-                .withAppearance(Appearances.MASKED)
-                .withControlType(Constants.CONTROL_INPUT)
-                .withDataType(it)
-                .build()
+    fun maskedAnswerShouldBeDisplayedIfItExistAndMaskedAppearanceIsUsedForTextDataTypes() {
+        val question = mock<QuestionDef>()
+        val prompt = MockFormEntryPromptBuilder()
+            .withQuestion(question)
+            .withAnswerDisplayText("blah")
+            .withAppearance(Appearances.MASKED)
+            .withControlType(Constants.CONTROL_INPUT)
+            .withDataType(Constants.DATATYPE_TEXT)
+            .build()
 
-            val answer = QuestionAnswerProcessor.getQuestionAnswer(prompt, mock(), mock())
+        val answer = QuestionAnswerProcessor.getQuestionAnswer(prompt, mock(), mock())
 
-            assertThat(answer, equalTo("••••••••••"))
-        }
+        assertThat(answer, equalTo("••••••••••"))
     }
 
     @Test
-    fun originalAnswerShouldBeDisplayedIfItExistAndMaskedAppearanceIsUsedForDataTypesOtherThanTextAndNumber() {
+    fun originalAnswerShouldBeDisplayedIfItExistAndMaskedAppearanceIsUsedForDataTypesOtherThanText() {
         listOf(
+            Constants.DATATYPE_INTEGER,
+            Constants.DATATYPE_DECIMAL,
             Constants.DATATYPE_DATE_TIME,
             Constants.DATATYPE_DATE,
             Constants.DATATYPE_TIME,
@@ -120,7 +104,7 @@ class QuestionAnswerProcessorTest {
     }
 
     @Test
-    fun originalAnswerShouldBeDisplayedIfItExistAndMaskedAppearanceIsUsedButControlTypeIsOtherThanInput() {
+    fun originalAnswerShouldBeDisplayedIfItExistAndMaskedAppearanceIsUsedForDataTypesAndControlTypeOtherThanInput() {
         listOf(
             Constants.CONTROL_RANGE,
             Constants.CONTROL_RANK,

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/AppearancesTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/AppearancesTest.kt
@@ -19,6 +19,7 @@ import android.content.res.Configuration
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
+import org.javarosa.core.model.Constants
 import org.javarosa.form.api.FormEntryPrompt
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -233,7 +234,8 @@ class AppearancesTest {
     }
 
     @Test
-    fun `useThousandSeparator returns false when 'thousands-sep' appearance is found but mixed with 'masked'`() {
+    fun `useThousandSeparator returns false when 'thousands-sep' appearance is found but mixed with 'masked' for text questions`() {
+        whenever(formEntryPrompt.dataType).thenReturn(Constants.DATATYPE_TEXT)
         whenever(formEntryPrompt.appearanceHint).thenReturn("thousands-sep masked")
         assertFalse(Appearances.useThousandSeparator(formEntryPrompt))
     }
@@ -369,6 +371,7 @@ class AppearancesTest {
 
     @Test
     fun `isMasked returns false when there is no appearance`() {
+        whenever(formEntryPrompt.dataType).thenReturn(Constants.DATATYPE_TEXT)
         assertFalse(Appearances.isMasked(formEntryPrompt))
 
         whenever(formEntryPrompt.appearanceHint).thenReturn("")
@@ -377,13 +380,25 @@ class AppearancesTest {
 
     @Test
     fun `isMasked returns false when non of supported appearances is found`() {
+        whenever(formEntryPrompt.dataType).thenReturn(Constants.DATATYPE_TEXT)
         whenever(formEntryPrompt.appearanceHint).thenReturn("blah")
         assertFalse(Appearances.isMasked(formEntryPrompt))
     }
 
     @Test
-    fun `isMasked returns true when 'masked' appearance is found`() {
+    fun `isMasked returns true when 'masked' appearance is found for text questions`() {
+        whenever(formEntryPrompt.dataType).thenReturn(Constants.DATATYPE_TEXT)
         whenever(formEntryPrompt.appearanceHint).thenReturn("masked")
         assertTrue(Appearances.isMasked(formEntryPrompt))
+    }
+
+    @Test
+    fun `isMasked returns false when 'masked' appearance is found for numeric questions`() {
+        whenever(formEntryPrompt.dataType).thenReturn(Constants.DATATYPE_INTEGER)
+        whenever(formEntryPrompt.appearanceHint).thenReturn("masked")
+        assertFalse(Appearances.isMasked(formEntryPrompt))
+
+        whenever(formEntryPrompt.dataType).thenReturn(Constants.DATATYPE_DECIMAL)
+        assertFalse(Appearances.isMasked(formEntryPrompt))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
@@ -2,12 +2,14 @@ package org.odk.collect.android.widgets;
 
 import androidx.annotation.NonNull;
 
+import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
 import java.text.NumberFormat;
@@ -15,12 +17,13 @@ import java.util.Locale;
 import java.util.Random;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
@@ -40,6 +43,7 @@ public class DecimalWidgetTest extends GeneralStringWidgetTest<DecimalWidget, De
     @NonNull
     @Override
     public DecimalWidget createWidget() {
+        when(formEntryPrompt.getDataType()).thenReturn(Constants.DATATYPE_DECIMAL);
         return new DecimalWidget(activity, new QuestionDetails(formEntryPrompt, readOnlyOverride));
     }
 
@@ -219,12 +223,11 @@ public class DecimalWidgetTest extends GeneralStringWidgetTest<DecimalWidget, De
         assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
     }
 
-    @Override
     @Test
-    public void verifyInputTypeWithMaskedAppearance() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
-        DecimalWidget widget = getWidget();
-        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
-        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+    public void answersShouldNotBeMaskedIfMaskedAppearanceIsUsed() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
+
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
@@ -2,11 +2,13 @@ package org.odk.collect.android.widgets;
 
 import androidx.annotation.NonNull;
 
+import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.DecimalData;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.javarosa.core.model.data.IAnswerData;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 import org.odk.collect.android.widgets.utilities.StringRequester;
@@ -16,11 +18,12 @@ import java.util.Locale;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
@@ -42,6 +45,7 @@ public class ExDecimalWidgetTest extends GeneralExStringWidgetTest<ExDecimalWidg
     @NonNull
     @Override
     public ExDecimalWidget createWidget() {
+        when(formEntryPrompt.getDataType()).thenReturn(Constants.DATATYPE_DECIMAL);
         return new ExDecimalWidget(activity, new QuestionDetails(formEntryPrompt), new FakeWaitingForDataRegistry(), stringRequester);
     }
 
@@ -103,13 +107,11 @@ public class ExDecimalWidgetTest extends GeneralExStringWidgetTest<ExDecimalWidg
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
     }
 
-    @Override
     @Test
-    public void verifyInputTypeWithMaskedAppearance() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
-        ExDecimalWidget widget = getWidget();
-        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
-        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
-        assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+    public void answersShouldNotBeMaskedIfMaskedAppearanceIsUsed() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
+
+        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
@@ -2,10 +2,12 @@ package org.odk.collect.android.widgets;
 
 import androidx.annotation.NonNull;
 
+import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.IntegerData;
 import org.mockito.Mock;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.junit.Test;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 import org.odk.collect.android.widgets.utilities.StringRequester;
@@ -13,8 +15,10 @@ import org.odk.collect.android.widgets.utilities.StringRequester;
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
@@ -33,6 +37,7 @@ public class ExIntegerWidgetTest extends GeneralExStringWidgetTest<ExIntegerWidg
     @NonNull
     @Override
     public ExIntegerWidget createWidget() {
+        when(formEntryPrompt.getDataType()).thenReturn(Constants.DATATYPE_INTEGER);
         return new ExIntegerWidget(activity, new QuestionDetails(formEntryPrompt), new FakeWaitingForDataRegistry(), stringRequester);
     }
 
@@ -77,13 +82,11 @@ public class ExIntegerWidgetTest extends GeneralExStringWidgetTest<ExIntegerWidg
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
     }
 
-    @Override
     @Test
-    public void verifyInputTypeWithMaskedAppearance() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
-        ExIntegerWidget widget = getWidget();
-        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
-        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
-        assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+    public void answersShouldNotBeMaskedIfMaskedAppearanceIsUsed() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
+
+        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
@@ -4,16 +4,21 @@ import androidx.annotation.NonNull;
 
 import net.bytebuddy.utility.RandomString;
 
+import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.StringData;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 import org.odk.collect.android.widgets.utilities.StringRequester;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.MASKED;
 
@@ -33,6 +38,7 @@ public class ExStringWidgetTest extends GeneralExStringWidgetTest<ExStringWidget
     @NonNull
     @Override
     public ExStringWidget createWidget() {
+        when(formEntryPrompt.getDataType()).thenReturn(Constants.DATATYPE_TEXT);
         return new ExStringWidget(activity, new QuestionDetails(formEntryPrompt), new FakeWaitingForDataRegistry(), stringRequester);
     }
 
@@ -57,7 +63,6 @@ public class ExStringWidgetTest extends GeneralExStringWidgetTest<ExStringWidget
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
     }
 
-    @Override
     @Test
     public void verifyInputTypeWithMaskedAppearance() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
@@ -65,5 +70,19 @@ public class ExStringWidgetTest extends GeneralExStringWidgetTest<ExStringWidget
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD));
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+    }
+
+    @Test
+    public void answersShouldNotBeMaskedIfMaskedAppearanceIsNotUsed() {
+        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+    }
+
+    @Test
+    public void answersShouldBeMaskedIfMaskedAppearanceIsUsed() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
+
+        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
+        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
@@ -2,16 +2,20 @@ package org.odk.collect.android.widgets;
 
 import androidx.annotation.NonNull;
 
+import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.IntegerData;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.junit.Test;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
@@ -26,6 +30,7 @@ public class IntegerWidgetTest extends GeneralStringWidgetTest<IntegerWidget, In
     @NonNull
     @Override
     public IntegerWidget createWidget() {
+        when(formEntryPrompt.getDataType()).thenReturn(Constants.DATATYPE_INTEGER);
         return new IntegerWidget(activity, new QuestionDetails(formEntryPrompt, readOnlyOverride));
     }
 
@@ -63,12 +68,11 @@ public class IntegerWidgetTest extends GeneralStringWidgetTest<IntegerWidget, In
         assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
     }
 
-    @Override
     @Test
-    public void verifyInputTypeWithMaskedAppearance() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
-        IntegerWidget widget = getWidget();
-        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
-        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+    public void answersShouldNotBeMaskedIfMaskedAppearanceIsUsed() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
+
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
@@ -4,12 +4,17 @@ import androidx.annotation.NonNull;
 
 import net.bytebuddy.utility.RandomString;
 
+import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.StringData;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.junit.Test;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
@@ -28,6 +33,7 @@ public class StringNumberWidgetTest extends GeneralStringWidgetTest<StringNumber
     @NonNull
     @Override
     public StringNumberWidget createWidget() {
+        when(formEntryPrompt.getDataType()).thenReturn(Constants.DATATYPE_TEXT);
         return new StringNumberWidget(activity, new QuestionDetails(formEntryPrompt, readOnlyOverride));
     }
 
@@ -61,12 +67,25 @@ public class StringNumberWidgetTest extends GeneralStringWidgetTest<StringNumber
         assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
     }
 
-    @Override
     @Test
     public void verifyInputTypeWithMaskedAppearance() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
         StringNumberWidget widget = getWidget();
         assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER));
         assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+    }
+
+    @Test
+    public void answersShouldNotBeMaskedIfMaskedAppearanceIsNotUsed() {
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+    }
+
+    @Test
+    public void answersShouldBeMaskedIfMaskedAppearanceIsUsed() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
+
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringWidgetTest.java
@@ -2,6 +2,9 @@ package org.odk.collect.android.widgets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.MASKED;
 
@@ -13,9 +16,11 @@ import androidx.annotation.NonNull;
 
 import net.bytebuddy.utility.RandomString;
 
+import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.StringData;
 import org.junit.Test;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
 /**
@@ -26,6 +31,7 @@ public class StringWidgetTest extends GeneralStringWidgetTest<StringWidget, Stri
     @NonNull
     @Override
     public StringWidget createWidget() {
+        when(formEntryPrompt.getDataType()).thenReturn(Constants.DATATYPE_TEXT);
         return new StringWidget(activity, new QuestionDetails(formEntryPrompt, readOnlyOverride));
     }
 
@@ -44,12 +50,25 @@ public class StringWidgetTest extends GeneralStringWidgetTest<StringWidget, Stri
         assertThat(widget.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
     }
 
-    @Override
     @Test
     public void verifyInputTypeWithMaskedAppearance() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
         StringWidget widget = getWidget();
         assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD));
         assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+    }
+
+    @Test
+    public void answersShouldNotBeMaskedIfMaskedAppearanceIsNotUsed() {
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
+    }
+
+    @Test
+    public void answersShouldBeMaskedIfMaskedAppearanceIsUsed() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
+
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
+        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
@@ -2,20 +2,16 @@ package org.odk.collect.android.widgets.base;
 
 import static junit.framework.Assert.assertTrue;
 
-import android.text.method.PasswordTransformationMethod;
 import android.view.View;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.WidgetTestActivity;
-import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.ExStringWidget;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -69,22 +65,5 @@ public abstract class GeneralExStringWidgetTest<W extends ExStringWidget, A exte
     }
 
     @Test
-    public void answersShouldNotBeMaskedIfMaskedAppearanceIsNotUsed() {
-        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-    }
-
-    @Test
-    public void answersShouldBeMaskedIfMaskedAppearanceIsUsed() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
-
-        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
-        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
-    }
-
-    @Test
     public abstract void verifyInputType();
-
-    @Test
-    public abstract void verifyInputTypeWithMaskedAppearance();
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.widgets.base;
 
 import static junit.framework.Assert.assertTrue;
 
-import android.text.method.PasswordTransformationMethod;
 import android.view.View;
 
 import org.javarosa.core.model.QuestionDef;
@@ -11,13 +10,10 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.WidgetTestActivity;
-import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.StringWidget;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -108,22 +104,5 @@ public abstract class GeneralStringWidgetTest<W extends StringWidget, A extends 
     }
 
     @Test
-    public void answersShouldNotBeMaskedIfMaskedAppearanceIsNotUsed() {
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-    }
-
-    @Test
-    public void answersShouldBeMaskedIfMaskedAppearanceIsUsed() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
-
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
-    }
-
-    @Test
     public abstract void verifyInputType();
-
-    @Test
-    public abstract void verifyInputTypeWithMaskedAppearance();
 }


### PR DESCRIPTION
Closes #6122 

#### Why is this the best possible solution? Were any other approaches considered?
As discussed in the issue we should stop supporting the masked appearance in numeric questions as this is not easy to achieve because of Android limitations.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This brings some more changes than just fixing the issue. We have decided that we should not support the masked appearance in numeric questions (integer/decimal) so now it will be available only for text questions ([default text question](https://docs.getodk.org/form-question-types/#default-text-widget)/[external text question](https://docs.getodk.org/form-question-types/#external-app-string-widget)/[number text question](https://docs.getodk.org/form-question-types/#number-text-widget)).

#### Do we need any specific form for testing your changes? If so, please attach one.
The form from the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
