### PR TITLE
Fixed resetting layers to none in preferences

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
@@ -151,7 +151,7 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
         // Clear the reference layer if it does not exist or it isn't supported by the new basemap.
         val layerId = settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER)
         if (layerId != null) {
-            val layer = referenceLayerRepository.getSupported(layerId)
+            val layer = referenceLayerRepository.get(layerId)
             if (layer == null) {
                 settingsProvider.getUnprotectedSettings().save(ProjectKeys.KEY_REFERENCE_LAYER, null)
             }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
@@ -151,8 +151,8 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
         // Clear the reference layer if it does not exist or it isn't supported by the new basemap.
         val layerId = settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER)
         if (layerId != null) {
-            val layer = referenceLayerRepository.get(layerId)
-            if (layer == null || !cftor.supportsLayer(layer.file)) {
+            val layer = referenceLayerRepository.getSupported(layerId)
+            if (layer == null) {
                 settingsProvider.getUnprotectedSettings().save(ProjectKeys.KEY_REFERENCE_LAYER, null)
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
@@ -155,8 +155,6 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
             if (layer == null) {
                 settingsProvider.getUnprotectedSettings().save(ProjectKeys.KEY_REFERENCE_LAYER, null)
             }
-
-            settingsProvider.getUnprotectedSettings().save(ProjectKeys.KEY_REFERENCE_LAYER, null)
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragmentTest.kt
@@ -94,7 +94,6 @@ class MapsPreferencesFragmentTest {
         val settings = settingsProvider.getUnprotectedSettings()
         settings.save(ProjectKeys.KEY_REFERENCE_LAYER, "blah")
         val layer = ReferenceLayer("blah", TempFiles.createTempFile(), "blah")
-        whenever(referenceLayerRepository.getSupported("blah")).thenReturn(layer)
         whenever(referenceLayerRepository.get("blah")).thenReturn(layer)
 
         val scenario = launcherRule.launch(MapsPreferencesFragment::class.java)

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragmentTest.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.android.preferences.screens
 
 import android.content.Context
+import androidx.preference.Preference
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.gson.Gson
 import org.hamcrest.CoreMatchers.equalTo
@@ -15,13 +16,17 @@ import org.odk.collect.android.application.initialization.AnalyticsInitializer
 import org.odk.collect.android.application.initialization.MapsInitializer
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.projects.ProjectsDataService
+import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
+import org.odk.collect.maps.layers.ReferenceLayer
+import org.odk.collect.maps.layers.ReferenceLayerRepository
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys
+import org.odk.collect.shared.TempFiles
 import org.odk.collect.shared.strings.UUIDGenerator
 
 @RunWith(AndroidJUnit4::class)
@@ -37,6 +42,7 @@ class MapsPreferencesFragmentTest {
     private val projectsRepository = mock<ProjectsRepository>().apply {
         whenever(get(project.uuid)).thenReturn(project)
     }
+    private val referenceLayerRepository = mock<ReferenceLayerRepository>()
     private val settingsProvider = InMemSettingsProvider()
 
     @Before
@@ -63,6 +69,13 @@ class MapsPreferencesFragmentTest {
             override fun providesSettingsProvider(context: Context): SettingsProvider {
                 return settingsProvider
             }
+
+            override fun providesReferenceLayerRepository(
+                storagePathProvider: StoragePathProvider,
+                settingsProvider: SettingsProvider
+            ): ReferenceLayerRepository {
+                return referenceLayerRepository
+            }
         })
     }
 
@@ -74,5 +87,23 @@ class MapsPreferencesFragmentTest {
         launcherRule.launch(MapsPreferencesFragment::class.java)
 
         assertThat(settings.getString(ProjectKeys.KEY_REFERENCE_LAYER), equalTo(null))
+    }
+
+    @Test
+    fun `if saved layer exist its name is displayed`() {
+        val settings = settingsProvider.getUnprotectedSettings()
+        settings.save(ProjectKeys.KEY_REFERENCE_LAYER, "blah")
+        val layer = ReferenceLayer("blah", TempFiles.createTempFile(), "blah")
+        whenever(referenceLayerRepository.getSupported("blah")).thenReturn(layer)
+        whenever(referenceLayerRepository.get("blah")).thenReturn(layer)
+
+        val scenario = launcherRule.launch(MapsPreferencesFragment::class.java)
+
+        scenario.onFragment {
+            assertThat(
+                it.findPreference<Preference>(ProjectKeys.KEY_REFERENCE_LAYER)!!.summary,
+                equalTo("blah")
+            )
+        }
     }
 }

--- a/maps/src/main/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepository.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepository.kt
@@ -28,6 +28,14 @@ class DirectoryReferenceLayerRepository(
         }
     }
 
+    override fun getSupported(id: String): ReferenceLayer? {
+        val layer = get(id)
+        if (layer != null && mapConfigurator.supportsLayer(layer.file)) {
+            return layer
+        }
+        return null
+    }
+
     override fun addLayer(file: File, shared: Boolean) {
         if (shared) {
             file.copyTo(File(sharedLayersDirPath, file.name), true)

--- a/maps/src/main/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepository.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepository.kt
@@ -46,7 +46,7 @@ class DirectoryReferenceLayerRepository(
         }
     }
 
-    private fun getIdForFile(directoryPath: String, file: File) =
+    fun getIdForFile(directoryPath: String, file: File) =
         PathUtils.getRelativeFilePath(directoryPath, file.absolutePath)
 
     private fun getName(file: File): String {

--- a/maps/src/main/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepository.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepository.kt
@@ -21,19 +21,11 @@ class DirectoryReferenceLayerRepository(
     override fun get(id: String): ReferenceLayer? {
         val file = getAllFilesWithDirectory().firstOrNull { getIdForFile(it.second, it.first) == id }
 
-        return if (file != null) {
+        return if (file != null && mapConfigurator.supportsLayer(file.first)) {
             ReferenceLayer(getIdForFile(file.second, file.first), file.first, getName(file.first))
         } else {
             null
         }
-    }
-
-    override fun getSupported(id: String): ReferenceLayer? {
-        val layer = get(id)
-        if (layer != null && mapConfigurator.supportsLayer(layer.file)) {
-            return layer
-        }
-        return null
     }
 
     override fun addLayer(file: File, shared: Boolean) {

--- a/maps/src/main/java/org/odk/collect/maps/layers/ReferenceLayerRepository.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/ReferenceLayerRepository.kt
@@ -6,6 +6,7 @@ interface ReferenceLayerRepository {
 
     fun getAll(): List<ReferenceLayer>
     fun get(id: String): ReferenceLayer?
+    fun getSupported(id: String): ReferenceLayer?
     fun addLayer(file: File, shared: Boolean)
     fun delete(id: String)
 }

--- a/maps/src/main/java/org/odk/collect/maps/layers/ReferenceLayerRepository.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/ReferenceLayerRepository.kt
@@ -6,7 +6,6 @@ interface ReferenceLayerRepository {
 
     fun getAll(): List<ReferenceLayer>
     fun get(id: String): ReferenceLayer?
-    fun getSupported(id: String): ReferenceLayer?
     fun addLayer(file: File, shared: Boolean)
     fun delete(id: String)
 }

--- a/maps/src/test/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepositoryTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepositoryTest.kt
@@ -86,7 +86,7 @@ class DirectoryReferenceLayerRepositoryTest {
     }
 
     @Test
-    fun get_returnsLayer() {
+    fun get_returnsProperLayer() {
         val file1 = TempFiles.createTempFile(sharedLayersDir)
         val file2 = TempFiles.createTempFile(sharedLayersDir)
         mapConfigurator.apply {
@@ -96,6 +96,17 @@ class DirectoryReferenceLayerRepositoryTest {
 
         val file2Layer = repository.getAll().first { it.file == file2 }
         assertThat(repository.get(file2Layer.id)!!.file, equalTo(file2))
+    }
+
+    @Test
+    fun get_returnsNullIfLayerIsNotSupported() {
+        val file = TempFiles.createTempFile(sharedLayersDir)
+        mapConfigurator.apply {
+            addFile(file, false, file.name)
+        }
+
+        val fileId = repository.getIdForFile(sharedLayersDir.absolutePath, file)
+        assertThat(repository.get(fileId), equalTo(null))
     }
 
     @Test

--- a/maps/src/test/java/org/odk/collect/maps/layers/MapFragmentReferenceLayerUtilsTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/MapFragmentReferenceLayerUtilsTest.kt
@@ -45,12 +45,15 @@ class MapFragmentReferenceLayerUtilsTest {
     @Test
     fun whenOfflineLayerFileExist_should_getReferenceLayerFileReturnThatFile() {
         val layersPath = createTempDir().absolutePath
-        File(layersPath, "blah").writeBytes(byteArrayOf())
+        val file = File(layersPath, "blah").also {
+            it.writeBytes(byteArrayOf())
+        }
 
         val config = Bundle()
         config.putString(MapFragment.KEY_REFERENCE_LAYER, "blah")
 
         val mapConfigurator = mock<MapConfigurator>().also {
+            whenever(it.supportsLayer(file)).thenReturn(true)
             whenever(it.getDisplayName(File(layersPath, "blah"))).thenReturn("blah")
         }
 


### PR DESCRIPTION
Closes #6192 

#### Why is this the best possible solution? Were any other approaches considered?
It was a stupid mistake with an extra line left in https://github.com/getodk/collect/pull/6184/files#diff-36f54d94492ef437156984d26797b377ab56d837b458397629723df876d81e1dR159
I've added more tests to cover this case.
The only additional change worth discussing is that I've reworked the `get` method from [DirectoryReferenceLayerRepository.kt](https://github.com/getodk/collect/pull/6193/commits/417055fe7ac1bfb1c319966b0245e803d231f1d2#diff-3b613311b01941bd000bafd5d5b725b4ea1ef8fa92a9f8a7b0f713e1f5def591) so that now it doesn't return a layer if it's an unsupported one. Thanks to that I don't have to check if a layer is supported in preferences. This might look weird at first glance but it matches what `getAll` does so now it's consistent.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Everything that is related to displaying proper layers/layer names is at risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
