### PR TITLE
Create dependency backup for release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,14 +345,6 @@ workflows:
   commit:
     jobs:
       - compile
-      - create_dependency_backup:
-          requires:
-            - compile
-          filters:
-            tags:
-              only: /^v((20)[0-9]{2})\.\d+\.\d+$/ # matches semvers like v1.2.3
-            branches:
-              ignore: /.*/
       - check_quality:
           requires:
             - compile
@@ -393,3 +385,16 @@ workflows:
       - test_instrumented:
           requires:
             - compile
+
+  release:
+    jobs:
+      - compile:
+          filters:
+            tags:
+              only: /^v((20)[0-9]{2})\.\d+\.\d+$/ # matches semvers like v1.2.3
+            branches:
+              ignore: /.*/
+      - create_dependency_backup:
+          requires:
+            - compile
+


### PR DESCRIPTION
Previously this didn't work because the `create_dependency_backup` job relied on a job that didn't get run on tags. Looking at [CircleCI's docs](https://circleci.com/docs/configuration-reference/#tags), it seems like the first job in a workflow needs to have the tag filter to have it run on tags. Given that, I've created a new `release` workflow that should run on new tags.