### PR TITLE
Fixed setting fragment factories

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
@@ -137,19 +137,17 @@ public class GeoPointMapActivity extends LocalizedActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
+        ((GeoDependencyComponentProvider) getApplication()).getGeoDependencyComponent().inject(this);
         getSupportFragmentManager().setFragmentFactory(new FragmentFactoryBuilder()
                 .forClass(MapFragment.class, () -> (Fragment) mapFragmentFactory.createMapFragment())
                 .forClass(OfflineMapLayersPicker.class, () -> new OfflineMapLayersPicker(getActivityResultRegistry(), referenceLayerRepository, scheduler, settingsProvider, externalWebPageHelper))
                 .build()
         );
+        super.onCreate(savedInstanceState);
 
         requireLocationPermissions(this);
 
         previousState = savedInstanceState;
-
-        ((GeoDependencyComponentProvider) getApplication()).getGeoDependencyComponent().inject(this);
 
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         try {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
@@ -150,7 +150,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
     };
 
     @Override public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+        ((GeoDependencyComponentProvider) getApplication()).getGeoDependencyComponent().inject(this);
 
         getSupportFragmentManager().setFragmentFactory(new FragmentFactoryBuilder()
                 .forClass(MapFragment.class, () -> (Fragment) mapFragmentFactory.createMapFragment())
@@ -158,11 +158,11 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
                 .build()
         );
 
+        super.onCreate(savedInstanceState);
+
         requireLocationPermissions(this);
 
         previousState = savedInstanceState;
-
-        ((GeoDependencyComponentProvider) getApplication()).getGeoDependencyComponent().inject(this);
 
         if (savedInstanceState != null) {
             restoredPoints = savedInstanceState.getParcelableArrayList(POINTS_KEY);

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapActivityTest.java
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapActivityTest.java
@@ -1,6 +1,9 @@
 package org.odk.collect.geo.geopoint;
 
 import static android.app.Activity.RESULT_OK;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -32,6 +35,7 @@ import org.odk.collect.geo.support.RobolectricApplication;
 import org.odk.collect.maps.MapFragmentFactory;
 import org.odk.collect.maps.MapPoint;
 import org.odk.collect.maps.layers.ReferenceLayerRepository;
+import org.odk.collect.settings.InMemSettingsProvider;
 import org.odk.collect.settings.SettingsProvider;
 import org.odk.collect.webpage.ExternalWebPageHelper;
 import org.robolectric.shadows.ShadowApplication;
@@ -77,7 +81,7 @@ public class GeoPointMapActivityTest {
                     @NonNull
                     @Override
                     public SettingsProvider providesSettingsProvider() {
-                        return mock();
+                        return new InMemSettingsProvider();
                     }
 
                     @NonNull
@@ -164,5 +168,15 @@ public class GeoPointMapActivityTest {
         mapFragment.ready();
 
         assertThat(mapFragment.isRetainMockAccuracy(), is(false));
+    }
+
+    @Test
+    public void recreatingTheActivityWithTheLayersDialogDisplayedDoesNotCrashTheApp() {
+        ActivityScenario<GeoPointMapActivity> scenario = launcherRule.launch(GeoPointMapActivity.class);
+        mapFragment.ready();
+
+        onView(withId(R.id.layer_menu)).perform(click());
+
+        scenario.recreate();
     }
 }

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.kt
@@ -37,6 +37,7 @@ import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragmentFactory
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.layers.ReferenceLayerRepository
+import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.webpage.ExternalWebPageHelper
 import org.robolectric.Shadows
@@ -79,7 +80,7 @@ class GeoPolyActivityTest {
                 }
 
                 override fun providesSettingsProvider(): SettingsProvider {
-                    return mock()
+                    return InMemSettingsProvider()
                 }
 
                 override fun providesExternalWebPageHelper(): ExternalWebPageHelper {
@@ -280,6 +281,16 @@ class GeoPolyActivityTest {
         launcherRule.launch<Activity>(intent)
         mapFragment.ready()
         assertThat(mapFragment.isPolyDraggable(0), equalTo(false))
+    }
+
+    @Test
+    fun recreatingTheActivityWithTheLayersDialogDisplayedDoesNotCrashTheApp() {
+        val scenario = launcherRule.launch(GeoPolyActivity::class.java)
+        mapFragment.ready()
+
+        onView(withId(R.id.layers)).perform(click())
+
+        scenario.recreate()
     }
 
     private fun startInput(mode: Int) {

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -103,8 +103,8 @@ class FakeMapFragment : Fragment(), MapFragment {
         markerIcons[featureId] = markerIconDescription
     }
 
-    override fun getMarkerPoint(featureId: Int): MapPoint {
-        return markers[featureId]!!
+    override fun getMarkerPoint(featureId: Int): MapPoint? {
+        return markers[featureId]
     }
 
     override fun addPolyLine(lineDescription: LineDescription): Int {


### PR DESCRIPTION
Closes #6194 
Closes #6196 

#### Why is this the best possible solution? Were any other approaches considered?
Fragment factories should be set before calling `super.onCreate` and that was the issue. Moving that also required earlier dagger initialization so I also had to do that before calling `super.onCreate`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think we can focus on testing the issue only. If the map in geowidgets is displayed properly along with the layers dialog everything should be fine.

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
