### PR TITLE
Upgrade to JavaRosa release

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -35,7 +35,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.1.0"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.9"
-    const val javarosa_online = "org.getodk:javarosa:4.4.0-SNAPSHOT"
+    const val javarosa_online = "org.getodk:javarosa:4.4.0"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val javarosa = javarosa_online
     const val karumi_dexter = "com.karumi:dexter:6.2.3"


### PR DESCRIPTION
Just switches to the released version (no changes).