### PR TITLE
Fixed deleting current layer

### DIFF
--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
@@ -124,6 +124,10 @@ class OfflineMapLayersPicker(
         ).observe(this) { (layers, checkedLayerId, expandedLayerIds) ->
             updateAdapter(layers, checkedLayerId, expandedLayerIds, adapter)
         }
+
+        sharedViewModel.existingLayers.observe(this) { layers ->
+            stateViewModel.onLayersChanged(layers.map { it.id }.plus(null))
+        }
     }
 
     override fun onStart() {
@@ -149,9 +153,6 @@ class OfflineMapLayersPicker(
         MaterialAlertDialogBuilder(requireActivity())
             .setMessage(requireActivity().getLocalizedString(org.odk.collect.strings.R.string.delete_layer_confirmation_message, layerItem.name))
             .setPositiveButton(org.odk.collect.strings.R.string.delete_layer) { _, _ ->
-                if (layerItem.id == stateViewModel.getCheckedLayer()) {
-                    stateViewModel.onLayerChecked(null)
-                }
                 sharedViewModel.deleteLayer(layerItem.id!!)
             }
             .setNegativeButton(org.odk.collect.strings.R.string.cancel, null)

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersStateViewModel.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersStateViewModel.kt
@@ -8,7 +8,9 @@ import org.odk.collect.androidshared.livedata.NonNullLiveData
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys
 
-class OfflineMapLayersStateViewModel(settingsProvider: SettingsProvider) : ViewModel() {
+class OfflineMapLayersStateViewModel(
+    private val settingsProvider: SettingsProvider
+) : ViewModel() {
     private val _expandedLayerIds = MutableNonNullLiveData<List<String?>>(emptyList())
     val expandedLayerIds: NonNullLiveData<List<String?>> = _expandedLayerIds
 
@@ -25,6 +27,13 @@ class OfflineMapLayersStateViewModel(settingsProvider: SettingsProvider) : ViewM
             _expandedLayerIds.value = _expandedLayerIds.value.filter { it != layerId }
         } else {
             _expandedLayerIds.value = _expandedLayerIds.value.plus(layerId)
+        }
+    }
+
+    fun onLayersChanged(layerIds: List<String?>) {
+        if (!layerIds.contains(_checkedLayerId.value)) {
+            _checkedLayerId.value = null
+            settingsProvider.getUnprotectedSettings().save(ProjectKeys.KEY_REFERENCE_LAYER, null)
         }
     }
 


### PR DESCRIPTION
Closes #6189 

#### Why is this the best possible solution? Were any other approaches considered?
When the current layer is deleted we not only have to set the selection to `none` but also save it in settings. That second action was missing.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should only fix the issue. I don't think it can have any side effects or put at risk anything else.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
