### PR TITLE
Add filter strategy for optimized entity name/property queries

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
@@ -86,6 +86,12 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         return getEntities(list).firstOrNull { it.id == id }
     }
 
+    override fun getAllByProperty(list: String, property: String, value: String): List<Entity.Saved> {
+        return getEntities(list).filter { entity ->
+            entity.properties.firstOrNull { it.first == property }?.second == value
+        }
+    }
+
     private fun writeEntities(entities: List<Entity.New>) {
         val map = mutableMapOf<String, MutableList<JsonEntity>>()
         entities.forEach {

--- a/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
@@ -82,6 +82,10 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         writeEntities(existing)
     }
 
+    override fun getById(list: String, id: String): Entity.Saved? {
+        return getEntities(list).firstOrNull { it.id == id }
+    }
+
     private fun writeEntities(entities: List<Entity.New>) {
         val map = mutableMapOf<String, MutableList<JsonEntity>>()
         entities.forEach {

--- a/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
@@ -88,7 +88,7 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
 
     override fun getAllByProperty(list: String, property: String, value: String): List<Entity.Saved> {
         return getEntities(list).filter { entity ->
-            entity.properties.firstOrNull { it.first == property }?.second == value
+            entity.properties.any { (first, second) -> first == property && second == value }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -10,9 +10,14 @@ import org.odk.collect.android.tasks.FormLoaderTask.FormEntryControllerFactory
 import org.odk.collect.entities.javarosa.filter.LocalEntitiesFilterStrategy
 import org.odk.collect.entities.javarosa.finalization.EntityFormFinalizationProcessor
 import org.odk.collect.entities.storage.EntitiesRepository
+import org.odk.collect.settings.keys.ProjectKeys
+import org.odk.collect.shared.settings.Settings
 import java.io.File
 
-class CollectFormEntryControllerFactory(val entitiesRepository: EntitiesRepository) :
+class CollectFormEntryControllerFactory(
+    private val entitiesRepository: EntitiesRepository,
+    private val settings: Settings
+) :
     FormEntryControllerFactory {
     override fun create(formDef: FormDef, formMediaDir: File): FormEntryController {
         val externalDataManager = ExternalDataManagerImpl(formMediaDir).also {
@@ -21,8 +26,11 @@ class CollectFormEntryControllerFactory(val entitiesRepository: EntitiesReposito
 
         return FormEntryController(FormEntryModel(formDef)).also {
             it.addFunctionHandler(ExternalDataHandlerPull(externalDataManager))
-            it.addFilterStrategy(LocalEntitiesFilterStrategy(entitiesRepository))
             it.addPostProcessor(EntityFormFinalizationProcessor())
+
+            if (settings.getBoolean(ProjectKeys.KEY_LOCAL_ENTITIES)) {
+                it.addFilterStrategy(LocalEntitiesFilterStrategy(entitiesRepository))
+            }
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -9,21 +9,19 @@ import org.odk.collect.android.dynamicpreload.handler.ExternalDataHandlerPull
 import org.odk.collect.android.tasks.FormLoaderTask.FormEntryControllerFactory
 import org.odk.collect.entities.javarosa.filter.LocalEntitiesFilterStrategy
 import org.odk.collect.entities.javarosa.finalization.EntityFormFinalizationProcessor
+import org.odk.collect.entities.storage.EntitiesRepository
 import java.io.File
 
-class CollectFormEntryControllerFactory :
+class CollectFormEntryControllerFactory(val entitiesRepository: EntitiesRepository) :
     FormEntryControllerFactory {
     override fun create(formDef: FormDef, formMediaDir: File): FormEntryController {
         val externalDataManager = ExternalDataManagerImpl(formMediaDir).also {
             Collect.getInstance().externalDataManager = it
         }
 
-        val projectsDataService = Collect.getInstance().component.currentProjectProvider()
-        val projectId = projectsDataService.getCurrentProject().uuid
-
         return FormEntryController(FormEntryModel(formDef)).also {
             it.addFunctionHandler(ExternalDataHandlerPull(externalDataManager))
-            it.addFilterStrategy(LocalEntitiesFilterStrategy(Collect.getInstance().component.entitiesRepositoryProvider().create(projectId)))
+            it.addFilterStrategy(LocalEntitiesFilterStrategy(entitiesRepository))
             it.addPostProcessor(EntityFormFinalizationProcessor())
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -7,6 +7,7 @@ import org.odk.collect.android.application.Collect
 import org.odk.collect.android.dynamicpreload.ExternalDataManagerImpl
 import org.odk.collect.android.dynamicpreload.handler.ExternalDataHandlerPull
 import org.odk.collect.android.tasks.FormLoaderTask.FormEntryControllerFactory
+import org.odk.collect.entities.javarosa.filter.LocalEntitiesFilterStrategy
 import org.odk.collect.entities.javarosa.finalization.EntityFormFinalizationProcessor
 import java.io.File
 
@@ -20,7 +21,11 @@ class CollectFormEntryControllerFactory :
         val externalDataHandlerPull = ExternalDataHandlerPull(externalDataManager)
         formDef.evaluationContext.addFunctionHandler(externalDataHandlerPull)
 
+        val projectsDataService = Collect.getInstance().component.currentProjectProvider()
+        val projectId = projectsDataService.getCurrentProject().uuid
+
         return FormEntryController(FormEntryModel(formDef)).also {
+            it.addFilterStrategy(LocalEntitiesFilterStrategy(Collect.getInstance().component.entitiesRepositoryProvider().create(projectId)))
             it.addPostProcessor(EntityFormFinalizationProcessor())
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -18,9 +18,6 @@ class CollectFormEntryControllerFactory :
             Collect.getInstance().externalDataManager = it
         }
 
-        val externalDataHandlerPull = ExternalDataHandlerPull(externalDataManager)
-        formDef.evaluationContext.addFunctionHandler(externalDataHandlerPull)
-
         val projectsDataService = Collect.getInstance().component.currentProjectProvider()
         val projectId = projectsDataService.getCurrentProject().uuid
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -25,6 +25,7 @@ class CollectFormEntryControllerFactory :
         val projectId = projectsDataService.getCurrentProject().uuid
 
         return FormEntryController(FormEntryModel(formDef)).also {
+            it.addFunctionHandler(ExternalDataHandlerPull(externalDataManager))
             it.addFilterStrategy(LocalEntitiesFilterStrategy(Collect.getInstance().component.entitiesRepositoryProvider().create(projectId)))
             it.addPostProcessor(EntityFormFinalizationProcessor())
         }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -625,8 +625,9 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory(ProjectsDataService projectsDataService, EntitiesRepositoryProvider entitiesRepositoryProvider) {
-        EntitiesRepository entitiesRepository = entitiesRepositoryProvider.create(projectsDataService.getCurrentProject().getUuid());
-        return new CollectFormEntryControllerFactory(entitiesRepository);
+    public FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory(ProjectsDataService projectsDataService, EntitiesRepositoryProvider entitiesRepositoryProvider, SettingsProvider settingsProvider) {
+        String projectId = projectsDataService.getCurrentProject().getUuid();
+        EntitiesRepository entitiesRepository = entitiesRepositoryProvider.create(projectId);
+        return new CollectFormEntryControllerFactory(entitiesRepository, settingsProvider.getUnprotectedSettings(projectId));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -94,15 +94,16 @@ import org.odk.collect.android.utilities.WebCredentialsUtils;
 import org.odk.collect.android.version.VersionInformation;
 import org.odk.collect.android.views.BarcodeViewDecoder;
 import org.odk.collect.androidshared.bitmap.ImageCompressor;
-import org.odk.collect.async.network.ConnectivityProvider;
-import org.odk.collect.async.network.NetworkStateProvider;
 import org.odk.collect.androidshared.system.IntentLauncher;
 import org.odk.collect.androidshared.system.IntentLauncherImpl;
 import org.odk.collect.androidshared.utils.ScreenUtils;
 import org.odk.collect.async.CoroutineAndWorkManagerScheduler;
 import org.odk.collect.async.Scheduler;
+import org.odk.collect.async.network.ConnectivityProvider;
+import org.odk.collect.async.network.NetworkStateProvider;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.audiorecorder.recording.AudioRecorderFactory;
+import org.odk.collect.entities.storage.EntitiesRepository;
 import org.odk.collect.forms.FormsRepository;
 import org.odk.collect.imageloader.GlideImageLoader;
 import org.odk.collect.imageloader.ImageLoader;
@@ -624,7 +625,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory(SettingsProvider settingsProvider) {
-        return new CollectFormEntryControllerFactory();
+    public FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory(ProjectsDataService projectsDataService, EntitiesRepositoryProvider entitiesRepositoryProvider) {
+        EntitiesRepository entitiesRepository = entitiesRepositoryProvider.create(projectsDataService.getCurrentProject().getUuid());
+        return new CollectFormEntryControllerFactory(entitiesRepository);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -107,7 +107,7 @@ class InstancesDataService(
 
                 val formMediaDir = File(form.formMediaPath)
                 val formEntryController =
-                    CollectFormEntryControllerFactory().create(formDef, formMediaDir)
+                    CollectFormEntryControllerFactory(entitiesRepository).create(formDef, formMediaDir)
                 val formController =
                     FormEntryUseCases.loadDraft(form, instance, formEntryController)
                 if (formController == null) {

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -107,7 +107,10 @@ class InstancesDataService(
 
                 val formMediaDir = File(form.formMediaPath)
                 val formEntryController =
-                    CollectFormEntryControllerFactory(entitiesRepository).create(formDef, formMediaDir)
+                    CollectFormEntryControllerFactory(
+                        entitiesRepository,
+                        projectDependencyModule.generalSettings
+                    ).create(formDef, formMediaDir)
                 val formController =
                     FormEntryUseCases.loadDraft(form, instance, formEntryController)
                 if (formController == null) {

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -370,8 +370,14 @@ abstract class EntitiesRepositoryTest {
             "Léoville Barton 2008",
             properties = listOf("vintage" to "2008")
         )
-        val canet =
-            Entity.New("wines", "2", "Pontet-Canet 2014", properties = listOf("vintage" to "2014"))
+
+        val canet = Entity.New(
+            "wines",
+            "2",
+            "Pontet-Canet 2014",
+            properties = listOf("vintage" to "2014")
+        )
+
         repository.save(leoville, canet)
 
         val wines = repository.getEntities("wines")
@@ -391,10 +397,15 @@ abstract class EntitiesRepositoryTest {
             "Léoville Barton 2008",
             properties = listOf("vintage" to "2008")
         )
-        val canet =
-            Entity.New("wines", "2", "Pontet-Canet 2014", properties = listOf("vintage" to "2014"))
-        repository.save(leoville, canet)
 
+        val canet = Entity.New(
+            "wines",
+            "2",
+            "Pontet-Canet 2014",
+            properties = listOf("vintage" to "2014")
+        )
+
+        repository.save(leoville, canet)
         assertThat(repository.getAllByProperty("wines", "vintage", "2024"), equalTo(emptyList()))
     }
 
@@ -408,10 +419,14 @@ abstract class EntitiesRepositoryTest {
             "Léoville Barton 2008",
             properties = listOf("vintage" to "2008")
         )
-        val dows =
-            Entity.New("ports", "2", "Dow's 1983", properties = listOf("vintage" to "1983"))
-        repository.save(leoville, dows)
+        val dows = Entity.New(
+            "ports",
+            "2",
+            "Dow's 1983",
+            properties = listOf("vintage" to "1983")
+        )
 
+        repository.save(leoville, dows)
         assertThat(repository.getAllByProperty("wines", "vintage", "1983"), equalTo(emptyList()))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -320,4 +320,43 @@ abstract class EntitiesRepositoryTest {
         assertThat(wines[1].index, equalTo(1))
         assertThat(wines[2].index, equalTo(2))
     }
+
+    @Test
+    fun `#getAllById returns entities with matching id`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
+        val canet = Entity.New("wines", "2", "Pontet-Canet 2014")
+        repository.save(leoville, canet)
+
+        val wines = repository.getEntities("wines")
+
+        val queriedLeoville = repository.getById("wines", "1")
+        assertThat(queriedLeoville, equalTo(wines.first { it.id == "1" }))
+
+        val queriedCanet = repository.getById("wines", "2")
+        assertThat(queriedCanet, equalTo(wines.first { it.id == "2" }))
+    }
+
+    @Test
+    fun `#getAllById returns null when there are no matches`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
+        val canet = Entity.New("wines", "2", "Pontet-Canet 2014")
+        repository.save(leoville, canet)
+
+        assertThat(repository.getById("wines", "3"), equalTo(null))
+    }
+
+    @Test
+    fun `#getAllById returns null when there is a match in a different list`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
+        val ardbeg = Entity.New("whisky", "2", "Ardbeg 10")
+        repository.save(leoville, ardbeg)
+
+        assertThat(repository.getById("whisky", "1"), equalTo(null))
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -322,7 +322,7 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
-    fun `#getAllById returns entities with matching id`() {
+    fun `#getById returns entities with matching id`() {
         val repository = buildSubject()
 
         val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
@@ -339,7 +339,7 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
-    fun `#getAllById returns null when there are no matches`() {
+    fun `#getById returns null when there are no matches`() {
         val repository = buildSubject()
 
         val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
@@ -350,7 +350,7 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
-    fun `#getAllById returns null when there is a match in a different list`() {
+    fun `#getById returns null when there is a match in a different list`() {
         val repository = buildSubject()
 
         val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
@@ -358,5 +358,60 @@ abstract class EntitiesRepositoryTest {
         repository.save(leoville, ardbeg)
 
         assertThat(repository.getById("whisky", "1"), equalTo(null))
+    }
+
+    @Test
+    fun `#getById returns entities with matching property value`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New(
+            "wines",
+            "1",
+            "Léoville Barton 2008",
+            properties = listOf("vintage" to "2008")
+        )
+        val canet =
+            Entity.New("wines", "2", "Pontet-Canet 2014", properties = listOf("vintage" to "2014"))
+        repository.save(leoville, canet)
+
+        val wines = repository.getEntities("wines")
+        assertThat(
+            repository.getAllByProperty("wines", "vintage", "2014"),
+            containsInAnyOrder(wines.first { it.id == "2" })
+        )
+    }
+
+    @Test
+    fun `#getAllByProperty returns empty list when there are no matches`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New(
+            "wines",
+            "1",
+            "Léoville Barton 2008",
+            properties = listOf("vintage" to "2008")
+        )
+        val canet =
+            Entity.New("wines", "2", "Pontet-Canet 2014", properties = listOf("vintage" to "2014"))
+        repository.save(leoville, canet)
+
+        assertThat(repository.getAllByProperty("wines", "vintage", "2024"), equalTo(emptyList()))
+    }
+
+    @Test
+    fun `#getAllByProperty returns empty list when there is a match in a different list`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New(
+            "wines",
+            "1",
+            "Léoville Barton 2008",
+            properties = listOf("vintage" to "2008")
+        )
+        val dows =
+            Entity.New("ports", "2", "Dow's 1983", properties = listOf("vintage" to "1983"))
+        repository.save(leoville, dows)
+
+        assertThat(repository.getAllByProperty("wines", "vintage", "1983"), equalTo(emptyList()))
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -2,8 +2,8 @@ package org.odk.collect.entities
 
 import org.javarosa.core.model.instance.CsvExternalInstance
 import org.javarosa.core.model.instance.TreeElement
-import org.odk.collect.entities.browser.EntityItemElement
 import org.odk.collect.entities.javarosa.finalization.EntitiesExtra
+import org.odk.collect.entities.javarosa.parse.EntityItemElement
 import org.odk.collect.entities.javarosa.spec.EntityAction
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -1,0 +1,66 @@
+package org.odk.collect.entities.javarosa.filter
+
+import org.javarosa.core.model.CompareToNodeExpression
+import org.javarosa.core.model.condition.EvaluationContext
+import org.javarosa.core.model.condition.FilterStrategy
+import org.javarosa.core.model.instance.DataInstance
+import org.javarosa.core.model.instance.TreeReference
+import org.javarosa.xpath.expr.XPathEqExpr
+import org.javarosa.xpath.expr.XPathExpression
+import org.odk.collect.entities.storage.EntitiesRepository
+import org.odk.collect.entities.storage.Entity
+import java.util.function.Supplier
+
+class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesRepository) :
+    FilterStrategy {
+    override fun filter(
+        sourceInstance: DataInstance<*>,
+        nodeSet: TreeReference,
+        predicate: XPathExpression,
+        children: MutableList<TreeReference>,
+        evaluationContext: EvaluationContext,
+        next: Supplier<MutableList<TreeReference>>
+    ): List<TreeReference> {
+        val candidate = CompareToNodeExpression.parse(predicate)
+
+        return when (val original = candidate?.original) {
+            is XPathEqExpr -> {
+                if (original.isEqual) {
+                    when {
+                        (candidate.nodeSide.steps[0].name.name == "name") -> {
+                            val value = candidate.evalContextSide(sourceInstance, evaluationContext)
+                            val entity =
+                                entitiesRepository.getById(
+                                    sourceInstance.instanceId,
+                                    value as String
+                                )
+
+                            if (entity != null) {
+                                listOf(convertToReference(nodeSet, entity))
+                            } else {
+                                emptyList()
+                            }
+                        }
+
+                        else -> next.get()
+                    }
+                } else {
+                    next.get()
+                }
+            }
+
+            else -> {
+                next.get()
+            }
+        }
+    }
+
+    private fun convertToReference(
+        nodeSet: TreeReference,
+        entity: Entity.Saved
+    ): TreeReference {
+        return nodeSet.clone().also {
+            it.setMultiplicity(it.size() - 1, entity.index)
+        }
+    }
+}

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -8,9 +8,17 @@ import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.xpath.expr.XPathEqExpr
 import org.javarosa.xpath.expr.XPathExpression
 import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceAdapter
+import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceProvider
 import org.odk.collect.entities.storage.EntitiesRepository
 import java.util.function.Supplier
 
+/**
+ * A JavaRosa [FilterStrategy] that will use an [EntitiesRepository] to perform filters. For
+ * supported expressions, this prevents JavaRosa from using it's standard [FilterStrategy] chain
+ * which requires loading the whole secondary instance into memory (assuming that
+ * [LocalEntitiesInstanceProvider] or similar is used to take advantage of JavaRosa's partial
+ * parsing).
+ */
 class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
     FilterStrategy {
 

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -3,21 +3,18 @@ package org.odk.collect.entities.javarosa.filter
 import org.javarosa.core.model.CompareToNodeExpression
 import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.condition.FilterStrategy
-import org.javarosa.core.model.data.StringData
 import org.javarosa.core.model.instance.DataInstance
-import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.xpath.expr.XPathEqExpr
 import org.javarosa.xpath.expr.XPathExpression
-import org.odk.collect.entities.browser.EntityItemElement
+import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceAdapter
 import org.odk.collect.entities.storage.EntitiesRepository
-import org.odk.collect.entities.storage.Entity
 import java.util.function.Supplier
 
-class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesRepository) :
+class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
     FilterStrategy {
 
-    private val lists = entitiesRepository.getLists()
+    private val dataAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
 
     override fun filter(
         sourceInstance: DataInstance<*>,
@@ -27,7 +24,7 @@ class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesReposi
         evaluationContext: EvaluationContext,
         next: Supplier<MutableList<TreeReference>>
     ): List<TreeReference> {
-        if (!lists.contains(sourceInstance.instanceId)) {
+        if (!dataAdapter.supportsInstance(sourceInstance)) {
             return next.get()
         }
 
@@ -35,39 +32,15 @@ class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesReposi
         return when (val original = candidate?.original) {
             is XPathEqExpr -> {
                 if (original.isEqual) {
-                    val filterChild = candidate.nodeSide.steps[0].name.name
+                    val child = candidate.nodeSide.steps[0].name.name
+                    val value = candidate.evalContextSide(sourceInstance, evaluationContext)
 
-                    when {
-                        filterChild == "name" -> {
-                            val value = candidate.evalContextSide(sourceInstance, evaluationContext)
-                            val entity = entitiesRepository.getById(
-                                sourceInstance.instanceId,
-                                value as String
-                            )
-
-                            if (entity != null) {
-                                val element = convertToElement(sourceInstance, entity)
-                                sourceInstance.replacePartialElements(listOf(element))
-                                listOf(element.ref)
-                            } else {
-                                emptyList()
-                            }
-                        }
-
-                        !listOf("label", "__version").contains(filterChild) -> {
-                            val value = candidate.evalContextSide(sourceInstance, evaluationContext)
-                            val entities = entitiesRepository.getAllByProperty(
-                                sourceInstance.instanceId,
-                                filterChild,
-                                value as String
-                            )
-
-                            val elements = entities.map { convertToElement(sourceInstance, it) }
-                            sourceInstance.replacePartialElements(elements)
-                            elements.map { it.ref }
-                        }
-
-                        else -> next.get()
+                    val results = dataAdapter.queryEq(sourceInstance, child, value as String)
+                    return if (results != null) {
+                        sourceInstance.replacePartialElements(results)
+                        results.map { it.ref }
+                    } else {
+                        next.get()
                     }
                 } else {
                     next.get()
@@ -78,32 +51,5 @@ class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesReposi
                 next.get()
             }
         }
-    }
-
-    private fun convertToElement(
-        sourceInstance: DataInstance<*>,
-        entity: Entity.Saved
-    ): TreeElement {
-        val name = TreeElement(EntityItemElement.ID)
-        val label = TreeElement(EntityItemElement.LABEL)
-        val version = TreeElement(EntityItemElement.VERSION)
-
-        name.value = StringData(entity.id)
-        label.value = StringData(entity.label)
-        version.value = StringData(entity.version.toString())
-
-        val item = TreeElement("item", entity.index)
-        item.addChild(name)
-        item.addChild(label)
-        item.addChild(version)
-
-        entity.properties.forEach { property ->
-            val propertyElement = TreeElement(property.first)
-            propertyElement.value = StringData(property.second)
-            item.addChild(propertyElement)
-        }
-
-        item.parent = sourceInstance.root
-        return item
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -16,6 +16,9 @@ import java.util.function.Supplier
 
 class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesRepository) :
     FilterStrategy {
+
+    private val lists = entitiesRepository.getLists()
+
     override fun filter(
         sourceInstance: DataInstance<*>,
         nodeSet: TreeReference,
@@ -24,7 +27,7 @@ class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesReposi
         evaluationContext: EvaluationContext,
         next: Supplier<MutableList<TreeReference>>
     ): List<TreeReference> {
-        if (!entitiesRepository.getLists().contains(sourceInstance.instanceId)) {
+        if (!lists.contains(sourceInstance.instanceId)) {
             return next.get()
         }
 

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -3,10 +3,13 @@ package org.odk.collect.entities.javarosa.filter
 import org.javarosa.core.model.CompareToNodeExpression
 import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.condition.FilterStrategy
+import org.javarosa.core.model.data.StringData
 import org.javarosa.core.model.instance.DataInstance
+import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.xpath.expr.XPathEqExpr
 import org.javarosa.xpath.expr.XPathExpression
+import org.odk.collect.entities.browser.EntityItemElement
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
 import java.util.function.Supplier
@@ -40,7 +43,9 @@ class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesReposi
                                 )
 
                             if (entity != null) {
-                                listOf(convertToReference(nodeSet, entity))
+                                val element = convertToElement(sourceInstance, entity)
+                                sourceInstance.replacePartialElements(listOf(element))
+                                listOf(element.ref)
                             } else {
                                 emptyList()
                             }
@@ -59,12 +64,30 @@ class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesReposi
         }
     }
 
-    private fun convertToReference(
-        nodeSet: TreeReference,
+    private fun convertToElement(
+        sourceInstance: DataInstance<*>,
         entity: Entity.Saved
-    ): TreeReference {
-        return nodeSet.clone().also {
-            it.setMultiplicity(it.size() - 1, entity.index)
+    ): TreeElement {
+        val name = TreeElement(EntityItemElement.ID)
+        val label = TreeElement(EntityItemElement.LABEL)
+        val version = TreeElement(EntityItemElement.VERSION)
+
+        name.value = StringData(entity.id)
+        label.value = StringData(entity.label)
+        version.value = StringData(entity.version.toString())
+
+        val item = TreeElement("item", entity.index)
+        item.addChild(name)
+        item.addChild(label)
+        item.addChild(version)
+
+        entity.properties.forEach { property ->
+            val propertyElement = TreeElement(property.first)
+            propertyElement.value = StringData(property.second)
+            item.addChild(propertyElement)
         }
+
+        item.parent = sourceInstance.root
+        return item
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -24,7 +24,7 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
         evaluationContext: EvaluationContext,
         next: Supplier<MutableList<TreeReference>>
     ): List<TreeReference> {
-        if (!dataAdapter.supportsInstance(sourceInstance)) {
+        if (!dataAdapter.supportsInstance(sourceInstance.instanceId)) {
             return next.get()
         }
 
@@ -35,10 +35,17 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
                     val child = candidate.nodeSide.steps[0].name.name
                     val value = candidate.evalContextSide(sourceInstance, evaluationContext)
 
-                    val results = dataAdapter.queryEq(sourceInstance, child, value as String)
+                    val results = dataAdapter.queryEq(
+                        sourceInstance.instanceId,
+                        child,
+                        value as String
+                    )
                     return if (results != null) {
                         sourceInstance.replacePartialElements(results)
-                        results.map { it.ref }
+                        results.map {
+                            it.parent = sourceInstance.root
+                            it.ref
+                        }
                     } else {
                         next.get()
                     }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -21,6 +21,10 @@ class LocalEntitiesFilterStrategy(private val entitiesRepository: EntitiesReposi
         evaluationContext: EvaluationContext,
         next: Supplier<MutableList<TreeReference>>
     ): List<TreeReference> {
+        if (!entitiesRepository.getLists().contains(sourceInstance.instanceId)) {
+            return next.get()
+        }
+
         val candidate = CompareToNodeExpression.parse(predicate)
 
         return when (val original = candidate?.original) {

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesExternalInstanceParserFactory.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesExternalInstanceParserFactory.kt
@@ -12,7 +12,7 @@ class LocalEntitiesExternalInstanceParserFactory(
         val parser = ExternalInstanceParser()
 
         if (enabled()) {
-            parser.addFileInstanceParser(LocalEntitiesFileInstanceParser(entitiesRepositoryProvider))
+            parser.addInstanceProvider(LocalEntitiesInstanceProvider(entitiesRepositoryProvider))
         }
 
         return parser

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesExternalInstanceParserFactory.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesExternalInstanceParserFactory.kt
@@ -6,7 +6,7 @@ import org.odk.collect.entities.storage.EntitiesRepository
 
 class LocalEntitiesExternalInstanceParserFactory(
     private val entitiesRepositoryProvider: () -> EntitiesRepository,
-    private val enabled: () -> Boolean = { true }
+    private val enabled: () -> Boolean
 ) : ExternalInstanceParserFactory {
     override fun getExternalInstanceParser(): ExternalInstanceParser {
         val parser = ExternalInstanceParser()

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesExternalInstanceParserFactory.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesExternalInstanceParserFactory.kt
@@ -6,7 +6,7 @@ import org.odk.collect.entities.storage.EntitiesRepository
 
 class LocalEntitiesExternalInstanceParserFactory(
     private val entitiesRepositoryProvider: () -> EntitiesRepository,
-    private val enabled: () -> Boolean
+    private val enabled: () -> Boolean = { true }
 ) : ExternalInstanceParserFactory {
     override fun getExternalInstanceParser(): ExternalInstanceParser {
         val parser = ExternalInstanceParser()

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -1,0 +1,74 @@
+package org.odk.collect.entities.javarosa.intance
+
+import org.javarosa.core.model.data.StringData
+import org.javarosa.core.model.instance.DataInstance
+import org.javarosa.core.model.instance.TreeElement
+import org.odk.collect.entities.browser.EntityItemElement
+import org.odk.collect.entities.storage.EntitiesRepository
+import org.odk.collect.entities.storage.Entity
+
+class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepository) {
+
+    private val lists = entitiesRepository.getLists()
+
+    fun supportsInstance(sourceInstance: DataInstance<*>): Boolean {
+        return lists.contains(sourceInstance.instanceId)
+    }
+
+    fun queryEq(sourceInstance: DataInstance<*>, child: String, value: String): List<TreeElement>? {
+        return when {
+            child == "name" -> {
+                val entity = entitiesRepository.getById(
+                    sourceInstance.instanceId,
+                    value
+                )
+
+                if (entity != null) {
+                    val element = convertToElement(sourceInstance, entity)
+                    listOf(element)
+                } else {
+                    emptyList()
+                }
+            }
+
+            !listOf("label", "__version").contains(child) -> {
+                val entities = entitiesRepository.getAllByProperty(
+                    sourceInstance.instanceId,
+                    child,
+                    value
+                )
+
+                entities.map { convertToElement(sourceInstance, it) }
+            }
+
+            else -> null
+        }
+    }
+
+    private fun convertToElement(
+        sourceInstance: DataInstance<*>,
+        entity: Entity.Saved
+    ): TreeElement {
+        val name = TreeElement(EntityItemElement.ID)
+        val label = TreeElement(EntityItemElement.LABEL)
+        val version = TreeElement(EntityItemElement.VERSION)
+
+        name.value = StringData(entity.id)
+        label.value = StringData(entity.label)
+        version.value = StringData(entity.version.toString())
+
+        val item = TreeElement("item", entity.index)
+        item.addChild(name)
+        item.addChild(label)
+        item.addChild(version)
+
+        entity.properties.forEach { property ->
+            val propertyElement = TreeElement(property.first)
+            propertyElement.value = StringData(property.second)
+            item.addChild(propertyElement)
+        }
+
+        item.parent = sourceInstance.root
+        return item
+    }
+}

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -2,7 +2,7 @@ package org.odk.collect.entities.javarosa.intance
 
 import org.javarosa.core.model.data.StringData
 import org.javarosa.core.model.instance.TreeElement
-import org.odk.collect.entities.browser.EntityItemElement
+import org.odk.collect.entities.javarosa.parse.EntityItemElement
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
 
@@ -35,7 +35,7 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
                 }
             }
 
-            !listOf("label", "__version").contains(child) -> {
+            !listOf(EntityItemElement.LABEL, EntityItemElement.VERSION).contains(child) -> {
                 val entities = entitiesRepository.getAllByProperty(
                     instanceId,
                     child,

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -15,8 +15,14 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
     }
 
     fun getAll(instanceId: String, partial: Boolean): List<TreeElement> {
-        return entitiesRepository.getEntities(instanceId).map { entity ->
-            convertToElement(entity, partial)
+        return entitiesRepository.getEntities(instanceId).mapIndexed { index, entity ->
+            if (partial && index == 0) {
+                convertToElement(entity, true)
+            } else if (partial) {
+                TreeElement("item", entity.index, true)
+            } else {
+                convertToElement(entity, false)
+            }
         }
     }
 

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceProvider.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceProvider.kt
@@ -6,14 +6,14 @@ import org.javarosa.xform.parse.ExternalInstanceParser
 import org.odk.collect.entities.browser.EntityItemElement
 import org.odk.collect.entities.storage.EntitiesRepository
 
-internal class LocalEntitiesFileInstanceParser(private val entitiesRepositoryProvider: () -> EntitiesRepository) :
-    ExternalInstanceParser.FileInstanceParser {
+internal class LocalEntitiesInstanceProvider(private val entitiesRepositoryProvider: () -> EntitiesRepository) :
+    ExternalInstanceParser.InstanceProvider {
 
-    override fun parse(instanceId: String, path: String): TreeElement {
-        return parse(instanceId, path, false)
+    override fun get(instanceId: String, instanceSrc: String): TreeElement {
+        return get(instanceId, instanceSrc, false)
     }
 
-    override fun parse(instanceId: String, path: String, partial: Boolean): TreeElement {
+    override fun get(instanceId: String, instanceSrc: String, partial: Boolean): TreeElement {
         val root = TreeElement("root", 0)
 
         val entitiesRepository = entitiesRepositoryProvider()

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceProvider.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceProvider.kt
@@ -1,9 +1,7 @@
 package org.odk.collect.entities.javarosa.intance
 
-import org.javarosa.core.model.data.StringData
 import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.xform.parse.ExternalInstanceParser
-import org.odk.collect.entities.browser.EntityItemElement
 import org.odk.collect.entities.storage.EntitiesRepository
 
 internal class LocalEntitiesInstanceProvider(private val entitiesRepositoryProvider: () -> EntitiesRepository) :
@@ -15,42 +13,13 @@ internal class LocalEntitiesInstanceProvider(private val entitiesRepositoryProvi
 
     override fun get(instanceId: String, instanceSrc: String, partial: Boolean): TreeElement {
         val root = TreeElement("root", 0)
-
-        val entitiesRepository = entitiesRepositoryProvider()
-        entitiesRepository.getEntities(instanceId).forEach { entity ->
-            val name = TreeElement(EntityItemElement.ID)
-            val label = TreeElement(EntityItemElement.LABEL)
-            val version = TreeElement(EntityItemElement.VERSION)
-
-            if (!partial) {
-                name.value = StringData(entity.id)
-                label.value = StringData(entity.label)
-                version.value = StringData(entity.version.toString())
-            }
-
-            val item = TreeElement("item", entity.index, partial)
-            item.addChild(name)
-            item.addChild(label)
-            item.addChild(version)
-
-            entity.properties.forEach { property ->
-                val propertyElement = TreeElement(property.first)
-
-                if (!partial) {
-                    propertyElement.value = StringData(property.second)
-                }
-
-                item.addChild(propertyElement)
-            }
-
-            root.addChild(item)
-        }
-
+        createDataAdapter().getAll(instanceId, partial).forEach { root.addChild(it) }
         return root
     }
 
     override fun isSupported(instanceId: String, instanceSrc: String): Boolean {
-        val entitiesRepository = entitiesRepositoryProvider()
-        return entitiesRepository.getLists().contains(instanceId)
+        return createDataAdapter().supportsInstance(instanceId)
     }
+
+    private fun createDataAdapter() = LocalEntitiesInstanceAdapter(entitiesRepositoryProvider())
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/parse/EntityItemElement.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/parse/EntityItemElement.kt
@@ -1,4 +1,4 @@
-package org.odk.collect.entities.browser
+package org.odk.collect.entities.javarosa.parse
 
 internal object EntityItemElement {
     const val ID = "name"

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/spec/EntityFormParser.java
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/spec/EntityFormParser.java
@@ -7,13 +7,13 @@ import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ATTRIBUTE_BASE_VERSION;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ATTRIBUTE_CREATE;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ATTRIBUTE_DATASET;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ATTRIBUTE_ID;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ATTRIBUTE_UPDATE;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ELEMENT_ENTITY;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ELEMENT_LABEL;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_BASE_VERSION;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_CREATE;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_DATASET;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_ID;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_UPDATE;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ELEMENT_ENTITY;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ELEMENT_LABEL;
 
 public class EntityFormParser {
 

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/spec/FormEntityElement.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/spec/FormEntityElement.kt
@@ -1,6 +1,6 @@
 package org.odk.collect.entities.javarosa.spec
 
-internal object EntityConstants {
+internal object FormEntityElement {
     const val ELEMENT_ENTITY = "entity"
     const val ELEMENT_LABEL = "label"
 

--- a/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
@@ -7,4 +7,5 @@ interface EntitiesRepository {
     fun clear()
     fun addList(list: String)
     fun delete(id: String)
+    fun getById(list: String, id: String): Entity.Saved?
 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
@@ -8,4 +8,5 @@ interface EntitiesRepository {
     fun addList(list: String)
     fun delete(id: String)
     fun getById(list: String, id: String): Entity.Saved?
+    fun getAllByProperty(list: String, property: String, value: String): List<Entity.Saved>
 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -40,6 +40,16 @@ class InMemEntitiesRepository : EntitiesRepository {
         return getEntities(list).firstOrNull { it.id == id }
     }
 
+    override fun getAllByProperty(
+        list: String,
+        property: String,
+        value: String
+    ): List<Entity.Saved> {
+        return getEntities(list).filter { entity ->
+            entity.properties.firstOrNull { it.first == property }?.second == value
+        }
+    }
+
     override fun save(vararg entities: Entity) {
         entities.forEach { entity ->
             lists.add(entity.list)

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -46,7 +46,7 @@ class InMemEntitiesRepository : EntitiesRepository {
         value: String
     ): List<Entity.Saved> {
         return getEntities(list).filter { entity ->
-            entity.properties.firstOrNull { it.first == property }?.second == value
+            entity.properties.any { (first, second) -> first == property && second == value }
         }
     }
 

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -36,6 +36,10 @@ class InMemEntitiesRepository : EntitiesRepository {
         entities.removeIf { it.id == id }
     }
 
+    override fun getById(list: String, id: String): Entity.Saved? {
+        return getEntities(list).firstOrNull { it.id == id }
+    }
+
     override fun save(vararg entities: Entity) {
         entities.forEach { entity ->
             lists.add(entity.list)

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -312,4 +312,13 @@ private class MeasurableEntitiesRepository(private val wrapped: EntitiesReposito
         accesses += 1
         return wrapped.getById(list, id)
     }
+
+    override fun getAllByProperty(
+        list: String,
+        property: String,
+        value: String
+    ): List<Entity.Saved> {
+        accesses += 1
+        return wrapped.getAllByProperty(list, property, value)
+    }
 }

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -307,4 +307,9 @@ private class MeasurableEntitiesRepository(private val wrapped: EntitiesReposito
         accesses += 1
         wrapped.delete(id)
     }
+
+    override fun getById(list: String, id: String): Entity.Saved? {
+        accesses += 1
+        return wrapped.getById(list, id)
+    }
 }

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -5,8 +5,8 @@ import org.apache.commons.csv.CSVPrinter
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
-import org.odk.collect.entities.browser.EntityItemElement
 import org.odk.collect.entities.javarosa.finalization.EntitiesExtra
+import org.odk.collect.entities.javarosa.parse.EntityItemElement
 import org.odk.collect.entities.javarosa.spec.EntityAction
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/EntityFormParserTest.java
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/EntityFormParserTest.java
@@ -8,10 +8,10 @@ import org.odk.collect.entities.javarosa.spec.EntityFormParser;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ATTRIBUTE_CREATE;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ATTRIBUTE_UPDATE;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ELEMENT_ENTITY;
-import static org.odk.collect.entities.javarosa.spec.EntityConstants.ELEMENT_LABEL;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_CREATE;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_UPDATE;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ELEMENT_ENTITY;
+import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ELEMENT_LABEL;
 
 public class EntityFormParserTest {
 

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
@@ -3,8 +3,8 @@ package org.odk.collect.entities.javarosa
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
-import org.odk.collect.entities.browser.EntityItemElement
 import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceProvider
+import org.odk.collect.entities.javarosa.parse.EntityItemElement
 import org.odk.collect.entities.storage.Entity
 import org.odk.collect.entities.storage.InMemEntitiesRepository
 

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
@@ -4,11 +4,11 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.odk.collect.entities.browser.EntityItemElement
-import org.odk.collect.entities.javarosa.intance.LocalEntitiesFileInstanceParser
+import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceProvider
 import org.odk.collect.entities.storage.Entity
 import org.odk.collect.entities.storage.InMemEntitiesRepository
 
-class LocalEntitiesFileInstanceParserTest {
+class LocalEntitiesInstanceProviderTest {
 
     private val entitiesRepository = InMemEntitiesRepository()
 
@@ -23,8 +23,8 @@ class LocalEntitiesFileInstanceParserTest {
             )
         entitiesRepository.save(entity)
 
-        val parser = LocalEntitiesFileInstanceParser { entitiesRepository }
-        val instance = parser.parse("people", "people.csv")
+        val parser = LocalEntitiesInstanceProvider { entitiesRepository }
+        val instance = parser.get("people", "people.csv")
         assertThat(instance.numChildren, equalTo(1))
 
         val item = instance.getChildAt(0)!!
@@ -44,8 +44,8 @@ class LocalEntitiesFileInstanceParserTest {
             )
         entitiesRepository.save(entity)
 
-        val parser = LocalEntitiesFileInstanceParser { entitiesRepository }
-        val instance = parser.parse("people", "people.csv")
+        val parser = LocalEntitiesInstanceProvider { entitiesRepository }
+        val instance = parser.get("people", "people.csv")
         assertThat(instance.numChildren, equalTo(1))
 
         val item = instance.getChildAt(0)!!
@@ -65,8 +65,8 @@ class LocalEntitiesFileInstanceParserTest {
             )
         entitiesRepository.save(entity)
 
-        val parser = LocalEntitiesFileInstanceParser { entitiesRepository }
-        val instance = parser.parse("people", "people.csv", true)
+        val parser = LocalEntitiesInstanceProvider { entitiesRepository }
+        val instance = parser.get("people", "people.csv", true)
         assertThat(instance.numChildren, equalTo(1))
 
         val item = instance.getChildAt(0)!!
@@ -95,8 +95,8 @@ class LocalEntitiesFileInstanceParserTest {
         val repository = InMemEntitiesRepository()
         repository.save(*entities)
 
-        val parser = LocalEntitiesFileInstanceParser { repository }
-        val instance = parser.parse("people", "people.csv", false)
+        val parser = LocalEntitiesInstanceProvider { repository }
+        val instance = parser.get("people", "people.csv", false)
 
         val first = instance.getChildAt(0)!!
         assertThat(first.getFirstChild("name")!!.value!!.value, equalTo("1"))

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
@@ -54,27 +54,39 @@ class LocalEntitiesInstanceProviderTest {
     }
 
     @Test
-    fun `partial parse returns elements without values`() {
-        val entity =
+    fun `partial parse returns elements without values for first item and just item for others`() {
+        val entity = arrayOf(
             Entity.New(
                 "people",
                 "1",
                 "Shiv Roy",
                 properties = listOf(Pair("age", "35")),
                 version = 1
+            ),
+            Entity.New(
+                "people",
+                "2",
+                "Kendall Roy",
+                properties = listOf(Pair("age", "40")),
+                version = 1
             )
-        entitiesRepository.save(entity)
+        )
+        entitiesRepository.save(*entity)
 
         val parser = LocalEntitiesInstanceProvider { entitiesRepository }
         val instance = parser.get("people", "people.csv", true)
-        assertThat(instance.numChildren, equalTo(1))
+        assertThat(instance.numChildren, equalTo(2))
 
-        val item = instance.getChildAt(0)!!
-        assertThat(item.isPartial, equalTo(true))
-        assertThat(item.numChildren, equalTo(4))
-        0.until(item.numChildren).forEach {
-            assertThat(item.getChildAt(it).value?.value, equalTo(null))
+        val item1 = instance.getChildAt(0)!!
+        assertThat(item1.isPartial, equalTo(true))
+        assertThat(item1.numChildren, equalTo(4))
+        0.until(item1.numChildren).forEach {
+            assertThat(item1.getChildAt(it).value?.value, equalTo(null))
         }
+
+        val item2 = instance.getChildAt(1)!!
+        assertThat(item2.isPartial, equalTo(true))
+        assertThat(item2.numChildren, equalTo(0))
     }
 
     @Test

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -66,7 +66,8 @@ class LocalEntitiesFilterStrategyTest {
 
     @Test
     fun `returns matching nodes when entity matches name`() {
-        entitiesRepository.save(Entity.New("things", "thing", "Thing"))
+        entitiesRepository.save(Entity.New("things", "thing1", "Thing 1"))
+        entitiesRepository.save(Entity.New("things", "thing2", "Thing 2"))
 
         val scenario = Scenario.init(
             "Secondary instance form",
@@ -84,7 +85,7 @@ class LocalEntitiesFilterStrategyTest {
                         t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
                         bind("/data/question").type("string"),
                         bind("/data/calculate").type("string")
-                            .calculate("instance('things')/root/item[name='thing']/label")
+                            .calculate("instance('things')/root/item[name='thing1']/label")
                     )
                 ),
                 body(
@@ -95,7 +96,7 @@ class LocalEntitiesFilterStrategyTest {
         )
 
         assertThat(fallthroughFilterStrategy.fellThrough, equalTo(false))
-        assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing"))
+        assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing 1"))
     }
 
     @Test

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -7,6 +7,7 @@ import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.condition.FilterStrategy
 import org.javarosa.core.model.data.StringData
 import org.javarosa.core.model.instance.DataInstance
+import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.form.api.FormEntryController
 import org.javarosa.form.api.FormEntryModel
@@ -22,12 +23,13 @@ import org.javarosa.test.XFormsElement.model
 import org.javarosa.test.XFormsElement.t
 import org.javarosa.test.XFormsElement.title
 import org.javarosa.xform.parse.ExternalInstanceParser
+import org.javarosa.xform.parse.ExternalInstanceParser.InstanceProvider
 import org.javarosa.xform.util.XFormUtils
 import org.javarosa.xpath.expr.XPathExpression
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.odk.collect.entities.javarosa.intance.LocalEntitiesExternalInstanceParserFactory
+import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceProvider
 import org.odk.collect.entities.storage.Entity
 import org.odk.collect.entities.storage.InMemEntitiesRepository
 import java.util.function.Supplier
@@ -36,6 +38,8 @@ class LocalEntitiesFilterStrategyTest {
 
     private val entitiesRepository = InMemEntitiesRepository()
     private val fallthroughFilterStrategy = FallthroughFilterStrategy()
+    private val instanceProvider =
+        SpyInstanceProvider(LocalEntitiesInstanceProvider(::entitiesRepository))
 
     private val controllerSupplier: (FormDef) -> FormEntryController = { formDef ->
         FormEntryController(FormEntryModel(formDef)).also {
@@ -46,9 +50,11 @@ class LocalEntitiesFilterStrategyTest {
 
     @Before
     fun setup() {
-        XFormUtils.setExternalInstanceParserFactory(
-            LocalEntitiesExternalInstanceParserFactory(::entitiesRepository)
-        )
+        XFormUtils.setExternalInstanceParserFactory {
+            ExternalInstanceParser().also {
+                it.addInstanceProvider(instanceProvider)
+            }
+        }
     }
 
     @After
@@ -88,6 +94,42 @@ class LocalEntitiesFilterStrategyTest {
 
         assertThat(fallthroughFilterStrategy.fellThrough, equalTo(false))
         assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing"))
+    }
+
+    @Test
+    fun `replaces partial elements when entity matches name`() {
+        entitiesRepository.save(
+            Entity.New("things", "thing", "Thing"),
+            Entity.New("things", "other", "Other")
+        )
+
+        Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("instance('things')/root/item[name='thing']/label")
+                    )
+                ),
+                body(
+                    input("/data/calculate")
+                )
+            ),
+            controllerSupplier
+        )
+
+        assertThat(instanceProvider.fullParsePerformed, equalTo(false))
     }
 
     @Test
@@ -225,7 +267,7 @@ class LocalEntitiesFilterStrategyTest {
     }
 }
 
-class FallthroughFilterStrategy : FilterStrategy {
+private class FallthroughFilterStrategy : FilterStrategy {
 
     var fellThrough = false
         private set
@@ -240,5 +282,26 @@ class FallthroughFilterStrategy : FilterStrategy {
     ): MutableList<TreeReference> {
         fellThrough = true
         return next.get()
+    }
+}
+
+private class SpyInstanceProvider(private val wrapped: InstanceProvider) : InstanceProvider {
+    var fullParsePerformed = false
+        private set
+
+    override fun get(instanceId: String, instanceSrc: String): TreeElement {
+        return wrapped.get(instanceId, instanceSrc)
+    }
+
+    override fun get(instanceId: String, instanceSrc: String, partial: Boolean): TreeElement {
+        if (!partial) {
+            fullParsePerformed = true
+        }
+
+        return wrapped.get(instanceId, instanceSrc, partial)
+    }
+
+    override fun isSupported(instanceId: String, instanceSrc: String): Boolean {
+        return wrapped.isSupported(instanceId, instanceSrc)
     }
 }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -76,6 +76,78 @@ class LocalEntitiesFilterStrategyTest {
     }
 
     @Test
+    fun `works correctly with name != expressions`() {
+        entitiesRepository.addList("things")
+
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        instance(
+                            "things",
+                            t("item", t("label", "Thing"), t("name", "thing"))
+                        ),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("instance('things')/root/item[name!='other']/label")
+                    )
+                ),
+                body(
+                    input("/data/calculate")
+                )
+            ),
+            controllerSupplier
+        )
+
+        assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing"))
+    }
+
+    @Test
+    fun `works correctly with non eq name expressions`() {
+        entitiesRepository.addList("things")
+
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        instance(
+                            "things",
+                            t("item", t("label", "Thing"), t("name", "thing"))
+                        ),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("instance('things')/root/item[starts-with(name, 'thing')]/label")
+                    )
+                ),
+                body(
+                    input("/data/calculate")
+                )
+            ),
+            controllerSupplier
+        )
+
+        assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing"))
+    }
+
+    @Test
     fun `does not effect name queries on non entity instances`() {
         val scenario = Scenario.init(
             "Secondary instance form",

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -1,0 +1,58 @@
+package org.odk.collect.entities.javarosa.filter
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.javarosa.core.model.data.StringData
+import org.javarosa.test.BindBuilderXFormsElement.bind
+import org.javarosa.test.Scenario
+import org.javarosa.test.XFormsElement.body
+import org.javarosa.test.XFormsElement.head
+import org.javarosa.test.XFormsElement.html
+import org.javarosa.test.XFormsElement.input
+import org.javarosa.test.XFormsElement.instance
+import org.javarosa.test.XFormsElement.mainInstance
+import org.javarosa.test.XFormsElement.model
+import org.javarosa.test.XFormsElement.t
+import org.javarosa.test.XFormsElement.title
+import org.javarosa.xform.util.XFormUtils
+import org.junit.Test
+import org.odk.collect.entities.storage.InMemEntitiesRepository
+import java.io.InputStreamReader
+
+class LocalEntitiesFilterStrategyTest {
+
+    @Test
+    fun `does not effect name queries on non entity instances`() {
+        val xForm = html(
+            head(
+                title("Secondary instance form"),
+                model(
+                    mainInstance(
+                        t(
+                            "data id=\"create-entity-form\"",
+                            t("question"),
+                            t("calculate")
+                        )
+                    ),
+                    instance(
+                        "secondary",
+                        t("item", t("label", "Thing"), t("name", "thing"))
+                    ),
+                    bind("/data/question").type("string"),
+                    bind("/data/calculate").type("string")
+                        .calculate("instance('secondary')/root/item[name='thing']/label")
+                )
+            ),
+            body(
+                input("/data/calculate")
+            )
+        )
+
+        val xml = xForm.asXml()
+        val formDef = XFormUtils.getFormRaw(InputStreamReader(xml.byteInputStream()))
+        formDef.addFilterStrategy(LocalEntitiesFilterStrategy(InMemEntitiesRepository()))
+
+        val scenario = Scenario.init(formDef)
+        assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing"))
+    }
+}

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -57,6 +57,40 @@ class LocalEntitiesFilterStrategyTest {
     }
 
     @Test
+    fun `returns matching nodes when entity matches name`() {
+        entitiesRepository.save(Entity.New("things", "thing", "Thing"))
+
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("instance('things')/root/item[name='thing']/label")
+                    )
+                ),
+                body(
+                    input("/data/calculate")
+                )
+            ),
+            controllerSupplier
+        )
+
+        assertThat(fallthroughFilterStrategy.fellThrough, equalTo(false))
+        assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing"))
+    }
+
+    @Test
     fun `returns empty nodeset when no entity matches name`() {
         entitiesRepository.addList("things")
 

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -3,7 +3,11 @@ package org.odk.collect.entities.javarosa.filter
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.javarosa.core.model.FormDef
+import org.javarosa.core.model.condition.EvaluationContext
+import org.javarosa.core.model.condition.FilterStrategy
 import org.javarosa.core.model.data.StringData
+import org.javarosa.core.model.instance.DataInstance
+import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.form.api.FormEntryController
 import org.javarosa.form.api.FormEntryModel
 import org.javarosa.test.BindBuilderXFormsElement.bind
@@ -17,15 +21,58 @@ import org.javarosa.test.XFormsElement.mainInstance
 import org.javarosa.test.XFormsElement.model
 import org.javarosa.test.XFormsElement.t
 import org.javarosa.test.XFormsElement.title
+import org.javarosa.xpath.expr.XPathExpression
 import org.junit.Test
 import org.odk.collect.entities.storage.InMemEntitiesRepository
+import java.util.function.Supplier
 
 class LocalEntitiesFilterStrategyTest {
 
+    private val entitiesRepository = InMemEntitiesRepository()
+    private val fallthroughFilterStrategy = FallthroughFilterStrategy()
+
     private val controllerSupplier: (FormDef) -> FormEntryController = { formDef ->
         FormEntryController(FormEntryModel(formDef)).also {
-            it.addFilterStrategy(LocalEntitiesFilterStrategy(InMemEntitiesRepository()))
+            it.addFilterStrategy(LocalEntitiesFilterStrategy(entitiesRepository))
+            it.addFilterStrategy(fallthroughFilterStrategy)
         }
+    }
+
+    @Test
+    fun `returns empty nodeset when no entity matches name`() {
+        entitiesRepository.addList("things")
+
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        instance(
+                            "things",
+                            t("item", t("label", "Thing"), t("name", "thing"))
+                        ),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("instance('things')/root/item[name='other']/label")
+                    )
+                ),
+                body(
+                    input("/data/calculate")
+                )
+            ),
+            controllerSupplier
+        )
+
+        assertThat(fallthroughFilterStrategy.fellThrough, equalTo(false))
+        assertThat(scenario.answerOf<StringData>("/data/calculate"), equalTo(null))
     }
 
     @Test
@@ -60,5 +107,23 @@ class LocalEntitiesFilterStrategyTest {
         )
 
         assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing"))
+    }
+}
+
+class FallthroughFilterStrategy : FilterStrategy {
+
+    var fellThrough = false
+        private set
+
+    override fun filter(
+        sourceInstance: DataInstance<*>,
+        nodeSet: TreeReference,
+        predicate: XPathExpression,
+        children: MutableList<TreeReference>,
+        evaluationContext: EvaluationContext,
+        next: Supplier<MutableList<TreeReference>>
+    ): MutableList<TreeReference> {
+        fellThrough = true
+        return next.get()
     }
 }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -21,8 +21,14 @@ import org.javarosa.test.XFormsElement.mainInstance
 import org.javarosa.test.XFormsElement.model
 import org.javarosa.test.XFormsElement.t
 import org.javarosa.test.XFormsElement.title
+import org.javarosa.xform.parse.ExternalInstanceParser
+import org.javarosa.xform.util.XFormUtils
 import org.javarosa.xpath.expr.XPathExpression
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
+import org.odk.collect.entities.javarosa.intance.LocalEntitiesExternalInstanceParserFactory
+import org.odk.collect.entities.storage.Entity
 import org.odk.collect.entities.storage.InMemEntitiesRepository
 import java.util.function.Supplier
 
@@ -36,6 +42,18 @@ class LocalEntitiesFilterStrategyTest {
             it.addFilterStrategy(LocalEntitiesFilterStrategy(entitiesRepository))
             it.addFilterStrategy(fallthroughFilterStrategy)
         }
+    }
+
+    @Before
+    fun setup() {
+        XFormUtils.setExternalInstanceParserFactory(
+            LocalEntitiesExternalInstanceParserFactory(::entitiesRepository)
+        )
+    }
+
+    @After
+    fun teardown() {
+        XFormUtils.setExternalInstanceParserFactory { ExternalInstanceParser() }
     }
 
     @Test
@@ -55,10 +73,7 @@ class LocalEntitiesFilterStrategyTest {
                                 t("calculate")
                             )
                         ),
-                        instance(
-                            "things",
-                            t("item", t("label", "Thing"), t("name", "thing"))
-                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
                         bind("/data/question").type("string"),
                         bind("/data/calculate").type("string")
                             .calculate("instance('things')/root/item[name='other']/label")
@@ -77,7 +92,7 @@ class LocalEntitiesFilterStrategyTest {
 
     @Test
     fun `works correctly with name != expressions`() {
-        entitiesRepository.addList("things")
+        entitiesRepository.save(Entity.New("things", "thing", "Thing"))
 
         val scenario = Scenario.init(
             "Secondary instance form",
@@ -92,10 +107,7 @@ class LocalEntitiesFilterStrategyTest {
                                 t("calculate")
                             )
                         ),
-                        instance(
-                            "things",
-                            t("item", t("label", "Thing"), t("name", "thing"))
-                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
                         bind("/data/question").type("string"),
                         bind("/data/calculate").type("string")
                             .calculate("instance('things')/root/item[name!='other']/label")
@@ -113,7 +125,7 @@ class LocalEntitiesFilterStrategyTest {
 
     @Test
     fun `works correctly with non eq name expressions`() {
-        entitiesRepository.addList("things")
+        entitiesRepository.save(Entity.New("things", "thing", "Thing"))
 
         val scenario = Scenario.init(
             "Secondary instance form",
@@ -128,10 +140,7 @@ class LocalEntitiesFilterStrategyTest {
                                 t("calculate")
                             )
                         ),
-                        instance(
-                            "things",
-                            t("item", t("label", "Thing"), t("name", "thing"))
-                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
                         bind("/data/question").type("string"),
                         bind("/data/calculate").type("string")
                             .calculate("instance('things')/root/item[starts-with(name, 'thing')]/label")

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -2,7 +2,10 @@ package org.odk.collect.entities.javarosa.filter
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.javarosa.core.model.FormDef
 import org.javarosa.core.model.data.StringData
+import org.javarosa.form.api.FormEntryController
+import org.javarosa.form.api.FormEntryModel
 import org.javarosa.test.BindBuilderXFormsElement.bind
 import org.javarosa.test.Scenario
 import org.javarosa.test.XFormsElement.body
@@ -14,45 +17,48 @@ import org.javarosa.test.XFormsElement.mainInstance
 import org.javarosa.test.XFormsElement.model
 import org.javarosa.test.XFormsElement.t
 import org.javarosa.test.XFormsElement.title
-import org.javarosa.xform.util.XFormUtils
 import org.junit.Test
 import org.odk.collect.entities.storage.InMemEntitiesRepository
-import java.io.InputStreamReader
 
 class LocalEntitiesFilterStrategyTest {
 
+    private val controllerSupplier: (FormDef) -> FormEntryController = { formDef ->
+        FormEntryController(FormEntryModel(formDef)).also {
+            it.addFilterStrategy(LocalEntitiesFilterStrategy(InMemEntitiesRepository()))
+        }
+    }
+
     @Test
     fun `does not effect name queries on non entity instances`() {
-        val xForm = html(
-            head(
-                title("Secondary instance form"),
-                model(
-                    mainInstance(
-                        t(
-                            "data id=\"create-entity-form\"",
-                            t("question"),
-                            t("calculate")
-                        )
-                    ),
-                    instance(
-                        "secondary",
-                        t("item", t("label", "Thing"), t("name", "thing"))
-                    ),
-                    bind("/data/question").type("string"),
-                    bind("/data/calculate").type("string")
-                        .calculate("instance('secondary')/root/item[name='thing']/label")
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        instance(
+                            "secondary",
+                            t("item", t("label", "Thing"), t("name", "thing"))
+                        ),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("instance('secondary')/root/item[name='thing']/label")
+                    )
+                ),
+                body(
+                    input("/data/calculate")
                 )
             ),
-            body(
-                input("/data/calculate")
-            )
+            controllerSupplier
         )
 
-        val xml = xForm.asXml()
-        val formDef = XFormUtils.getFormRaw(InputStreamReader(xml.byteInputStream()))
-        formDef.addFilterStrategy(LocalEntitiesFilterStrategy(InMemEntitiesRepository()))
-
-        val scenario = Scenario.init(formDef)
         assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing"))
     }
 }


### PR DESCRIPTION
Closes #5623

~~Blocked by #6261~~
~~Blocked by https://github.com/getodk/javarosa/pull/780~~
~~Blocked by https://github.com/getodk/javarosa/pull/782~~

The "closes" here is slightly cheating as we'll also need to a better implementation of `EntitiesRepository` (using SQLite most likely) to get the real world load time gains. Additionally, the total memory footprint won't have dropped - the current `EntitiesRepository` implementation requires a whole list in memory for both `getById` and `getByProperty`. That all said, we're assuming that our new implementation (which we'll build as part #6012) will give us faster lookups and memory use that's only increased by the number of results (as opposed to needing the whole list in memory ever). @lognaturel is putting together a project for testing all this, and we've decided that this implementation is a good enough structural change to serve as a foundation we can tweak to get the performance we want.

#### Why is this the best possible solution? Were any other approaches considered?

The basic idea here is to query the `EntitiesRepository` for `name=` and `<property>=` predicates instead of letting JavaRosa use its own built in `FilterStrategy` chain. Combined with "partial parsing" (provided by `LocalEntitiesInstanceProvider`) and the new `DataInstance#replacePartialElement` this lets us keep the majority of the entity list out of memory until its all needed (like when we show an unfiltered select).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This risk here will be to forms that use filtered selects and calculations based on secondary instances. Entity forms are the most likely to have problems, but there is some risk that there are some unintended consequences for non-entity forms as well.

There's no need to test the actual performance increase/decrease here. As I said in the introduction, that will be hard to properly verify until other changes are made.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
