### PR TITLE
Fixed displaying the number of unsupported layers

### DIFF
--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersImporter.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersImporter.kt
@@ -79,7 +79,7 @@ class OfflineMapLayersImporter(
                     dismiss()
                     showNoSupportedLayersWarning(layersToImport.value.numberOfUnsupportedLayers)
                 } else if (layersToImport.value.numberOfUnsupportedLayers > 0) {
-                    showSomeUnsupportedLayersWarning(layersToImport.value.numberOfSelectedLayers - layersToImport.value.numberOfUnsupportedLayers)
+                    showSomeUnsupportedLayersWarning(layersToImport.value.numberOfUnsupportedLayers)
                 }
             }
         }

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
@@ -281,6 +281,53 @@ class OfflineMapLayersImporterTest {
         }
     }
 
+    @Test
+    fun `the warning dialog shows correct number of unsupported layers`() {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+
+        launchFragment().onFragment {
+            // Three unsupported layers
+            it.viewModel.loadLayersToImport(
+                listOf(
+                    TempFiles.createTempFile("layerA", ".txt").toUri(),
+                    TempFiles.createTempFile("layerB", ".txt").toUri(),
+                    TempFiles.createTempFile("layerC", ".txt").toUri()
+                ),
+                context
+            )
+            scheduler.flush()
+            onView(withText(context.getLocalizedQuantityString(R.plurals.non_mbtiles_files_selected_title, 3, 3))).inRoot(isDialog()).check(matches(isDisplayed()))
+        }
+
+        launchFragment().onFragment {
+            // Two unsupported layers
+            it.viewModel.loadLayersToImport(
+                listOf(
+                    TempFiles.createTempFile("layerA", ".txt").toUri(),
+                    TempFiles.createTempFile("layerB", ".txt").toUri(),
+                    TempFiles.createTempFile("layerC", MbtilesFile.FILE_EXTENSION).toUri()
+                ),
+                context
+            )
+            scheduler.flush()
+            onView(withText(context.getLocalizedQuantityString(R.plurals.non_mbtiles_files_selected_title, 2, 2))).inRoot(isDialog()).check(matches(isDisplayed()))
+        }
+
+        launchFragment().onFragment {
+            // One unsupported layer
+            it.viewModel.loadLayersToImport(
+                listOf(
+                    TempFiles.createTempFile("layerA", ".txt").toUri(),
+                    TempFiles.createTempFile("layerB", MbtilesFile.FILE_EXTENSION).toUri(),
+                    TempFiles.createTempFile("layerC", MbtilesFile.FILE_EXTENSION).toUri()
+                ),
+                context
+            )
+            scheduler.flush()
+            onView(withText(context.getLocalizedQuantityString(R.plurals.non_mbtiles_files_selected_title, 1, 1))).inRoot(isDialog()).check(matches(isDisplayed()))
+        }
+    }
+
     private fun launchFragment(): FragmentScenario<OfflineMapLayersImporter> {
         return fragmentScenarioLauncherRule.launchInContainer(OfflineMapLayersImporter::class.java)
     }


### PR DESCRIPTION
Closes #6237 

#### Why is this the best possible solution? Were any other approaches considered?
It's just a small bug fix. Nothing to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the number of unsupported layers displayed in the warning dialog.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
