### PR TITLE
Use recommended ValidatingObjectInputStream

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormIndexTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormIndexTask.java
@@ -18,14 +18,16 @@ package org.odk.collect.android.tasks;
 
 import android.os.AsyncTask;
 
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.instance.TreeReference;
 import org.odk.collect.android.javarosawrapper.FormController;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 
 import timber.log.Timber;
 
@@ -90,7 +92,8 @@ public class SaveFormIndexTask extends AsyncTask<Void, Void, String> {
             String instanceName = formController
                     .getInstanceFile()
                     .getName();
-            ObjectInputStream ois = new ObjectInputStream(new FileInputStream(SaveFormToDisk.getFormIndexFile(instanceName)));
+            ValidatingObjectInputStream ois = new ValidatingObjectInputStream(new FileInputStream(SaveFormToDisk.getFormIndexFile(instanceName)));
+            ois.accept(FormIndex.class, TreeReference.class, String.class, ArrayList.class);
             formIndex = (FormIndex) ois.readObject();
             ois.close();
         } catch (Exception e) {


### PR DESCRIPTION
[`ValidatingObjectInputStream`](https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/serialization/ValidatingObjectInputStream.html) is generally recommended over `ObjectInputStream`.

Unfortunately I can't verify that this works because the feature doesn't work on my device. I get an exception like the following both on the Play Store version and in this branch when I try to open a draft with moving backwards disabled (note that this requires opting out of the proposed automatic settings changes when disallowing moving backwards):

```
java.io.FileNotFoundException: /storage/emulated/0/Android/data/org.odk.collect.android/files/projects/DEMO/.cache/All question types_2024-08-14_13-47-23.xml.index: open failed: ENOENT (No such file or directory)
```

When I `adb` into the device, I can see that the file exists and has a serialized `FormIndex`.

The only idea I have is that it could be an Android 14 permission error.

#### Why is this the best possible solution? Were any other approaches considered?
There are other similar libraries to consider but we already import apache commons io so this felt like the best one to use.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No intended user-facing change. I think regression risk is very low.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [ ] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
       Currently failing because I don't have all the correct class names specified because I can't run locally
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
