### PR TITLE
Fixed the counter widget in rtl languages

### DIFF
--- a/collect_app/src/main/res/drawable-ldrtl/counter_minus_button_background.xml
+++ b/collect_app/src/main/res/drawable-ldrtl/counter_minus_button_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/color_on_surface_low_emphasis">
+    <item>
+        <shape android:shape="rectangle">
+            <corners
+                android:topRightRadius="?dialogCornerRadius"
+                android:bottomRightRadius="?dialogCornerRadius" />
+            <solid android:color="?colorSurfaceContainerHighest" />
+        </shape>
+    </item>
+</ripple>

--- a/collect_app/src/main/res/drawable-ldrtl/counter_plus_button_background.xml
+++ b/collect_app/src/main/res/drawable-ldrtl/counter_plus_button_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/color_on_surface_low_emphasis">
+    <item>
+        <shape android:shape="rectangle">
+            <corners
+                android:topLeftRadius="?dialogCornerRadius"
+                android:bottomLeftRadius="?dialogCornerRadius" />
+            <solid android:color="?colorSurfaceContainerHighest" />
+        </shape>
+    </item>
+</ripple>


### PR DESCRIPTION
Closes #6365

#### Why is this the best possible solution? Were any other approaches considered?
I attempted to use android:autoMirrored="true", which works with vector drawables, but it doesn't seem to have any effect in this case. Therefore, providing separate versions of the files for RTL languages appears to be the only solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It just requires testing how the counter widget looks in both LTR and RTL languages. That's the only thing I changed.

#### Do we need any specific form for testing your changes? If so, please attach one.
The one from https://github.com/getodk/collect/pull/6306.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
