### PR TITLE
Fix rotation for read only polylines

### DIFF
--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -22,8 +22,8 @@ internal class DynamicPolyLineFeature(
     private val featureClickListener: MapFragment.FeatureListener?,
     private val featureDragEndListener: MapFragment.FeatureListener?,
     private val lineDescription: LineDescription
-) : MapFeature {
-    val mapPoints = mutableListOf<MapPoint>()
+) : LineFeature {
+    override val points = mutableListOf<MapPoint>()
     private val pointAnnotations = mutableListOf<PointAnnotation>()
     private val pointAnnotationClickListener = ClickListener()
     private val pointAnnotationDragListener = DragListener()
@@ -31,7 +31,7 @@ internal class DynamicPolyLineFeature(
 
     init {
         lineDescription.points.forEach {
-            mapPoints.add(it)
+            points.add(it)
             pointAnnotations.add(
                 MapUtils.createPointAnnotation(
                     pointAnnotationManager,
@@ -72,11 +72,11 @@ internal class DynamicPolyLineFeature(
         }
 
         pointAnnotations.clear()
-        mapPoints.clear()
+        points.clear()
     }
 
     fun appendPoint(point: MapPoint) {
-        mapPoints.add(point)
+        points.add(point)
         pointAnnotations.add(
             MapUtils.createPointAnnotation(
                 pointAnnotationManager,
@@ -94,13 +94,13 @@ internal class DynamicPolyLineFeature(
         if (pointAnnotations.isNotEmpty()) {
             pointAnnotationManager.delete(pointAnnotations.last())
             pointAnnotations.removeLast()
-            mapPoints.removeLast()
+            points.removeLast()
             updateLine()
         }
     }
 
     private fun updateLine() {
-        val points = mapPoints
+        val points = points
             .map {
                 Point.fromLngLat(it.longitude, it.latitude, it.altitude)
             }
@@ -145,7 +145,7 @@ internal class DynamicPolyLineFeature(
         override fun onAnnotationDrag(annotation: com.mapbox.maps.plugin.annotation.Annotation<*>) {
             pointAnnotations.forEachIndexed { index, pointAnnotation ->
                 if (annotation.id == pointAnnotation.id) {
-                    mapPoints[index] = MapUtils.mapPointFromPointAnnotation(pointAnnotation)
+                    points[index] = MapUtils.mapPointFromPointAnnotation(pointAnnotation)
                 }
             }
             updateLine()

--- a/mapbox/src/main/java/org/odk/collect/mapbox/LineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/LineFeature.kt
@@ -1,0 +1,7 @@
+package org.odk.collect.mapbox
+
+import org.odk.collect.maps.MapPoint
+
+interface LineFeature : MapFeature {
+    val points: List<MapPoint>
+}

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -389,8 +389,8 @@ class MapboxMapFragment :
 
     override fun getPolyLinePoints(featureId: Int): List<MapPoint> {
         val feature = features[featureId]
-        return if (feature is DynamicPolyLineFeature) {
-            feature.mapPoints
+        return if (feature is LineFeature) {
+            feature.points
         } else {
             emptyList()
         }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
@@ -14,16 +14,16 @@ internal class StaticPolyLineFeature(
     private val featureId: Int,
     private val featureClickListener: MapFragment.FeatureListener?,
     private val lineDescription: LineDescription
-) : MapFeature {
-    private val mapPoints = mutableListOf<MapPoint>()
+) : LineFeature {
+    override val points = mutableListOf<MapPoint>()
     private var polylineAnnotation: PolylineAnnotation? = null
 
     init {
         lineDescription.points.forEach {
-            mapPoints.add(it)
+            points.add(it)
         }
 
-        val points = mapPoints
+        val points = points
             .map {
                 Point.fromLngLat(it.longitude, it.latitude, it.altitude)
             }
@@ -65,6 +65,6 @@ internal class StaticPolyLineFeature(
         polylineAnnotation?.let {
             polylineAnnotationManager.delete(it)
         }
-        mapPoints.clear()
+        points.clear()
     }
 }


### PR DESCRIPTION
Closes #6133 

#### Why is this the best possible solution? Were any other approaches considered?

This is kind of a worst case bug for maps where it affects all three engines, but the code needed fixed sits inside the three different `MapFragment` implementations. There's a pretty obvious "smell" here that we could be sharing some state to avoid this in some way. I think we want to make improvements to that in the next release cycle.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should hopefully just fix the bug! I've not made changes outside the OSM code.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
