### PR TITLE
Guard against incorrect paths

### DIFF
--- a/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
+++ b/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
@@ -11,7 +11,13 @@ object PathUtils {
 
     @JvmStatic
     fun getAbsoluteFilePath(dirPath: String, filePath: String): String {
-        return if (filePath.startsWith(dirPath)) filePath else dirPath + File.separator + filePath
+        val absolutePath = if (filePath.startsWith(dirPath)) filePath else dirPath + File.separator + filePath
+
+        if (File(absolutePath).canonicalPath.startsWith(dirPath)) {
+            return absolutePath
+        } else {
+            throw SecurityException()
+        }
     }
 
     // https://stackoverflow.com/questions/2679699/what-characters-allowed-in-file-names-on-android

--- a/shared/src/test/java/org/odk/collect/shared/PathUtilsTest.kt
+++ b/shared/src/test/java/org/odk/collect/shared/PathUtilsTest.kt
@@ -24,6 +24,11 @@ class PathUtilsTest {
         assertThat(path, equalTo("/root/dir/file"))
     }
 
+    @Test(expected = SecurityException::class)
+    fun `getAbsoluteFilePath() throws SecurityException when filePath is outside the dirPath`() {
+        PathUtils.getAbsoluteFilePath("/root/dir", "../tmp/file")
+    }
+
     @Test
     fun `getRelativeFilePath() returns filePath with dirPath removed`() {
         val path = PathUtils.getRelativeFilePath("/root/dir", "/root/dir/file")


### PR DESCRIPTION
This makes sure that paths expanded using `PathUtils#getAbsoluteFilePath` are always pointing at paths with the provided `dirPath`.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here! As far as we know there's no valid reason to have a path outside the `dirPath` expanded.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Hard to test this specifically. A general check of saving and sending forms is probably worthwhile.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
