### PR TITLE
Stream CSV when processing server entities

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -35,7 +35,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.1.0"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.9"
-    const val javarosa_online = "org.getodk:javarosa:5.0.0-SNAPSHOT"
+    const val javarosa_online = "org.getodk:javarosa:5.0.0-SNAPSHOT-8a22ede"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val javarosa = javarosa_online
     const val karumi_dexter = "com.karumi:dexter:6.2.3"


### PR DESCRIPTION
Closes #6350 
~~Blocked by https://github.com/getodk/javarosa/pull/792~~

This removes the CSV to XML parsing that was being performed and instead just parses the instance CSV directly as a stream which should improve the memory footprint when downloading entity forms. There may be a slight speed up as well as we don't convert the CSV to an in-mem XML representation, but this will be minor at best.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The main risk will be to forms with entities (follow up and update forms). Nothing else should be affected. The only device that predictably experienced OOMs was @lognaturel's Galaxy A13, so let's let her confirm that this fixes that.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
