### PR TITLE
Fixed margins in offline layers

### DIFF
--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPickerAdapter.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPickerAdapter.kt
@@ -4,7 +4,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
-import androidx.core.view.isVisible
+import androidx.core.view.isInvisible
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
@@ -43,7 +43,7 @@ class OfflineMapLayersPickerAdapter(
         holder.binding.radioButton.setChecked(layer.isChecked)
         holder.binding.title.text = layer.name
         holder.binding.path.text = layer.file?.absolutePath
-        holder.binding.arrow.isVisible = layer.id != null
+        holder.binding.arrow.isInvisible = layer.id == null
 
         if (layer.isExpanded) {
             holder.binding.arrow.setImageDrawable(ContextCompat.getDrawable(holder.binding.root.context, org.odk.collect.icons.R.drawable.ic_baseline_collapse_24))

--- a/maps/src/main/res/layout/offline_map_layers_importer.xml
+++ b/maps/src/main/res/layout/offline_map_layers_importer.xml
@@ -129,8 +129,7 @@
                         android:layout_height="wrap_content"
                         android:paddingStart="@dimen/margin_standard"
                         android:text="@string/all_projects_option"
-                        android:textAppearance="?textAppearanceBodyMedium"
-                        android:translationX="-5dp" />
+                        android:textAppearance="?textAppearanceBodyMedium" />
 
                     <RadioButton
                         android:id="@+id/current_project_option"
@@ -138,8 +137,7 @@
                         android:layout_height="wrap_content"
                         android:paddingStart="@dimen/margin_standard"
                         android:text="@string/current_project_option"
-                        android:textAppearance="?textAppearanceBodyMedium"
-                        android:translationX="-5dp" />
+                        android:textAppearance="?textAppearanceBodyMedium" />
                 </RadioGroup>
             </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
Closes #6195 

#### Why is this the best possible solution? Were any other approaches considered?
I've just fixed margins but there is much more we could do to display translations correctly in rtl languages however it seems to be a separate issue reported at https://github.com/getodk/collect/issues/5561. For example, the layer name should be aligned to the right (the first screenshot from #6195) but it's not.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just verify that now we have proper margins in the list of existing layers and in the list of layers to import. Nothing else has changed.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
