### PR TITLE
Add `trunkVersion` and `branchId` support

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
@@ -110,6 +110,49 @@ class EntityFormTest {
     }
 
     @Test
+    fun fillingEntityCreateForm_withUpdate_doesNotCreateEntityForFollowUpForms() {
+        testDependencies.server.addForm("one-question-entity-create-and-update.xml")
+        testDependencies.server.addForm(
+            "one-question-entity-update.xml",
+            listOf(EntityListItem("people.csv"))
+        )
+
+        rule.withMatchExactlyProject(testDependencies.server.url)
+            .enableLocalEntitiesInForms()
+
+            .startBlankForm("One Question Entity Registration")
+            .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("Name", "Logan Roy"))
+
+            .startBlankForm("One Question Entity Update")
+            .assertQuestion("Select person")
+            .assertText("Roman Roy")
+            .assertTextDoesNotExist("Logan Roy")
+    }
+
+    @Test
+    fun fillingEntityUpdateForm_withCreate_doesNotUpdateEntityForFollowUpForms() {
+        testDependencies.server.addForm(
+            "one-question-entity-update-and-create.xml",
+            listOf(EntityListItem("people.csv"))
+        )
+
+        rule.withMatchExactlyProject(testDependencies.server.url)
+            .enableLocalEntitiesInForms()
+
+            .startBlankForm("One Question Entity Update")
+            .assertQuestion("Select person")
+            .clickOnText("Roman Roy")
+            .swipeToNextQuestion("Name")
+            .answerQuestion("Name", "Romulus Roy")
+            .swipeToEndScreen()
+            .clickFinalize()
+
+            .startBlankForm("One Question Entity Update")
+            .assertTextDoesNotExist("Romulus Roy")
+            .assertText("Roman Roy")
+    }
+
+    @Test
     fun entityListSecondaryInstancesAreConsistentBetweenFollowUpForms() {
         testDependencies.server.apply {
             addForm(

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
@@ -24,7 +24,7 @@ class EntityFormTest {
         .around(rule)
 
     @Test
-    fun fillingEntityRegistrationForm_beforeCreatingEntityList_doesNotCreateEntityForFollowUpForms() {
+    fun fillingEntityRegistrationForm_doesNotShowEntitiesInNonEntityListForm() {
         testDependencies.server.addForm("one-question-entity-registration.xml")
         testDependencies.server.addForm(
             "one-question-entity-update.xml",

--- a/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
@@ -25,7 +25,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
                 entity.properties,
                 entity.state,
                 index,
-                entity.trunkVersion
+                entity.trunkVersion,
+                entity.branchId
             )
         }
     }
@@ -53,7 +54,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
                         version = entity.version,
                         properties = mergeProperties(existing.toEntity(entity.list), entity),
                         state = state,
-                        trunkVersion = entity.trunkVersion
+                        trunkVersion = entity.trunkVersion,
+                        branchId = entity.branchId
                     ).toJson()
                 )
             } else {
@@ -170,7 +172,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         val version: Int,
         val properties: Map<String, String>,
         val offline: Boolean,
-        val trunkVersion: Int?
+        val trunkVersion: Int?,
+        val branchId: String
     )
 
     private fun JsonEntity.toEntity(list: String): Entity.New {
@@ -187,7 +190,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
             this.version,
             this.properties.entries.map { Pair(it.key, it.value) },
             state,
-            this.trunkVersion
+            this.trunkVersion,
+            this.branchId
         )
     }
 
@@ -198,7 +202,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
             this.version,
             this.properties.toMap(),
             this.state == Entity.State.OFFLINE,
-            this.trunkVersion
+            this.trunkVersion,
+            this.branchId
         )
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/entities/JsonFileEntitiesRepository.kt
@@ -24,7 +24,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
                 entity.version,
                 entity.properties,
                 entity.state,
-                index
+                index,
+                entity.trunkVersion
             )
         }
     }
@@ -51,7 +52,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
                         entity.label ?: existing.label,
                         version = entity.version,
                         properties = mergeProperties(existing.toEntity(entity.list), entity),
-                        state = state
+                        state = state,
+                        trunkVersion = entity.trunkVersion
                     ).toJson()
                 )
             } else {
@@ -86,7 +88,11 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         return getEntities(list).firstOrNull { it.id == id }
     }
 
-    override fun getAllByProperty(list: String, property: String, value: String): List<Entity.Saved> {
+    override fun getAllByProperty(
+        list: String,
+        property: String,
+        value: String
+    ): List<Entity.Saved> {
         return getEntities(list).filter { entity ->
             entity.properties.any { (first, second) -> first == property && second == value }
         }
@@ -163,7 +169,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
         val label: String?,
         val version: Int,
         val properties: Map<String, String>,
-        val offline: Boolean
+        val offline: Boolean,
+        val trunkVersion: Int?
     )
 
     private fun JsonEntity.toEntity(list: String): Entity.New {
@@ -179,7 +186,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
             this.label,
             this.version,
             this.properties.entries.map { Pair(it.key, it.value) },
-            state
+            state,
+            this.trunkVersion
         )
     }
 
@@ -189,7 +197,8 @@ class JsonFileEntitiesRepository(directory: File) : EntitiesRepository {
             this.label,
             this.version,
             this.properties.toMap(),
-            this.state == Entity.State.OFFLINE
+            this.state == Entity.State.OFFLINE,
+            this.trunkVersion
         )
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -29,8 +29,22 @@ abstract class EntitiesRepositoryTest {
     fun `#getEntities returns entities for list`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008")
-        val whisky = Entity.New("whiskys", "2", "Lagavulin 16")
+        val wine = Entity.New(
+            "wines",
+            "1",
+            "Léoville Barton 2008",
+            version = 2,
+            trunkVersion = 1
+        )
+
+        val whisky = Entity.New(
+            "whiskys",
+            "2",
+            "Lagavulin 16",
+            version = 3,
+            trunkVersion = 1
+        )
+
         repository.save(wine)
         repository.save(whisky)
 
@@ -47,10 +61,15 @@ abstract class EntitiesRepositoryTest {
     fun `#save updates existing entity with matching id`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008", version = 1)
+        val wine = Entity.New(
+            "wines",
+            "1",
+            "Léoville Barton 2008",
+            trunkVersion = 1
+        )
         repository.save(wine)
 
-        val updatedWine = Entity.New("wines", wine.id, "Léoville Barton 2009", version = 2)
+        val updatedWine = wine.copy(label = "Léoville Barton 2009", version = 2)
         repository.save(updatedWine)
 
         val wines = repository.getEntities("wines")

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -19,18 +19,31 @@ object LocalEntityUseCases {
         formEntities?.entities?.forEach { formEntity ->
             val id = formEntity.id
             if (id != null && entitiesRepository.getLists().contains(formEntity.dataset)) {
-                val existing = entitiesRepository.getById(formEntity.dataset, formEntity.id)
-                if (formEntity.action != EntityAction.UPDATE || existing != null) {
-                    val entity = Entity.New(
-                        formEntity.dataset,
-                        id,
-                        formEntity.label,
-                        formEntity.version,
-                        formEntity.properties,
-                        trunkVersion = existing?.trunkVersion
-                    )
+                when (formEntity.action) {
+                    EntityAction.CREATE -> {
+                        val entity = Entity.New(
+                            formEntity.dataset,
+                            id,
+                            formEntity.label,
+                            formEntity.version,
+                            formEntity.properties
+                        )
 
-                    entitiesRepository.save(entity)
+                        entitiesRepository.save(entity)
+                    }
+
+                    EntityAction.UPDATE -> {
+                        val existing = entitiesRepository.getById(formEntity.dataset, formEntity.id)
+                        if (existing != null) {
+                            entitiesRepository.save(
+                                existing.copy(
+                                    label = formEntity.label,
+                                    properties = formEntity.properties,
+                                    version = existing.version + 1
+                                )
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -8,7 +8,6 @@ import org.odk.collect.entities.javarosa.spec.EntityAction
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
 import java.io.File
-import java.util.UUID
 
 object LocalEntityUseCases {
 
@@ -70,18 +69,10 @@ object LocalEntityUseCases {
             val entity = parseEntityFromItem(item, list) ?: return
             val existing = missing.remove(entity.id)
 
-            if (existing == null || existing.version < entity.version) {
+            if (existing == null || existing.version <= entity.version) {
                 Pair(new + entity, missing)
-            } else if (existing.version == entity.version) {
-                val update = existing.copy(
-                    state = Entity.State.ONLINE,
-                    trunkVersion = entity.version,
-                    branchId = UUID.randomUUID().toString()
-                )
-                Pair(new + update, missing)
             } else if (existing.state == Entity.State.OFFLINE) {
-                val update =
-                    existing.copy(state = Entity.State.ONLINE, trunkVersion = entity.version)
+                val update = existing.copy(state = Entity.State.ONLINE)
                 Pair(new + update, missing)
             } else {
                 Pair(new, missing)

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -8,6 +8,7 @@ import org.odk.collect.entities.javarosa.spec.EntityAction
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
 import java.io.File
+import java.util.UUID
 
 object LocalEntityUseCases {
 
@@ -71,6 +72,13 @@ object LocalEntityUseCases {
 
             if (existing == null || existing.version < entity.version) {
                 Pair(new + entity, missing)
+            } else if (existing.version == entity.version) {
+                val update = existing.copy(
+                    state = Entity.State.ONLINE,
+                    trunkVersion = entity.version,
+                    branchId = UUID.randomUUID().toString()
+                )
+                Pair(new + update, missing)
             } else if (existing.state == Entity.State.OFFLINE) {
                 val update =
                     existing.copy(state = Entity.State.ONLINE, trunkVersion = entity.version)

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -19,7 +19,10 @@ object LocalEntityUseCases {
         formEntities?.entities?.forEach { formEntity ->
             val id = formEntity.id
             if (id != null && entitiesRepository.getLists().contains(formEntity.dataset)) {
-                if (formEntity.action != EntityAction.UPDATE || entitiesRepository.getEntities(formEntity.dataset).any { it.id == id }) {
+                if (formEntity.action != EntityAction.UPDATE || entitiesRepository.getEntities(
+                        formEntity.dataset
+                    ).any { it.id == id }
+                ) {
                     val entity = Entity.New(
                         formEntity.dataset,
                         id,
@@ -57,7 +60,9 @@ object LocalEntityUseCases {
             if (existing == null || existing.version < entity.version) {
                 Pair(new + entity, missing)
             } else if (existing.state == Entity.State.OFFLINE) {
-                Pair(new + existing.copy(state = Entity.State.ONLINE), missing)
+                val update =
+                    existing.copy(state = Entity.State.ONLINE, trunkVersion = entity.version)
+                Pair(new + update, missing)
             } else {
                 Pair(new, missing)
             }
@@ -100,7 +105,14 @@ object LocalEntityUseCases {
                 }
             }
 
-        val entity = Entity.New(list, id, label, version, properties, state = Entity.State.ONLINE)
-        return entity
+        return Entity.New(
+            list,
+            id,
+            label,
+            version,
+            properties,
+            state = Entity.State.ONLINE,
+            trunkVersion = version
+        )
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -25,7 +25,7 @@ object LocalEntityUseCases {
                             formEntity.dataset,
                             id,
                             formEntity.label,
-                            formEntity.version,
+                            1,
                             formEntity.properties
                         )
 

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -19,16 +19,15 @@ object LocalEntityUseCases {
         formEntities?.entities?.forEach { formEntity ->
             val id = formEntity.id
             if (id != null && entitiesRepository.getLists().contains(formEntity.dataset)) {
-                if (formEntity.action != EntityAction.UPDATE || entitiesRepository.getEntities(
-                        formEntity.dataset
-                    ).any { it.id == id }
-                ) {
+                val existing = entitiesRepository.getById(formEntity.dataset, formEntity.id)
+                if (formEntity.action != EntityAction.UPDATE || existing != null) {
                     val entity = Entity.New(
                         formEntity.dataset,
                         id,
                         formEntity.label,
                         formEntity.version,
-                        formEntity.properties
+                        formEntity.properties,
+                        trunkVersion = existing?.trunkVersion
                     )
 
                     entitiesRepository.save(entity)

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntitiesExtra.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntitiesExtra.kt
@@ -1,3 +1,3 @@
 package org.odk.collect.entities.javarosa.finalization
 
-data class EntitiesExtra(val entities: List<Entity>)
+data class EntitiesExtra(val entities: List<FormEntity>)

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.java
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.java
@@ -36,12 +36,12 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
             String dataset = EntityFormParser.parseDataset(entityElement);
 
             if (action == EntityAction.CREATE) {
-                Entity entity = createEntity(entityElement, 1, dataset, saveTos, mainInstance, action);
+                FormEntity entity = createEntity(entityElement, 1, dataset, saveTos, mainInstance, action);
                 formEntryModel.getExtras().put(new EntitiesExtra(asList(entity)));
             } else if (action == EntityAction.UPDATE) {
                 int baseVersion = EntityFormParser.parseBaseVersion(entityElement);
                 int newVersion = baseVersion + 1;
-                Entity entity = createEntity(entityElement, newVersion, dataset, saveTos, mainInstance, action);
+                FormEntity entity = createEntity(entityElement, newVersion, dataset, saveTos, mainInstance, action);
                 formEntryModel.getExtras().put(new EntitiesExtra(asList(entity)));
             } else {
                 formEntryModel.getExtras().put(new EntitiesExtra(emptyList()));
@@ -49,7 +49,7 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
         }
     }
 
-    private Entity createEntity(TreeElement entityElement, int version, String dataset, List<Pair<XPathReference, String>> saveTos, FormInstance mainInstance, EntityAction action) {
+    private FormEntity createEntity(TreeElement entityElement, int version, String dataset, List<Pair<XPathReference, String>> saveTos, FormInstance mainInstance, EntityAction action) {
         List<Pair<String, String>> fields = saveTos.stream().map(saveTo -> {
             IDataReference reference = saveTo.getFirst();
             IAnswerData answerData = mainInstance.resolveReference(reference).getValue();
@@ -63,6 +63,6 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
 
         String id = EntityFormParser.parseId(entityElement);
         String label = EntityFormParser.parseLabel(entityElement);
-        return new Entity(action, dataset, id, label, version, fields);
+        return new FormEntity(action, dataset, id, label, version, fields);
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.java
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.java
@@ -35,13 +35,8 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
             EntityAction action = EntityFormParser.parseAction(entityElement);
             String dataset = EntityFormParser.parseDataset(entityElement);
 
-            if (action == EntityAction.CREATE) {
-                FormEntity entity = createEntity(entityElement, 1, dataset, saveTos, mainInstance, action);
-                formEntryModel.getExtras().put(new EntitiesExtra(asList(entity)));
-            } else if (action == EntityAction.UPDATE) {
-                int baseVersion = EntityFormParser.parseBaseVersion(entityElement);
-                int newVersion = baseVersion + 1;
-                FormEntity entity = createEntity(entityElement, newVersion, dataset, saveTos, mainInstance, action);
+            if (action == EntityAction.CREATE || action == EntityAction.UPDATE) {
+                FormEntity entity = createEntity(entityElement, dataset, saveTos, mainInstance, action);
                 formEntryModel.getExtras().put(new EntitiesExtra(asList(entity)));
             } else {
                 formEntryModel.getExtras().put(new EntitiesExtra(emptyList()));
@@ -49,7 +44,7 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
         }
     }
 
-    private FormEntity createEntity(TreeElement entityElement, int version, String dataset, List<Pair<XPathReference, String>> saveTos, FormInstance mainInstance, EntityAction action) {
+    private FormEntity createEntity(TreeElement entityElement, String dataset, List<Pair<XPathReference, String>> saveTos, FormInstance mainInstance, EntityAction action) {
         List<Pair<String, String>> fields = saveTos.stream().map(saveTo -> {
             IDataReference reference = saveTo.getFirst();
             IAnswerData answerData = mainInstance.resolveReference(reference).getValue();
@@ -63,6 +58,6 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
 
         String id = EntityFormParser.parseId(entityElement);
         String label = EntityFormParser.parseLabel(entityElement);
-        return new FormEntity(action, dataset, id, label, version, fields);
+        return new FormEntity(action, dataset, id, label, fields);
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/FormEntity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/FormEntity.kt
@@ -7,6 +7,5 @@ class FormEntity(
     @JvmField val dataset: String,
     @JvmField val id: String?,
     @JvmField val label: String?,
-    @JvmField val version: Int,
     @JvmField val properties: List<Pair<String, String>>
 )

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/FormEntity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/FormEntity.kt
@@ -2,7 +2,7 @@ package org.odk.collect.entities.javarosa.finalization
 
 import org.odk.collect.entities.javarosa.spec.EntityAction
 
-class Entity(
+class FormEntity(
     @JvmField val action: EntityAction,
     @JvmField val dataset: String,
     @JvmField val id: String?,

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -60,11 +60,13 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
         val label = TreeElement(EntityItemElement.LABEL)
         val version = TreeElement(EntityItemElement.VERSION)
         val trunkVersion = TreeElement(EntityItemElement.TRUNK_VERSION)
+        val branchId = TreeElement(EntityItemElement.BRANCH_ID)
 
         if (!partial) {
             name.value = StringData(entity.id)
             label.value = StringData(entity.label)
             version.value = StringData(entity.version.toString())
+            branchId.value = StringData(entity.branchId)
 
             if (entity.trunkVersion != null) {
                 trunkVersion.value = StringData(entity.trunkVersion.toString())
@@ -76,6 +78,7 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
         item.addChild(label)
         item.addChild(version)
         item.addChild(trunkVersion)
+        item.addChild(branchId)
 
         entity.properties.forEach { property ->
             val propertyElement = TreeElement(property.first)

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -59,17 +59,23 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
         val name = TreeElement(EntityItemElement.ID)
         val label = TreeElement(EntityItemElement.LABEL)
         val version = TreeElement(EntityItemElement.VERSION)
+        val trunkVersion = TreeElement(EntityItemElement.TRUNK_VERSION)
 
         if (!partial) {
             name.value = StringData(entity.id)
             label.value = StringData(entity.label)
             version.value = StringData(entity.version.toString())
+
+            if (entity.trunkVersion != null) {
+                trunkVersion.value = StringData(entity.trunkVersion.toString())
+            }
         }
 
         val item = TreeElement("item", entity.index, partial)
         item.addChild(name)
         item.addChild(label)
         item.addChild(version)
+        item.addChild(trunkVersion)
 
         entity.properties.forEach { property ->
             val propertyElement = TreeElement(property.first)

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/parse/EntityFormParseProcessor.java
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/parse/EntityFormParseProcessor.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 public class EntityFormParseProcessor implements XFormParser.BindAttributeProcessor, XFormParser.FormDefProcessor, XFormParser.ModelAttributeProcessor {
 
     private static final String ENTITIES_NAMESPACE = "http://www.opendatakit.org/xforms/entities";
-    private static final String[] SUPPORTED_VERSIONS = {"2022.1", "2023.1"};
+    private static final String[] SUPPORTED_VERSIONS = {"2022.1", "2023.1", "2024.1"};
 
     private final List<Pair<XPathReference, String>> saveTos = new ArrayList<>();
     private boolean versionPresent;

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/parse/EntityItemElement.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/parse/EntityItemElement.kt
@@ -4,4 +4,5 @@ internal object EntityItemElement {
     const val ID = "name"
     const val LABEL = "label"
     const val VERSION = "__version"
+    const val TRUNK_VERSION = "__trunkVersion"
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/parse/EntityItemElement.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/parse/EntityItemElement.kt
@@ -5,4 +5,5 @@ internal object EntityItemElement {
     const val LABEL = "label"
     const val VERSION = "__version"
     const val TRUNK_VERSION = "__trunkVersion"
+    const val BRANCH_ID = "__branchId"
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/spec/EntityFormParser.java
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/spec/EntityFormParser.java
@@ -63,18 +63,29 @@ public class EntityFormParser {
         String create = entity.getAttributeValue(null, ATTRIBUTE_CREATE);
         String update = entity.getAttributeValue(null, ATTRIBUTE_UPDATE);
 
-        if (update != null) {
-            if (XPathFuncExpr.boolStr(update)) {
-                return EntityAction.UPDATE;
-            }
-        }
-
+        boolean shouldCreate = false;
         if (create != null) {
             if (XPathFuncExpr.boolStr(create)) {
-                return EntityAction.CREATE;
+                shouldCreate = true;
             }
         }
 
-        return null;
+        boolean shouldUpdate = false;
+        if (update != null) {
+            if (XPathFuncExpr.boolStr(update)) {
+                shouldUpdate = true;
+            }
+        }
+
+        if (shouldCreate && shouldUpdate) {
+            return null;
+        } else if (shouldCreate) {
+            return EntityAction.CREATE;
+        } else if (shouldUpdate) {
+            return EntityAction.UPDATE;
+        } else {
+            return null;
+        }
+
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/spec/EntityFormParser.java
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/spec/EntityFormParser.java
@@ -1,19 +1,18 @@
 package org.odk.collect.entities.javarosa.spec;
 
-import org.javarosa.core.model.data.IAnswerData;
-import org.javarosa.core.model.instance.FormInstance;
-import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.xpath.expr.XPathFuncExpr;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_BASE_VERSION;
 import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_CREATE;
 import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_DATASET;
 import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_ID;
 import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ATTRIBUTE_UPDATE;
 import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ELEMENT_ENTITY;
 import static org.odk.collect.entities.javarosa.spec.FormEntityElement.ELEMENT_LABEL;
+
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.xpath.expr.XPathFuncExpr;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class EntityFormParser {
 
@@ -45,14 +44,6 @@ public class EntityFormParser {
     @Nullable
     public static String parseId(TreeElement entity) {
         return entity.getAttributeValue("", ATTRIBUTE_ID);
-    }
-
-    public static Integer parseBaseVersion(TreeElement entity) {
-        try {
-            return Integer.valueOf(entity.getAttributeValue("", ATTRIBUTE_BASE_VERSION));
-        } catch (NumberFormatException e) {
-            return 0;
-        }
     }
 
     @Nullable

--- a/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
@@ -7,6 +7,7 @@ sealed interface Entity {
     val version: Int
     val properties: List<Pair<String, String>>
     val state: State
+    val trunkVersion: Int?
 
     data class New(
         override val list: String,
@@ -14,7 +15,8 @@ sealed interface Entity {
         override val label: String?,
         override val version: Int = 1,
         override val properties: List<Pair<String, String>> = emptyList(),
-        override val state: State = State.OFFLINE
+        override val state: State = State.OFFLINE,
+        override val trunkVersion: Int? = null
     ) : Entity
 
     data class Saved(
@@ -24,7 +26,8 @@ sealed interface Entity {
         override val version: Int = 1,
         override val properties: List<Pair<String, String>> = emptyList(),
         override val state: State = State.OFFLINE,
-        val index: Int
+        val index: Int,
+        override val trunkVersion: Int? = null
     ) : Entity
 
     enum class State {
@@ -45,7 +48,8 @@ sealed interface Entity {
             entity.label,
             entity.version,
             entity.properties,
-            entity.state
+            entity.state,
+            entity.trunkVersion
         )
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
@@ -1,5 +1,7 @@
 package org.odk.collect.entities.storage
 
+import java.util.UUID
+
 sealed interface Entity {
     val list: String
     val id: String
@@ -8,6 +10,7 @@ sealed interface Entity {
     val properties: List<Pair<String, String>>
     val state: State
     val trunkVersion: Int?
+    val branchId: String
 
     data class New(
         override val list: String,
@@ -16,7 +19,8 @@ sealed interface Entity {
         override val version: Int = 1,
         override val properties: List<Pair<String, String>> = emptyList(),
         override val state: State = State.OFFLINE,
-        override val trunkVersion: Int? = null
+        override val trunkVersion: Int? = null,
+        override val branchId: String = UUID.randomUUID().toString()
     ) : Entity
 
     data class Saved(
@@ -27,7 +31,8 @@ sealed interface Entity {
         override val properties: List<Pair<String, String>> = emptyList(),
         override val state: State = State.OFFLINE,
         val index: Int,
-        override val trunkVersion: Int? = null
+        override val trunkVersion: Int? = null,
+        override val branchId: String = UUID.randomUUID().toString()
     ) : Entity
 
     enum class State {
@@ -49,7 +54,8 @@ sealed interface Entity {
             entity.version,
             entity.properties,
             entity.state,
-            entity.trunkVersion
+            entity.trunkVersion,
+            entity.branchId
         )
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -19,7 +19,8 @@ class InMemEntitiesRepository : EntitiesRepository {
                 entity.properties,
                 entity.state,
                 index,
-                entity.trunkVersion
+                entity.trunkVersion,
+                entity.branchId
             )
         }
     }
@@ -71,7 +72,8 @@ class InMemEntitiesRepository : EntitiesRepository {
                         version = entity.version,
                         properties = mergeProperties(existing, entity),
                         state = state,
-                        trunkVersion = entity.trunkVersion
+                        trunkVersion = entity.trunkVersion,
+                        branchId = entity.branchId
                     )
                 )
             } else {
@@ -83,7 +85,8 @@ class InMemEntitiesRepository : EntitiesRepository {
                         entity.version,
                         entity.properties,
                         entity.state,
-                        entity.trunkVersion
+                        entity.trunkVersion,
+                        entity.branchId
                     )
                 )
             }

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -18,7 +18,8 @@ class InMemEntitiesRepository : EntitiesRepository {
                 entity.version,
                 entity.properties,
                 entity.state,
-                index
+                index,
+                entity.trunkVersion
             )
         }
     }
@@ -69,7 +70,8 @@ class InMemEntitiesRepository : EntitiesRepository {
                         entity.label ?: existing.label,
                         version = entity.version,
                         properties = mergeProperties(existing, entity),
-                        state = state
+                        state = state,
+                        trunkVersion = entity.trunkVersion
                     )
                 )
             } else {
@@ -80,7 +82,8 @@ class InMemEntitiesRepository : EntitiesRepository {
                         entity.label,
                         entity.version,
                         entity.properties,
-                        entity.state
+                        entity.state,
+                        entity.trunkVersion
                     )
                 )
             }

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -20,6 +20,31 @@ class LocalEntityUseCasesTest {
     private val entitiesRepository = InMemEntitiesRepository()
 
     @Test
+    fun `updateLocalEntitiesFromForm does not override trunk version`() {
+        entitiesRepository.save(
+            Entity.New(
+                "things",
+                "id",
+                "label",
+                version = 1,
+                trunkVersion = 1
+            )
+        )
+
+        val formEntity =
+            FormEntity(EntityAction.UPDATE, "things", "id", "label", 2, emptyList())
+        val formEntities =
+            EntitiesExtra(
+                listOf(formEntity)
+            )
+
+        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
+        val entities = entitiesRepository.getEntities("things")
+        assertThat(entities.size, equalTo(1))
+        assertThat(entities[0].trunkVersion, equalTo(1))
+    }
+
+    @Test
     fun `updateLocalEntitiesFromForm does not save updated entity that doesn't already exist`() {
         val formEntity =
             FormEntity(EntityAction.UPDATE, "things", "1", "1", 1, emptyList())

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -57,10 +57,12 @@ class LocalEntityUseCasesTest {
         assertThat(songs.size, equalTo(1))
         assertThat(songs[0].label, equalTo("Noah"))
         assertThat(songs[0].version, equalTo(2))
+        assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
+        assertThat(songs[0].trunkVersion, equalTo(2))
     }
 
     @Test
-    fun `updateLocalEntitiesFromServer does not override offline version if the online version is older`() {
+    fun `updateLocalEntitiesFromServer updates trunkVersion and state if the online version is older`() {
         entitiesRepository.save(Entity.New("songs", "noah", "Noah", 2))
         val csv = createEntityList(Entity.New("songs", "noah", "Noa", 1))
 
@@ -69,10 +71,12 @@ class LocalEntityUseCasesTest {
         assertThat(songs.size, equalTo(1))
         assertThat(songs[0].label, equalTo("Noah"))
         assertThat(songs[0].version, equalTo(2))
+        assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
+        assertThat(songs[0].trunkVersion, equalTo(1))
     }
 
     @Test
-    fun `updateLocalEntitiesFromServer does not override offline version if the online version is the same`() {
+    fun `updateLocalEntitiesFromServer updates trunkVersion and state if the online version is the same`() {
         entitiesRepository.save(Entity.New("songs", "noah", "Noah", 2))
         val csv = createEntityList(Entity.New("songs", "noah", "Noa", 2))
 
@@ -81,6 +85,8 @@ class LocalEntityUseCasesTest {
         assertThat(songs.size, equalTo(1))
         assertThat(songs[0].label, equalTo("Noah"))
         assertThat(songs[0].version, equalTo(2))
+        assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
+        assertThat(songs[0].trunkVersion, equalTo(2))
     }
 
     @Test

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -23,16 +23,19 @@ class LocalEntityUseCasesTest {
     private val entitiesRepository = InMemEntitiesRepository()
 
     @Test
-    fun `updateLocalEntitiesFromForm creates a new branchId for new entities`() {
+    fun `updateLocalEntitiesFromForm saves a new entity on create`() {
         entitiesRepository.addList("things")
 
         val formEntity =
-            FormEntity(EntityAction.CREATE, "things", "id", "label", emptyList())
+            FormEntity(EntityAction.CREATE, "things", "id", "label", listOf("property" to "value"))
         val formEntities = EntitiesExtra(listOf(formEntity))
         LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
 
         val entities = entitiesRepository.getEntities("things")
         assertThat(entities.size, equalTo(1))
+        assertThat(entities[0].id, equalTo(formEntity.id))
+        assertThat(entities[0].label, equalTo(formEntity.label))
+        assertThat(entities[0].properties, equalTo(formEntity.properties))
         assertThat(entities[0].branchId, not(blankOrNullString()))
     }
 
@@ -70,14 +73,14 @@ class LocalEntityUseCasesTest {
         )
 
         val formEntity =
-            FormEntity(EntityAction.UPDATE, "things", "id", "label", emptyList())
+            FormEntity(EntityAction.UPDATE, "things", "id", "label", listOf("prop" to "value 2"))
         val formEntities = EntitiesExtra(listOf(formEntity))
 
         LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
         val entities = entitiesRepository.getEntities("things")
         assertThat(entities.size, equalTo(1))
         assertThat(entities[0].properties.size, equalTo(1))
-        assertThat(entities[0].properties[0], equalTo("prop" to "value"))
+        assertThat(entities[0].properties[0], equalTo("prop" to "value 2"))
     }
 
     @Test

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -20,6 +20,50 @@ class LocalEntityUseCasesTest {
     private val entitiesRepository = InMemEntitiesRepository()
 
     @Test
+    fun `updateLocalEntitiesFromForm increments version on update`() {
+        entitiesRepository.save(
+            Entity.New(
+                "things",
+                "id",
+                "label",
+                version = 1
+            )
+        )
+
+        val formEntity =
+            FormEntity(EntityAction.UPDATE, "things", "id", "label", -1, emptyList())
+        val formEntities = EntitiesExtra(listOf(formEntity))
+
+        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
+        val entities = entitiesRepository.getEntities("things")
+        assertThat(entities.size, equalTo(1))
+        assertThat(entities[0].version, equalTo(2))
+    }
+
+    @Test
+    fun `updateLocalEntitiesFromForm updates properties on update`() {
+        entitiesRepository.save(
+            Entity.New(
+                "things",
+                "id",
+                "label",
+                version = 1,
+                properties = listOf("prop" to "value")
+            )
+        )
+
+        val formEntity =
+            FormEntity(EntityAction.UPDATE, "things", "id", "label", -1, emptyList())
+        val formEntities = EntitiesExtra(listOf(formEntity))
+
+        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
+        val entities = entitiesRepository.getEntities("things")
+        assertThat(entities.size, equalTo(1))
+        assertThat(entities[0].properties.size, equalTo(1))
+        assertThat(entities[0].properties[0], equalTo("prop" to "value"))
+    }
+
+    @Test
     fun `updateLocalEntitiesFromForm does not override trunk version`() {
         entitiesRepository.save(
             Entity.New(
@@ -33,10 +77,7 @@ class LocalEntityUseCasesTest {
 
         val formEntity =
             FormEntity(EntityAction.UPDATE, "things", "id", "label", 2, emptyList())
-        val formEntities =
-            EntitiesExtra(
-                listOf(formEntity)
-            )
+        val formEntities = EntitiesExtra(listOf(formEntity))
 
         LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
         val entities = entitiesRepository.getEntities("things")
@@ -48,10 +89,7 @@ class LocalEntityUseCasesTest {
     fun `updateLocalEntitiesFromForm does not save updated entity that doesn't already exist`() {
         val formEntity =
             FormEntity(EntityAction.UPDATE, "things", "1", "1", 1, emptyList())
-        val formEntities =
-            EntitiesExtra(
-                listOf(formEntity)
-            )
+        val formEntities = EntitiesExtra(listOf(formEntity))
         entitiesRepository.addList("things")
 
         LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
@@ -62,10 +100,7 @@ class LocalEntityUseCasesTest {
     fun `updateLocalEntitiesFromForm does not save entity that doesn't have an ID`() {
         val formEntity =
             FormEntity(EntityAction.CREATE, "things", null, "1", 1, emptyList())
-        val formEntities =
-            EntitiesExtra(
-                listOf(formEntity)
-            )
+        val formEntities = EntitiesExtra(listOf(formEntity))
         entitiesRepository.addList("things")
 
         LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -6,6 +6,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.odk.collect.entities.javarosa.finalization.EntitiesExtra
+import org.odk.collect.entities.javarosa.finalization.FormEntity
 import org.odk.collect.entities.javarosa.parse.EntityItemElement
 import org.odk.collect.entities.javarosa.spec.EntityAction
 import org.odk.collect.entities.storage.EntitiesRepository
@@ -20,18 +21,11 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromForm does not save updated entity that doesn't already exist`() {
-        val entity =
-            org.odk.collect.entities.javarosa.finalization.Entity(
-                EntityAction.UPDATE,
-                "things",
-                "1",
-                "1",
-                1,
-                emptyList()
-            )
+        val formEntity =
+            FormEntity(EntityAction.UPDATE, "things", "1", "1", 1, emptyList())
         val formEntities =
             EntitiesExtra(
-                listOf(entity)
+                listOf(formEntity)
             )
         entitiesRepository.addList("things")
 
@@ -41,18 +35,11 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromForm does not save entity that doesn't have an ID`() {
-        val entity =
-            org.odk.collect.entities.javarosa.finalization.Entity(
-                EntityAction.CREATE,
-                "things",
-                null,
-                "1",
-                1,
-                emptyList()
-            )
+        val formEntity =
+            FormEntity(EntityAction.CREATE, "things", null, "1", 1, emptyList())
         val formEntities =
             EntitiesExtra(
-                listOf(entity)
+                listOf(formEntity)
             )
         entitiesRepository.addList("things")
 

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -31,7 +31,7 @@ class LocalEntityUseCasesTest {
         )
 
         val formEntity =
-            FormEntity(EntityAction.UPDATE, "things", "id", "label", -1, emptyList())
+            FormEntity(EntityAction.UPDATE, "things", "id", "label", emptyList())
         val formEntities = EntitiesExtra(listOf(formEntity))
 
         LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
@@ -53,7 +53,7 @@ class LocalEntityUseCasesTest {
         )
 
         val formEntity =
-            FormEntity(EntityAction.UPDATE, "things", "id", "label", -1, emptyList())
+            FormEntity(EntityAction.UPDATE, "things", "id", "label", emptyList())
         val formEntities = EntitiesExtra(listOf(formEntity))
 
         LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
@@ -76,7 +76,7 @@ class LocalEntityUseCasesTest {
         )
 
         val formEntity =
-            FormEntity(EntityAction.UPDATE, "things", "id", "label", 2, emptyList())
+            FormEntity(EntityAction.UPDATE, "things", "id", "label", emptyList())
         val formEntities = EntitiesExtra(listOf(formEntity))
 
         LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
@@ -88,7 +88,7 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromForm does not save updated entity that doesn't already exist`() {
         val formEntity =
-            FormEntity(EntityAction.UPDATE, "things", "1", "1", 1, emptyList())
+            FormEntity(EntityAction.UPDATE, "things", "1", "1", emptyList())
         val formEntities = EntitiesExtra(listOf(formEntity))
         entitiesRepository.addList("things")
 
@@ -99,7 +99,7 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromForm does not save entity that doesn't have an ID`() {
         val formEntity =
-            FormEntity(EntityAction.CREATE, "things", null, "1", 1, emptyList())
+            FormEntity(EntityAction.CREATE, "things", null, "1", emptyList())
         val formEntities = EntitiesExtra(listOf(formEntity))
         entitiesRepository.addList("things")
 

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/EntitiesTest.java
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/EntitiesTest.java
@@ -127,7 +127,6 @@ public class EntitiesTest {
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo(scenario.answerOf("/data/meta/entity/@id").getValue()));
         assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
-        assertThat(entities.get(0).version, equalTo(1));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
         assertThat(entities.get(0).action, equalTo(EntityAction.CREATE));
     }
@@ -213,7 +212,6 @@ public class EntitiesTest {
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo("123"));
         assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
-        assertThat(entities.get(0).version, equalTo(2));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
         assertThat(entities.get(0).action, equalTo(EntityAction.UPDATE));
     }
@@ -255,7 +253,6 @@ public class EntitiesTest {
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo("123"));
         assertThat(entities.get(0).label, equalTo(null));
-        assertThat(entities.get(0).version, equalTo(2));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
     }
 
@@ -296,7 +293,7 @@ public class EntitiesTest {
     }
 
     @Test
-    public void fillingFormWithCreateAndUpdate_makesEntityAvailableAsSecondVersion() throws IOException, XFormParser.ParseException {
+    public void fillingFormWithCreateAndUpdate_makesEntityAvailableAsUpdateVersion() throws IOException, XFormParser.ParseException {
         Scenario scenario = Scenario.init("Create entity form", XFormsElement.html(
             asList(
                 new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
@@ -334,13 +331,12 @@ public class EntitiesTest {
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo("123"));
         assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
-        assertThat(entities.get(0).version, equalTo(2));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
         assertThat(entities.get(0).action, equalTo(EntityAction.UPDATE));
     }
 
     @Test
-    public void fillingFormWithCreateAndUpdate_butNoBaseVersion_makesEntityAvailableAsFirstVersion() throws IOException, XFormParser.ParseException {
+    public void fillingFormWithCreateAndUpdate_butNoBaseVersion_makesEntityAvailableAsUpdate() throws IOException, XFormParser.ParseException {
         Scenario scenario = Scenario.init("Create entity form", XFormsElement.html(
             asList(
                 new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
@@ -378,7 +374,6 @@ public class EntitiesTest {
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo("123"));
         assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
-        assertThat(entities.get(0).version, equalTo(1));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
         assertThat(entities.get(0).action, equalTo(EntityAction.UPDATE));
     }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/EntitiesTest.java
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/EntitiesTest.java
@@ -293,7 +293,7 @@ public class EntitiesTest {
     }
 
     @Test
-    public void fillingFormWithCreateAndUpdate_makesEntityAvailableAsUpdateVersion() throws IOException, XFormParser.ParseException {
+    public void fillingFormWithCreateAndUpdate_doesNotMakeEntityAvailable() throws IOException, XFormParser.ParseException {
         Scenario scenario = Scenario.init("Create entity form", XFormsElement.html(
             asList(
                 new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
@@ -327,55 +327,7 @@ public class EntitiesTest {
 
         scenario.finalizeInstance();
         List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
-        assertThat(entities.size(), equalTo(1));
-        assertThat(entities.get(0).dataset, equalTo("people"));
-        assertThat(entities.get(0).id, equalTo("123"));
-        assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
-        assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
-        assertThat(entities.get(0).action, equalTo(EntityAction.UPDATE));
-    }
-
-    @Test
-    public void fillingFormWithCreateAndUpdate_butNoBaseVersion_makesEntityAvailableAsUpdate() throws IOException, XFormParser.ParseException {
-        Scenario scenario = Scenario.init("Create entity form", XFormsElement.html(
-            asList(
-                new Pair<>("entities", "http://www.opendatakit.org/xforms/entities")
-            ),
-            head(
-                title("Upsert entity form"),
-                model(asList(new Pair<>("entities:entities-version", "2023.1.0")),
-                    mainInstance(
-                        t("data id=\"upsert-entity-form\"",
-                            t("name"),
-                            t("meta",
-                                t("entity dataset=\"people\" create=\"1\" update=\"1\" id=\"123\"",
-                                    t("label")
-                                )
-                            )
-                        )
-                    ),
-                    bind("/data/name").type("string").withAttribute("entities", "saveto", "name"),
-                    bind("/data/meta/entity/label").type("string").calculate("/data/name")
-                )
-            ),
-            body(
-                input("/data/name")
-            )
-        ));
-
-        scenario.getFormEntryController().addPostProcessor(new EntityFormFinalizationProcessor());
-
-        scenario.next();
-        scenario.answer("Tom Wambsgans");
-
-        scenario.finalizeInstance();
-        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
-        assertThat(entities.size(), equalTo(1));
-        assertThat(entities.get(0).dataset, equalTo("people"));
-        assertThat(entities.get(0).id, equalTo("123"));
-        assertThat(entities.get(0).label, equalTo("Tom Wambsgans"));
-        assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
-        assertThat(entities.get(0).action, equalTo(EntityAction.UPDATE));
+        assertThat(entities.size(), equalTo(0));
     }
 
     @Test

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/EntitiesTest.java
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/EntitiesTest.java
@@ -27,7 +27,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.entities.javarosa.finalization.EntitiesExtra;
-import org.odk.collect.entities.javarosa.finalization.Entity;
+import org.odk.collect.entities.javarosa.finalization.FormEntity;
 import org.odk.collect.entities.javarosa.finalization.EntityFormFinalizationProcessor;
 import org.odk.collect.entities.javarosa.parse.EntityXFormParserFactory;
 import org.odk.collect.entities.javarosa.spec.EntityAction;
@@ -82,7 +82,7 @@ public class EntitiesTest {
         scenario.answer("Tom Wambsgans");
 
         scenario.finalizeInstance();
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(0));
     }
 
@@ -122,7 +122,7 @@ public class EntitiesTest {
         scenario.answer("Tom Wambsgans");
 
         scenario.finalizeInstance();
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo(scenario.answerOf("/data/meta/entity/@id").getValue()));
@@ -166,7 +166,7 @@ public class EntitiesTest {
         scenario.getFormEntryController().addPostProcessor(new EntityFormFinalizationProcessor());
         scenario.finalizeInstance();
 
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo(null));
@@ -208,7 +208,7 @@ public class EntitiesTest {
         scenario.answer("Tom Wambsgans");
 
         scenario.finalizeInstance();
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo("123"));
@@ -250,7 +250,7 @@ public class EntitiesTest {
         scenario.answer("Tom Wambsgans");
 
         scenario.finalizeInstance();
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo("123"));
@@ -288,7 +288,7 @@ public class EntitiesTest {
         scenario.getFormEntryController().addPostProcessor(new EntityFormFinalizationProcessor());
         scenario.finalizeInstance();
 
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo(null));
@@ -329,7 +329,7 @@ public class EntitiesTest {
         scenario.answer("Tom Wambsgans");
 
         scenario.finalizeInstance();
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo("123"));
@@ -373,7 +373,7 @@ public class EntitiesTest {
         scenario.answer("Tom Wambsgans");
 
         scenario.finalizeInstance();
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).id, equalTo("123"));
@@ -419,7 +419,7 @@ public class EntitiesTest {
         scenario.answer(scenario.choicesOf("/data/join").get(0));
 
         scenario.finalizeInstance();
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
 
         scenario.newInstance();
@@ -468,7 +468,7 @@ public class EntitiesTest {
         deserializedScenario.answer("Shiv Roy");
 
         deserializedScenario.finalizeInstance();
-        List<Entity> entities = deserializedScenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = deserializedScenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).dataset, equalTo("people"));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Shiv Roy"))));
@@ -505,7 +505,7 @@ public class EntitiesTest {
         scenario.answer("Tom Wambsgans");
 
         scenario.finalizeInstance();
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", "Tom Wambsgans"))));
     }
@@ -541,7 +541,7 @@ public class EntitiesTest {
         scenario.answer(scenario.choicesOf("/data/team").get(0));
 
         scenario.finalizeInstance();
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("team", "kendall"))));
     }
@@ -574,7 +574,7 @@ public class EntitiesTest {
         scenario.getFormEntryController().addPostProcessor(new EntityFormFinalizationProcessor());
         scenario.finalizeInstance();
 
-        List<Entity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
+        List<FormEntity> entities = scenario.getFormEntryController().getModel().getExtras().get(EntitiesExtra.class).getEntities();
         assertThat(entities.size(), equalTo(1));
         assertThat(entities.get(0).properties, equalTo(asList(new Pair<>("name", ""))));
     }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
@@ -28,7 +28,7 @@ class LocalEntitiesInstanceProviderTest {
         assertThat(instance.numChildren, equalTo(1))
 
         val item = instance.getChildAt(0)!!
-        assertThat(item.numChildren, equalTo(5))
+        assertThat(item.numChildren, equalTo(6))
         assertThat(item.getFirstChild("age")?.value?.value, equalTo("35"))
         assertThat(item.getFirstChild("born")?.value?.value, equalTo("England"))
     }
@@ -49,8 +49,47 @@ class LocalEntitiesInstanceProviderTest {
         assertThat(instance.numChildren, equalTo(1))
 
         val item = instance.getChildAt(0)!!
-        assertThat(item.numChildren, equalTo(3))
+        assertThat(item.numChildren, equalTo(4))
         assertThat(item.getFirstChild(EntityItemElement.VERSION)?.value?.value, equalTo("1"))
+    }
+
+    @Test
+    fun `includes trunk version in local entity elements`() {
+        val entity =
+            Entity.New(
+                "people",
+                "1",
+                "Shiv Roy",
+                trunkVersion = 1
+            )
+        entitiesRepository.save(entity)
+
+        val parser = LocalEntitiesInstanceProvider { entitiesRepository }
+        val instance = parser.get("people", "people.csv")
+        assertThat(instance.numChildren, equalTo(1))
+
+        val item = instance.getChildAt(0)!!
+        assertThat(item.numChildren, equalTo(4))
+        assertThat(item.getFirstChild(EntityItemElement.TRUNK_VERSION)?.value?.value, equalTo("1"))
+    }
+
+    @Test
+    fun `includes blank trunk version when it is null`() {
+        val entity =
+            Entity.New(
+                "people",
+                "1",
+                "Shiv Roy",
+                trunkVersion = null
+            )
+        entitiesRepository.save(entity)
+
+        val parser = LocalEntitiesInstanceProvider { entitiesRepository }
+        val instance = parser.get("people", "people.csv")
+        assertThat(instance.numChildren, equalTo(1))
+
+        val item = instance.getChildAt(0)!!
+        assertThat(item.getFirstChild(EntityItemElement.TRUNK_VERSION)?.value, equalTo(null))
     }
 
     @Test
@@ -79,7 +118,7 @@ class LocalEntitiesInstanceProviderTest {
 
         val item1 = instance.getChildAt(0)!!
         assertThat(item1.isPartial, equalTo(true))
-        assertThat(item1.numChildren, equalTo(4))
+        assertThat(item1.numChildren, equalTo(5))
         0.until(item1.numChildren).forEach {
             assertThat(item1.getChildAt(it).value?.value, equalTo(null))
         }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
@@ -28,7 +28,7 @@ class LocalEntitiesInstanceProviderTest {
         assertThat(instance.numChildren, equalTo(1))
 
         val item = instance.getChildAt(0)!!
-        assertThat(item.numChildren, equalTo(6))
+        assertThat(item.numChildren, equalTo(7))
         assertThat(item.getFirstChild("age")?.value?.value, equalTo("35"))
         assertThat(item.getFirstChild("born")?.value?.value, equalTo("England"))
     }
@@ -49,7 +49,7 @@ class LocalEntitiesInstanceProviderTest {
         assertThat(instance.numChildren, equalTo(1))
 
         val item = instance.getChildAt(0)!!
-        assertThat(item.numChildren, equalTo(4))
+        assertThat(item.numChildren, equalTo(5))
         assertThat(item.getFirstChild(EntityItemElement.VERSION)?.value?.value, equalTo("1"))
     }
 
@@ -69,8 +69,31 @@ class LocalEntitiesInstanceProviderTest {
         assertThat(instance.numChildren, equalTo(1))
 
         val item = instance.getChildAt(0)!!
-        assertThat(item.numChildren, equalTo(4))
+        assertThat(item.numChildren, equalTo(5))
         assertThat(item.getFirstChild(EntityItemElement.TRUNK_VERSION)?.value?.value, equalTo("1"))
+    }
+
+    @Test
+    fun `includes branch id in local entity elements`() {
+        val entity =
+            Entity.New(
+                "people",
+                "1",
+                "Shiv Roy",
+                branchId = "branch-1"
+            )
+        entitiesRepository.save(entity)
+
+        val parser = LocalEntitiesInstanceProvider { entitiesRepository }
+        val instance = parser.get("people", "people.csv")
+        assertThat(instance.numChildren, equalTo(1))
+
+        val item = instance.getChildAt(0)!!
+        assertThat(item.numChildren, equalTo(5))
+        assertThat(
+            item.getFirstChild(EntityItemElement.BRANCH_ID)?.value?.value,
+            equalTo("branch-1")
+        )
     }
 
     @Test
@@ -118,7 +141,7 @@ class LocalEntitiesInstanceProviderTest {
 
         val item1 = instance.getChildAt(0)!!
         assertThat(item1.isPartial, equalTo(true))
-        assertThat(item1.numChildren, equalTo(5))
+        assertThat(item1.numChildren, equalTo(6))
         0.until(item1.numChildren).forEach {
             assertThat(item1.getChildAt(it).value?.value, equalTo(null))
         }

--- a/test-forms/src/main/resources/forms/one-question-entity-create-and-update.xml
+++ b/test-forms/src/main/resources/forms/one-question-entity-create-and-update.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:entities="http://www.opendatakit.org/xforms/entities">
+	<h:head>
+		<h:title>One Question Entity Registration</h:title>
+		<model odk:xforms-version="1.0.0" entities:entities-version="2024.1.0">
+			<instance>
+				<data id="one_question_entity" version="1">
+					<name/>
+					<meta>
+						<instanceID/>
+						<instanceName/>
+						<entity dataset="people" create="1" update="1" id="">
+							<label/>
+						</entity>
+					</meta>
+				</data>
+			</instance>
+			<bind nodeset="/data/name" type="string" entities:saveto="full_name"/>
+
+			<bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+
+			<bind nodeset="/data/meta/entity/@id" type="string"/>
+			<setvalue event="odk-instance-first-load" ref="/data/meta/entity/@id" value="uuid()"/>
+			<bind calculate="/data/name" nodeset="/data/meta/entity/label" type="string"/>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/name">
+			<label>Name</label>
+		</input>
+	</h:body>
+</h:html>

--- a/test-forms/src/main/resources/forms/one-question-entity-follow-up.xml
+++ b/test-forms/src/main/resources/forms/one-question-entity-follow-up.xml
@@ -2,7 +2,7 @@
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:entities="http://www.opendatakit.org/xforms/entities">
 	<h:head>
 		<h:title>One Question Entity Follow Up</h:title>
-		<model odk:xforms-version="1.0.0" entities:entities-version="2023.1.0">
+		<model odk:xforms-version="1.0.0" entities:entities-version="2024.1.0">
 			<instance>
 				<data id="one_question_entity_follow_up" version="1">
 					<person/>

--- a/test-forms/src/main/resources/forms/one-question-entity-registration.xml
+++ b/test-forms/src/main/resources/forms/one-question-entity-registration.xml
@@ -2,7 +2,7 @@
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:entities="http://www.opendatakit.org/xforms/entities">
 	<h:head>
 		<h:title>One Question Entity Registration</h:title>
-		<model odk:xforms-version="1.0.0" entities:entities-version="2022.1.1">
+		<model odk:xforms-version="1.0.0" entities:entities-version="2024.1.0">
 			<instance>
 				<data id="one_question_entity" version="1">
 					<name/>

--- a/test-forms/src/main/resources/forms/one-question-entity-update-and-create.xml
+++ b/test-forms/src/main/resources/forms/one-question-entity-update-and-create.xml
@@ -10,7 +10,7 @@
 					<meta>
 						<instanceID/>
 						<instanceName/>
-						<entity dataset="people" create="true" update="true" id="" baseVersion="" trunkVersion="">
+						<entity dataset="people" create="true" update="true" id="" baseVersion="" trunkVersion="" branchId="">
 							<label/>
 						</entity>
 					</meta>
@@ -28,6 +28,7 @@
 			<bind calculate="/data/name" nodeset="/data/meta/entity/label" type="string"/>
 			<bind nodeset="/data/meta/entity/@baseVersion" calculate="instance('people')/root/item[name=/data/person]/__version" type="string"/>
 			<bind nodeset="/data/meta/entity/@trunkVersion" calculate="instance('people')/root/item[name=/data/person]/__trunkVersion" type="string"/>
+			<bind nodeset="/data/meta/entity/@branchId" calculate="instance('people')/root/item[name=/data/person]/__branchId" type="string"/>
 		</model>
 	</h:head>
 	<h:body>

--- a/test-forms/src/main/resources/forms/one-question-entity-update-and-create.xml
+++ b/test-forms/src/main/resources/forms/one-question-entity-update-and-create.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:entities="http://www.opendatakit.org/xforms/entities">
+	<h:head>
+		<h:title>One Question Entity Update</h:title>
+		<model odk:xforms-version="1.0.0" entities:entities-version="2024.1.0">
+			<instance>
+				<data id="one_question_entity_update" version="1">
+					<person/>
+					<name/>
+					<meta>
+						<instanceID/>
+						<instanceName/>
+						<entity dataset="people" create="true" update="true" id="" baseVersion="" trunkVersion="">
+							<label/>
+						</entity>
+					</meta>
+				</data>
+			</instance>
+
+			<instance id="people" src="jr://file-csv/people.csv"/>
+
+			<bind nodeset="/data/person" type="string"/>
+			<bind nodeset="/data/name" type="string" entities:saveto="full_name"/>
+
+			<bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+
+			<bind nodeset="/data/meta/entity/@id" type="string" calculate="/data/person"/>
+			<bind calculate="/data/name" nodeset="/data/meta/entity/label" type="string"/>
+			<bind nodeset="/data/meta/entity/@baseVersion" calculate="instance('people')/root/item[name=/data/person]/__version" type="string"/>
+			<bind nodeset="/data/meta/entity/@trunkVersion" calculate="instance('people')/root/item[name=/data/person]/__trunkVersion" type="string"/>
+		</model>
+	</h:head>
+	<h:body>
+		<select1 ref="/data/person">
+			<label>Select person</label>
+			<itemset nodeset="instance('people')/root/item">
+				<value ref="name"/>
+				<label ref="label"/>
+			</itemset>
+		</select1>
+		<input ref="/data/name">
+			<label>Name</label>
+		</input>
+	</h:body>
+</h:html>

--- a/test-forms/src/main/resources/forms/one-question-entity-update.xml
+++ b/test-forms/src/main/resources/forms/one-question-entity-update.xml
@@ -10,7 +10,7 @@
 					<meta>
 						<instanceID/>
 						<instanceName/>
-						<entity dataset="people" update="true" id="" baseVersion="" trunkVersion="">
+						<entity dataset="people" update="true" id="" baseVersion="" trunkVersion="" branchId="">
 							<label/>
 						</entity>
 					</meta>
@@ -28,6 +28,7 @@
 			<bind calculate="/data/name" nodeset="/data/meta/entity/label" type="string"/>
 			<bind nodeset="/data/meta/entity/@baseVersion" calculate="instance('people')/root/item[name=/data/person]/__version" type="string"/>
 			<bind nodeset="/data/meta/entity/@trunkVersion" calculate="instance('people')/root/item[name=/data/person]/__trunkVersion" type="string"/>
+			<bind nodeset="/data/meta/entity/@branchId" calculate="instance('people')/root/item[name=/data/person]/__branchId" type="string"/>
 		</model>
 	</h:head>
 	<h:body>

--- a/test-forms/src/main/resources/forms/one-question-entity-update.xml
+++ b/test-forms/src/main/resources/forms/one-question-entity-update.xml
@@ -2,7 +2,7 @@
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:entities="http://www.opendatakit.org/xforms/entities">
 	<h:head>
 		<h:title>One Question Entity Update</h:title>
-		<model odk:xforms-version="1.0.0" entities:entities-version="2023.1.0">
+		<model odk:xforms-version="1.0.0" entities:entities-version="2024.1.0">
 			<instance>
 				<data id="one_question_entity_update" version="1">
 					<person/>
@@ -10,7 +10,7 @@
 					<meta>
 						<instanceID/>
 						<instanceName/>
-						<entity dataset="people" update="true" id="" baseVersion="">
+						<entity dataset="people" update="true" id="" baseVersion="" trunkVersion="">
 							<label/>
 						</entity>
 					</meta>
@@ -27,6 +27,7 @@
 			<bind nodeset="/data/meta/entity/@id" type="string" calculate="/data/person"/>
 			<bind calculate="/data/name" nodeset="/data/meta/entity/label" type="string"/>
 			<bind nodeset="/data/meta/entity/@baseVersion" calculate="instance('people')/root/item[name=/data/person]/__version" type="string"/>
+			<bind nodeset="/data/meta/entity/@trunkVersion" calculate="instance('people')/root/item[name=/data/person]/__trunkVersion" type="string"/>
 		</model>
 	</h:head>
 	<h:body>


### PR DESCRIPTION
Closes #6245 
~~Blocked by #6267~~

As well as adding support for forms to receive `__trunkVersion` and `__branchId` and keeping track of these values correctly, this also changes how we increment `__version`. Before, Collect would parse the `baseVersion`, increment it and then store the result. This meant that a form might manipulate the `baseVersion` in an unexpected way which would Collect would honour. After chatting with @lognaturel, we've decided that this was actually an incorrect implementation of the following line in the spec:

> MUST increment the __version of its local entity representation by 1 when an update is successfully applied

Instead, we now increment our own representation of `__version` (`Entity#version`) and ignore the `baseVersion` in submissions.

I've also cleaned up how Collect treats forms that have both an `update` and a `create` action and added tests to define that behaviour.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here! I'll put comments inline for anything that seems worth mentioning.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This is mostly all additional, but there's a risk that changes to the way we increment version and to how we treat forms that have both an `update` and `create` action might alter how we expect Collect to behave. It'd be worth testing both of these out and checking we're happy with how everything works.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
