### PR TITLE
Let `Error`s crash the app during form loading

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -197,7 +197,7 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
         } catch (StackOverflowError e) {
             Timber.e(e);
             errorMsg = getLocalizedString(Collect.getInstance(), org.odk.collect.strings.R.string.too_complex_form);
-        } catch (Exception | Error e) {
+        } catch (Exception e) {
             Timber.w(e);
             errorMsg = "An unknown error has occurred. Please ask your project leadership to email support@getodk.org with information about this form.";
             errorMsg += "\n\n" + e.getMessage();


### PR DESCRIPTION
Closes #6268

This means that OOM (and other Errors) will correctly end the app process and not end up being obscured in crash reporting.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The risk here is that there is an `Error` that we do want to catch. This feels unlikely though: JavaRosa typically outputs `RuntimeException` (even though it shouldn't) in very exceptional circumstance. 

I did spot one use of `Error` in JavaRosa that happens in the case where there are problems setting up `PrototypeFactory` (due to class has collisions). This seemed very exceptional though, and is probably worth crashing over.

In terms of testing, I think the best thing is to just check form loading with "broken" forms that should show errors instead of crashing to double-check those haven't regressed.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
