### PR TITLE
Add message to PathUtils exception

### DIFF
--- a/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
+++ b/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
@@ -16,7 +16,7 @@ object PathUtils {
         if (File(absolutePath).canonicalPath.startsWith(dirPath)) {
             return absolutePath
         } else {
-            throw SecurityException()
+            throw SecurityException("Invalid path: $absolutePath")
         }
     }
 


### PR DESCRIPTION
Makes it clearer what's happening to both the user and in Crashlytics.