### PR TITLE
Fixed hiding error in external widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -236,6 +236,7 @@ public class ExStringWidget extends QuestionWidget implements WidgetDataReceiver
 
     @Override
     public void hideError() {
+        super.hideError();
         binding.widgetAnswerText.setError(null);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -75,7 +75,7 @@ public abstract class QuestionWidget extends FrameLayout implements Widget {
     private final View guidanceTextLayout;
     private final View textLayout;
     private final TextView warningText;
-    protected final View errorLayout;
+    public final View errorLayout;
     protected final Settings settings;
     private AtomicBoolean expanded;
     protected final ThemeUtils themeUtils;

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.widgets.base;
 import static junit.framework.Assert.assertTrue;
 
 import android.view.View;
+import android.widget.TextView;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.junit.Test;
@@ -11,6 +12,7 @@ import org.odk.collect.android.support.WidgetTestActivity;
 import org.odk.collect.android.widgets.ExStringWidget;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
@@ -62,6 +64,26 @@ public abstract class GeneralExStringWidgetTest<W extends ExStringWidget, A exte
 
         assertThat(viewsRegisterForContextMenu.get(0).getId(), is(widget.getId()));
         assertThat(viewsRegisterForContextMenu.get(1).getId(), is(widget.getId()));
+    }
+
+    @Test
+    public void errorDisappearsOnSetData() {
+        ExStringWidget widget = getWidget();
+        widget.displayError("blah");
+        widget.setData("answer");
+
+        assertThat(widget.errorLayout.getVisibility(), equalTo(TextView.GONE));
+        assertThat(widget.getBackground(), equalTo(null));
+    }
+
+    @Test
+    public void errorDisappearsOnAddingAnswerManuallyViaTheTextField() {
+        ExStringWidget widget = getWidget();
+        widget.displayError("blah");
+        widget.binding.widgetAnswerText.getBinding().editText.setText("answer");
+
+        assertThat(widget.errorLayout.getVisibility(), equalTo(TextView.GONE));
+        assertThat(widget.getBackground(), equalTo(null));
     }
 
     @Test


### PR DESCRIPTION
Closes #6266 

#### Why is this the best possible solution? Were any other approaches considered?
It's a bug fix so nothing to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks? 
This fixes hiding errors in external string widgets. Other widgets should not be affected but we can't be sure maybe we have similar issues with other types of questions as well (it would be good to test them).

#### Do we need any specific form for testing your changes? If so, please attach one.
The form that is attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
