### PR TITLE
Fixed memory leaks in form-filling 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryViewModelFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryViewModelFactory.kt
@@ -129,10 +129,10 @@ class FormEntryViewModelFactory(
                     fusedLocationClient,
                     BackgroundLocationHelper(
                         permissionsProvider,
-                        settingsProvider.getUnprotectedSettings()
-                    ) {
-                        formSessionRepository.get(sessionId).value?.formController
-                    }
+                        settingsProvider.getUnprotectedSettings(),
+                        formSessionRepository,
+                        sessionId
+                    )
                 )
 
                 BackgroundLocationViewModel(locationManager)

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -429,7 +429,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 autoSendSettingsProvider,
                 formsRepositoryProvider,
                 instancesRepositoryProvider,
-                new SavepointsRepositoryProvider(this, storagePathProvider),
+                savepointsRepositoryProvider,
                 new QRCodeCreatorImpl(),
                 new HtmlPrinter(),
                 instancesDataService

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyActivity.java
@@ -59,7 +59,6 @@ import org.odk.collect.android.instancemanagement.autosend.AutoSendSettingsProvi
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.javarosawrapper.JavaRosaFormController;
 import org.odk.collect.android.projects.ProjectsDataService;
-import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.FormsRepositoryProvider;
@@ -194,7 +193,7 @@ public class FormHierarchyActivity extends LocalizedActivity implements DeleteRe
     public FormsRepositoryProvider formsRepositoryProvider;
 
     @Inject
-    public StoragePathProvider storagePathProvider;
+    public SavepointsRepositoryProvider savepointsRepositoryProvider;
 
     @Inject
     public InstancesDataService instancesDataService;
@@ -232,7 +231,7 @@ public class FormHierarchyActivity extends LocalizedActivity implements DeleteRe
                 autoSendSettingsProvider,
                 formsRepositoryProvider,
                 instancesRepositoryProvider,
-                new SavepointsRepositoryProvider(this, storagePathProvider),
+                savepointsRepositoryProvider,
                 new QRCodeCreatorImpl(),
                 new HtmlPrinter(),
                 instancesDataService


### PR DESCRIPTION
Closes #5976 

#### Why is this the best possible solution? Were any other approaches considered?
The first problem I was able to reproduce was building `SavepointsRepositoryProvider` and passing activity as a context. `SavepointsRepositoryProvider` similar to other database repository providers needs a context but it should be the application one instead.

Another problem was passing data to `BackgroundLocationHelper`. Here instead of using lambda functions to pass the form controller we should pass `formSessionRepository` and `sessionId` to let `BackgroundLocationHelper` get the form controller when it needs it similar to what other objects constructed in `FormEntryViewModelFactory` do.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please make sure the leaks do not occur anymore. Additionally, it would be good to test background audio recordings briefly (just to check if it works with no crashes) as the code related to this functionality has been updated. 
There might be other leaks caused by device rotation but I was able to reproduce only the two described above. If there is something more you can still see please let me know.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
