### PR TITLE
Fix forms not being deletable

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteSavedFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteSavedFormTest.kt
@@ -44,7 +44,7 @@ class DeleteSavedFormTest {
     }
 
     @Test
-    fun whenFormHasCreatedEntity_doesNotAppearInListToDelete() {
+    fun whenFinalizedFormHasCreatedALocalEntity_doesNotAppearInListToDelete() {
         testDependencies.server.addForm("one-question-entity-registration.xml")
 
         rule.withMatchExactlyProject(testDependencies.server.url)

--- a/forms/build.gradle.kts
+++ b/forms/build.gradle.kts
@@ -14,4 +14,6 @@ java {
 
 dependencies {
     implementation(Dependencies.kotlin_stdlib)
+    testImplementation(Dependencies.junit)
+    testImplementation(Dependencies.hamcrest)
 }

--- a/forms/src/main/java/org/odk/collect/forms/instances/Instance.java
+++ b/forms/src/main/java/org/odk/collect/forms/instances/Instance.java
@@ -83,7 +83,7 @@ public final class Instance {
         private String geometry;
 
         private Long dbId;
-        private boolean canDeleteBeforeSend;
+        private boolean canDeleteBeforeSend = true;
 
         public Builder() {
 

--- a/forms/src/test/java/org/odk/collect/forms/instances/InstanceTest.kt
+++ b/forms/src/test/java/org/odk/collect/forms/instances/InstanceTest.kt
@@ -1,0 +1,14 @@
+package org.odk.collect.forms.instances
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+
+class InstanceTest {
+
+    @Test
+    fun `canDeleteBeforeSend is true by default`() {
+        val instance = Instance.Builder().build()
+        assertThat(instance.canDeleteBeforeSend(), equalTo(true))
+    }
+}


### PR DESCRIPTION
Closes #6338

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss! The problem was just that `Instance` objects created via `Instance.Builder` had the wrong default value.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should just fix the issue. It'll be good to check that forms can be deleted when expected.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
