### PR TITLE
Dismiss the offline layers confirmation dialog on activity recreation

### DIFF
--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
@@ -116,6 +116,13 @@ class OfflineMapLayersPicker(
             dismiss()
         }
 
+        if (sharedViewModel.layersToImport.value?.value == null) {
+            DialogFragmentUtils.dismissDialog(
+                OfflineMapLayersImporter::class.java,
+                childFragmentManager
+            )
+        }
+
         return binding.root
     }
 

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
@@ -823,6 +823,30 @@ class OfflineMapLayersPickerTest {
         )
     }
 
+    @Test
+    fun `the confirmation dialog is dismissed o activity recreation`() {
+        val scenario = launchFragment()
+
+        uris.add(Uri.parse("blah"))
+        Interactions.clickOn(withText(string.add_layer))
+
+        scenario.onFragment {
+            assertThat(
+                it.childFragmentManager.findFragmentByTag(OfflineMapLayersImporter::class.java.name),
+                instanceOf(OfflineMapLayersImporter::class.java)
+            )
+        }
+
+        scenario.recreate()
+
+        scenario.onFragment {
+            assertThat(
+                it.childFragmentManager.findFragmentByTag(OfflineMapLayersImporter::class.java.name),
+                equalTo(null)
+            )
+        }
+    }
+
     private fun launchFragment(): FragmentScenario<OfflineMapLayersPicker> {
         return fragmentScenarioLauncherRule.launchInContainer(OfflineMapLayersPicker::class.java)
     }


### PR DESCRIPTION
Closes #6219 

#### Why is this the best possible solution? Were any other approaches considered?
We agreed in the issue that dismissing the dialog is the solution we want for now.
I wanted to handle that case in `OfflineMapLayersImporter` but it didn't seem to be easy so I did it in `OfflineMapLayersPicker` (the dialog that shows the confirmation dialog).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This requires ensuring that the dialog is being dismissed on activity recreation (the case described in the issue). This should not happen on configuration changes (for example when you rotate your device).

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
