### PR TITLE
Text question type should allow new lines, wrap text, and respect the rows attribute

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/WidgetAnswerText.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/views/WidgetAnswerText.kt
@@ -59,11 +59,9 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
             }
         })
         if (isMasked) {
-            binding.editText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+            binding.editText.inputType = binding.editText.inputType or InputType.TYPE_TEXT_VARIATION_PASSWORD
             binding.editText.transformationMethod = PasswordTransformationMethod.getInstance()
             binding.textView.transformationMethod = PasswordTransformationMethod.getInstance()
-        } else {
-            binding.editText.inputType = InputType.TYPE_CLASS_TEXT
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
-import android.text.method.SingleLineTransformationMethod;
 
 import androidx.annotation.NonNull;
 
@@ -216,6 +215,6 @@ public class DecimalWidgetTest extends GeneralStringWidgetTest<DecimalWidget, De
     public void verifyInputType() {
         DecimalWidget widget = getWidget();
         assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
-        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod(), equalTo(null));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
-import android.text.method.SingleLineTransformationMethod;
 
 import androidx.annotation.NonNull;
 
@@ -99,7 +98,7 @@ public class ExDecimalWidgetTest extends GeneralExStringWidgetTest<ExDecimalWidg
     public void verifyInputType() {
         ExDecimalWidget widget = getWidget();
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
-        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), equalTo(null));
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
-import android.text.method.SingleLineTransformationMethod;
 
 import androidx.annotation.NonNull;
 
@@ -73,7 +72,7 @@ public class ExIntegerWidgetTest extends GeneralExStringWidgetTest<ExIntegerWidg
     public void verifyInputType() {
         ExIntegerWidget widget = getWidget();
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
-        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), equalTo(null));
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
@@ -24,7 +24,6 @@ import static org.odk.collect.android.utilities.Appearances.MASKED;
 
 import android.text.InputType;
 import android.text.method.PasswordTransformationMethod;
-import android.text.method.SingleLineTransformationMethod;
 
 /**
  * @author James Knight
@@ -58,8 +57,8 @@ public class ExStringWidgetTest extends GeneralExStringWidgetTest<ExStringWidget
     @Test
     public void verifyInputType() {
         ExStringWidget widget = getWidget();
-        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT));
-        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_MULTI_LINE));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), equalTo(null));
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
     }
 
@@ -67,7 +66,7 @@ public class ExStringWidgetTest extends GeneralExStringWidgetTest<ExStringWidget
     public void verifyInputTypeWithMaskedAppearance() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
         ExStringWidget widget = getWidget();
-        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD));
+        assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_MULTI_LINE | InputType.TYPE_TEXT_VARIATION_PASSWORD));
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
@@ -84,4 +84,10 @@ public class ExStringWidgetTest extends GeneralExStringWidgetTest<ExStringWidget
         assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
         assertThat(getSpyWidget().binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
     }
+
+    @Test
+    public void whenNumberOfRowsSpecifiedEditTextShouldHaveProperNumberOfMinLines() {
+        when(questionDef.getAdditionalAttribute(null, "rows")).thenReturn("5");
+        assertThat(getWidget().binding.widgetAnswerText.getBinding().editText.getMinLines(), equalTo(5));
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
-import android.text.method.SingleLineTransformationMethod;
 
 import androidx.annotation.NonNull;
 
@@ -60,6 +59,6 @@ public class IntegerWidgetTest extends GeneralStringWidgetTest<IntegerWidget, In
     public void verifyInputType() {
         IntegerWidget widget = getWidget();
         assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
-        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod(), equalTo(null));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
@@ -4,12 +4,9 @@ import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.utilities.Appearances.MASKED;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
 
 import android.text.InputType;
-import android.text.method.PasswordTransformationMethod;
-import android.text.method.SingleLineTransformationMethod;
 
 import androidx.annotation.NonNull;
 
@@ -60,14 +57,6 @@ public class StringNumberWidgetTest extends GeneralStringWidgetTest<StringNumber
     public void verifyInputType() {
         StringNumberWidget widget = getWidget();
         assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER));
-        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
-    }
-
-    @Test
-    public void verifyInputTypeWithMaskedAppearance() {
-        when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
-        StringNumberWidget widget = getWidget();
-        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER));
-        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod(), equalTo(null));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringWidgetTest.java
@@ -69,4 +69,10 @@ public class StringWidgetTest extends GeneralStringWidgetTest<StringWidget, Stri
         assertThat(getSpyWidget().widgetAnswerText.getBinding().editText.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
         assertThat(getSpyWidget().widgetAnswerText.getBinding().textView.getTransformationMethod(), is(instanceOf(PasswordTransformationMethod.class)));
     }
+
+    @Test
+    public void whenNumberOfRowsSpecifiedEditTextShouldHaveProperNumberOfMinLines() {
+        when(questionDef.getAdditionalAttribute(null, "rows")).thenReturn("5");
+        assertThat(getWidget().widgetAnswerText.getBinding().editText.getMinLines(), equalTo(5));
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringWidgetTest.java
@@ -10,7 +10,6 @@ import static org.odk.collect.android.utilities.Appearances.MASKED;
 
 import android.text.InputType;
 import android.text.method.PasswordTransformationMethod;
-import android.text.method.SingleLineTransformationMethod;
 
 import androidx.annotation.NonNull;
 
@@ -45,16 +44,15 @@ public class StringWidgetTest extends GeneralStringWidgetTest<StringWidget, Stri
     @Test
     public void verifyInputType() {
         StringWidget widget = getWidget();
-        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT));
-        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(SingleLineTransformationMethod.class));
-        assertThat(widget.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_MULTI_LINE));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod(), equalTo(null));
     }
 
     @Test
     public void verifyInputTypeWithMaskedAppearance() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(MASKED);
         StringWidget widget = getWidget();
-        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD));
+        assertThat(widget.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_MULTI_LINE | InputType.TYPE_TEXT_VARIATION_PASSWORD));
         assertThat(widget.widgetAnswerText.getBinding().editText.getTransformationMethod().getClass(), equalTo(PasswordTransformationMethod.class));
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
@@ -4,10 +4,8 @@ import static junit.framework.Assert.assertTrue;
 
 import android.view.View;
 
-import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IAnswerData;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.WidgetTestActivity;
 import org.odk.collect.android.widgets.StringWidget;
@@ -24,15 +22,6 @@ import java.util.List;
  */
 public abstract class GeneralStringWidgetTest<W extends StringWidget, A extends IAnswerData>
         extends QuestionWidgetTest<W, A> {
-
-    @Mock
-    QuestionDef questionDef;
-
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        when(formEntryPrompt.getQuestion()).thenReturn(questionDef);
-    }
 
     @Override
     public void callingClearShouldRemoveTheExistingAnswer() {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/WidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/WidgetTest.java
@@ -37,6 +37,9 @@ public abstract class WidgetTest {
 
     protected final SettingsProvider settingsProvider = TestSettingsProvider.getSettingsProvider();
 
+    @Mock
+    protected QuestionDef questionDef;
+
     @Before
     @OverridingMethodsMustInvokeSuper
     public void setUp() throws Exception {
@@ -48,7 +51,7 @@ public abstract class WidgetTest {
         when(formEntryPrompt.getIndex()).thenReturn(mock(FormIndex.class));
         when(formEntryPrompt.getIndex().toString()).thenReturn("0, 0");
         when(formEntryPrompt.getFormElement()).thenReturn(formElement);
-        when(formEntryPrompt.getQuestion()).thenReturn(mock(QuestionDef.class));
+        when(formEntryPrompt.getQuestion()).thenReturn(questionDef);
     }
 
     @Test


### PR DESCRIPTION
Closes #6270 

The problem was that when we started setting input types programmatically (to support the masked appearance) we did that in the wrong way. Instead of adding  
`InputType.TYPE_TEXT_VARIATION_PASSWORD` if needed **to the default input types** we removed the default ones always using only `InputType.TYPE_CLASS_TEXT` or `InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD` instead. Because of that, we lost  `InputType.TYPE_TEXT_FLAG_CAP_SENTENCES` and `InputType.TYPE_TEXT_FLAG_MULTI_LINE` that normally are applied by default.

#### Why is this the best possible solution? Were any other approaches considered?
Instead of clearing the default input type and adding `InputType.TYPE_CLASS_TEXT` or `InputType.TYPE_TEXT_VARIATION_PASSWORD` we need to mix the existing input type with `InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that the masked appearance is working well with string widgets and that text fields can expand and have multiple lines (as it was before v2024.2). 

#### Do we need any specific form for testing your changes? If so, please attach one.
I used this one: 
[maskedANDRows.xlsx](https://github.com/user-attachments/files/16279499/maskedANDRows.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
