### PR TITLE
Fixed displaying progress indicator while loading layers

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/async/TrackableWorker.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/async/TrackableWorker.kt
@@ -12,13 +12,13 @@ class TrackableWorker(private val scheduler: Scheduler) {
     private val _isWorking = MutableNonNullLiveData(false)
     val isWorking: NonNullLiveData<Boolean> = _isWorking
 
-    private var counter = AtomicInteger(0)
+    private var activeBackgroundJobsCounter = AtomicInteger(0)
 
     fun <T> immediate(background: Supplier<T>, foreground: Consumer<T>) {
-        counter.incrementAndGet()
+        activeBackgroundJobsCounter.incrementAndGet()
         _isWorking.value = true
         scheduler.immediate(background) { result ->
-            if (counter.decrementAndGet() == 0) {
+            if (activeBackgroundJobsCounter.decrementAndGet() == 0) {
                 _isWorking.value = false
             }
             foreground.accept(result)

--- a/androidshared/src/main/java/org/odk/collect/androidshared/async/TrackableWorker.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/async/TrackableWorker.kt
@@ -3,6 +3,7 @@ package org.odk.collect.androidshared.async
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidshared.livedata.NonNullLiveData
 import org.odk.collect.async.Scheduler
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
 import java.util.function.Supplier
 
@@ -11,10 +12,15 @@ class TrackableWorker(private val scheduler: Scheduler) {
     private val _isWorking = MutableNonNullLiveData(false)
     val isWorking: NonNullLiveData<Boolean> = _isWorking
 
+    private var counter = AtomicInteger(0)
+
     fun <T> immediate(background: Supplier<T>, foreground: Consumer<T>) {
+        counter.incrementAndGet()
         _isWorking.value = true
         scheduler.immediate(background) { result ->
-            _isWorking.value = false
+            if (counter.decrementAndGet() == 0) {
+                _isWorking.value = false
+            }
             foreground.accept(result)
         }
     }

--- a/androidshared/src/test/java/org/odk/collect/androidshared/async/TrackableWorkerTest.kt
+++ b/androidshared/src/test/java/org/odk/collect/androidshared/async/TrackableWorkerTest.kt
@@ -1,0 +1,28 @@
+package org.odk.collect.androidshared.async
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.testshared.FakeScheduler
+
+@RunWith(AndroidJUnit4::class)
+class TrackableWorkerTest {
+    private val scheduler = FakeScheduler()
+    private val trackableWorker = TrackableWorker(scheduler)
+
+    @Test
+    fun `TrackableWorker counts work in progress`() {
+        trackableWorker.immediate {}
+        trackableWorker.immediate {}
+
+        scheduler.runFirstBackground()
+        scheduler.runFirstForeground()
+        assertThat(trackableWorker.isWorking.value, equalTo(true))
+
+        scheduler.runFirstBackground()
+        scheduler.runFirstForeground()
+        assertThat(trackableWorker.isWorking.value, equalTo(false))
+    }
+}

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersImporter.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersImporter.kt
@@ -56,7 +56,7 @@ class OfflineMapLayersImporter(
         super.onViewCreated(view, savedInstanceState)
         val binding = OfflineMapLayersImporterBinding.bind(view)
 
-        viewModel.isLoading.observe(this) { isLoading ->
+        viewModel.trackableWorker.isWorking.observe(this) { isLoading ->
             if (isLoading) {
                 binding.addLayerButton.isEnabled = false
                 binding.layers.visibility = View.GONE

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
@@ -124,7 +124,7 @@ class OfflineMapLayersPicker(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val binding = OfflineMapLayersPickerBinding.bind(view)
 
-        sharedViewModel.isLoading.observe(this) { isLoading ->
+        sharedViewModel.trackableWorker.isWorking.observe(this) { isLoading ->
             if (isLoading) {
                 binding.progressIndicator.visibility = View.VISIBLE
                 binding.layers.visibility = View.GONE

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeScheduler.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeScheduler.kt
@@ -77,6 +77,12 @@ class FakeScheduler : Scheduler {
         return flow.flowOn(backgroundDispatcher)
     }
 
+    fun runFirstForeground() {
+        if (foregroundTasks.isNotEmpty()) {
+            foregroundTasks.removeFirst().run()
+        }
+    }
+
     fun runForeground() {
         while (foregroundTasks.isNotEmpty()) {
             foregroundTasks.remove().run()
@@ -100,6 +106,12 @@ class FakeScheduler : Scheduler {
                     it.lastRun = currentTime
                 }
             }
+        }
+    }
+
+    fun runFirstBackground() {
+        if (backgroundTasks.isNotEmpty()) {
+            backgroundTasks.removeFirst().run()
         }
     }
 


### PR DESCRIPTION
Closes #6221 

#### Why is this the best possible solution? Were any other approaches considered?
I wasn't able to reproduce the issue (probably everything worked to fast on my emulators) but I agree with what is said in the issue:
> It looks like this is because we use one LiveData to represent "loading" for OfflineMapLayersViewModel and when the Activity is recreated loadExistingLayers finishes quickly and sets isLoading to false. We can either split out two progress states, or use TrackableWorker and modify it to count work in progress rather just being on/off.

That's what I did to solve the problem.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It reworks the way we handle showing/hiding progress indicators while loading a list of layers (the existing ones or those to import). [TrackableWorker](https://github.com/getodk/collect/blob/master/androidshared/src/main/java/org/odk/collect/androidshared/async/TrackableWorker.kt) has been updated to be aware of the number of active background jobs and that's the class we use to display progress indicators in other places in the app but I believe that if it works well in offline layers it will work well in the whole app as well.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
