### PR TITLE
Offline maps UI improvements

### DIFF
--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
@@ -189,7 +189,7 @@ class OfflineMapLayersPicker(
                     checkedLayerId == it.id,
                     expandedLayerIds.contains(it.id)
                 )
-            }.sortedBy { it.name }
+            }
         )
         adapter.setData(newData)
     }

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
@@ -180,15 +180,17 @@ class OfflineMapLayersPicker(
             )
         )
 
-        newData.addAll(layers.map {
-            CheckableReferenceLayer(
-                it.id,
-                it.file,
-                it.name,
-                checkedLayerId == it.id,
-                expandedLayerIds.contains(it.id)
-            )
-        })
+        newData.addAll(
+            layers.map {
+                CheckableReferenceLayer(
+                    it.id,
+                    it.file,
+                    it.name,
+                    checkedLayerId == it.id,
+                    expandedLayerIds.contains(it.id)
+                )
+            }.sortedBy { it.name }
+        )
         adapter.setData(newData)
     }
 }

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersViewModel.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersViewModel.kt
@@ -38,7 +38,7 @@ class OfflineMapLayersViewModel(
         _isLoading.value = true
         scheduler.immediate(
             background = {
-                val layers = referenceLayerRepository.getAll()
+                val layers = referenceLayerRepository.getAll().sortedBy { it.name }
                 _isLoading.postValue(false)
                 _existingLayers.postValue(layers)
             },

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersViewModel.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersViewModel.kt
@@ -65,7 +65,7 @@ class OfflineMapLayersViewModel(
                     }
                 }
                 _isLoading.postValue(false)
-                _layersToImport.postValue(layers)
+                _layersToImport.postValue(layers.sortedBy { it.name })
             },
             foreground = { }
         )

--- a/maps/src/main/res/layout/offline_map_layers_importer.xml
+++ b/maps/src/main/res/layout/offline_map_layers_importer.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent">
 
     <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/add_project_toolbar"
+        android:id="@+id/toolbar_container"
         style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -24,118 +24,122 @@
         <include layout="@layout/app_bar_shadow"/>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="@+id/shadow_up"
-        app:layout_constraintEnd_toEndOf="parent"
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/layers_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/layers_list_title"
+        android:textAppearance="?textAppearanceTitleLarge"
+        android:layout_marginHorizontal="@dimen/margin_standard"
+        android:layout_marginTop="@dimen/margin_small"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_container"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/add_project_toolbar">
+        app:layout_constraintEnd_toEndOf="parent" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layers_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintVertical_bias="0"
+        app:layout_constraintStart_toStartOf="@id/layers_title"
+        app:layout_constraintEnd_toEndOf="@id/layers_title"
+        app:layout_constraintBottom_toTopOf="@id/container"
+        app:layout_constraintTop_toBottomOf="@id/layers_title"
+        app:layout_constraintVertical_chainStyle="packed">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/layers"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_small"
+            app:layout_constrainedHeight="true"
+            app:layout_constraintVertical_bias="0"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progress_indicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="@dimen/margin_small"
+            app:layout_constrainedHeight="true"
+            app:layout_constraintVertical_bias="0"
+            android:indeterminate="true"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/layers_container"
+        app:layout_constraintBottom_toTopOf="@id/bottom_divider"
+        app:layout_constraintStart_toStartOf="@id/layers_title"
+        app:layout_constraintEnd_toEndOf="@id/layers_title">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/select_layer_access_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/select_layer_access_title"
+            android:textAppearance="?textAppearanceTitleLarge"
+            android:layout_marginTop="@dimen/margin_standard"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/select_layer_access_subtitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/select_layer_access_subtitle"
+            android:textAppearance="?textAppearanceBodyMedium"
+            android:layout_marginTop="@dimen/margin_standard"
+            app:layout_constraintTop_toBottomOf="@id/select_layer_access_title"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <RadioGroup
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_standard"
-            app:layout_constraintBottom_toTopOf="@+id/constraintLayout">
+            android:paddingBottom="@dimen/margin_small"
+            android:layout_marginTop="@dimen/margin_extra_extra_small"
+            android:checkedButton="@id/all_projects_option"
+            app:layout_constraintTop_toBottomOf="@id/select_layer_access_subtitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/layers_title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/layers_list_title"
-                android:textAppearance="?textAppearanceTitleLarge"
-                android:layout_marginTop="@dimen/margin_standard"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/layers"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_small"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layers_title" />
-
-            <com.google.android.material.progressindicator.CircularProgressIndicator
-                android:id="@+id/progress_indicator"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="@dimen/margin_small"
-                android:indeterminate="true"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layers_title" />
-
-            <androidx.constraintlayout.widget.Barrier
-                android:id="@+id/barrier"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                app:barrierDirection="bottom"
-                app:constraint_referenced_ids="layers,progress_indicator" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/select_layer_access_title"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/select_layer_access_title"
-                android:textAppearance="?textAppearanceTitleLarge"
-                android:layout_marginTop="@dimen/margin_standard"
-                app:layout_constraintTop_toBottomOf="@id/barrier"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/select_layer_access_subtitle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/select_layer_access_subtitle"
-                android:textAppearance="?textAppearanceBodyMedium"
-                android:layout_marginTop="@dimen/margin_standard"
-                app:layout_constraintTop_toBottomOf="@id/select_layer_access_title"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
-
-            <RadioGroup
+            <RadioButton
+                android:id="@+id/all_projects_option"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="@dimen/margin_small"
-                android:layout_marginTop="@dimen/margin_extra_extra_small"
-                android:checkedButton="@id/all_projects_option"
-                app:layout_constraintTop_toBottomOf="@id/select_layer_access_subtitle"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent">
+                android:paddingStart="@dimen/margin_standard"
+                android:translationX="-5dp"
+                android:textAppearance="?textAppearanceBodyMedium"
+                android:text="@string/all_projects_option"/>
 
-                <RadioButton
-                    android:id="@+id/all_projects_option"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingStart="@dimen/margin_standard"
-                    android:translationX="-5dp"
-                    android:textAppearance="?textAppearanceBodyMedium"
-                    android:text="@string/all_projects_option"/>
+            <RadioButton
+                android:id="@+id/current_project_option"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="@dimen/margin_standard"
+                android:translationX="-5dp"
+                android:textAppearance="?textAppearanceBodyMedium"
+                android:text="@string/current_project_option"/>
+        </RadioGroup>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-                <RadioButton
-                    android:id="@+id/current_project_option"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingStart="@dimen/margin_standard"
-                    android:translationX="-5dp"
-                    android:textAppearance="?textAppearanceBodyMedium"
-                    android:text="@string/current_project_option"/>
-            </RadioGroup>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </ScrollView>
-
-    <ImageView
-        android:id="@+id/shadow_up"
+    <View
+        android:id="@+id/bottom_divider"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:src="@drawable/shadow_up"
-        android:layout_marginBottom="@dimen/margin_small"
+        android:layout_height="1dp"
+        android:background="@drawable/list_item_divider"
+        android:layout_marginBottom="@dimen/margin_extra_extra_small"
         app:layout_constraintBottom_toTopOf="@id/cancel_button" />
 
     <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
@@ -144,7 +148,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/cancel"
-        android:layout_marginEnd="@dimen/margin_small"
+        android:layout_marginBottom="@dimen/margin_extra_extra_small"
         app:layout_constraintBottom_toBottomOf="@id/add_layer_button"
         app:layout_constraintEnd_toStartOf="@id/add_layer_button"
         app:layout_constraintTop_toTopOf="@id/add_layer_button" />

--- a/maps/src/main/res/layout/offline_map_layers_picker_item.xml
+++ b/maps/src/main/res/layout/offline_map_layers_picker_item.xml
@@ -10,7 +10,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:button="@drawable/radio_button_inset"
-        android:paddingEnd="@dimen/margin_standard"
         android:paddingVertical="@dimen/margin_extra_small"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
@@ -4,8 +4,6 @@ import androidx.core.net.toUri
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.scrollTo
-import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -31,6 +29,7 @@ import org.odk.collect.strings.R
 import org.odk.collect.testshared.EspressoHelpers
 import org.odk.collect.testshared.FakeScheduler
 import org.odk.collect.testshared.RecyclerViewMatcher
+import org.odk.collect.testshared.RecyclerViewMatcher.Companion.withRecyclerView
 import org.odk.collect.testshared.RobolectricHelpers
 import java.io.File
 
@@ -156,8 +155,8 @@ class OfflineMapLayersImporterTest {
         scheduler.flush()
 
         onView(withId(org.odk.collect.maps.R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(2)))
-        onView(withText(file2.name)).check(matches(isDisplayed()))
-        onView(withText(file1.name)).check(matches(isDisplayed()))
+        onView(withRecyclerView(org.odk.collect.maps.R.id.layers).atPositionOnView(0, org.odk.collect.maps.R.id.layer_name)).check(matches(withText(file2.name)))
+        onView(withRecyclerView(org.odk.collect.maps.R.id.layers).atPositionOnView(1, org.odk.collect.maps.R.id.layer_name)).check(matches(withText(file1.name)))
     }
 
     @Test
@@ -174,8 +173,8 @@ class OfflineMapLayersImporterTest {
         scenario.recreate()
 
         onView(withId(org.odk.collect.maps.R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(2)))
-        onView(withText(file1.name)).check(matches(isDisplayed()))
-        onView(withText(file2.name)).check(matches(isDisplayed()))
+        onView(withRecyclerView(org.odk.collect.maps.R.id.layers).atPositionOnView(0, org.odk.collect.maps.R.id.layer_name)).check(matches(withText(file1.name)))
+        onView(withRecyclerView(org.odk.collect.maps.R.id.layers).atPositionOnView(1, org.odk.collect.maps.R.id.layer_name)).check(matches(withText(file2.name)))
     }
 
     @Test
@@ -190,8 +189,7 @@ class OfflineMapLayersImporterTest {
         scheduler.flush()
 
         onView(withId(org.odk.collect.maps.R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(1)))
-        onView(withText(file1.name)).check(matches(isDisplayed()))
-        onView(withText(file2.name)).check(doesNotExist())
+        onView(withRecyclerView(org.odk.collect.maps.R.id.layers).atPositionOnView(0, org.odk.collect.maps.R.id.layer_name)).check(matches(withText(file1.name)))
     }
 
     @Test
@@ -229,7 +227,7 @@ class OfflineMapLayersImporterTest {
 
         scheduler.flush()
 
-        onView(withId(org.odk.collect.maps.R.id.current_project_option)).perform(scrollTo(), click())
+        onView(withId(org.odk.collect.maps.R.id.current_project_option)).perform(click())
 
         onView(withId(org.odk.collect.maps.R.id.add_layer_button)).perform(click())
         scheduler.flush()

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
@@ -145,9 +145,9 @@ class OfflineMapLayersImporterTest {
     }
 
     @Test
-    fun `the list of selected layers should be displayed`() {
-        val file1 = TempFiles.createTempFile("layer1", MbtilesFile.FILE_EXTENSION)
-        val file2 = TempFiles.createTempFile("layer2", MbtilesFile.FILE_EXTENSION)
+    fun `the list of selected layers should be displayed in A-Z order`() {
+        val file1 = TempFiles.createTempFile("layerB", MbtilesFile.FILE_EXTENSION)
+        val file2 = TempFiles.createTempFile("layerA", MbtilesFile.FILE_EXTENSION)
 
         launchFragment().onFragment {
             it.viewModel.loadLayersToImport(listOf(file1.toUri(), file2.toUri()), it.requireContext())
@@ -156,8 +156,8 @@ class OfflineMapLayersImporterTest {
         scheduler.flush()
 
         onView(withId(org.odk.collect.maps.R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(2)))
-        onView(withText(file1.name)).check(matches(isDisplayed()))
         onView(withText(file2.name)).check(matches(isDisplayed()))
+        onView(withText(file1.name)).check(matches(isDisplayed()))
     }
 
     @Test

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
@@ -541,6 +541,31 @@ class OfflineMapLayersPickerTest {
     }
 
     @Test
+    fun `deleting one of the layers keeps the list sorted in A-Z order`() {
+        whenever(referenceLayerRepository.getAll()).thenReturn(listOf(
+            ReferenceLayer("1", TempFiles.createTempFile(), "layerC"),
+            ReferenceLayer("2", TempFiles.createTempFile(), "layerB"),
+            ReferenceLayer("3", TempFiles.createTempFile(), "layerA")
+        ))
+
+        launchFragment()
+
+        scheduler.flush()
+
+        onView(withId(R.id.layers)).perform(scrollToPosition<RecyclerView.ViewHolder>(2))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.arrow)).perform(click())
+        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.delete_layer)).perform(scrollTo(), click())
+
+        onView(withText(string.delete_layer)).inRoot(isDialog()).perform(click())
+        scheduler.flush()
+
+        onView(withId(R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(3)))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.title)).check(matches(withText("layerA")))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.title)).check(matches(withText("layerC")))
+    }
+
+    @Test
     fun `progress indicator is displayed during deleting layers`() {
         val layerFile1 = TempFiles.createTempFile("layer1", MbtilesFile.FILE_EXTENSION)
         whenever(referenceLayerRepository.getAll()).thenReturn(listOf(

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
@@ -254,11 +254,11 @@ class OfflineMapLayersPickerTest {
     }
 
     @Test
-    fun `if there are multiple layers all of them are displayed along with the 'None'`() {
+    fun `if there are multiple layers all of them are displayed along with the 'None' and sorted in A-Z order`() {
         whenever(referenceLayerRepository.getAll()).thenReturn(
             listOf(
-                ReferenceLayer("1", TempFiles.createTempFile(), "layer1"),
-                ReferenceLayer("2", TempFiles.createTempFile(), "layer2")
+                ReferenceLayer("1", TempFiles.createTempFile(), "layerB"),
+                ReferenceLayer("2", TempFiles.createTempFile(), "layerA")
             )
         )
 
@@ -268,8 +268,8 @@ class OfflineMapLayersPickerTest {
 
         onView(withId(R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(3)))
         onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.title)).check(matches(withText("layer1")))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.title)).check(matches(withText("layer2")))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.title)).check(matches(withText("layerA")))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.title)).check(matches(withText("layerB")))
     }
 
     @Test

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -495,7 +495,7 @@
     <string name="get_help_with_reference_layers">Learn more about adding MBTiles.</string>
 
     <!-- Text for button that lets the user select a reference layer on their device to add -->
-    <string name="add_layer">Add layer</string>
+    <string name="add_layer">Add layers</string>
 
     <!-- Text for button that lets the user delete a reference layer -->
     <string name="delete_layer">Delete layer</string>
@@ -504,8 +504,8 @@
     <string name="layers_list_title">Layers</string>
 
     <!-- Text for title and subtitle above options for how the layer can be access -->
-    <string name="select_layer_access_title">Select layer access</string>
-    <string name="select_layer_access_subtitle">Do you want the layer available in all projects or your current project only?</string>
+    <string name="select_layer_access_title">Select layers access</string>
+    <string name="select_layer_access_subtitle">Do you want the layers available in all projects or your current project only?</string>
 
     <!-- Text for option where layer should be available to all projects -->
     <string name="all_projects_option">All projects</string>
@@ -514,7 +514,7 @@
     <string name="current_project_option">Current project only</string>
 
     <!-- Text for message displayed in a dialog to confirm that the layer should be deleted -->
-    <string name="delete_layer_confirmation_message">Are you sure you want to delete %1$s offline layers?</string>
+    <string name="delete_layer_confirmation_message">Are you sure you want to delete %1$s offline layer?</string>
 
     <string name="record_geopoint">Record a point</string>
     <string name="location_accuracy">Accuracy: %1$s m</string>


### PR DESCRIPTION
Closes #6172 
~~Blocked by #6190~~

#### Why is this the best possible solution? Were any other approaches considered?
The changes is a result of reviewing the current implementation and the discussion we had in the issue.
I don't think there is anything to discuss here.
I've added two extra small changes:
-  [Removed redundant padding](https://github.com/getodk/collect/pull/6188/commits/30bfbb907ac7cf8e321811322f5ef64ca4dbc60d)
- improved the bottom menu in the confirmation dialog so that it looks like the one used in the bottom sheet: 
https://github.com/getodk/collect/pull/6188/files#diff-03b9624c2809a62c168f32e5115f8b741290012e5f6a56f769798547c7ff85a3R130

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The changes I have implemented:
- the list of existing layers and layers to import should be sorted in A-Z order
- made all references to "layer" plural rather than the current mix of singular/plural
- reworked the confirmation dialog so that if the list of layers to import is long it grows but does not push the two options that are below (to select the destination directory) off the screen.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
