### PR TITLE
Add analytics for INSTANCE_UPLOAD

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceUploadActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceUploadActionTest.kt
@@ -22,7 +22,7 @@ import org.odk.collect.android.utilities.ApplicationConstants
 @RunWith(AndroidJUnit4::class)
 class InstanceUploadActionTest {
 
-    private val rule = CollectTestRule(useDemoProject = false)
+    private val rule = CollectTestRule()
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDependencies = TestDependencies()
 
@@ -32,7 +32,7 @@ class InstanceUploadActionTest {
 
     @Test
     fun whenIntentIncludesURLExtra_instancesAreUploadedToThatURL() {
-        rule.startAtFirstLaunch().clickTryCollect()
+        rule.startAtMainMenu()
             .copyForm("one-question.xml")
             .startBlankForm("One Question")
             .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("what is your age", "34"))
@@ -56,7 +56,7 @@ class InstanceUploadActionTest {
 
     @Test
     fun whenInstanceDoesNotExist_showsError() {
-        rule.startAtFirstLaunch().clickTryCollect()
+        rule.startAtMainMenu()
 
         val intent = Intent("org.odk.collect.android.INSTANCE_UPLOAD")
         intent.type = InstancesContract.CONTENT_TYPE

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceUploadActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceUploadActionTest.kt
@@ -31,7 +31,7 @@ class InstanceUploadActionTest {
         .around(rule)
 
     @Test
-    fun canUploadInstanceToDifferentServer() {
+    fun whenIntentIncludesURLExtra_instancesAreUploadedToThatURL() {
         rule.startAtFirstLaunch().clickTryCollect()
             .copyForm("one-question.xml")
             .startBlankForm("One Question")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceUploadActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceUploadActionTest.kt
@@ -1,40 +1,68 @@
 package org.odk.collect.android.feature.external
 
+import android.content.Context
 import android.content.Intent
+import android.provider.BaseColumns._ID
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.odk.collect.android.external.InstancesContract
-import org.odk.collect.android.instancemanagement.send.InstanceUploaderActivity
+import org.odk.collect.android.support.TestDependencies
+import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.OkDialog
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain
+import org.odk.collect.android.utilities.ApplicationConstants
 
 @RunWith(AndroidJUnit4::class)
 class InstanceUploadActionTest {
 
-    val collectTestRule = CollectTestRule()
+    private val rule = CollectTestRule(useDemoProject = false)
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val testDependencies = TestDependencies()
 
     @get:Rule
-    val rule: RuleChain = TestRuleChain.chain()
-        .around(collectTestRule)
+    val chain: RuleChain = TestRuleChain.chain(testDependencies)
+        .around(rule)
+
+    @Test
+    fun canUploadInstanceToDifferentServer() {
+        rule.startAtFirstLaunch().clickTryCollect()
+            .copyForm("one-question.xml")
+            .startBlankForm("One Question")
+            .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("what is your age", "34"))
+
+        val instanceId =
+            context.contentResolver.query(InstancesContract.getUri("DEMO"), null, null, null, null)
+                .use {
+                    it!!.moveToFirst()
+                    it.getLong(it.getColumnIndex(_ID))
+                }
+
+        val intent = Intent("org.odk.collect.android.INSTANCE_UPLOAD")
+        intent.type = InstancesContract.CONTENT_TYPE
+        intent.putExtra(ApplicationConstants.BundleKeys.URL, testDependencies.server.url)
+        intent.putExtra("instances", longArrayOf(instanceId))
+
+        rule.launch(intent, OkDialog())
+            .assertTextInDialog("One Question - Success")
+        assertThat(testDependencies.server.submissions.size, equalTo(1))
+    }
 
     @Test
     fun whenInstanceDoesNotExist_showsError() {
-        val instanceIds = longArrayOf(11)
-        instanceUploadAction(instanceIds)
+        rule.startAtFirstLaunch().clickTryCollect()
 
-        OkDialog()
-            .assertOnPage()
-            .assertText(org.odk.collect.strings.R.string.no_forms_uploaded)
-    }
-
-    private fun instanceUploadAction(instanceIds: LongArray) {
         val intent = Intent("org.odk.collect.android.INSTANCE_UPLOAD")
         intent.type = InstancesContract.CONTENT_TYPE
-        intent.putExtra("instances", instanceIds)
-        collectTestRule.launch<InstanceUploaderActivity>(intent)
+        intent.putExtra("instances", longArrayOf(11))
+
+        rule.launch(intent, OkDialog())
+            .assertText(org.odk.collect.strings.R.string.no_forms_uploaded)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -99,4 +99,9 @@ object AnalyticsEvents {
     const val DELETE_SAVED_FORM_FEW = "DeleteSavedFormFew" // < 10
     const val DELETE_SAVED_FORM_TENS = "DeleteSavedFormTens" // >= 10
     const val DELETE_SAVED_FORM_HUNDREDS = "DeleteSavedFormHundreds" // >= 100
+
+    /**
+     * Tracks how often the INSTANCE_UPLOAD action is used with a custom server URL
+     */
+    const val INSTANCE_UPLOAD_CUSTOM_SERVER = "InstanceUploadCustomServer"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
@@ -14,21 +14,28 @@
 
 package org.odk.collect.android.tasks;
 
+import static org.odk.collect.android.analytics.AnalyticsEvents.SUBMISSION;
+import static org.odk.collect.strings.localization.LocalizedApplicationKt.getLocalizedString;
+
+import android.net.Uri;
+import android.os.AsyncTask;
+
 import org.odk.collect.analytics.Analytics;
+import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.instancemanagement.InstanceDeleter;
 import org.odk.collect.android.instancemanagement.InstancesDataService;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
-import org.odk.collect.android.projects.ProjectsDataService;
-import org.odk.collect.android.utilities.InstanceAutoDeleteChecker;
-import org.odk.collect.android.utilities.InstancesRepositoryProvider;
-import org.odk.collect.forms.FormsRepository;
-import org.odk.collect.forms.instances.Instance;
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
-import org.odk.collect.android.upload.InstanceServerUploader;
+import org.odk.collect.android.projects.ProjectsDataService;
 import org.odk.collect.android.upload.FormUploadAuthRequestedException;
 import org.odk.collect.android.upload.FormUploadException;
+import org.odk.collect.android.upload.InstanceServerUploader;
+import org.odk.collect.android.utilities.InstanceAutoDeleteChecker;
+import org.odk.collect.android.utilities.InstancesRepositoryProvider;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
+import org.odk.collect.forms.FormsRepository;
+import org.odk.collect.forms.instances.Instance;
 import org.odk.collect.forms.instances.InstancesRepository;
 import org.odk.collect.metadata.PropertyManager;
 import org.odk.collect.settings.SettingsProvider;
@@ -40,12 +47,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
-
-import static org.odk.collect.android.analytics.AnalyticsEvents.SUBMISSION;
-import static org.odk.collect.strings.localization.LocalizedApplicationKt.getLocalizedString;
-
-import android.net.Uri;
-import android.os.AsyncTask;
 
 /**
  * Background task for uploading completed forms.
@@ -99,6 +100,10 @@ public class InstanceUploaderTask extends AsyncTask<Long, Integer, InstanceUploa
             Instance instance = instancesToUpload.get(i);
 
             publishProgress(i + 1, instancesToUpload.size());
+
+            if (completeDestinationUrl != null) {
+                Analytics.log(AnalyticsEvents.INSTANCE_UPLOAD_CUSTOM_SERVER);
+            }
 
             try {
                 String destinationUrl = uploader.getUrlToSubmitTo(instance, deviceId, completeDestinationUrl, null);


### PR DESCRIPTION
Adds analytics for `INSTANCE_UPLOAD` when used with custom server. I also added a test for that workflow so that I could validate where the analytics should go.