### PR TITLE
Add index to local entities

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
@@ -15,7 +15,7 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         return readJson().keys
     }
 
-    override fun getEntities(list: String): List<Entity> {
+    override fun getEntities(list: String): List<Entity.Saved> {
         return readEntities().filter { it.list == list }
     }
 
@@ -35,7 +35,7 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
 
                 entityList.remove(existing)
                 entityList.add(
-                    Entity(
+                    Entity.New(
                         entity.list,
                         entity.id,
                         entity.label ?: existing.label,
@@ -72,7 +72,7 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         writeEntities(existing)
     }
 
-    private fun writeEntities(entities: MutableList<Entity>) {
+    private fun writeEntities(entities: MutableList<Entity.Saved>) {
         val map = mutableMapOf<String, MutableList<JsonEntity>>()
         entities.forEach {
             map.getOrPut(it.list) { mutableListOf() }.add(it.toJson())
@@ -81,7 +81,7 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         writeJson(map)
     }
 
-    private fun readEntities(): MutableList<Entity> {
+    private fun readEntities(): MutableList<Entity.Saved> {
         return readJson().entries.flatMap { (list, entities) ->
             entities.map { it.toEntity(list) }
         }.toMutableList()
@@ -146,14 +146,14 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         val offline: Boolean
     )
 
-    private fun JsonEntity.toEntity(list: String): Entity {
+    private fun JsonEntity.toEntity(list: String): Entity.Saved {
         val state = if (this.offline) {
             Entity.State.OFFLINE
         } else {
             Entity.State.ONLINE
         }
 
-        return Entity(
+        return Entity.Saved(
             list,
             this.id,
             this.label,

--- a/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
@@ -16,7 +16,17 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
     }
 
     override fun getEntities(list: String): List<Entity.Saved> {
-        return readEntities().filter { it.list == list }
+        return readEntities().filter { it.list == list }.mapIndexed { index, entity ->
+            Entity.Saved(
+                entity.list,
+                entity.id,
+                entity.label,
+                entity.version,
+                entity.properties,
+                entity.state,
+                index
+            )
+        }
     }
 
     override fun save(vararg entities: Entity) {
@@ -72,7 +82,7 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         writeEntities(existing)
     }
 
-    private fun writeEntities(entities: MutableList<Entity.Saved>) {
+    private fun writeEntities(entities: List<Entity.New>) {
         val map = mutableMapOf<String, MutableList<JsonEntity>>()
         entities.forEach {
             map.getOrPut(it.list) { mutableListOf() }.add(it.toJson())
@@ -81,7 +91,7 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         writeJson(map)
     }
 
-    private fun readEntities(): MutableList<Entity.Saved> {
+    private fun readEntities(): MutableList<Entity.New> {
         return readJson().entries.flatMap { (list, entities) ->
             entities.map { it.toEntity(list) }
         }.toMutableList()
@@ -146,14 +156,14 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         val offline: Boolean
     )
 
-    private fun JsonEntity.toEntity(list: String): Entity.Saved {
+    private fun JsonEntity.toEntity(list: String): Entity.New {
         val state = if (this.offline) {
             Entity.State.OFFLINE
         } else {
             Entity.State.ONLINE
         }
 
-        return Entity.Saved(
+        return Entity.New(
             list,
             this.id,
             this.label,

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -266,11 +266,12 @@ abstract class EntitiesRepositoryTest {
     fun `#save does not change index when updating an existing entity`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008", version = 1)
-        repository.save(wine)
+        val first = Entity.New("wines", "1", "Léoville Barton 2008")
+        val second = Entity.New("wines", "2", "Pontet Canet 2014")
+        repository.save(first, second)
         assertThat(repository.getEntities("wines")[0].index, equalTo(0))
 
-        val updatedWine = wine.copy(label = "Léoville Barton 2009")
+        val updatedWine = first.copy(label = "Léoville Barton 2009")
         repository.save(updatedWine)
 
         assertThat(repository.getEntities("wines")[0].index, equalTo(0))

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -5,6 +5,7 @@ import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
+import org.odk.collect.android.entities.support.EntitySameAsMatcher.Companion.sameEntityAs
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
 
@@ -16,8 +17,8 @@ abstract class EntitiesRepositoryTest {
     fun `#getLists returns lists for saved entities`() {
         val repository = buildSubject()
 
-        val wine = Entity("wines", "1", "Léoville Barton 2008")
-        val whisky = Entity("whiskys", "2", "Lagavulin 16")
+        val wine = Entity.New("wines", "1", "Léoville Barton 2008")
+        val whisky = Entity.New("whiskys", "2", "Lagavulin 16")
         repository.save(wine)
         repository.save(whisky)
 
@@ -28,97 +29,97 @@ abstract class EntitiesRepositoryTest {
     fun `#getEntities returns entities for list`() {
         val repository = buildSubject()
 
-        val wine = Entity("wines", "1", "Léoville Barton 2008")
-        val whisky = Entity("whiskys", "2", "Lagavulin 16")
+        val wine = Entity.New("wines", "1", "Léoville Barton 2008")
+        val whisky = Entity.New("whiskys", "2", "Lagavulin 16")
         repository.save(wine)
         repository.save(whisky)
 
         val wines = repository.getEntities("wines")
         assertThat(wines.size, equalTo(1))
-        assertThat(wines[0], equalTo(wine))
+        assertThat(wines[0], sameEntityAs(wine))
 
         val whiskys = repository.getEntities("whiskys")
         assertThat(whiskys.size, equalTo(1))
-        assertThat(whiskys[0], equalTo(whisky))
+        assertThat(whiskys[0], sameEntityAs(whisky))
     }
 
     @Test
     fun `#save updates existing entity with matching id`() {
         val repository = buildSubject()
 
-        val wine = Entity("wines", "1", "Léoville Barton 2008", version = 1)
+        val wine = Entity.New("wines", "1", "Léoville Barton 2008", version = 1)
         repository.save(wine)
 
-        val updatedWine = Entity("wines", wine.id, "Léoville Barton 2009", version = 2)
+        val updatedWine = Entity.New("wines", wine.id, "Léoville Barton 2009", version = 2)
         repository.save(updatedWine)
 
         val wines = repository.getEntities("wines")
-        assertThat(wines, contains(updatedWine))
+        assertThat(wines, contains(sameEntityAs(updatedWine)))
     }
 
     @Test
     fun `#save creates entity with matching id in different list`() {
         val repository = buildSubject()
 
-        val wine = Entity("wines", "1", "Léoville Barton 2008", version = 1)
+        val wine = Entity.New("wines", "1", "Léoville Barton 2008", version = 1)
         repository.save(wine)
 
-        val updatedWine = Entity("whisky", wine.id, "Edradour 10", version = 2)
+        val updatedWine = Entity.New("whisky", wine.id, "Edradour 10", version = 2)
         repository.save(updatedWine)
 
         val wines = repository.getEntities("wines")
-        assertThat(wines, contains(wine))
+        assertThat(wines, contains(sameEntityAs(wine)))
         val whiskys = repository.getEntities("whisky")
-        assertThat(whiskys, contains(updatedWine))
+        assertThat(whiskys, contains(sameEntityAs(updatedWine)))
     }
 
     @Test
     fun `#save updates existing entity with matching id and version`() {
         val repository = buildSubject()
 
-        val wine = Entity("wines", "1", "Léoville Barton 2008", version = 1)
+        val wine = Entity.New("wines", "1", "Léoville Barton 2008", version = 1)
         repository.save(wine)
 
         val updatedWine = wine.copy(label = "Léoville Barton 2009")
         repository.save(updatedWine)
 
         val wines = repository.getEntities("wines")
-        assertThat(wines, contains(updatedWine))
+        assertThat(wines, contains(sameEntityAs(updatedWine)))
     }
 
     @Test
     fun `#save updates state on existing entity when it is offline`() {
         val repository = buildSubject()
 
-        val wine = Entity("wines", "1", "Léoville Barton 2008", state = Entity.State.OFFLINE)
+        val wine = Entity.New("wines", "1", "Léoville Barton 2008", state = Entity.State.OFFLINE)
         repository.save(wine)
 
         val updatedWine = wine.copy(state = Entity.State.ONLINE)
         repository.save(updatedWine)
 
         val wines = repository.getEntities("wines")
-        assertThat(wines, contains(updatedWine))
+        assertThat(wines, contains(sameEntityAs(updatedWine)))
     }
 
     @Test
     fun `#save does not update state on existing entity when it is online`() {
         val repository = buildSubject()
 
-        val wine = Entity("wines", "1", "Léoville Barton 2008", state = Entity.State.ONLINE)
+        val wine = Entity.New("wines", "1", "Léoville Barton 2008", state = Entity.State.ONLINE)
         repository.save(wine)
 
         val updatedWine = wine.copy(state = Entity.State.OFFLINE)
         repository.save(updatedWine)
 
         val wines = repository.getEntities("wines")
-        assertThat(wines, contains(wine))
+        assertThat(wines, contains(sameEntityAs(wine)))
     }
 
     @Test
     fun `#save adds new properties`() {
         val repository = buildSubject()
 
-        val wine = Entity(
+        val wine = Entity.New(
             "wines",
             "1",
             "Léoville Barton 2008",
@@ -127,7 +128,7 @@ abstract class EntitiesRepositoryTest {
         )
         repository.save(wine)
 
-        val updatedWine = Entity(
+        val updatedWine = Entity.New(
             "wines",
             wine.id,
             "Léoville Barton 2008",
@@ -145,7 +146,7 @@ abstract class EntitiesRepositoryTest {
     fun `#save updates existing properties`() {
         val repository = buildSubject()
 
-        val wine = Entity(
+        val wine = Entity.New(
             "wines",
             "1",
             "Léoville Barton 2008",
@@ -154,7 +155,7 @@ abstract class EntitiesRepositoryTest {
         )
         repository.save(wine)
 
-        val updatedWine = Entity(
+        val updatedWine = Entity.New(
             "wines",
             wine.id,
             "Léoville Barton 2008",
@@ -172,7 +173,7 @@ abstract class EntitiesRepositoryTest {
     fun `#save does not update existing label if new one is null`() {
         val repository = buildSubject()
 
-        val wine = Entity(
+        val wine = Entity.New(
             "wines",
             "1",
             "Léoville Barton 2008",
@@ -181,7 +182,7 @@ abstract class EntitiesRepositoryTest {
         )
         repository.save(wine)
 
-        val updatedWine = Entity(
+        val updatedWine = Entity.New(
             "wines",
             wine.id,
             null,
@@ -204,7 +205,7 @@ abstract class EntitiesRepositoryTest {
         repository.addList("blah")
         assertThat(repository.getLists(), containsInAnyOrder("wines", "blah"))
 
-        repository.save(Entity("wines", "blah", "Blah"))
+        repository.save(Entity.New("wines", "blah", "Blah"))
         assertThat(repository.getLists(), containsInAnyOrder("wines", "blah"))
     }
 
@@ -212,8 +213,8 @@ abstract class EntitiesRepositoryTest {
     fun `#clear deletes all entities`() {
         val repository = buildSubject()
 
-        val wine = Entity("wines", "1", "Léoville Barton 2008")
-        val whisky = Entity("whiskys", "2", "Lagavulin 16")
+        val wine = Entity.New("wines", "1", "Léoville Barton 2008")
+        val whisky = Entity.New("whiskys", "2", "Lagavulin 16")
         repository.save(wine)
         repository.save(whisky)
 
@@ -227,8 +228,8 @@ abstract class EntitiesRepositoryTest {
     fun `#save can save multiple entities`() {
         val repository = buildSubject()
 
-        val wine = Entity("wines", "1", "Léoville Barton 2008")
-        val whisky = Entity("whiskys", "2", "Lagavulin 16")
+        val wine = Entity.New("wines", "1", "Léoville Barton 2008")
+        val whisky = Entity.New("whiskys", "2", "Lagavulin 16")
         repository.save(wine, whisky)
 
         assertThat(repository.getLists(), containsInAnyOrder("wines", "whiskys"))
@@ -247,12 +248,12 @@ abstract class EntitiesRepositoryTest {
     fun `#delete removes an entity`() {
         val repository = buildSubject()
 
-        val leoville = Entity("wines", "1", "Léoville Barton 2008")
-        val canet = Entity("wines", "2", "Pontet-Canet 2014")
+        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
+        val canet = Entity.New("wines", "2", "Pontet-Canet 2014")
         repository.save(leoville, canet)
 
         repository.delete("1")
 
-        assertThat(repository.getEntities("wines"), containsInAnyOrder(canet))
+        assertThat(repository.getEntities("wines"), containsInAnyOrder(sameEntityAs(canet)))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/JsonFileEntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/JsonFileEntitiesRepositoryTest.kt
@@ -4,6 +4,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
+import org.odk.collect.android.entities.support.EntitySameAsMatcher.Companion.sameEntityAs
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
 import org.odk.collect.shared.TempFiles
@@ -24,10 +25,10 @@ class JsonFileEntitiesRepositoryTest : EntitiesRepositoryTest() {
         val two = JsonFileEntitiesRepository(directory)
         val three = JsonFileEntitiesRepository(File(TempFiles.getPathInTempDir()))
 
-        val entity = Entity("stuff", "1", "A thing")
+        val entity = Entity.New("stuff", "1", "A thing")
         one.save(entity)
         assertThat(two.getLists(), contains("stuff"))
-        assertThat(two.getEntities("stuff"), contains(entity))
+        assertThat(two.getEntities("stuff"), contains(sameEntityAs(entity)))
         assertThat(three.getLists().size, equalTo(0))
     }
 
@@ -35,7 +36,7 @@ class JsonFileEntitiesRepositoryTest : EntitiesRepositoryTest() {
     fun `clears data if backing file can't be parsed by current code`() {
         val repository = buildSubject()
         repository.addList("stuff")
-        repository.save(Entity("stuff", "123", null))
+        repository.save(Entity.New("stuff", "123", null))
 
         val filesInDir = directory.listFiles()
         assertThat(filesInDir!!.size, equalTo(1))
@@ -44,7 +45,7 @@ class JsonFileEntitiesRepositoryTest : EntitiesRepositoryTest() {
 
         assertThat(repository.getEntities("stuff").size, equalTo(0))
 
-        repository.save(Entity("stuff", "123", null))
+        repository.save(Entity.New("stuff", "123", null))
         assertThat(repository.getEntities("stuff").size, equalTo(1))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/support/EntitySameAsMatcher.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/support/EntitySameAsMatcher.kt
@@ -1,0 +1,25 @@
+package org.odk.collect.android.entities.support
+
+import org.hamcrest.Description
+import org.hamcrest.TypeSafeMatcher
+import org.odk.collect.entities.storage.Entity
+
+class EntitySameAsMatcher(private val expected: Entity) : TypeSafeMatcher<Entity>() {
+    override fun describeTo(description: Description) {
+        description.appendText("is the same as $expected")
+    }
+
+    override fun matchesSafely(item: Entity?): Boolean {
+        return if (item != null) {
+            expected.sameAs(item)
+        } else {
+            false
+        }
+    }
+
+    companion object {
+        fun sameEntityAs(entity: Entity): EntitySameAsMatcher {
+            return EntitySameAsMatcher(entity)
+        }
+    }
+}

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -20,7 +20,7 @@ object LocalEntityUseCases {
             val id = formEntity.id
             if (id != null && entitiesRepository.getLists().contains(formEntity.dataset)) {
                 if (formEntity.action != EntityAction.UPDATE || entitiesRepository.getEntities(formEntity.dataset).any { it.id == id }) {
-                    val entity = Entity(
+                    val entity = Entity.New(
                         formEntity.dataset,
                         id,
                         formEntity.label,
@@ -100,7 +100,7 @@ object LocalEntityUseCases {
                 }
             }
 
-        val entity = Entity(list, id, label, version, properties, state = Entity.State.ONLINE)
+        val entity = Entity.New(list, id, label, version, properties, state = Entity.State.ONLINE)
         return entity
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/browser/EntitiesFragment.kt
+++ b/entities/src/main/java/org/odk/collect/entities/browser/EntitiesFragment.kt
@@ -40,7 +40,7 @@ class EntitiesFragment(private val viewModelFactory: ViewModelProvider.Factory) 
     }
 }
 
-private class EntitiesAdapter(private val data: List<Entity>) :
+private class EntitiesAdapter(private val data: List<Entity.Saved>) :
     RecyclerView.Adapter<EntityViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, position: Int): EntityViewHolder {
@@ -63,7 +63,7 @@ private class EntityViewHolder(context: Context) : ViewHolder(EntityItemView(con
         matchParentWidth()
     }
 
-    fun setEntity(entity: Entity) {
+    fun setEntity(entity: Entity.Saved) {
         (itemView as EntityItemView).setEntity(entity)
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/browser/EntitiesViewModel.kt
+++ b/entities/src/main/java/org/odk/collect/entities/browser/EntitiesViewModel.kt
@@ -21,8 +21,8 @@ class EntitiesViewModel(
         }
     }
 
-    fun getEntities(list: String): LiveData<List<Entity>> {
-        val result = MutableLiveData<List<Entity>>(emptyList())
+    fun getEntities(list: String): LiveData<List<Entity.Saved>> {
+        val result = MutableLiveData<List<Entity.Saved>>(emptyList())
         scheduler.immediate {
             result.postValue(entitiesRepository.getEntities(list))
         }

--- a/entities/src/main/java/org/odk/collect/entities/browser/EntityItemView.kt
+++ b/entities/src/main/java/org/odk/collect/entities/browser/EntityItemView.kt
@@ -11,7 +11,7 @@ class EntityItemView(context: Context) : FrameLayout(context) {
 
     val binding = EntityItemLayoutBinding.inflate(LayoutInflater.from(context), this, true)
 
-    fun setEntity(entity: Entity) {
+    fun setEntity(entity: Entity.Saved) {
         binding.label.text = entity.label
         binding.properties.text = entity.properties
             .sortedBy { it.first }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesFileInstanceParser.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesFileInstanceParser.kt
@@ -17,7 +17,7 @@ internal class LocalEntitiesFileInstanceParser(private val entitiesRepositoryPro
         val root = TreeElement("root", 0)
 
         val entitiesRepository = entitiesRepositoryProvider()
-        entitiesRepository.getEntities(instanceId).forEachIndexed { index, entity ->
+        entitiesRepository.getEntities(instanceId).forEach { entity ->
             val name = TreeElement(EntityItemElement.ID)
             val label = TreeElement(EntityItemElement.LABEL)
             val version = TreeElement(EntityItemElement.VERSION)
@@ -28,7 +28,7 @@ internal class LocalEntitiesFileInstanceParser(private val entitiesRepositoryPro
                 version.value = StringData(entity.version.toString())
             }
 
-            val item = TreeElement("item", index, partial)
+            val item = TreeElement("item", entity.index, partial)
             item.addChild(name)
             item.addChild(label)
             item.addChild(version)

--- a/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
@@ -3,7 +3,7 @@ package org.odk.collect.entities.storage
 interface EntitiesRepository {
     fun save(vararg entities: Entity)
     fun getLists(): Set<String>
-    fun getEntities(list: String): List<Entity>
+    fun getEntities(list: String): List<Entity.Saved>
     fun clear()
     fun addList(list: String)
     fun delete(id: String)

--- a/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
@@ -23,7 +23,8 @@ sealed interface Entity {
         override val label: String?,
         override val version: Int = 1,
         override val properties: List<Pair<String, String>> = emptyList(),
-        override val state: State = State.OFFLINE
+        override val state: State = State.OFFLINE,
+        val index: Int
     ) : Entity
 
     enum class State {

--- a/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
@@ -1,15 +1,50 @@
 package org.odk.collect.entities.storage
 
-data class Entity @JvmOverloads constructor(
-    val list: String,
-    val id: String,
-    val label: String?,
-    val version: Int = 1,
-    val properties: List<Pair<String, String>> = emptyList(),
-    val state: State = State.OFFLINE
-) {
+sealed interface Entity {
+    val list: String
+    val id: String
+    val label: String?
+    val version: Int
+    val properties: List<Pair<String, String>>
+    val state: State
+
+    data class New(
+        override val list: String,
+        override val id: String,
+        override val label: String?,
+        override val version: Int = 1,
+        override val properties: List<Pair<String, String>> = emptyList(),
+        override val state: State = State.OFFLINE
+    ) : Entity
+
+    data class Saved(
+        override val list: String,
+        override val id: String,
+        override val label: String?,
+        override val version: Int = 1,
+        override val properties: List<Pair<String, String>> = emptyList(),
+        override val state: State = State.OFFLINE
+    ) : Entity
+
     enum class State {
         OFFLINE,
         ONLINE
+    }
+
+    fun sameAs(entity: Entity): Boolean {
+        val a = convertToNew(this)
+        val b = convertToNew(entity)
+        return a == b
+    }
+
+    private fun convertToNew(entity: Entity): New {
+        return New(
+            entity.list,
+            entity.id,
+            entity.label,
+            entity.version,
+            entity.properties,
+            entity.state
+        )
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -3,14 +3,24 @@ package org.odk.collect.entities.storage
 class InMemEntitiesRepository : EntitiesRepository {
 
     private val lists = mutableSetOf<String>()
-    private val entities = mutableListOf<Entity.Saved>()
+    private val entities = mutableListOf<Entity.New>()
 
     override fun getLists(): Set<String> {
         return lists
     }
 
     override fun getEntities(list: String): List<Entity.Saved> {
-        return entities.filter { it.list == list }
+        return entities.filter { it.list == list }.mapIndexed { index, entity ->
+            Entity.Saved(
+                entity.list,
+                entity.id,
+                entity.label,
+                entity.version,
+                entity.properties,
+                entity.state,
+                index
+            )
+        }
     }
 
     override fun clear() {
@@ -39,7 +49,7 @@ class InMemEntitiesRepository : EntitiesRepository {
 
                 this.entities.remove(existing)
                 this.entities.add(
-                    Entity.Saved(
+                    Entity.New(
                         entity.list,
                         entity.id,
                         entity.label ?: existing.label,
@@ -50,7 +60,7 @@ class InMemEntitiesRepository : EntitiesRepository {
                 )
             } else {
                 this.entities.add(
-                    Entity.Saved(
+                    Entity.New(
                         entity.list,
                         entity.id,
                         entity.label,

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -3,13 +3,13 @@ package org.odk.collect.entities.storage
 class InMemEntitiesRepository : EntitiesRepository {
 
     private val lists = mutableSetOf<String>()
-    private val entities = mutableListOf<Entity>()
+    private val entities = mutableListOf<Entity.Saved>()
 
     override fun getLists(): Set<String> {
         return lists
     }
 
-    override fun getEntities(list: String): List<Entity> {
+    override fun getEntities(list: String): List<Entity.Saved> {
         return entities.filter { it.list == list }
     }
 
@@ -39,7 +39,7 @@ class InMemEntitiesRepository : EntitiesRepository {
 
                 this.entities.remove(existing)
                 this.entities.add(
-                    Entity(
+                    Entity.Saved(
                         entity.list,
                         entity.id,
                         entity.label ?: existing.label,
@@ -49,7 +49,16 @@ class InMemEntitiesRepository : EntitiesRepository {
                     )
                 )
             } else {
-                this.entities.add(entity)
+                this.entities.add(
+                    Entity.Saved(
+                        entity.list,
+                        entity.id,
+                        entity.label,
+                        entity.version,
+                        entity.properties,
+                        entity.state
+                    )
+                )
             }
         }
     }

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -3,7 +3,6 @@ package org.odk.collect.entities
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVPrinter
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.odk.collect.entities.browser.EntityItemElement
@@ -11,7 +10,6 @@ import org.odk.collect.entities.javarosa.finalization.EntitiesExtra
 import org.odk.collect.entities.javarosa.spec.EntityAction
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
-import org.odk.collect.entities.storage.Entity.State.ONLINE
 import org.odk.collect.entities.storage.InMemEntitiesRepository
 import org.odk.collect.shared.TempFiles
 import java.io.File
@@ -69,10 +67,9 @@ class LocalEntityUseCasesTest {
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
-        assertThat(
-            songs,
-            containsInAnyOrder(Entity.Saved("songs", "noah", "Noah", 2, state = ONLINE))
-        )
+        assertThat(songs.size, equalTo(1))
+        assertThat(songs[0].label, equalTo("Noah"))
+        assertThat(songs[0].version, equalTo(2))
     }
 
     @Test
@@ -82,10 +79,9 @@ class LocalEntityUseCasesTest {
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
-        assertThat(
-            songs,
-            containsInAnyOrder(Entity.Saved("songs", "noah", "Noah", 2, state = ONLINE))
-        )
+        assertThat(songs.size, equalTo(1))
+        assertThat(songs[0].label, equalTo("Noah"))
+        assertThat(songs[0].version, equalTo(2))
     }
 
     @Test
@@ -95,10 +91,9 @@ class LocalEntityUseCasesTest {
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
-        assertThat(
-            songs,
-            containsInAnyOrder(Entity.Saved("songs", "noah", "Noah", 2, state = ONLINE))
-        )
+        assertThat(songs.size, equalTo(1))
+        assertThat(songs[0].label, equalTo("Noah"))
+        assertThat(songs[0].version, equalTo(2))
     }
 
     @Test
@@ -109,10 +104,8 @@ class LocalEntityUseCasesTest {
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
-        assertThat(
-            songs,
-            containsInAnyOrder(Entity.Saved("songs", "noah", "Noah", 3, state = ONLINE))
-        )
+        assertThat(songs.size, equalTo(1))
+        assertThat(songs[0].properties, equalTo(emptyList()))
     }
 
     @Test
@@ -125,19 +118,9 @@ class LocalEntityUseCasesTest {
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
-        assertThat(
-            songs,
-            containsInAnyOrder(
-                Entity.Saved(
-                    "songs",
-                    "noah",
-                    "Noah",
-                    2,
-                    listOf(Pair("length", "4:58")),
-                    state = ONLINE
-                )
-            )
-        )
+        assertThat(songs.size, equalTo(1))
+        assertThat(songs[0].version, equalTo(2))
+        assertThat(songs[0].properties, equalTo(listOf(Pair("length", "4:58"))))
     }
 
     @Test
@@ -182,10 +165,8 @@ class LocalEntityUseCasesTest {
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
-        assertThat(
-            songs,
-            containsInAnyOrder(Entity.Saved("songs", "cathedrals", label = "", state = ONLINE))
-        )
+        assertThat(songs.size, equalTo(1))
+        assertThat(songs[0].label, equalTo(""))
     }
 
     @Test
@@ -215,13 +196,7 @@ class LocalEntityUseCasesTest {
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
-        assertThat(
-            songs,
-            containsInAnyOrder(
-                Entity.Saved("songs", "cathedrals", "Cathedrals", state = ONLINE),
-                Entity.Saved("songs", "noah", "Noah")
-            )
-        )
+        assertThat(songs.size, equalTo(2))
     }
 
     @Test
@@ -235,7 +210,8 @@ class LocalEntityUseCasesTest {
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", secondCsv, entitiesRepository)
 
         val songs = entitiesRepository.getEntities("songs")
-        assertThat(songs, containsInAnyOrder(Entity.Saved("songs", "noah", "Noah", state = ONLINE)))
+        assertThat(songs.size, equalTo(1))
+        assertThat(songs[0].id, equalTo("noah"))
     }
 
     @Test

--- a/entities/src/test/java/org/odk/collect/entities/browser/EntityItemViewTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/browser/EntityItemViewTest.kt
@@ -20,7 +20,7 @@ class EntityItemViewTest {
     fun `sorts order of properties`() {
         val view = EntityItemView(context)
         view.setEntity(
-            Entity(
+            Entity.Saved(
                 "songs",
                 "1",
                 "S.D.O.S",
@@ -35,7 +35,7 @@ class EntityItemViewTest {
     @Test
     fun `shows offline pill when entity is offline`() {
         val view = EntityItemView(context)
-        val entity = Entity("songs", "1", "S.D.O.S")
+        val entity = Entity.Saved("songs", "1", "S.D.O.S")
 
         view.setEntity(entity.copy(state = Entity.State.OFFLINE))
         assertThat(view.binding.offlinePill.isVisible, equalTo(true))

--- a/entities/src/test/java/org/odk/collect/entities/browser/EntityItemViewTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/browser/EntityItemViewTest.kt
@@ -24,7 +24,8 @@ class EntityItemViewTest {
                 "songs",
                 "1",
                 "S.D.O.S",
-                properties = listOf(Pair("name", "S.D.O.S"), Pair("length", "2:50"))
+                properties = listOf(Pair("name", "S.D.O.S"), Pair("length", "2:50")),
+                index = 0
             )
         )
 
@@ -35,7 +36,7 @@ class EntityItemViewTest {
     @Test
     fun `shows offline pill when entity is offline`() {
         val view = EntityItemView(context)
-        val entity = Entity.Saved("songs", "1", "S.D.O.S")
+        val entity = Entity.Saved("songs", "1", "S.D.O.S", index = 0)
 
         view.setEntity(entity.copy(state = Entity.State.OFFLINE))
         assertThat(view.binding.offlinePill.isVisible, equalTo(true))

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesFileInstanceParserTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesFileInstanceParserTest.kt
@@ -76,4 +76,23 @@ class LocalEntitiesFileInstanceParserTest {
             assertThat(item.getChildAt(it).value?.value, equalTo(null))
         }
     }
+
+    @Test
+    fun `uses entity index for multiplicity`() {
+        val entity =
+            Entity.New(
+                "people",
+                "1",
+                "Shiv Roy",
+                version = 1
+            )
+        val repository = InMemEntitiesRepository()
+        repository.save(entity)
+
+        val parser = LocalEntitiesFileInstanceParser { repository }
+        val instance = parser.parse("people", "people.csv", true)
+
+        val item = instance.getChildAt(0)!!
+        assertThat(item.multiplicity, equalTo(0))
+    }
 }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesFileInstanceParserTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesFileInstanceParserTest.kt
@@ -79,20 +79,31 @@ class LocalEntitiesFileInstanceParserTest {
 
     @Test
     fun `uses entity index for multiplicity`() {
-        val entity =
+        val entities = arrayOf(
             Entity.New(
                 "people",
                 "1",
-                "Shiv Roy",
-                version = 1
+                "Shiv Roy"
+            ),
+            Entity.New(
+                "people",
+                "2",
+                "Kendall Roy"
             )
+        )
+
         val repository = InMemEntitiesRepository()
-        repository.save(entity)
+        repository.save(*entities)
 
         val parser = LocalEntitiesFileInstanceParser { repository }
-        val instance = parser.parse("people", "people.csv", true)
+        val instance = parser.parse("people", "people.csv", false)
 
-        val item = instance.getChildAt(0)!!
-        assertThat(item.multiplicity, equalTo(0))
+        val first = instance.getChildAt(0)!!
+        assertThat(first.getFirstChild("name")!!.value!!.value, equalTo("1"))
+        assertThat(first.multiplicity, equalTo(0))
+
+        val second = instance.getChildAt(1)!!
+        assertThat(second.getFirstChild("name")!!.value!!.value, equalTo("2"))
+        assertThat(second.multiplicity, equalTo(1))
     }
 }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesFileInstanceParserTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesFileInstanceParserTest.kt
@@ -15,7 +15,7 @@ class LocalEntitiesFileInstanceParserTest {
     @Test
     fun `includes properties in local entity elements`() {
         val entity =
-            Entity(
+            Entity.New(
                 "people",
                 "1",
                 "Shiv Roy",
@@ -36,7 +36,7 @@ class LocalEntitiesFileInstanceParserTest {
     @Test
     fun `includes version in local entity elements`() {
         val entity =
-            Entity(
+            Entity.New(
                 "people",
                 "1",
                 "Shiv Roy",
@@ -56,7 +56,7 @@ class LocalEntitiesFileInstanceParserTest {
     @Test
     fun `partial parse returns elements without values`() {
         val entity =
-            Entity(
+            Entity.New(
                 "people",
                 "1",
                 "Shiv Roy",


### PR DESCRIPTION
Work towards #5623 

This adds a new `index` property for local entities that can be used as the multiplicity (XPath "index") for each `TreeElement` when we generate a secondary instance. This isn't strictly required right now, but it will be needed later when we want to query `EntitiesRepository` in a `FilterStrategy` to allow for optimized entity filters (ultimately allowing larger entity lists to be used).

#### Why is this the best possible solution? Were any other approaches considered?

The biggest change here was actually switching to a `New`/`Saved` sealed class/ADT pattern for `Entity` to allow for properties that are only available after saving (with `EntitiesRepository`). This allows us to keep the logic of generating `index` entirely within the repository implementations. Any other quirks will be pointed out inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The biggest risk here is that the changes here could mess with forms that use entity lists in selects or calculations. It would be good to play around with those along with deleting (on the server) and adding entities (both on different devices/server and offline).

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
