### PR TITLE
Fix autosend when using unsupported `auto-send` values

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -189,6 +189,13 @@ abstract class Page<T : Page<T>> {
         return this as T
     }
 
+    fun assertTextDoesNotExistInDialog(text: String?): T {
+        onView(allOf(withText(text), withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+            .inRoot(isDialog())
+            .check(doesNotExist())
+        return this as T
+    }
+
     fun checkIsSnackbarWithQuantityDisplayed(message: Int, quantity: Int): T {
         return checkIsSnackbarWithMessageDisplayed(
             ApplicationProvider.getApplicationContext<Application>()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/SelectMinimalDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/SelectMinimalDialogPage.kt
@@ -2,7 +2,7 @@ package org.odk.collect.android.support.pages
 
 class SelectMinimalDialogPage(private val formName: String) : Page<SelectMinimalDialogPage>() {
     override fun assertOnPage(): SelectMinimalDialogPage {
-        assertTextDoesNotExist(formName)
+        assertTextDoesNotExistInDialog(formName)
         return this
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -8,7 +8,9 @@ import org.odk.collect.android.application.Collect
 import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler
 import org.odk.collect.android.formentry.FormEntryUseCases
 import org.odk.collect.android.formmanagement.CollectFormEntryControllerFactory
+import org.odk.collect.android.instancemanagement.autosend.FormAutoSendMode
 import org.odk.collect.android.instancemanagement.autosend.InstanceAutoSendFetcher
+import org.odk.collect.android.instancemanagement.autosend.getAutoSendMode
 import org.odk.collect.android.notifications.Notifier
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface
 import org.odk.collect.android.projects.ProjectDependencyProviderFactory
@@ -218,7 +220,7 @@ class InstancesDataService(
     }
 
     fun instanceFinalized(projectId: String, form: Form) {
-        if (form.autoSend != null && form.autoSend == "true") {
+        if (form.getAutoSendMode() == FormAutoSendMode.FORCED) {
             instanceSubmitScheduler.scheduleFormAutoSend(projectId)
         } else {
             instanceSubmitScheduler.scheduleAutoSend(projectId)

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/FormExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/FormExt.kt
@@ -17,7 +17,7 @@ fun Form.shouldFormBeSentAutomatically(isAutoSendEnabledInSettings: Boolean): Bo
 }
 
 fun Form.getAutoSendMode(): FormAutoSendMode {
-    return if (autoSend == "false") {
+    return if (autoSend?.trim()?.lowercase() == "false") {
         FormAutoSendMode.OPT_OUT
     } else if (autoSend?.trim()?.lowercase() == "true") {
         FormAutoSendMode.FORCED

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/FormExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/FormExt.kt
@@ -10,8 +10,24 @@ fun Form.shouldFormBeSentAutomatically(isAutoSendEnabledInSettings: Boolean): Bo
     }
 
     return if (isAutoSendEnabledInSettings) {
-        autoSend == null || autoSend.trim().lowercase() != "false"
+        autoSend == null || getAutoSendMode() != FormAutoSendMode.OPT_OUT
     } else {
-        autoSend != null && autoSend.trim().lowercase() == "true"
+        autoSend != null && getAutoSendMode() == FormAutoSendMode.FORCED
     }
+}
+
+fun Form.getAutoSendMode(): FormAutoSendMode {
+    return if (autoSend == "false") {
+        FormAutoSendMode.OPT_OUT
+    } else if (autoSend?.trim()?.lowercase() == "true") {
+        FormAutoSendMode.FORCED
+    } else {
+        FormAutoSendMode.NEUTRAL
+    }
+}
+
+enum class FormAutoSendMode {
+    OPT_OUT,
+    FORCED,
+    NEUTRAL
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/FormExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/FormExt.kt
@@ -10,9 +10,9 @@ fun Form.shouldFormBeSentAutomatically(isAutoSendEnabledInSettings: Boolean): Bo
     }
 
     return if (isAutoSendEnabledInSettings) {
-        autoSend == null || getAutoSendMode() != FormAutoSendMode.OPT_OUT
+        getAutoSendMode() != FormAutoSendMode.OPT_OUT
     } else {
-        autoSend != null && getAutoSendMode() == FormAutoSendMode.FORCED
+        getAutoSendMode() == FormAutoSendMode.FORCED
     }
 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcher.kt
@@ -10,17 +10,17 @@ object InstanceAutoSendFetcher {
     fun getInstancesToAutoSend(
         instancesRepository: InstancesRepository,
         formsRepository: FormsRepository,
-        formAutoSend: Boolean = false
+        forcedOnly: Boolean = false
     ): List<Instance> {
         val allFinalizedForms = instancesRepository.getAllByStatus(
             Instance.STATUS_COMPLETE,
             Instance.STATUS_SUBMISSION_FAILED
         )
 
-        val filter: (Form) -> Boolean = if (formAutoSend) {
-            { form -> form.autoSend != null && form.autoSend == "true" }
+        val filter: (Form) -> Boolean = if (forcedOnly) {
+            { form -> form.getAutoSendMode() == FormAutoSendMode.FORCED }
         } else {
-            { form -> form.autoSend == null }
+            { form -> form.getAutoSendMode() == FormAutoSendMode.NEUTRAL }
         }
 
         return allFinalizedForms.filter {

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/FormExtTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/FormExtTest.kt
@@ -7,72 +7,74 @@ import org.odk.collect.formstest.FormFixtures
 
 class FormExtTest {
     @Test
-    fun `should return true when auto send is not set on a form level and enabled in settings`() {
+    fun `#shouldFormBeSentAutomatically returns true when auto send is not set on a form level and enabled in settings`() {
         val form = FormFixtures.form()
         val result = form.shouldFormBeSentAutomatically(true)
         assertThat(result, equalTo(true))
     }
 
     @Test
-    fun `should return true when auto send is enabled on a form level and enabled in settings`() {
+    fun `#shouldFormBeSentAutomatically returns true when auto send is enabled on a form level and enabled in settings`() {
         val form = FormFixtures.form(autoSend = "true")
         val result = form.shouldFormBeSentAutomatically(true)
         assertThat(result, equalTo(true))
     }
 
     @Test
-    fun `should return true when auto send is enabled on a form level but not sanitized and enabled in settings`() {
-        val form = FormFixtures.form(autoSend = " True ")
-        val result = form.shouldFormBeSentAutomatically(true)
-        assertThat(result, equalTo(true))
-    }
-
-    @Test
-    fun `should return true when auto send is set on a form level but with a wrong value and enabled in settings`() {
-        val form = FormFixtures.form(autoSend = "something")
-        val result = form.shouldFormBeSentAutomatically(true)
-        assertThat(result, equalTo(true))
-    }
-
-    @Test
-    fun `should return true when auto send is enabled on a form level and disabled in settings`() {
+    fun `#shouldFormBeSentAutomatically returns true when auto send is enabled on a form level and disabled in settings`() {
         val form = FormFixtures.form(autoSend = "true")
         val result = form.shouldFormBeSentAutomatically(false)
         assertThat(result, equalTo(true))
     }
 
     @Test
-    fun `should return true when auto send is enabled on a form level but not sanitized and disabled in settings`() {
-        val form = FormFixtures.form(autoSend = " True ")
-        val result = form.shouldFormBeSentAutomatically(false)
-        assertThat(result, equalTo(true))
-    }
-
-    @Test
-    fun `should return false when auto send is not set on a form level and disabled in settings`() {
+    fun `#shouldFormBeSentAutomatically returns false when auto send is not set on a form level and disabled in settings`() {
         val form = FormFixtures.form()
         val result = form.shouldFormBeSentAutomatically(false)
         assertThat(result, equalTo(false))
     }
 
     @Test
-    fun `should return false when auto send is disabled on a form level and disabled in settings`() {
+    fun `#shouldFormBeSentAutomatically returns false when auto send is disabled on a form level and disabled in settings`() {
         val form = FormFixtures.form(autoSend = "false")
         val result = form.shouldFormBeSentAutomatically(false)
         assertThat(result, equalTo(false))
     }
 
     @Test
-    fun `should return false when auto send is disabled on a form level and enabled in settings`() {
+    fun `#shouldFormBeSentAutomatically returns false when auto send is disabled on a form level and enabled in settings`() {
         val form = FormFixtures.form(autoSend = "false")
         val result = form.shouldFormBeSentAutomatically(true)
         assertThat(result, equalTo(false))
     }
 
     @Test
-    fun `should return false when auto send is set on a form level but with a wrong value and disabled in settings`() {
-        val form = FormFixtures.form(autoSend = "something")
-        val result = form.shouldFormBeSentAutomatically(false)
-        assertThat(result, equalTo(false))
+    fun `#getAutoSendMode returns NEUTRAL when autoSend is unsupported`() {
+        val form = FormFixtures.form(autoSend = "blah")
+        assertThat(form.getAutoSendMode(), equalTo(FormAutoSendMode.NEUTRAL))
+    }
+
+    @Test
+    fun `#getAutoSendMode returns FORCED when autoSend is true but incorrectly cased`() {
+        val form = FormFixtures.form(autoSend = "TRUE")
+        assertThat(form.getAutoSendMode(), equalTo(FormAutoSendMode.FORCED))
+    }
+
+    @Test
+    fun `#getAutoSendMode returns FORCED when autoSend is true but with whitespace`() {
+        val form = FormFixtures.form(autoSend = " true ")
+        assertThat(form.getAutoSendMode(), equalTo(FormAutoSendMode.FORCED))
+    }
+
+    @Test
+    fun `#getAutoSendMode returns OPT_OUT when autoSend is false but incorrectly cased`() {
+        val form = FormFixtures.form(autoSend = "FALSE")
+        assertThat(form.getAutoSendMode(), equalTo(FormAutoSendMode.OPT_OUT))
+    }
+
+    @Test
+    fun `#getAutoSendMode returns OPT_OUT when autoSend is false but with whitespace`() {
+        val form = FormFixtures.form(autoSend = " false ")
+        assertThat(form.getAutoSendMode(), equalTo(FormAutoSendMode.OPT_OUT))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcherTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/autosend/InstanceAutoSendFetcherTest.kt
@@ -85,6 +85,8 @@ class InstanceAutoSendFetcherTest {
             contains(
                 instanceOfFormWithoutSpecifiedAutoSendComplete.instanceFilePath,
                 instanceOfFormWithoutSpecifiedAutoSendSubmissionFailed.instanceFilePath,
+                instanceOfFormWithCustomAutoSendComplete.instanceFilePath,
+                instanceOfFormWithCustomAutoSendSubmissionFailed.instanceFilePath
             )
         )
     }
@@ -121,7 +123,7 @@ class InstanceAutoSendFetcherTest {
         val instancesToSend = InstanceAutoSendFetcher.getInstancesToAutoSend(
             instancesRepository,
             formsRepository,
-            formAutoSend = true
+            forcedOnly = true
         )
 
         assertThat(

--- a/forms/src/main/java/org/odk/collect/forms/Form.java
+++ b/forms/src/main/java/org/odk/collect/forms/Form.java
@@ -262,6 +262,7 @@ public final class Form {
         return language;
     }
 
+    @Nullable
     public String getAutoSend() {
         return autoSend;
     }


### PR DESCRIPTION
Closes #6203

This makes the `auto-send` attribute behaviour (mostly) consistent with older versions. It works as [described in the spec](https://getodk.github.io/xforms-spec/#submission-attributes), with two additions:

- Unsupported values (like "bubblegum", "desktop", "agent dale cooper" etc) are all treated as if there is no `auto-send` attribute and forms will be auto sent based on the setting in Collect. It's likely that people have been using "default" thinking that this means something, but it doesn't.
- The supported values work if the case is wrong ("True" or "tRue" for example) and if they have extra whitespace ("   true" for example).

#### Why is this the best possible solution? Were any other approaches considered?

The biggest change here was to introduce a three element enum to try and make this less confusing. The `auto-send` attribute isn't really a "true" or "false" system - it's a "true" or "false" or "undefined" and to add to that "true" and "false" aren't really opposites. I think going with "forced", "opt-out" and "neutral" is more descriptive.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Nothing has changed except for auto send, but it's always a bit of a minefield due to the fact it has both a setting and a form attribute. I think waiting for a `behaviour verified` tag before merging would be good here.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
