### PR TITLE
Fixed SingleSelectViewModel

### DIFF
--- a/lists/src/main/java/org/odk/collect/lists/selects/SelectItem.kt
+++ b/lists/src/main/java/org/odk/collect/lists/selects/SelectItem.kt
@@ -1,3 +1,3 @@
 package org.odk.collect.lists.selects
 
-data class SelectItem<T>(val id: String, val item: T, val selected: Boolean = false)
+data class SelectItem<T>(val id: String, val item: T)

--- a/lists/src/main/java/org/odk/collect/lists/selects/SingleSelectViewModel.kt
+++ b/lists/src/main/java/org/odk/collect/lists/selects/SingleSelectViewModel.kt
@@ -6,15 +6,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import org.odk.collect.androidshared.livedata.LiveDataUtils
 
-class SingleSelectViewModel(data: LiveData<List<SelectItem<*>>>) : ViewModel() {
+class SingleSelectViewModel(
+    selected: String?,
+    data: LiveData<List<SelectItem<*>>>
+) : ViewModel() {
 
-    private val _selected = MutableLiveData<String?>(null)
+    private val _selected = MutableLiveData<String?>(selected)
     private val selected = LiveDataUtils.zip(_selected, data).map { (selected, data) ->
-        if (selected != null && data.any { it.id == selected }) {
-            selected
-        } else {
-            data.find { it.selected }?.id
-        }
+        selected.takeIf { id -> data.any { it.id == id } }
     }
 
     fun getSelected(): LiveData<String?> {

--- a/lists/src/test/java/org/odk/collect/lists/selects/SingleSelectViewModelTest.kt
+++ b/lists/src/test/java/org/odk/collect/lists/selects/SingleSelectViewModelTest.kt
@@ -1,0 +1,68 @@
+package org.odk.collect.lists.selects
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.odk.collect.androidtest.getOrAwaitValue
+
+class SingleSelectViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun `nothing is selected on viewmodel initialization if selected item id is null`() {
+        val selected = null
+        val data: LiveData<List<SelectItem<*>>> = MutableLiveData(listOf(SelectItem("1", 1), SelectItem("2", 2)))
+        val viewModel = SingleSelectViewModel(selected, data)
+
+        assertThat(viewModel.getSelected().getOrAwaitValue(), equalTo(null))
+    }
+
+    @Test
+    fun `nothing is selected on viewmodel initialization if selected item id is not null but there is no item witch matching id`() {
+        val selected = "0"
+        val data: LiveData<List<SelectItem<*>>> = MutableLiveData(listOf(SelectItem("1", 1), SelectItem("2", 2)))
+        val viewModel = SingleSelectViewModel(selected, data)
+
+        assertThat(viewModel.getSelected().getOrAwaitValue(), equalTo(null))
+    }
+
+    @Test
+    fun `proper item is selected on viewmodel initialization if selected item id is not null`() {
+        val selected = "1"
+        val data: LiveData<List<SelectItem<*>>> = MutableLiveData(listOf(SelectItem("1", 1), SelectItem("2", 2)))
+        val viewModel = SingleSelectViewModel(selected, data)
+
+        assertThat(viewModel.getSelected().getOrAwaitValue(), equalTo("1"))
+    }
+
+    @Test
+    fun `getSelected returns selected item id`() {
+        val selected = null
+        val data: LiveData<List<SelectItem<*>>> = MutableLiveData(listOf(SelectItem("1", 1), SelectItem("2", 2)))
+        val viewModel = SingleSelectViewModel(selected, data)
+
+        viewModel.select("1")
+        assertThat(viewModel.getSelected().getOrAwaitValue(), equalTo("1"))
+
+        viewModel.select("2")
+        assertThat(viewModel.getSelected().getOrAwaitValue(), equalTo("2"))
+    }
+
+    @Test
+    fun `clear unselects selected item`() {
+        val selected = null
+        val data: LiveData<List<SelectItem<*>>> = MutableLiveData(listOf(SelectItem("1", 1), SelectItem("2", 2)))
+        val viewModel = SingleSelectViewModel(selected, data)
+
+        viewModel.select("1")
+        assertThat(viewModel.getSelected().getOrAwaitValue(), equalTo("1"))
+        viewModel.clear()
+        assertThat(viewModel.getSelected().getOrAwaitValue(), equalTo(null))
+    }
+}

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
@@ -57,16 +57,14 @@ class OfflineMapLayersPicker(
     private val checkedStateViewModel: SingleSelectViewModel by viewModels {
         viewModelFactory {
             addInitializer(SingleSelectViewModel::class) {
-                SingleSelectViewModel(sharedViewModel.existingLayers.map {
-                    it.map { layer ->
-                        SelectItem(
-                            layer.id,
-                            layer,
-                            settingsProvider.getUnprotectedSettings()
-                                .getString(ProjectKeys.KEY_REFERENCE_LAYER) == layer.id
-                        )
+                SingleSelectViewModel(
+                    settingsProvider.getUnprotectedSettings().getString(ProjectKeys.KEY_REFERENCE_LAYER),
+                    sharedViewModel.existingLayers.map {
+                        it.map { layer ->
+                            SelectItem(layer.id, layer)
+                        }
                     }
-                })
+                )
             }
         }
     }


### PR DESCRIPTION
Closes #6228 

#### Why is this the best possible solution? Were any other approaches considered?
I've found some bugs in the implementation of managing selectable items that I've fixed:
- the `selected` field in [SelectItem](https://github.com/getodk/collect/pull/6239/files#diff-0facc00d4aeeca1525f3eb074ed67a898442e70b56f4f4ab2050248b9ae555daR3) was never updated and used only in `SingleSelectViewModel` (in a wrong way BTW -see the point below). We already have a separate field in `SingleSelectViewModel` for keeping track of the selected item: https://github.com/getodk/collect/pull/6239/files#diff-f1d7927cf51ea62dd7b9064ae93e9f1a4900bb625d210e9f1acf1685e9d3c3c5R14. This is how `MultiSelectViewModel` works as well - it relies on its field where selected items are kept.
- the code responsible for updating the selected item id in https://github.com/getodk/collect/pull/6239/files#diff-f1d7927cf51ea62dd7b9064ae93e9f1a4900bb625d210e9f1acf1685e9d3c3c5L13 was not working well as after trying to set the value to null the already saved value was kept (related to what I described above).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please focus on testing selecting offline layers / changing the selection / changing to none etc. as the code responsible for this has been updated. I don't think other parts of the feature could be affected here.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
