### PR TITLE
Support symlink `dirPath` in `getAbsoluteFilePath`

### DIFF
--- a/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
+++ b/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
@@ -11,12 +11,13 @@ object PathUtils {
 
     @JvmStatic
     fun getAbsoluteFilePath(dirPath: String, filePath: String): String {
-        val absolutePath = if (filePath.startsWith(dirPath)) filePath else dirPath + File.separator + filePath
+        val absolutePath =
+            if (filePath.startsWith(dirPath)) filePath else dirPath + File.separator + filePath
 
         if (File(absolutePath).canonicalPath.startsWith(File(dirPath).canonicalPath)) {
             return absolutePath
         } else {
-            throw SecurityException("Invalid path: $absolutePath")
+            throw SecurityException("Contact support@getodk.org. Attempt to access file outside of Collect directory: $absolutePath")
         }
     }
 

--- a/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
+++ b/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
@@ -13,7 +13,7 @@ object PathUtils {
     fun getAbsoluteFilePath(dirPath: String, filePath: String): String {
         val absolutePath = if (filePath.startsWith(dirPath)) filePath else dirPath + File.separator + filePath
 
-        if (File(absolutePath).canonicalPath.startsWith(dirPath)) {
+        if (File(absolutePath).canonicalPath.startsWith(File(dirPath).canonicalPath)) {
             return absolutePath
         } else {
             throw SecurityException("Invalid path: $absolutePath")

--- a/shared/src/main/java/org/odk/collect/shared/TempFiles.kt
+++ b/shared/src/main/java/org/odk/collect/shared/TempFiles.kt
@@ -84,7 +84,7 @@ object TempFiles {
     }
 
     private fun getTempDir(): File {
-        val tmpDir = File(System.getProperty("java.io.tmpdir", "."), " org.odk.collect.shared.TempFiles")
+        val tmpDir = File(System.getProperty("java.io.tmpdir", "."), "org.odk.collect.shared.TempFiles")
         if (!tmpDir.exists()) {
             tmpDir.mkdir()
         }

--- a/shared/src/test/java/org/odk/collect/shared/PathUtilsTest.kt
+++ b/shared/src/test/java/org/odk/collect/shared/PathUtilsTest.kt
@@ -3,6 +3,7 @@ package org.odk.collect.shared
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
+import java.io.File
 
 class PathUtilsTest {
 
@@ -27,6 +28,17 @@ class PathUtilsTest {
     @Test(expected = SecurityException::class)
     fun `getAbsoluteFilePath() throws SecurityException when filePath is outside the dirPath`() {
         PathUtils.getAbsoluteFilePath("/root/dir", "../tmp/file")
+    }
+
+    @Test
+    fun `getAbsoluteFilePath() works when dirPath is not canonical`() {
+        val tempDir = TempFiles.createTempDir()
+        val nonCanonicalPath =
+            tempDir.canonicalPath + File.separator + ".." + File.separator + tempDir.name
+        assertThat(File(nonCanonicalPath).canonicalPath, equalTo(tempDir.canonicalPath))
+
+        val path = PathUtils.getAbsoluteFilePath(nonCanonicalPath, "file")
+        assertThat(path, equalTo(nonCanonicalPath + File.separator + "file"))
     }
 
     @Test


### PR DESCRIPTION
This will mean that any theoretical devices that have external storage under a symlink won't see crashes and also fixes tests on macOS.

I've also updated the error message to make sure it pushes users to contact support.

#### Why is this the best possible solution? Were any other approaches considered?

I couldn't think of an alternative other than using the canonical version of `dirPath` for the comparison. One extra thing we could have done is to return a canonical path as well. For example, if we were expanding `file` to be under `/root/dir/../dir` we'd get `/root/dir/../dir/file` rather than `/root/dir/file` back. I felt like only modifying the check keeps this as low risk as possible however.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's worth checking the same things as https://github.com/getodk/collect/pull/6340. The biggest risk for reviewers to think about is if this potentially alters the behaviour in way we don't want.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
