### PR TITLE
Add partial parsing for entities

### DIFF
--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesFileInstanceParserTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesFileInstanceParserTest.kt
@@ -52,4 +52,28 @@ class LocalEntitiesFileInstanceParserTest {
         assertThat(item.numChildren, equalTo(3))
         assertThat(item.getFirstChild(EntityItemElement.VERSION)?.value?.value, equalTo("1"))
     }
+
+    @Test
+    fun `partial parse returns elements without values`() {
+        val entity =
+            Entity(
+                "people",
+                "1",
+                "Shiv Roy",
+                properties = listOf(Pair("age", "35")),
+                version = 1
+            )
+        entitiesRepository.save(entity)
+
+        val parser = LocalEntitiesFileInstanceParser { entitiesRepository }
+        val instance = parser.parse("people", "people.csv", true)
+        assertThat(instance.numChildren, equalTo(1))
+
+        val item = instance.getChildAt(0)!!
+        assertThat(item.isPartial, equalTo(true))
+        assertThat(item.numChildren, equalTo(4))
+        0.until(item.numChildren).forEach {
+            assertThat(item.getChildAt(it).value?.value, equalTo(null))
+        }
+    }
 }


### PR DESCRIPTION
Work towards #5623
~~Blocked by #6236~~ 
~~Blocked by https://github.com/getodk/javarosa/pull/775~~

This adds support for the JavaRosa's new "partial" parsing. Now, entities will not be fully loaded into memory (we just load the elements without values) for forms until JavaRosa needs them. This only gives us minimal gains in memory for the moment (as all the entities will usually still get loaded into memory at some point), but lays the foundations for even more optimizations by querying `EntitiesRepository` directly in a `FilterStrategy` and the populating partials via `DataInsance#populatePartialElements` (which avoids the full parse).

#### Why is this the best possible solution? Were any other approaches considered?

I've just updated `LocalEntitiesFileInstanceParser` to use the new API for partial parsing so not a lot to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only risk is to forms that use entities as that's the only area with changes. It'd be good to check forms that contain selects for all entities and forms that use filtered selects.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
