### PR TITLE
Show entity id and version on list

### DIFF
--- a/entities/src/main/java/org/odk/collect/entities/browser/EntityItemView.kt
+++ b/entities/src/main/java/org/odk/collect/entities/browser/EntityItemView.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.entities.browser
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import android.widget.FrameLayout
@@ -11,8 +12,10 @@ class EntityItemView(context: Context) : FrameLayout(context) {
 
     val binding = EntityItemLayoutBinding.inflate(LayoutInflater.from(context), this, true)
 
+    @SuppressLint("SetTextI18n")
     fun setEntity(entity: Entity.Saved) {
         binding.label.text = entity.label
+        binding.id.text = "${entity.id} (${entity.version})"
         binding.properties.text = entity.properties
             .sortedBy { it.first }
             .joinToString(separator = "\n") { "${it.first}: ${it.second}" }

--- a/entities/src/main/res/layout/entity_item_layout.xml
+++ b/entities/src/main/res/layout/entity_item_layout.xml
@@ -35,6 +35,17 @@
         tools:text="Label" />
 
     <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_small"
+        android:layout_marginBottom="@dimen/margin_standard"
+        android:textAppearance="?textAppearanceLabelMedium"
+        app:layout_constraintStart_toStartOf="@id/guideline_start"
+        app:layout_constraintTop_toBottomOf="@id/label"
+        tools:text="e636bbe8-7707-4c6b-bee1-41698005ac23 (12)" />
+
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/properties"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -43,7 +54,7 @@
         android:textAppearance="?textAppearanceBodyMedium"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="@id/guideline_start"
-        app:layout_constraintTop_toBottomOf="@id/label"
+        app:layout_constraintTop_toBottomOf="@id/id"
         tools:text="property1: value1" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/entities/src/test/java/org/odk/collect/entities/browser/EntityItemViewTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/browser/EntityItemViewTest.kt
@@ -44,4 +44,13 @@ class EntityItemViewTest {
         view.setEntity(entity.copy(state = Entity.State.ONLINE))
         assertThat(view.binding.offlinePill.isVisible, equalTo(false))
     }
+
+    @Test
+    fun `shows id and version`() {
+        val view = EntityItemView(context)
+        val entity = Entity.Saved("songs", "1", "S.D.O.S", version = 11, index = 0)
+
+        view.setEntity(entity.copy(state = Entity.State.OFFLINE))
+        assertThat(view.binding.id.text, equalTo("${entity.id} (${entity.version})"))
+    }
 }


### PR DESCRIPTION
As discussed at #6307. This adds entity ID and version to the entity browser to make it easier to diagnose problems.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here. I just added a new view to show the info.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This only affects the entity browser which is not available in general releases so there's very little risk.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
