### PR TITLE
Always use map configurator that represents the current state

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -574,7 +574,9 @@ public class AppDependencyModule {
         return new DirectoryReferenceLayerRepository(
                 storagePathProvider.getOdkDirPath(StorageSubdirectory.SHARED_LAYERS),
                 storagePathProvider.getOdkDirPath(StorageSubdirectory.LAYERS),
-                MapConfiguratorProvider.getConfigurator(settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_BASEMAP_SOURCE))
+                () -> MapConfiguratorProvider.getConfigurator(
+                        settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_BASEMAP_SOURCE)
+                )
         );
     }
 

--- a/maps/src/main/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepository.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepository.kt
@@ -8,20 +8,20 @@ import java.io.File
 class DirectoryReferenceLayerRepository(
     private val sharedLayersDirPath: String,
     private val projectLayersDirPath: String,
-    private val mapConfigurator: MapConfigurator
+    private val getMapConfigurator: () -> MapConfigurator
 ) : ReferenceLayerRepository {
 
     override fun getAll(): List<ReferenceLayer> {
         return getAllFilesWithDirectory()
             .map { ReferenceLayer(getIdForFile(it.second, it.first), it.first, getName(it.first)) }
             .distinctBy { it.id }
-            .filter { mapConfigurator.supportsLayer(it.file) }
+            .filter { getMapConfigurator().supportsLayer(it.file) }
     }
 
     override fun get(id: String): ReferenceLayer? {
         val file = getAllFilesWithDirectory().firstOrNull { getIdForFile(it.second, it.first) == id }
 
-        return if (file != null && mapConfigurator.supportsLayer(file.first)) {
+        return if (file != null && getMapConfigurator().supportsLayer(file.first)) {
             ReferenceLayer(getIdForFile(file.second, file.first), file.first, getName(file.first))
         } else {
             null
@@ -50,6 +50,6 @@ class DirectoryReferenceLayerRepository(
         PathUtils.getRelativeFilePath(directoryPath, file.absolutePath)
 
     private fun getName(file: File): String {
-        return mapConfigurator.getDisplayName(file)
+        return getMapConfigurator().getDisplayName(file)
     }
 }

--- a/maps/src/test/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepositoryTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepositoryTest.kt
@@ -85,6 +85,23 @@ class DirectoryReferenceLayerRepositoryTest {
     }
 
     @Test
+    fun getAllAlwaysUsesMapConfiguratorThatRepresentsTheCurrentConfiguration() {
+        val file = TempFiles.createTempFile(sharedLayersDir)
+
+        mapConfigurator.apply {
+            addFile(file, false, file.name)
+        }
+
+        assertThat(repository.getAll().isEmpty(), equalTo(true))
+
+        mapConfigurator = StubMapConfigurator().apply {
+            addFile(file, true, file.name)
+        }
+
+        assertThat(repository.getAll().isEmpty(), equalTo(false))
+    }
+
+    @Test
     fun get_returnsProperLayer() {
         val file1 = TempFiles.createTempFile(sharedLayersDir)
         val file2 = TempFiles.createTempFile(sharedLayersDir)
@@ -161,6 +178,24 @@ class DirectoryReferenceLayerRepositoryTest {
     }
 
     @Test
+    fun getAlwaysUsesMapConfiguratorThatRepresentsTheCurrentConfiguration() {
+        val file = TempFiles.createTempFile(sharedLayersDir)
+
+        mapConfigurator.apply {
+            addFile(file, false, file.name)
+        }
+
+        val fileId = repository.getIdForFile(sharedLayersDir.absolutePath, file)
+        assertThat(repository.get(fileId), equalTo(null))
+
+        mapConfigurator = StubMapConfigurator().apply {
+            addFile(file, true, file.name)
+        }
+
+        assertThat(repository.get(fileId)!!.file, equalTo(file))
+    }
+
+    @Test
     fun addLayer_movesFileToTheSharedLayersDir_whenSharedIsTrue() {
         val file = TempFiles.createTempFile().also {
             it.writeText("blah")
@@ -203,23 +238,6 @@ class DirectoryReferenceLayerRepositoryTest {
         repository.delete(fileLayer1.id)
 
         assertThat(repository.getAll(), contains(fileLayer2))
-    }
-
-    @Test // https://github.com/getodk/collect/issues/6211
-    fun mapConfiguratorThatRepresentsTheCurrentConfigurationShouldBeUsedEveryTimeTheRepositoryIsCalled() {
-        val file = TempFiles.createTempFile(sharedLayersDir)
-
-        mapConfigurator.apply {
-            addFile(file, false, file.name)
-        }
-
-        assertThat(repository.getAll().isEmpty(), equalTo(true))
-
-        mapConfigurator = StubMapConfigurator().apply {
-            addFile(file, true, file.name)
-        }
-
-        assertThat(repository.getAll().isEmpty(), equalTo(false))
     }
 
     private class StubMapConfigurator : MapConfigurator {

--- a/maps/src/test/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepositoryTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepositoryTest.kt
@@ -16,7 +16,7 @@ import java.io.File
 class DirectoryReferenceLayerRepositoryTest {
     private val sharedLayersDir = TempFiles.createTempDir()
     private val projectLayersDir = TempFiles.createTempDir()
-    private val mapConfigurator = StubMapConfigurator()
+    private var mapConfigurator = StubMapConfigurator()
     private val repository = DirectoryReferenceLayerRepository(
         sharedLayersDir.absolutePath,
         projectLayersDir.absolutePath,
@@ -204,6 +204,23 @@ class DirectoryReferenceLayerRepositoryTest {
         repository.delete(fileLayer1.id)
 
         assertThat(repository.getAll(), contains(fileLayer2))
+    }
+
+    @Test // https://github.com/getodk/collect/issues/6211
+    fun mapConfiguratorThatRepresentsTheCurrentConfigurationShouldBeUsedEveryTimeTheRepositoryIsCalled() {
+        val file = TempFiles.createTempFile(sharedLayersDir)
+
+        mapConfigurator.apply {
+            addFile(file, false, file.name)
+        }
+
+        assertThat(repository.getAll().isEmpty(), equalTo(true))
+
+        mapConfigurator = StubMapConfigurator().apply {
+            addFile(file, true, file.name)
+        }
+
+        assertThat(repository.getAll().isEmpty(), equalTo(false))
     }
 
     private class StubMapConfigurator : MapConfigurator {

--- a/maps/src/test/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepositoryTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/DirectoryReferenceLayerRepositoryTest.kt
@@ -19,9 +19,8 @@ class DirectoryReferenceLayerRepositoryTest {
     private var mapConfigurator = StubMapConfigurator()
     private val repository = DirectoryReferenceLayerRepository(
         sharedLayersDir.absolutePath,
-        projectLayersDir.absolutePath,
-        mapConfigurator
-    )
+        projectLayersDir.absolutePath
+    ) { mapConfigurator }
 
     @Test
     fun getAll_returnsAllSupportedLayersInTheDirectory() {

--- a/maps/src/test/java/org/odk/collect/maps/layers/MapFragmentReferenceLayerUtilsTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/MapFragmentReferenceLayerUtilsTest.kt
@@ -60,7 +60,7 @@ class MapFragmentReferenceLayerUtilsTest {
         assertNotNull(
             MapFragmentReferenceLayerUtils.getReferenceLayerFile(
                 config,
-                DirectoryReferenceLayerRepository(layersPath, "", mapConfigurator)
+                DirectoryReferenceLayerRepository(layersPath, "") { mapConfigurator }
             )
         )
     }


### PR DESCRIPTION
Closes #6211 

#### Why is this the best possible solution? Were any other approaches considered?
The problem here was that `DirectoryReferenceLayerRepository` relies on `MapConfigurator` to ignore layers that are not supported. `DirectoryReferenceLayerRepository` is injected into `MapsPreferencesFragment` so once it's injected it's not updated/recreated as long as we are in `MapsPreferencesFragment`. We can change map providers (Google/Mpbox/OSM) in the same fragment and then if the map configurator is just passed to `DirectoryReferenceLayerRepository` as a parameter then we might end up with a map configurator that represents a different configuration than the current one.

To solve the problem instead of passing to `DirectoryReferenceLayerRepository` an object (map configurator) I pass a function that creates a new map configurator every time it's used.
 
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think we can focus on testing the scenario described in the issue. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
