### PR TITLE
Fix layers import view in landscape mode

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ChangesReasonPromptPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ChangesReasonPromptPage.java
@@ -9,7 +9,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-import org.odk.collect.android.support.WaitFor;
+import org.odk.collect.testshared.WaitFor;
 
 import java.util.concurrent.Callable;
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
@@ -19,7 +19,7 @@ import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.espresso.matcher.ViewMatchers;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.support.WaitFor;
+import org.odk.collect.testshared.WaitFor;
 
 public class FillBlankFormPage extends Page<FillBlankFormPage> {
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FirstLaunchPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FirstLaunchPage.kt
@@ -1,8 +1,8 @@
 package org.odk.collect.android.support.pages
 
 import androidx.test.espresso.matcher.ViewMatchers.withSubstring
-import org.odk.collect.android.support.Interactions
 import org.odk.collect.strings.R.string
+import org.odk.collect.testshared.Interactions
 
 class FirstLaunchPage : Page<FirstLaunchPage>() {
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -29,8 +29,8 @@ import androidx.test.core.app.ApplicationProvider;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.odk.collect.android.R;
-import org.odk.collect.android.support.Interactions;
-import org.odk.collect.android.support.WaitFor;
+import org.odk.collect.testshared.Interactions;
+import org.odk.collect.testshared.WaitFor;
 
 import java.util.concurrent.Callable;
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormHierarchyPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormHierarchyPage.java
@@ -13,7 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.test.espresso.contrib.RecyclerViewActions;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.support.WaitFor;
+import org.odk.collect.testshared.WaitFor;
 
 import java.util.concurrent.Callable;
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.StorageUtils;
 import org.odk.collect.android.support.TestScheduler;
-import org.odk.collect.android.support.WaitFor;
+import org.odk.collect.testshared.WaitFor;
 import org.odk.collect.strings.R.string;
 
 import java.io.IOException;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ManualProjectCreatorDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ManualProjectCreatorDialogPage.kt
@@ -3,7 +3,7 @@ package org.odk.collect.android.support.pages
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import org.odk.collect.android.support.WaitFor.tryAgainOnFail
+import org.odk.collect.testshared.WaitFor.tryAgainOnFail
 
 class ManualProjectCreatorDialogPage : Page<ManualProjectCreatorDialogPage>() {
     override fun assertOnPage(): ManualProjectCreatorDialogPage {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -10,7 +10,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
-import org.odk.collect.android.support.WaitFor.waitFor
+import org.odk.collect.testshared.WaitFor.waitFor
 
 class NotificationDrawer {
     private var isOpen = false

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -48,10 +48,6 @@ import org.odk.collect.android.R
 import org.odk.collect.android.application.Collect
 import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.support.ActivityHelpers.getLaunchIntent
-import org.odk.collect.android.support.Interactions
-import org.odk.collect.android.support.WaitFor.tryAgainOnFail
-import org.odk.collect.android.support.WaitFor.wait250ms
-import org.odk.collect.android.support.WaitFor.waitFor
 import org.odk.collect.android.support.actions.RotateAction
 import org.odk.collect.android.support.matchers.CustomMatchers.withIndex
 import org.odk.collect.android.support.rules.RecentAppsRule
@@ -61,7 +57,11 @@ import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.strings.localization.getLocalizedQuantityString
 import org.odk.collect.strings.localization.getLocalizedString
 import org.odk.collect.testshared.EspressoHelpers
+import org.odk.collect.testshared.Interactions
 import org.odk.collect.testshared.RecyclerViewMatcher
+import org.odk.collect.testshared.WaitFor.tryAgainOnFail
+import org.odk.collect.testshared.WaitFor.wait250ms
+import org.odk.collect.testshared.WaitFor.waitFor
 import timber.log.Timber
 import java.io.File
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -56,7 +56,7 @@ import org.odk.collect.androidshared.ui.ToastUtils.popRecordedToasts
 import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.strings.localization.getLocalizedQuantityString
 import org.odk.collect.strings.localization.getLocalizedString
-import org.odk.collect.testshared.EspressoHelpers
+import org.odk.collect.testshared.Assertions
 import org.odk.collect.testshared.Interactions
 import org.odk.collect.testshared.RecyclerViewMatcher
 import org.odk.collect.testshared.WaitFor.tryAgainOnFail
@@ -131,7 +131,7 @@ abstract class Page<T : Page<T>> {
     }
 
     fun assertText(text: String): T {
-        EspressoHelpers.assertText(text)
+        Assertions.assertText(text)
         return this as T
     }
 
@@ -185,7 +185,12 @@ abstract class Page<T : Page<T>> {
     }
 
     fun assertTextDoesNotExist(text: String?): T {
-        onView(allOf(withText(text), withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))).check(doesNotExist())
+        onView(
+            allOf(
+                withText(text),
+                withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)
+            )
+        ).check(doesNotExist())
         return this as T
     }
 
@@ -295,11 +300,13 @@ abstract class Page<T : Page<T>> {
     }
 
     fun getTranslatedString(id: Int?, vararg formatArgs: Any): String {
-        return ApplicationProvider.getApplicationContext<Collect>().getLocalizedString(id!!, *formatArgs)
+        return ApplicationProvider.getApplicationContext<Collect>()
+            .getLocalizedString(id!!, *formatArgs)
     }
 
     fun getTranslatedQuantityString(id: Int?, quantity: Int, vararg formatArgs: Any): String {
-        return ApplicationProvider.getApplicationContext<Collect>().getLocalizedQuantityString(id!!, quantity, *formatArgs)
+        return ApplicationProvider.getApplicationContext<Collect>()
+            .getLocalizedQuantityString(id!!, quantity, *formatArgs)
     }
 
     fun clickOnAreaWithIndex(clazz: String?, index: Int): T {
@@ -366,25 +373,56 @@ abstract class Page<T : Page<T>> {
     }
 
     fun checkIsSnackbarErrorVisible(): T {
-        onView(allOf(withId(com.google.android.material.R.id.snackbar_text))).check(matches(isDisplayed()))
+        onView(allOf(withId(com.google.android.material.R.id.snackbar_text))).check(
+            matches(
+                isDisplayed()
+            )
+        )
         return this as T
     }
 
     fun scrollToRecyclerViewItemAndClickText(text: String?): T {
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(hasDescendant(withText(text)), scrollTo()))
-        onView(withId(androidx.preference.R.id.recycler_view)).perform(RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(hasDescendant(withText(text)), click()))
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(
+            RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
+                hasDescendant(withText(text)),
+                scrollTo()
+            )
+        )
+        onView(withId(androidx.preference.R.id.recycler_view)).perform(
+            RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
+                hasDescendant(withText(text)),
+                click()
+            )
+        )
         return this as T
     }
 
     fun scrollToRecyclerViewItemAndClickText(string: Int): T {
-        onView(ViewMatchers.isAssignableFrom(RecyclerView::class.java)).perform(RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(hasDescendant(withText(getTranslatedString(string))), scrollTo()))
-        onView(ViewMatchers.isAssignableFrom(RecyclerView::class.java)).perform(RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(hasDescendant(withText(getTranslatedString(string))), click()))
+        onView(ViewMatchers.isAssignableFrom(RecyclerView::class.java)).perform(
+            RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
+                hasDescendant(withText(getTranslatedString(string))),
+                scrollTo()
+            )
+        )
+        onView(ViewMatchers.isAssignableFrom(RecyclerView::class.java)).perform(
+            RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
+                hasDescendant(withText(getTranslatedString(string))),
+                click()
+            )
+        )
         return this as T
     }
 
     fun clickOnElementInHierarchy(index: Int): T {
-        onView(withId(R.id.list)).perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(index))
-        onView(RecyclerViewMatcher.withRecyclerView(R.id.list).atPositionOnView(index, R.id.primary_text)).perform(click())
+        onView(withId(R.id.list)).perform(
+            RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(
+                index
+            )
+        )
+        onView(
+            RecyclerViewMatcher.withRecyclerView(R.id.list)
+                .atPositionOnView(index, R.id.primary_text)
+        ).perform(click())
         return this as T
     }
 
@@ -394,7 +432,10 @@ abstract class Page<T : Page<T>> {
     }
 
     fun checkIfElementInHierarchyMatchesToText(text: String?, index: Int): T {
-        onView(RecyclerViewMatcher.withRecyclerView(R.id.list).atPositionOnView(index, R.id.primary_text)).check(matches(withText(text)))
+        onView(
+            RecyclerViewMatcher.withRecyclerView(R.id.list)
+                .atPositionOnView(index, R.id.primary_text)
+        ).check(matches(withText(text)))
         return this as T
     }
 
@@ -412,7 +453,12 @@ abstract class Page<T : Page<T>> {
     }
 
     protected fun assertToolbarTitle(title: String?) {
-        onView(allOf(withText(title), isDescendantOfA(withId(org.odk.collect.androidshared.R.id.toolbar)))).check(matches(isDisplayed()))
+        onView(
+            allOf(
+                withText(title),
+                isDescendantOfA(withId(org.odk.collect.androidshared.R.id.toolbar))
+            )
+        ).check(matches(isDisplayed()))
     }
 
     protected fun assertToolbarTitle(title: Int) {
@@ -430,11 +476,14 @@ abstract class Page<T : Page<T>> {
     }
 
     fun clickOnContentDescription(string: Int): T {
-        EspressoHelpers.clickOnContentDescription(string)
+        Interactions.clickOn(withContentDescription(string))
         return this as T
     }
 
-    fun assertFileWithProjectNameUpdated(sanitizedOldProjectName: String, sanitizedNewProjectName: String): T {
+    fun assertFileWithProjectNameUpdated(
+        sanitizedOldProjectName: String,
+        sanitizedNewProjectName: String
+    ): T {
         val storagePathProvider = StoragePathProvider()
         Assert.assertFalse(File(storagePathProvider.getProjectRootDirPath() + File.separator + sanitizedOldProjectName).exists())
         Assert.assertTrue(File(storagePathProvider.getProjectRootDirPath() + File.separator + sanitizedNewProjectName).exists())

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -131,7 +131,7 @@ abstract class Page<T : Page<T>> {
     }
 
     fun assertText(text: String): T {
-        Assertions.assertText(text)
+        Assertions.assertText(withText(text))
         return this as T
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
@@ -10,7 +10,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.Matchers.allOf
-import org.odk.collect.android.support.WaitFor
+import org.odk.collect.testshared.WaitFor
 
 internal class ProjectSettingsDialogPage : Page<ProjectSettingsDialogPage>() {
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QRCodePage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QRCodePage.java
@@ -13,7 +13,7 @@ import android.graphics.Bitmap;
 import androidx.test.espresso.Espresso;
 
 import org.odk.collect.android.support.ActivityHelpers;
-import org.odk.collect.android.support.WaitFor;
+import org.odk.collect.testshared.WaitFor;
 import org.odk.collect.androidtest.DrawableMatcher;
 
 public class QRCodePage extends Page<QRCodePage> {

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormFillingActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormFillingActivityTest.kt
@@ -7,6 +7,9 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.DialogFragment
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.WorkManager
 import org.hamcrest.MatcherAssert.assertThat
@@ -36,12 +39,10 @@ import org.odk.collect.formstest.FormFixtures.form
 import org.odk.collect.strings.R
 import org.odk.collect.testshared.ActivityControllerRule
 import org.odk.collect.testshared.AssertIntentsHelper
-import org.odk.collect.testshared.EspressoHelpers.assertText
-import org.odk.collect.testshared.EspressoHelpers.assertTextInDialog
-import org.odk.collect.testshared.EspressoHelpers.clickOnContentDescription
-import org.odk.collect.testshared.EspressoHelpers.clickOnText
-import org.odk.collect.testshared.EspressoHelpers.clickOnTextInDialog
+import org.odk.collect.testshared.Assertions.assertText
+import org.odk.collect.testshared.Assertions.assertTextInDialog
 import org.odk.collect.testshared.FakeScheduler
+import org.odk.collect.testshared.Interactions
 import org.odk.collect.testshared.RobolectricHelpers.recreateWithProcessRestore
 import org.robolectric.Shadows.shadowOf
 import java.io.File
@@ -95,7 +96,7 @@ class FormFillingActivityTest {
         assertText("Two Question")
         assertText("What is your name?")
 
-        clickOnText(R.string.form_forward)
+        Interactions.clickOn(withText(R.string.form_forward))
         scheduler.flush()
         assertText("What is your age?")
 
@@ -133,11 +134,11 @@ class FormFillingActivityTest {
         assertText("Two Question")
         assertText("What is your name?")
 
-        clickOnText(R.string.form_forward)
+        Interactions.clickOn(withText(R.string.form_forward))
         scheduler.flush()
         assertText("What is your age?")
 
-        clickOnContentDescription(R.string.view_hierarchy)
+        Interactions.clickOn(withContentDescription(R.string.view_hierarchy))
         assertIntentsHelper.assertNewIntent(FormHierarchyActivity::class)
 
         // Recreate and assert we start FormHierarchyActivity
@@ -174,7 +175,7 @@ class FormFillingActivityTest {
         assertText("Two Question")
         assertText("What is your name?")
 
-        clickOnText(R.string.form_forward)
+        Interactions.clickOn(withText(R.string.form_forward))
         scheduler.flush()
         assertText("What is your age?")
 
@@ -219,12 +220,12 @@ class FormFillingActivityTest {
         assertText("Two Question")
         assertText("What is your name?")
 
-        clickOnText(R.string.form_forward)
+        Interactions.clickOn(withText(R.string.form_forward))
         scheduler.flush()
         assertText("What is your age?")
 
         // Open external app
-        clickOnContentDescription(R.string.launch_app)
+        Interactions.clickOn(withContentDescription(R.string.launch_app))
         assertIntentsHelper.assertNewIntent(hasAction("com.example.EXAMPLE"))
 
         // Recreate with result
@@ -259,7 +260,7 @@ class FormFillingActivityTest {
         scheduler.flush()
         assertTextInDialog("This form no longer exists, please email support@getodk.org with a description of what you were doing when this happened.")
 
-        clickOnTextInDialog(R.string.ok)
+        Interactions.clickOn(withText(R.string.ok), root = isDialog())
         assertThat(scenario.isFinishing, equalTo(true))
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormFillingActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormFillingActivityTest.kt
@@ -40,7 +40,6 @@ import org.odk.collect.strings.R
 import org.odk.collect.testshared.ActivityControllerRule
 import org.odk.collect.testshared.AssertIntentsHelper
 import org.odk.collect.testshared.Assertions.assertText
-import org.odk.collect.testshared.Assertions.assertTextInDialog
 import org.odk.collect.testshared.FakeScheduler
 import org.odk.collect.testshared.Interactions
 import org.odk.collect.testshared.RobolectricHelpers.recreateWithProcessRestore
@@ -93,12 +92,12 @@ class FormFillingActivityTest {
         // Start activity
         val initial = activityControllerRule.build(FormFillingActivity::class.java, intent).setup()
         scheduler.flush()
-        assertText("Two Question")
-        assertText("What is your name?")
+        assertText(withText("Two Question"))
+        assertText(withText("What is your name?"))
 
         Interactions.clickOn(withText(R.string.form_forward))
         scheduler.flush()
-        assertText("What is your age?")
+        assertText(withText("What is your age?"))
 
         // Recreate and assert we start FormHierarchyActivity
         val recreated = activityControllerRule.add {
@@ -113,8 +112,8 @@ class FormFillingActivityTest {
         shadowOf(recreated.get()).receiveResult(hierarchyIntent, Activity.RESULT_CANCELED, null)
         scheduler.flush()
 
-        assertText("Two Question")
-        assertText("What is your age?")
+        assertText(withText("Two Question"))
+        assertText(withText("What is your age?"))
     }
 
     @Test
@@ -131,12 +130,12 @@ class FormFillingActivityTest {
         // Start activity
         val initial = activityControllerRule.build(FormFillingActivity::class.java, intent).setup()
         scheduler.flush()
-        assertText("Two Question")
-        assertText("What is your name?")
+        assertText(withText("Two Question"))
+        assertText(withText("What is your name?"))
 
         Interactions.clickOn(withText(R.string.form_forward))
         scheduler.flush()
-        assertText("What is your age?")
+        assertText(withText("What is your age?"))
 
         Interactions.clickOn(withContentDescription(R.string.view_hierarchy))
         assertIntentsHelper.assertNewIntent(FormHierarchyActivity::class)
@@ -154,8 +153,8 @@ class FormFillingActivityTest {
         shadowOf(recreated.get()).receiveResult(hierarchyIntent, Activity.RESULT_CANCELED, null)
         scheduler.flush()
 
-        assertText("Two Question")
-        assertText("What is your age?")
+        assertText(withText("Two Question"))
+        assertText(withText("What is your age?"))
     }
 
     @Test
@@ -172,12 +171,12 @@ class FormFillingActivityTest {
         // Start activity
         val initial = activityControllerRule.build(FormFillingActivity::class.java, intent).setup()
         scheduler.flush()
-        assertText("Two Question")
-        assertText("What is your name?")
+        assertText(withText("Two Question"))
+        assertText(withText("What is your name?"))
 
         Interactions.clickOn(withText(R.string.form_forward))
         scheduler.flush()
-        assertText("What is your age?")
+        assertText(withText("What is your age?"))
 
         val initialFragmentManager = initial.get().supportFragmentManager
         DialogFragmentUtils.showIfNotShowing(TestDialogFragment::class.java, initialFragmentManager)
@@ -199,8 +198,8 @@ class FormFillingActivityTest {
         shadowOf(recreated.get()).receiveResult(hierarchyIntent, Activity.RESULT_CANCELED, null)
         scheduler.flush()
 
-        assertText("Two Question")
-        assertText("What is your age?")
+        assertText(withText("Two Question"))
+        assertText(withText("What is your age?"))
     }
 
     @Test
@@ -217,12 +216,12 @@ class FormFillingActivityTest {
         // Start activity
         val initial = activityControllerRule.build(FormFillingActivity::class.java, intent).setup()
         scheduler.flush()
-        assertText("Two Question")
-        assertText("What is your name?")
+        assertText(withText("Two Question"))
+        assertText(withText("What is your name?"))
 
         Interactions.clickOn(withText(R.string.form_forward))
         scheduler.flush()
-        assertText("What is your age?")
+        assertText(withText("What is your age?"))
 
         // Open external app
         Interactions.clickOn(withContentDescription(R.string.launch_app))
@@ -237,9 +236,9 @@ class FormFillingActivityTest {
         scheduler.flush()
 
         assertIntentsHelper.assertNoNewIntent()
-        assertText("Two Question")
-        assertText("What is your age?")
-        assertText("159")
+        assertText(withText("Two Question"))
+        assertText(withText("What is your age?"))
+        assertText(withText("159"))
     }
 
     /**
@@ -258,7 +257,10 @@ class FormFillingActivityTest {
 
         val scenario = scenarioLauncherRule.launch<FormFillingActivity>(intent)
         scheduler.flush()
-        assertTextInDialog("This form no longer exists, please email support@getodk.org with a description of what you were doing when this happened.")
+        assertText(
+            withText("This form no longer exists, please email support@getodk.org with a description of what you were doing when this happened."),
+            root = isDialog()
+        )
 
         Interactions.clickOn(withText(R.string.ok), root = isDialog())
         assertThat(scenario.isFinishing, equalTo(true))

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersImporter.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersImporter.kt
@@ -21,19 +21,21 @@ class OfflineMapLayersImporter(
     val viewModel: OfflineMapLayersViewModel by activityViewModels {
         object : ViewModelProvider.Factory {
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return OfflineMapLayersViewModel(referenceLayerRepository, scheduler, settingsProvider) as T
+                return OfflineMapLayersViewModel(
+                    referenceLayerRepository,
+                    scheduler,
+                    settingsProvider
+                ) as T
             }
         }
     }
-
-    private lateinit var binding: OfflineMapLayersImporterBinding
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = OfflineMapLayersImporterBinding.inflate(inflater)
+        val binding = OfflineMapLayersImporterBinding.inflate(inflater)
 
         binding.cancelButton.setOnClickListener {
             dismiss()
@@ -48,6 +50,7 @@ class OfflineMapLayersImporter(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val binding = OfflineMapLayersImporterBinding.bind(view)
 
         viewModel.isLoading.observe(this) { isLoading ->
             if (isLoading) {
@@ -74,6 +77,6 @@ class OfflineMapLayersImporter(
     }
 
     override fun getToolbar(): Toolbar {
-        return binding.toolbar
+        return OfflineMapLayersImporterBinding.bind(requireView()).toolbar
     }
 }

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
@@ -48,8 +48,6 @@ class OfflineMapLayersPicker(
         }
     }
 
-    private lateinit var binding: OfflineMapLayersPickerBinding
-
     private val getLayers = registerForActivityResult(ActivityResultContracts.GetMultipleContents(), registry) { uris ->
         if (uris.isNotEmpty()) {
             sharedViewModel.loadLayersToImport(uris, requireContext())
@@ -75,7 +73,7 @@ class OfflineMapLayersPicker(
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = OfflineMapLayersPickerBinding.inflate(inflater)
+        val binding = OfflineMapLayersPickerBinding.inflate(inflater)
 
         binding.mbtilesInfoGroup.addOnClickListener {
             externalWebPageHelper.openWebPageInCustomTab(
@@ -101,7 +99,7 @@ class OfflineMapLayersPicker(
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+        val binding = OfflineMapLayersPickerBinding.bind(view)
 
         sharedViewModel.isLoading.observe(this) { isLoading ->
             if (isLoading) {

--- a/maps/src/main/res/layout/offline_map_layers_importer.xml
+++ b/maps/src/main/res/layout/offline_map_layers_importer.xml
@@ -27,6 +27,7 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:fillViewport="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/toolbar_container">
 
@@ -64,11 +65,10 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/margin_small"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constrainedHeight="true"
                     app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHeight_max="320dp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0" />
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <com.google.android.material.progressindicator.CircularProgressIndicator
                     android:id="@+id/progress_indicator"
@@ -79,8 +79,7 @@
                     app:layout_constrainedHeight="true"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintVertical_bias="0" />
+                    app:layout_constraintTop_toTopOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -175,7 +174,6 @@
                 app:layout_constraintEnd_toEndOf="parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-
 
     </androidx.core.widget.NestedScrollView>
 

--- a/maps/src/main/res/layout/offline_map_layers_importer.xml
+++ b/maps/src/main/res/layout/offline_map_layers_importer.xml
@@ -19,149 +19,164 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:navigationIcon="@null"
-            app:title="@string/add_layer"/>
+            app:title="@string/add_layer" />
 
-        <include layout="@layout/app_bar_shadow"/>
+        <include layout="@layout/app_bar_shadow" />
     </com.google.android.material.appbar.AppBarLayout>
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/layers_title"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:text="@string/layers_list_title"
-        android:textAppearance="?textAppearanceTitleLarge"
-        android:layout_marginHorizontal="@dimen/margin_standard"
-        android:layout_marginTop="@dimen/margin_small"
-        app:layout_constraintTop_toBottomOf="@id/toolbar_container"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layers_container"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constrainedHeight="true"
-        app:layout_constraintVertical_bias="0"
-        app:layout_constraintStart_toStartOf="@id/layers_title"
-        app:layout_constraintEnd_toEndOf="@id/layers_title"
-        app:layout_constraintBottom_toTopOf="@id/container"
-        app:layout_constraintTop_toBottomOf="@id/layers_title"
-        app:layout_constraintVertical_chainStyle="packed">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/layers"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_small"
-            app:layout_constrainedHeight="true"
-            app:layout_constraintVertical_bias="0"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <com.google.android.material.progressindicator.CircularProgressIndicator
-            android:id="@+id/progress_indicator"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginVertical="@dimen/margin_small"
-            app:layout_constrainedHeight="true"
-            app:layout_constraintVertical_bias="0"
-            android:indeterminate="true"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/container"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/layers_container"
-        app:layout_constraintBottom_toTopOf="@id/bottom_divider"
-        app:layout_constraintStart_toStartOf="@id/layers_title"
-        app:layout_constraintEnd_toEndOf="@id/layers_title">
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/select_layer_access_title"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/select_layer_access_title"
-            android:textAppearance="?textAppearanceTitleLarge"
-            android:layout_marginTop="@dimen/margin_standard"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/select_layer_access_subtitle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/select_layer_access_subtitle"
-            android:textAppearance="?textAppearanceBodyMedium"
-            android:layout_marginTop="@dimen/margin_standard"
-            app:layout_constraintTop_toBottomOf="@id/select_layer_access_title"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
-
-        <RadioGroup
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/margin_small"
-            android:layout_marginTop="@dimen/margin_extra_extra_small"
-            android:checkedButton="@id/all_projects_option"
-            app:layout_constraintTop_toBottomOf="@id/select_layer_access_subtitle"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
-
-            <RadioButton
-                android:id="@+id/all_projects_option"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="@dimen/margin_standard"
-                android:translationX="-5dp"
-                android:textAppearance="?textAppearanceBodyMedium"
-                android:text="@string/all_projects_option"/>
-
-            <RadioButton
-                android:id="@+id/current_project_option"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="@dimen/margin_standard"
-                android:translationX="-5dp"
-                android:textAppearance="?textAppearanceBodyMedium"
-                android:text="@string/current_project_option"/>
-        </RadioGroup>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <View
-        android:id="@+id/bottom_divider"
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@drawable/list_item_divider"
-        android:layout_marginBottom="@dimen/margin_extra_extra_small"
-        app:layout_constraintBottom_toTopOf="@id/cancel_button" />
-
-    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
-        android:id="@+id/cancel_button"
-        style="?borderlessButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/cancel"
-        android:layout_marginBottom="@dimen/margin_extra_extra_small"
-        app:layout_constraintBottom_toBottomOf="@id/add_layer_button"
-        app:layout_constraintEnd_toStartOf="@id/add_layer_button"
-        app:layout_constraintTop_toTopOf="@id/add_layer_button" />
-
-    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
-        android:id="@+id/add_layer_button"
-        style="?materialButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_standard"
-        android:layout_marginBottom="@dimen/margin_extra_small"
-        android:text="@string/add_layer"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/toolbar_container">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/layers_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/margin_standard"
+                android:layout_marginTop="@dimen/margin_small"
+                android:text="@string/layers_list_title"
+                android:textAppearance="?textAppearanceTitleLarge"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layers_container"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constrainedHeight="true"
+                app:layout_constraintBottom_toTopOf="@id/container"
+                app:layout_constraintEnd_toEndOf="@id/layers_title"
+                app:layout_constraintStart_toStartOf="@id/layers_title"
+                app:layout_constraintTop_toBottomOf="@id/layers_title"
+                app:layout_constraintVertical_bias="0"
+                app:layout_constraintVertical_chainStyle="packed">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/layers"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constrainedHeight="true"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0" />
+
+                <com.google.android.material.progressindicator.CircularProgressIndicator
+                    android:id="@+id/progress_indicator"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/margin_small"
+                    android:indeterminate="true"
+                    app:layout_constrainedHeight="true"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/container"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toTopOf="@id/bottom_divider"
+                app:layout_constraintEnd_toEndOf="@id/layers_title"
+                app:layout_constraintStart_toStartOf="@id/layers_title"
+                app:layout_constraintTop_toBottomOf="@id/layers_container">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/select_layer_access_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_standard"
+                    android:text="@string/select_layer_access_title"
+                    android:textAppearance="?textAppearanceTitleLarge"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/select_layer_access_subtitle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_standard"
+                    android:text="@string/select_layer_access_subtitle"
+                    android:textAppearance="?textAppearanceBodyMedium"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/select_layer_access_title" />
+
+                <RadioGroup
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_extra_small"
+                    android:checkedButton="@id/all_projects_option"
+                    android:paddingBottom="@dimen/margin_small"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/select_layer_access_subtitle">
+
+                    <RadioButton
+                        android:id="@+id/all_projects_option"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingStart="@dimen/margin_standard"
+                        android:text="@string/all_projects_option"
+                        android:textAppearance="?textAppearanceBodyMedium"
+                        android:translationX="-5dp" />
+
+                    <RadioButton
+                        android:id="@+id/current_project_option"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingStart="@dimen/margin_standard"
+                        android:text="@string/current_project_option"
+                        android:textAppearance="?textAppearanceBodyMedium"
+                        android:translationX="-5dp" />
+                </RadioGroup>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <View
+                android:id="@+id/bottom_divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginBottom="@dimen/margin_extra_extra_small"
+                android:background="@drawable/list_item_divider"
+                app:layout_constraintBottom_toTopOf="@id/cancel_button" />
+
+            <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+                android:id="@+id/cancel_button"
+                style="?borderlessButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_extra_extra_small"
+                android:text="@string/cancel"
+                app:layout_constraintBottom_toBottomOf="@id/add_layer_button"
+                app:layout_constraintEnd_toStartOf="@id/add_layer_button"
+                app:layout_constraintTop_toTopOf="@id/add_layer_button" />
+
+            <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+                android:id="@+id/add_layer_button"
+                style="?materialButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/margin_standard"
+                android:layout_marginBottom="@dimen/margin_extra_small"
+                android:text="@string/add_layer"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    </androidx.core.widget.NestedScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
@@ -4,6 +4,7 @@ import androidx.core.net.toUri
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -203,7 +204,7 @@ class OfflineMapLayersImporterTest {
 
         scheduler.flush()
 
-        onView(withId(org.odk.collect.maps.R.id.add_layer_button)).perform(click())
+        onView(withId(org.odk.collect.maps.R.id.add_layer_button)).perform(scrollTo(), click())
         scheduler.flush()
 
         val fileCaptor = argumentCaptor<File>()
@@ -229,7 +230,7 @@ class OfflineMapLayersImporterTest {
 
         onView(withId(org.odk.collect.maps.R.id.current_project_option)).perform(click())
 
-        onView(withId(org.odk.collect.maps.R.id.add_layer_button)).perform(click())
+        onView(withId(org.odk.collect.maps.R.id.add_layer_button)).perform(scrollTo(), click())
         scheduler.flush()
 
         val fileCaptor = argumentCaptor<File>()

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
@@ -3,8 +3,6 @@ package org.odk.collect.maps.layers
 import androidx.core.net.toUri
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -64,7 +62,7 @@ class OfflineMapLayersImporterTest {
             scheduler.flush()
             assertThat(it.isVisible, equalTo(true))
             it.viewModel.loadLayersToImport(emptyList(), it.requireContext())
-            onView(withId(org.odk.collect.maps.R.id.add_layer_button)).perform(click())
+            Interactions.clickOn(withId(org.odk.collect.maps.R.id.add_layer_button))
             scheduler.flush()
             RobolectricHelpers.runLooper()
             assertThat(it.isVisible, equalTo(false))
@@ -120,12 +118,12 @@ class OfflineMapLayersImporterTest {
         launchFragment()
         scheduler.flush()
 
-        onView(withId(org.odk.collect.maps.R.id.current_project_option)).perform(click())
+        Interactions.clickOn(withId(org.odk.collect.maps.R.id.current_project_option))
 
         onView(withId(org.odk.collect.maps.R.id.all_projects_option)).check(matches(not(isChecked())))
         onView(withId(org.odk.collect.maps.R.id.current_project_option)).check(matches(isChecked()))
 
-        onView(withId(org.odk.collect.maps.R.id.all_projects_option)).perform(click())
+        Interactions.clickOn(withId(org.odk.collect.maps.R.id.all_projects_option))
 
         onView(withId(org.odk.collect.maps.R.id.all_projects_option)).check(matches(isChecked()))
         onView(withId(org.odk.collect.maps.R.id.current_project_option)).check(matches(not(isChecked())))
@@ -136,7 +134,7 @@ class OfflineMapLayersImporterTest {
         val scenario = launchFragment()
         scheduler.flush()
 
-        onView(withId(org.odk.collect.maps.R.id.current_project_option)).perform(click())
+        Interactions.clickOn(withId(org.odk.collect.maps.R.id.current_project_option))
 
         scenario.recreate()
 
@@ -204,7 +202,7 @@ class OfflineMapLayersImporterTest {
 
         scheduler.flush()
 
-        onView(withId(org.odk.collect.maps.R.id.add_layer_button)).perform(scrollTo(), click())
+        Interactions.clickOn(withId(org.odk.collect.maps.R.id.add_layer_button))
         scheduler.flush()
 
         val fileCaptor = argumentCaptor<File>()
@@ -228,9 +226,8 @@ class OfflineMapLayersImporterTest {
 
         scheduler.flush()
 
-        onView(withId(org.odk.collect.maps.R.id.current_project_option)).perform(click())
-
-        onView(withId(org.odk.collect.maps.R.id.add_layer_button)).perform(scrollTo(), click())
+        Interactions.clickOn(withId(org.odk.collect.maps.R.id.current_project_option))
+        Interactions.clickOn(withId(org.odk.collect.maps.R.id.add_layer_button))
         scheduler.flush()
 
         val fileCaptor = argumentCaptor<File>()

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
@@ -27,8 +27,8 @@ import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.shared.TempFiles
 import org.odk.collect.strings.R
-import org.odk.collect.testshared.EspressoHelpers
 import org.odk.collect.testshared.FakeScheduler
+import org.odk.collect.testshared.Interactions
 import org.odk.collect.testshared.RecyclerViewMatcher
 import org.odk.collect.testshared.RecyclerViewMatcher.Companion.withRecyclerView
 import org.odk.collect.testshared.RobolectricHelpers
@@ -53,7 +53,7 @@ class OfflineMapLayersImporterTest {
         launchFragment().onFragment {
             scheduler.flush()
             assertThat(it.isVisible, equalTo(true))
-            EspressoHelpers.clickOnText(R.string.cancel)
+            Interactions.clickOn(withText(R.string.cancel))
             assertThat(it.isVisible, equalTo(false))
         }
     }

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
@@ -350,7 +350,7 @@ class OfflineMapLayersPickerTest {
 
         EspressoHelpers.clickOnText(string.add_layer)
         scheduler.flush()
-        onView(withId(R.id.add_layer_button)).inRoot(isDialog()).perform(click())
+        onView(withId(R.id.add_layer_button)).inRoot(isDialog()).perform(scrollTo(), click())
 
         onView(withId(R.id.progress_indicator)).check(matches(isDisplayed()))
         onView(withId(R.id.layers)).check(matches(not(isDisplayed())))
@@ -375,7 +375,7 @@ class OfflineMapLayersPickerTest {
 
         EspressoHelpers.clickOnText(string.add_layer)
         scheduler.flush()
-        onView(withId(R.id.add_layer_button)).inRoot(isDialog()).perform(click())
+        onView(withId(R.id.add_layer_button)).inRoot(isDialog()).perform(scrollTo(), click())
         whenever(referenceLayerRepository.getAll()).thenReturn(
             listOf(
                 ReferenceLayer("1", TempFiles.createTempFile(), file1.name),

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
@@ -43,8 +43,8 @@ import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.shared.TempFiles
 import org.odk.collect.strings.R.string
-import org.odk.collect.testshared.EspressoHelpers
 import org.odk.collect.testshared.FakeScheduler
+import org.odk.collect.testshared.Interactions
 import org.odk.collect.testshared.RecyclerViewMatcher
 import org.odk.collect.testshared.RecyclerViewMatcher.Companion.withRecyclerView
 import org.odk.collect.webpage.ExternalWebPageHelper
@@ -64,7 +64,10 @@ class OfflineMapLayersPickerTest {
             input: I,
             options: ActivityOptionsCompat?
         ) {
-            assertThat(contract, instanceOf(ActivityResultContracts.GetMultipleContents()::class.java))
+            assertThat(
+                contract,
+                instanceOf(ActivityResultContracts.GetMultipleContents()::class.java)
+            )
             assertThat(input, equalTo("*/*"))
             dispatchResult(requestCode, uris)
         }
@@ -74,7 +77,13 @@ class OfflineMapLayersPickerTest {
     val fragmentScenarioLauncherRule = FragmentScenarioLauncherRule(
         FragmentFactoryBuilder()
             .forClass(OfflineMapLayersPicker::class) {
-                OfflineMapLayersPicker(testRegistry, referenceLayerRepository, scheduler, settingsProvider, externalWebPageHelper)
+                OfflineMapLayersPicker(
+                    testRegistry,
+                    referenceLayerRepository,
+                    scheduler,
+                    settingsProvider,
+                    externalWebPageHelper
+                )
             }.build()
     )
 
@@ -84,7 +93,7 @@ class OfflineMapLayersPickerTest {
 
         scenario.onFragment {
             assertThat(it.isVisible, equalTo(true))
-            EspressoHelpers.clickOnText(string.cancel)
+            Interactions.clickOn(withText(string.cancel))
             assertThat(it.isVisible, equalTo(false))
         }
     }
@@ -99,8 +108,11 @@ class OfflineMapLayersPickerTest {
 
         scheduler.flush()
 
-        EspressoHelpers.clickOnText(string.cancel)
-        assertThat(settingsProvider.getUnprotectedSettings().contains(ProjectKeys.KEY_REFERENCE_LAYER), equalTo(false))
+        Interactions.clickOn(withText(string.cancel))
+        assertThat(
+            settingsProvider.getUnprotectedSettings().contains(ProjectKeys.KEY_REFERENCE_LAYER),
+            equalTo(false)
+        )
     }
 
     @Test
@@ -118,7 +130,7 @@ class OfflineMapLayersPickerTest {
 
         scenario.onFragment {
             assertThat(it.isVisible, equalTo(true))
-            EspressoHelpers.clickOnText(string.save)
+            Interactions.clickOn(withText(string.save))
             assertThat(it.isVisible, equalTo(false))
         }
     }
@@ -142,8 +154,11 @@ class OfflineMapLayersPickerTest {
 
         scheduler.flush()
 
-        EspressoHelpers.clickOnText(string.save)
-        assertThat(settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER), equalTo(null))
+        Interactions.clickOn(withText(string.save))
+        assertThat(
+            settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER),
+            equalTo(null)
+        )
     }
 
     @Test
@@ -156,9 +171,12 @@ class OfflineMapLayersPickerTest {
 
         scheduler.flush()
 
-        EspressoHelpers.clickOnText("layer1")
-        EspressoHelpers.clickOnText(string.save)
-        assertThat(settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER), equalTo("1"))
+        Interactions.clickOn(withText("layer1"))
+        Interactions.clickOn(withText(string.save))
+        assertThat(
+            settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER),
+            equalTo("1")
+        )
     }
 
     @Test
@@ -171,8 +189,16 @@ class OfflineMapLayersPickerTest {
 
         scheduler.flush()
 
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(matches(isChecked()))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(matches(not(isChecked())))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(
+            matches(
+                isChecked()
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(
+            matches(
+                not(isChecked())
+            )
+        )
     }
 
     @Test
@@ -190,9 +216,21 @@ class OfflineMapLayersPickerTest {
 
         scheduler.flush()
 
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(matches(not(isChecked())))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(matches(not(isChecked())))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.radio_button)).check(matches(isChecked()))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(
+            matches(
+                not(isChecked())
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(
+            matches(
+                not(isChecked())
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.radio_button)).check(
+            matches(
+                isChecked()
+            )
+        )
     }
 
     @Test
@@ -208,8 +246,17 @@ class OfflineMapLayersPickerTest {
         scheduler.flush()
 
         onView(withId(R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(2)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(matches(isChecked()))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                0,
+                R.id.title
+            )
+        ).check(matches(withText(string.none)))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(
+            matches(
+                isChecked()
+            )
+        )
     }
 
     @Test
@@ -238,9 +285,12 @@ class OfflineMapLayersPickerTest {
 
         scheduler.flush()
 
-        EspressoHelpers.clickOnText(string.get_help_with_offline_layers)
+        Interactions.clickOn(withText(string.get_help_with_offline_layers))
 
-        verify(externalWebPageHelper).openWebPageInCustomTab(any(), eq(Uri.parse("https://docs.getodk.org/collect-offline-maps/#transferring-offline-tilesets-to-devices")))
+        verify(externalWebPageHelper).openWebPageInCustomTab(
+            any(),
+            eq(Uri.parse("https://docs.getodk.org/collect-offline-maps/#transferring-offline-tilesets-to-devices"))
+        )
     }
 
     @Test
@@ -250,7 +300,12 @@ class OfflineMapLayersPickerTest {
         scheduler.flush()
 
         onView(withId(R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(1)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                0,
+                R.id.title
+            )
+        ).check(matches(withText(string.none)))
     }
 
     @Test
@@ -267,9 +322,24 @@ class OfflineMapLayersPickerTest {
         scheduler.flush()
 
         onView(withId(R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(3)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.title)).check(matches(withText("layerA")))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.title)).check(matches(withText("layerB")))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                0,
+                R.id.title
+            )
+        ).check(matches(withText(string.none)))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                1,
+                R.id.title
+            )
+        ).check(matches(withText("layerA")))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                2,
+                R.id.title
+            )
+        ).check(matches(withText("layerB")))
     }
 
     @Test
@@ -282,13 +352,29 @@ class OfflineMapLayersPickerTest {
 
         scheduler.flush()
 
-        EspressoHelpers.clickOnText("layer1")
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(matches(not(isChecked())))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(matches(isChecked()))
+        Interactions.clickOn(withText("layer1"))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(
+            matches(
+                not(isChecked())
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(
+            matches(
+                isChecked()
+            )
+        )
 
-        EspressoHelpers.clickOnText(string.none)
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(matches(isChecked()))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(matches(not(isChecked())))
+        Interactions.clickOn(withText(string.none))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(
+            matches(
+                isChecked()
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(
+            matches(
+                not(isChecked())
+            )
+        )
     }
 
     @Test
@@ -301,10 +387,18 @@ class OfflineMapLayersPickerTest {
 
         scheduler.flush()
 
-        EspressoHelpers.clickOnText("layer1")
+        Interactions.clickOn(withText("layer1"))
         scenario.recreate()
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(matches(not(isChecked())))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(matches(isChecked()))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(
+            matches(
+                not(isChecked())
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.radio_button)).check(
+            matches(
+                isChecked()
+            )
+        )
     }
 
     @Test
@@ -312,7 +406,7 @@ class OfflineMapLayersPickerTest {
         val scenario = launchFragment()
 
         uris.add(Uri.parse("blah"))
-        EspressoHelpers.clickOnText(string.add_layer)
+        Interactions.clickOn(withText(string.add_layer))
 
         scenario.onFragment {
             assertThat(
@@ -326,7 +420,7 @@ class OfflineMapLayersPickerTest {
     fun `clicking the 'add layer' and selecting nothing does not display the confirmation dialog`() {
         val scenario = launchFragment()
 
-        EspressoHelpers.clickOnText(string.add_layer)
+        Interactions.clickOn(withText(string.add_layer))
 
         scenario.onFragment {
             assertThat(
@@ -348,7 +442,7 @@ class OfflineMapLayersPickerTest {
         uris.add(file1.toUri())
         uris.add(file2.toUri())
 
-        EspressoHelpers.clickOnText(string.add_layer)
+        Interactions.clickOn(withText(string.add_layer))
         scheduler.flush()
         onView(withId(R.id.add_layer_button)).inRoot(isDialog()).perform(scrollTo(), click())
 
@@ -373,7 +467,7 @@ class OfflineMapLayersPickerTest {
         uris.add(file1.toUri())
         uris.add(file2.toUri())
 
-        EspressoHelpers.clickOnText(string.add_layer)
+        Interactions.clickOn(withText(string.add_layer))
         scheduler.flush()
         onView(withId(R.id.add_layer_button)).inRoot(isDialog()).perform(scrollTo(), click())
         whenever(referenceLayerRepository.getAll()).thenReturn(
@@ -385,9 +479,24 @@ class OfflineMapLayersPickerTest {
         scheduler.flush()
 
         onView(withId(R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(3)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.title)).check(matches(withText(file1.name)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.title)).check(matches(withText(file2.name)))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                0,
+                R.id.title
+            )
+        ).check(matches(withText(string.none)))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                1,
+                R.id.title
+            )
+        ).check(matches(withText(file1.name)))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                2,
+                R.id.title
+            )
+        ).check(matches(withText(file2.name)))
     }
 
     @Test
@@ -409,11 +518,13 @@ class OfflineMapLayersPickerTest {
 
     @Test
     fun `recreating maintains expanded layers`() {
-        whenever(referenceLayerRepository.getAll()).thenReturn(listOf(
-            ReferenceLayer("1", TempFiles.createTempFile(), "layer1"),
-            ReferenceLayer("2", TempFiles.createTempFile(), "layer2"),
-            ReferenceLayer("3", TempFiles.createTempFile(), "layer3")
-        ))
+        whenever(referenceLayerRepository.getAll()).thenReturn(
+            listOf(
+                ReferenceLayer("1", TempFiles.createTempFile(), "layer1"),
+                ReferenceLayer("2", TempFiles.createTempFile(), "layer2"),
+                ReferenceLayer("3", TempFiles.createTempFile(), "layer3")
+            )
+        )
 
         val scenario = launchFragment()
 
@@ -434,10 +545,12 @@ class OfflineMapLayersPickerTest {
     fun `correct path is displayed after expanding layers`() {
         val file1 = TempFiles.createTempFile()
         val file2 = TempFiles.createTempFile()
-        whenever(referenceLayerRepository.getAll()).thenReturn(listOf(
-            ReferenceLayer("1", file1, "layer1"),
-            ReferenceLayer("2", file2, "layer2")
-        ))
+        whenever(referenceLayerRepository.getAll()).thenReturn(
+            listOf(
+                ReferenceLayer("1", file1, "layer1"),
+                ReferenceLayer("2", file2, "layer2")
+            )
+        )
 
         launchFragment()
 
@@ -447,22 +560,39 @@ class OfflineMapLayersPickerTest {
         onView(withId(R.id.layers)).perform(scrollToPosition<RecyclerView.ViewHolder>(2))
         onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.arrow)).perform(click())
 
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.path)).check(matches(withText(file1.absolutePath)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.path)).check(matches(withText(file2.absolutePath)))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.path)).check(
+            matches(
+                withText(
+                    file1.absolutePath
+                )
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.path)).check(
+            matches(
+                withText(
+                    file2.absolutePath
+                )
+            )
+        )
     }
 
     @Test
     fun `clicking delete shows the confirmation dialog`() {
-        whenever(referenceLayerRepository.getAll()).thenReturn(listOf(
-            ReferenceLayer("1", TempFiles.createTempFile(), "layer1")
-        ))
+        whenever(referenceLayerRepository.getAll()).thenReturn(
+            listOf(
+                ReferenceLayer("1", TempFiles.createTempFile(), "layer1")
+            )
+        )
 
         launchFragment()
 
         scheduler.flush()
 
         onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.arrow)).perform(click())
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(scrollTo(), click())
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(
+            scrollTo(),
+            click()
+        )
 
         onView(withText(string.cancel)).inRoot(isDialog()).check(matches(isDisplayed()))
         onView(withText(string.delete_layer)).inRoot(isDialog()).check(matches(isDisplayed()))
@@ -471,23 +601,38 @@ class OfflineMapLayersPickerTest {
     @Test
     fun `clicking delete and canceling does not remove the layer`() {
         val layerFile1 = TempFiles.createTempFile()
-        whenever(referenceLayerRepository.getAll()).thenReturn(listOf(
-            ReferenceLayer("1", layerFile1, "layer1")
-        ))
+        whenever(referenceLayerRepository.getAll()).thenReturn(
+            listOf(
+                ReferenceLayer("1", layerFile1, "layer1")
+            )
+        )
 
         launchFragment()
 
         scheduler.flush()
 
         onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.arrow)).perform(click())
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(scrollTo(), click())
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(
+            scrollTo(),
+            click()
+        )
 
         onView(withText(string.cancel)).inRoot(isDialog()).perform(click())
 
         onView(withId(R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(2)))
         onView(withId(R.id.layers)).perform(scrollToPosition<RecyclerView.ViewHolder>(0))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.title)).check(matches(withText("layer1")))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                0,
+                R.id.title
+            )
+        ).check(matches(withText(string.none)))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                1,
+                R.id.title
+            )
+        ).check(matches(withText("layer1")))
         verify(referenceLayerRepository, never()).delete("1")
     }
 
@@ -495,24 +640,39 @@ class OfflineMapLayersPickerTest {
     fun `clicking delete and confirming removes the layer`() {
         val layerFile1 = TempFiles.createTempFile()
         val layerFile2 = TempFiles.createTempFile()
-        whenever(referenceLayerRepository.getAll()).thenReturn(listOf(
-            ReferenceLayer("1", layerFile1, "layer1"),
-            ReferenceLayer("2", layerFile2, "layer2")
-        ))
+        whenever(referenceLayerRepository.getAll()).thenReturn(
+            listOf(
+                ReferenceLayer("1", layerFile1, "layer1"),
+                ReferenceLayer("2", layerFile2, "layer2")
+            )
+        )
 
         launchFragment()
 
         scheduler.flush()
 
         onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.arrow)).perform(click())
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(scrollTo(), click())
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(
+            scrollTo(),
+            click()
+        )
 
         onView(withText(string.delete_layer)).inRoot(isDialog()).perform(click())
         scheduler.flush()
 
         onView(withId(R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(2)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.title)).check(matches(withText("layer2")))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                0,
+                R.id.title
+            )
+        ).check(matches(withText(string.none)))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                1,
+                R.id.title
+            )
+        ).check(matches(withText("layer2")))
         verify(referenceLayerRepository).delete("1")
         verify(referenceLayerRepository, never()).delete("2")
     }
@@ -520,9 +680,11 @@ class OfflineMapLayersPickerTest {
     @Test
     fun `deleting the selected layer changes selection to 'none' and saves it`() {
         val layerFile1 = TempFiles.createTempFile()
-        whenever(referenceLayerRepository.getAll()).thenReturn(listOf(
-            ReferenceLayer("1", layerFile1, "layer1")
-        ))
+        whenever(referenceLayerRepository.getAll()).thenReturn(
+            listOf(
+                ReferenceLayer("1", layerFile1, "layer1")
+            )
+        )
         settingsProvider.getUnprotectedSettings().save(ProjectKeys.KEY_REFERENCE_LAYER, "1")
 
         launchFragment()
@@ -530,23 +692,40 @@ class OfflineMapLayersPickerTest {
         scheduler.flush()
 
         onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.arrow)).perform(click())
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(scrollTo(), click())
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(
+            scrollTo(),
+            click()
+        )
 
         onView(withText(string.delete_layer)).inRoot(isDialog()).perform(click())
         scheduler.flush()
 
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(matches(isChecked()))
-        assertThat(settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER), equalTo(null))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                0,
+                R.id.title
+            )
+        ).check(matches(withText(string.none)))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(
+            matches(
+                isChecked()
+            )
+        )
+        assertThat(
+            settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER),
+            equalTo(null)
+        )
     }
 
     @Test
     fun `deleting one of the layers keeps the list sorted in A-Z order`() {
-        whenever(referenceLayerRepository.getAll()).thenReturn(listOf(
-            ReferenceLayer("1", TempFiles.createTempFile(), "layerC"),
-            ReferenceLayer("2", TempFiles.createTempFile(), "layerB"),
-            ReferenceLayer("3", TempFiles.createTempFile(), "layerA")
-        ))
+        whenever(referenceLayerRepository.getAll()).thenReturn(
+            listOf(
+                ReferenceLayer("1", TempFiles.createTempFile(), "layerC"),
+                ReferenceLayer("2", TempFiles.createTempFile(), "layerB"),
+                ReferenceLayer("3", TempFiles.createTempFile(), "layerA")
+            )
+        )
 
         launchFragment()
 
@@ -554,30 +733,53 @@ class OfflineMapLayersPickerTest {
 
         onView(withId(R.id.layers)).perform(scrollToPosition<RecyclerView.ViewHolder>(2))
         onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.arrow)).perform(click())
-        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.delete_layer)).perform(scrollTo(), click())
+        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.delete_layer)).perform(
+            scrollTo(),
+            click()
+        )
 
         onView(withText(string.delete_layer)).inRoot(isDialog()).perform(click())
         scheduler.flush()
 
         onView(withId(R.id.layers)).check(matches(RecyclerViewMatcher.withListSize(3)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.title)).check(matches(withText(string.none)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.title)).check(matches(withText("layerA")))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(2, R.id.title)).check(matches(withText("layerC")))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                0,
+                R.id.title
+            )
+        ).check(matches(withText(string.none)))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                1,
+                R.id.title
+            )
+        ).check(matches(withText("layerA")))
+        onView(
+            withRecyclerView(R.id.layers).atPositionOnView(
+                2,
+                R.id.title
+            )
+        ).check(matches(withText("layerC")))
     }
 
     @Test
     fun `progress indicator is displayed during deleting layers`() {
         val layerFile1 = TempFiles.createTempFile("layer1", MbtilesFile.FILE_EXTENSION)
-        whenever(referenceLayerRepository.getAll()).thenReturn(listOf(
-            ReferenceLayer("1", layerFile1, "layer1"),
-        ))
+        whenever(referenceLayerRepository.getAll()).thenReturn(
+            listOf(
+                ReferenceLayer("1", layerFile1, "layer1"),
+            )
+        )
 
         launchFragment()
 
         scheduler.flush()
 
         onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.arrow)).perform(click())
-        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(scrollTo(), click())
+        onView(withRecyclerView(R.id.layers).atPositionOnView(1, R.id.delete_layer)).perform(
+            scrollTo(),
+            click()
+        )
         onView(withText(string.delete_layer)).inRoot(isDialog()).perform(click())
 
         onView(withId(R.id.progress_indicator)).check(matches(isDisplayed()))
@@ -590,15 +792,35 @@ class OfflineMapLayersPickerTest {
     }
 
     private fun assertLayerCollapsed(position: Int) {
-        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.arrow)).check(matches(withImageDrawable(org.odk.collect.icons.R.drawable.ic_baseline_expand_24)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.path)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.delete_layer)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE)))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.arrow)).check(
+            matches(
+                withImageDrawable(org.odk.collect.icons.R.drawable.ic_baseline_expand_24)
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.path)).check(
+            matches(
+                withEffectiveVisibility(ViewMatchers.Visibility.GONE)
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.delete_layer)).check(
+            matches(withEffectiveVisibility(ViewMatchers.Visibility.GONE))
+        )
     }
 
     private fun assertLayerExpanded(position: Int) {
-        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.arrow)).check(matches(withImageDrawable(org.odk.collect.icons.R.drawable.ic_baseline_collapse_24)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.path)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.delete_layer)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.arrow)).check(
+            matches(
+                withImageDrawable(org.odk.collect.icons.R.drawable.ic_baseline_collapse_24)
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.path)).check(
+            matches(
+                withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)
+            )
+        )
+        onView(withRecyclerView(R.id.layers).atPositionOnView(position, R.id.delete_layer)).check(
+            matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))
+        )
     }
 
     private fun launchFragment(): FragmentScenario<OfflineMapLayersPicker> {

--- a/test-shared/src/main/java/org/odk/collect/testshared/AssertIntentsHelper.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/AssertIntentsHelper.kt
@@ -3,7 +3,7 @@ package org.odk.collect.testshared
 import android.content.Intent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import org.hamcrest.Matcher
-import org.odk.collect.testshared.EspressoHelpers.assertIntents
+import org.odk.collect.testshared.Assertions.assertIntents
 import kotlin.reflect.KClass
 
 class AssertIntentsHelper {

--- a/test-shared/src/main/java/org/odk/collect/testshared/Assertions.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/Assertions.kt
@@ -1,14 +1,14 @@
 package org.odk.collect.testshared
 
 import android.content.Intent
+import android.view.View
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Root
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert.assertThat
@@ -17,22 +17,21 @@ import org.hamcrest.Matchers.equalTo
 
 object Assertions {
 
-    fun assertText(text: String) {
-        onView(allOf(withText(text), withEffectiveVisibility(VISIBLE)))
-            .check(matches(not(doesNotExist())))
+    fun assertText(view: Matcher<View>, root: Matcher<Root>? = null) {
+        val onView = if (root != null) {
+            onView(allOf(view, withEffectiveVisibility(VISIBLE))).inRoot(root)
+        } else {
+            onView(allOf(view, withEffectiveVisibility(VISIBLE)))
+        }
+
+        onView.check(matches(not(doesNotExist())))
     }
 
-    fun assertTextInDialog(text: String) {
-        onView(allOf(withText(text), withEffectiveVisibility(VISIBLE)))
-            .inRoot(isDialog())
-            .check(matches(not(doesNotExist())))
-    }
-
-    fun assertIntents(vararg matchers: Matcher<Intent>) {
+    fun assertIntents(vararg intentMatchers: Matcher<Intent>) {
         val intents = Intents.getIntents()
-        assertThat(matchers.size, equalTo(intents.size))
+        assertThat(intentMatchers.size, equalTo(intents.size))
 
-        matchers.forEachIndexed { index, matcher ->
+        intentMatchers.forEachIndexed { index, matcher ->
             assertThat(intents[index], matcher)
         }
     }

--- a/test-shared/src/main/java/org/odk/collect/testshared/Assertions.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/Assertions.kt
@@ -2,13 +2,11 @@ package org.odk.collect.testshared
 
 import android.content.Intent
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.not
@@ -17,7 +15,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.equalTo
 
-object EspressoHelpers {
+object Assertions {
 
     fun assertText(text: String) {
         onView(allOf(withText(text), withEffectiveVisibility(VISIBLE)))
@@ -28,22 +26,6 @@ object EspressoHelpers {
         onView(allOf(withText(text), withEffectiveVisibility(VISIBLE)))
             .inRoot(isDialog())
             .check(matches(not(doesNotExist())))
-    }
-
-    fun clickOnContentDescription(string: Int) {
-        onView(withContentDescription(string)).perform(click())
-    }
-
-    fun clickOnText(string: Int) {
-        onView(withText(string)).perform(click())
-    }
-
-    fun clickOnText(string: String) {
-        onView(withText(string)).perform(click())
-    }
-
-    fun clickOnTextInDialog(string: Int) {
-        onView(withText(string)).inRoot(isDialog()).perform(click())
     }
 
     fun assertIntents(vararg matchers: Matcher<Intent>) {

--- a/test-shared/src/main/java/org/odk/collect/testshared/Interactions.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/Interactions.kt
@@ -1,4 +1,4 @@
-package org.odk.collect.android.support
+package org.odk.collect.testshared
 
 import android.view.View
 import androidx.test.espresso.Espresso.closeSoftKeyboard
@@ -8,7 +8,7 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.scrollTo
 import org.hamcrest.Matcher
-import org.odk.collect.android.support.WaitFor.tryAgainOnFail
+import org.odk.collect.testshared.WaitFor.tryAgainOnFail
 
 object Interactions {
 

--- a/test-shared/src/main/java/org/odk/collect/testshared/WaitFor.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/WaitFor.kt
@@ -1,4 +1,4 @@
-package org.odk.collect.android.support
+package org.odk.collect.testshared
 
 import junit.framework.AssertionFailedError
 import java.util.concurrent.Callable


### PR DESCRIPTION
Closes #6212

This makes the whole layers import view scrollable, but also limits the max height of the list of layers so that it can also remain scrollable in cases with very long lists:

<img src="https://github.com/getodk/collect/assets/556280/6c1c6332-b9ff-4f47-b671-eaa96df90e38" width="320px"/>

So in landscape we end up with this:

<img src="https://github.com/getodk/collect/assets/556280/16d5df77-6aa4-4f5c-a9f9-c8b687177268" height="320px"/>

#### Why is this the best possible solution? Were any other approaches considered?

I haven't changed much here at the layout level other than nesting everything in a scroll view, adding a max height to the list and adjusting other parts to compensate for those changes.

Test wise, I've moved our `Interactions` helpers into `test-shared` so I could use them here to deal with clicks that might have to scroll.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only thing changed here is the import list, so that's all that needs to be looked at really!

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
