### PR TITLE
Fixed ExternalAppIntentProvider

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalAppIntentProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalAppIntentProvider.java
@@ -21,7 +21,7 @@ public class ExternalAppIntentProvider {
 
         String exSpec = appearance.substring(appearance.indexOf(Appearances.EX));
         if (exSpec.contains(")")) {
-            exSpec = exSpec.substring(0, exSpec.indexOf(')') + 1);
+            exSpec = exSpec.substring(0, exSpec.lastIndexOf(')') + 1);
         } else if (exSpec.contains(" ")) {
             exSpec = exSpec.substring(0, exSpec.indexOf(' '));
         }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppIntentProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppIntentProviderTest.kt
@@ -74,4 +74,12 @@ class ExternalAppIntentProviderTest {
         assertThat(resultIntent.extras!!.getString("param1"), `is`("value1"))
         assertThat(resultIntent.extras!!.getString("param2"), `is`("value2"))
     }
+
+    @Test
+    fun parametersCanContainParentheses() {
+        whenever(formEntryPrompt.appearanceHint)
+            .thenReturn("ex:com.example.collectanswersprovider(param='blah()')")
+        val resultIntent = externalAppIntentProvider.getIntentToRunExternalApp(null, formEntryPrompt)
+        assertThat(resultIntent.extras!!.getString("param"), `is`("blah()"))
+    }
 }


### PR DESCRIPTION
Closes #6246 

#### Why is this the best possible solution? Were any other approaches considered?
There is nothing to discuss here as it just fixes a small bug.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test starting external apps ideally with parameters like the counter app with `increment`/`autoincrement`. Nothing else than that (reading package names and parameters) can be affected by this change.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
