### PR TITLE
Don't use masked appearance in text number widget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.kt
@@ -20,7 +20,6 @@ import org.javarosa.core.model.Constants
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.dynamicpreload.ExternalDataUtil
 import org.odk.collect.androidshared.utils.ScreenUtils
-import java.lang.Exception
 
 object Appearances {
     // Date appearances
@@ -196,6 +195,8 @@ object Appearances {
     @JvmStatic
     fun isMasked(prompt: FormEntryPrompt): Boolean {
         val appearance = getSanitizedAppearanceHint(prompt)
-        return appearance.contains(MASKED) && prompt.dataType == Constants.DATATYPE_TEXT
+        return appearance.contains(MASKED) &&
+            !appearance.contains(NUMBERS) &&
+            prompt.dataType == Constants.DATATYPE_TEXT
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/AppearancesTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/AppearancesTest.kt
@@ -401,4 +401,11 @@ class AppearancesTest {
         whenever(formEntryPrompt.dataType).thenReturn(Constants.DATATYPE_DECIMAL)
         assertFalse(Appearances.isMasked(formEntryPrompt))
     }
+
+    @Test
+    fun `isMasked returns false when 'masked' appearance is found for text questions with 'numbers' appearance`() {
+        whenever(formEntryPrompt.dataType).thenReturn(Constants.DATATYPE_TEXT)
+        whenever(formEntryPrompt.appearanceHint).thenReturn("masked numbers")
+        assertFalse(Appearances.isMasked(formEntryPrompt))
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
@@ -1,5 +1,16 @@
 package org.odk.collect.android.widgets;
 
+import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
+
+import android.text.InputType;
+import android.text.method.SingleLineTransformationMethod;
+
 import androidx.annotation.NonNull;
 
 import org.javarosa.core.model.Constants;
@@ -9,26 +20,11 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
 import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.Random;
-
-import static junit.framework.TestCase.assertEquals;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.when;
-import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
-
-import android.text.InputType;
-import android.text.method.PasswordTransformationMethod;
-import android.text.method.SingleLineTransformationMethod;
 
 public class DecimalWidgetTest extends GeneralStringWidgetTest<DecimalWidget, DecimalData> {
 
@@ -221,13 +217,5 @@ public class DecimalWidgetTest extends GeneralStringWidgetTest<DecimalWidget, De
         DecimalWidget widget = getWidget();
         assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
         assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
-    }
-
-    @Test
-    public void answersShouldNotBeMaskedIfMaskedAppearanceIsUsed() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
-
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
@@ -1,25 +1,7 @@
 package org.odk.collect.android.widgets;
 
-import androidx.annotation.NonNull;
-
-import org.javarosa.core.model.Constants;
-import org.javarosa.core.model.data.DecimalData;
-import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.javarosa.core.model.data.IAnswerData;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.odk.collect.android.utilities.Appearances;
-import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
-import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
-import org.odk.collect.android.widgets.utilities.StringRequester;
-
-import java.text.NumberFormat;
-import java.util.Locale;
-
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -27,8 +9,22 @@ import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
-import android.text.method.PasswordTransformationMethod;
 import android.text.method.SingleLineTransformationMethod;
+
+import androidx.annotation.NonNull;
+
+import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.data.DecimalData;
+import org.javarosa.core.model.data.IAnswerData;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
+import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
+import org.odk.collect.android.widgets.utilities.StringRequester;
+
+import java.text.NumberFormat;
+import java.util.Locale;
 
 /**
  * @author James Knight
@@ -105,13 +101,5 @@ public class ExDecimalWidgetTest extends GeneralExStringWidgetTest<ExDecimalWidg
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
-    }
-
-    @Test
-    public void answersShouldNotBeMaskedIfMaskedAppearanceIsUsed() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
-
-        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
@@ -1,29 +1,24 @@
 package org.odk.collect.android.widgets;
 
-import androidx.annotation.NonNull;
-
-import org.javarosa.core.model.Constants;
-import org.javarosa.core.model.data.IntegerData;
-import org.mockito.Mock;
-import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.junit.Test;
-import org.odk.collect.android.utilities.Appearances;
-import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
-import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
-import org.odk.collect.android.widgets.utilities.StringRequester;
-
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
-import android.text.method.PasswordTransformationMethod;
 import android.text.method.SingleLineTransformationMethod;
+
+import androidx.annotation.NonNull;
+
+import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.data.IntegerData;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
+import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
+import org.odk.collect.android.widgets.utilities.StringRequester;
 
 /**
  * @author James Knight
@@ -80,13 +75,5 @@ public class ExIntegerWidgetTest extends GeneralExStringWidgetTest<ExIntegerWidg
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
-    }
-
-    @Test
-    public void answersShouldNotBeMaskedIfMaskedAppearanceIsUsed() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
-
-        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-        assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
@@ -1,26 +1,21 @@
 package org.odk.collect.android.widgets;
 
-import androidx.annotation.NonNull;
-
-import org.javarosa.core.model.Constants;
-import org.javarosa.core.model.data.IntegerData;
-import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.junit.Test;
-import org.odk.collect.android.utilities.Appearances;
-import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
-
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
-import android.text.method.PasswordTransformationMethod;
 import android.text.method.SingleLineTransformationMethod;
+
+import androidx.annotation.NonNull;
+
+import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.data.IntegerData;
+import org.junit.Test;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
 /**
  * @author James Knight
@@ -66,13 +61,5 @@ public class IntegerWidgetTest extends GeneralStringWidgetTest<IntegerWidget, In
         IntegerWidget widget = getWidget();
         assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
         assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
-    }
-
-    @Test
-    public void answersShouldNotBeMaskedIfMaskedAppearanceIsUsed() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
-
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
@@ -1,20 +1,6 @@
 package org.odk.collect.android.widgets;
 
-import androidx.annotation.NonNull;
-
-import net.bytebuddy.utility.RandomString;
-
-import org.javarosa.core.model.Constants;
-import org.javarosa.core.model.data.StringData;
-import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.junit.Test;
-import org.odk.collect.android.utilities.Appearances;
-import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
-
 import static junit.framework.TestCase.assertEquals;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
@@ -24,6 +10,16 @@ import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 import android.text.InputType;
 import android.text.method.PasswordTransformationMethod;
 import android.text.method.SingleLineTransformationMethod;
+
+import androidx.annotation.NonNull;
+
+import net.bytebuddy.utility.RandomString;
+
+import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.data.StringData;
+import org.junit.Test;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.widgets.base.GeneralStringWidgetTest;
 
 /**
  * @author James Knight
@@ -73,19 +69,5 @@ public class StringNumberWidgetTest extends GeneralStringWidgetTest<StringNumber
         StringNumberWidget widget = getWidget();
         assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER));
         assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
-    }
-
-    @Test
-    public void answersShouldNotBeMaskedIfMaskedAppearanceIsNotUsed() {
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(not(instanceOf(PasswordTransformationMethod.class))));
-    }
-
-    @Test
-    public void answersShouldBeMaskedIfMaskedAppearanceIsUsed() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(Appearances.MASKED);
-
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
-        assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
     }
 }


### PR DESCRIPTION
Closes #6214

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss as this just updates how we determine whether to use `masked` or not.

I've also removed tests around not using the masked appearance in the tests for subclasses of `StringWidget` and `ExStringWidget` as this is handled in the respective parent class tests. This was a follow-up to #6187.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Main changes are just around how `masked` applied.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
