### PR TITLE
Fixed updating layers on changing basemaps

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/MapsPreferencesFragment.kt
@@ -68,6 +68,13 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
         super.onSettingChanged(key)
         if (key == ProjectKeys.KEY_REFERENCE_LAYER) {
             findPreference<Preference>(ProjectKeys.KEY_REFERENCE_LAYER)!!.summary = getLayerName()
+        } else if (key == KEY_BASEMAP_SOURCE) {
+            val cftor = MapConfiguratorProvider.getConfigurator(settingsProvider.getUnprotectedSettings().getString(key))
+            if (!cftor.isAvailable(requireContext())) {
+                cftor.showUnavailableMessage(requireContext())
+            } else {
+                onBasemapSourceChanged(cftor)
+            }
         }
     }
 
@@ -109,16 +116,6 @@ class MapsPreferencesFragment : BaseProjectPreferencesFragment(), Preference.OnP
 
         basemapSourcePref.setIconSpaceReserved(false)
         onBasemapSourceChanged(MapConfiguratorProvider.getConfigurator())
-        basemapSourcePref.setOnPreferenceChangeListener { _: Preference?, value: Any ->
-            val cftor = MapConfiguratorProvider.getConfigurator(value.toString())
-            if (!cftor.isAvailable(requireContext())) {
-                cftor.showUnavailableMessage(requireContext())
-                false
-            } else {
-                onBasemapSourceChanged(cftor)
-                true
-            }
-        }
     }
 
     private fun initLayersPref() {

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersPicker.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.maps.layers
 
+import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -77,6 +78,11 @@ class OfflineMapLayersPicker(
                 childFragmentManager
             )
         }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        sharedViewModel.loadExistingLayers()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersViewModel.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersViewModel.kt
@@ -33,11 +33,7 @@ class OfflineMapLayersViewModel(
 
     private lateinit var tempLayersDir: File
 
-    init {
-        loadExistingLayers()
-    }
-
-    private fun loadExistingLayers() {
+    fun loadExistingLayers() {
         trackableWorker.immediate(
             background = {
                 val layers = referenceLayerRepository.getAll().sortedBy { it.name }

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersImporterTest.kt
@@ -102,7 +102,11 @@ class OfflineMapLayersImporterTest {
 
     @Test
     fun `the 'add layer' button is disabled during loading layers`() {
-        launchFragment()
+        val file = TempFiles.createTempFile("layer", MbtilesFile.FILE_EXTENSION)
+
+        launchFragment().onFragment {
+            it.viewModel.loadLayersToImport(listOf(file.toUri()), it.requireContext())
+        }
 
         onView(withId(org.odk.collect.maps.R.id.add_layer_button)).check(matches(not(isEnabled())))
         scheduler.flush()

--- a/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/layers/OfflineMapLayersPickerTest.kt
@@ -389,6 +389,7 @@ class OfflineMapLayersPickerTest {
 
         Interactions.clickOn(withText("layer1"))
         scenario.recreate()
+        scheduler.flush()
         onView(withRecyclerView(R.id.layers).atPositionOnView(0, R.id.radio_button)).check(
             matches(
                 not(isChecked())
@@ -535,6 +536,7 @@ class OfflineMapLayersPickerTest {
         onView(withRecyclerView(R.id.layers).atPositionOnView(3, R.id.arrow)).perform(click())
 
         scenario.recreate()
+        scheduler.flush()
 
         assertLayerExpanded(1)
         assertLayerCollapsed(2)


### PR DESCRIPTION
Closes #6248 

#### Why is this the best possible solution? Were any other approaches considered?
Loading new layers is triggered in the init block of the ViewModel (`OfflineMapLayersViewModel`). That ViewModel is scoped to its activity so the init block is called only on activity creation/recreation. As a result, it is possible to end up with two `OfflineMapLayersViewModel` opened - one scoped to `FormFillingActivity` and one scooped to `ProjectPreferencesActivity`  (see the scenario from the issue). When new layers are added in one of them the second one is not updated.
~~To fix the issue I factored out another ViewModel scoped to its fragment. Thanks to that loading new layers is triggered every time we show the fragment.~~
We decided that to fix the issue we should load the layers every time the fragment is attached (see the discussion below).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is the last pr in v2024.2 so please these the offline layers once again and not only focus on the issue itself. It's not a big change but definitely something that can break something there. This also makes changes to change map engines (Google, Mapbox etc) so playing with that is a good idea.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
