### PR TITLE
Optimize form download with entities

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -65,6 +65,7 @@ def secrets = getSecrets()
 def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxAccessToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
 def entitiesFilterTestProjectUrl = secrets.getProperty('ENTITIES_FILTER_TEST_PROJECT_URL', '')
+def entitiesFilterSearchTestProjectUrl = secrets.getProperty('ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL', '')
 
 android {
     compileSdk Versions.android_compile_sdk
@@ -146,6 +147,7 @@ android {
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             resValue("string", "mapbox_access_token", mapboxAccessToken)
             buildConfigField("String", "ENTITIES_FILTER_TEST_PROJECT_URL", "\"$entitiesFilterTestProjectUrl\"")
+            buildConfigField("String", "ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL", "\"$entitiesFilterSearchTestProjectUrl\"")
         }
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -66,7 +66,7 @@ class EntitiesBenchmarkTest {
             .clickOKOnDialog(MainMenuPage())
 
             .clickGetBlankForm()
-            .benchmark("Downloading form with http cache", 30, benchmarker) {
+            .benchmark("Downloading form with http cache", 20, benchmarker) {
                 it.clickGetSelected()
             }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -68,7 +68,7 @@ class EntitiesBenchmarkTest {
             .clickOKOnDialog(MainMenuPage())
 
             .clickGetBlankForm()
-            .benchmark("Downloading form with http cache", 75, benchmarker) {
+            .benchmark("Downloading form with http cache", 30, benchmarker) {
                 it.clickGetSelected()
             }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -66,13 +66,13 @@ class EntitiesBenchmarkTest {
             .clickOKOnDialog(MainMenuPage())
 
             .clickGetBlankForm()
-            .benchmark("Downloading form with http cache", 20, benchmarker) {
+            .benchmark("Downloading form with http cache", 25, benchmarker) {
                 it.clickGetSelected()
             }
 
             .clickOK(MainMenuPage())
             .clickGetBlankForm()
-            .benchmark("Downloading form second time with http cache", 90, benchmarker) {
+            .benchmark("Downloading form second time with http cache", 75, benchmarker) {
                 it.clickGetSelected()
             }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -5,27 +5,25 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.blankOrNullString
-import org.hamcrest.Matchers.lessThan
 import org.hamcrest.Matchers.not
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import org.odk.collect.android.benchmark.support.Benchmarker
+import org.odk.collect.android.benchmark.support.benchmark
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.MainMenuPage
-import org.odk.collect.android.support.pages.Page
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 import org.odk.collect.android.test.BuildConfig.ENTITIES_FILTER_TEST_PROJECT_URL
-import org.odk.collect.shared.TimeInMs
 import org.odk.collect.strings.R
 
 /**
- * Benchmarks the performance of entity follow up forms. [PROJECT_URL] should be set to a project
- * that contains the "100k Entities Filter" form.
+ * Benchmarks the performance of entity follow up forms. [ENTITIES_FILTER_TEST_PROJECT_URL] should
+ * be set to a project that contains the "100k Entities Filter" form.
  *
  * Devices that currently pass:
- * - Pixel 4a
  * - Fairphone 3
  *
  */
@@ -97,67 +95,10 @@ class EntitiesBenchmarkTest {
 
         benchmarker.assertResults()
     }
-
-    private fun clearAndroidCache() {
-        val application = ApplicationProvider.getApplicationContext<Application>()
-        application.cacheDir.deleteRecursively()
-        application.cacheDir.mkdir()
-    }
 }
 
-private class Stopwatch {
-
-    private val times = mutableMapOf<String, Long>()
-
-    fun <T> time(name: String, action: () -> T): T {
-        val startTime = System.currentTimeMillis()
-        val result = action()
-        val endTime = System.currentTimeMillis()
-
-        times[name] = (endTime - startTime) / TimeInMs.ONE_SECOND
-        return result
-    }
-
-    fun getTime(name: String): Long {
-        return times[name]!!
-    }
-}
-
-private fun <T : Page<T>, Y : Page<Y>> Y.benchmark(
-    name: String,
-    target: Long,
-    benchmarker: Benchmarker,
-    action: (Y) -> T
-): T {
-    return benchmarker.benchmark(name, target) {
-        action(this)
-    }
-}
-
-private class Benchmarker {
-    private val stopwatch = Stopwatch()
-    private val targets = mutableMapOf<String, Long>()
-
-    fun <T> benchmark(name: String, target: Long, action: () -> T): T {
-        targets[name] = target
-        return stopwatch.time(name) {
-            action()
-        }
-    }
-
-    fun assertResults() {
-        printResults()
-
-        targets.entries.forEach {
-            val time = stopwatch.getTime(it.key)
-            assertThat("\"${it.key}\" took ${time}s!", time, lessThan(it.value))
-        }
-    }
-
-    private fun printResults() {
-        println("Benchmark results:")
-        targets.keys.forEach {
-            println("$it: ${stopwatch.getTime(it)}s")
-        }
-    }
+private fun clearAndroidCache() {
+    val application = ApplicationProvider.getApplicationContext<Application>()
+    application.cacheDir.deleteRecursively()
+    application.cacheDir.mkdir()
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/SearchBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/SearchBenchmarkTest.kt
@@ -1,0 +1,73 @@
+package org.odk.collect.android.benchmark
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.blankOrNullString
+import org.hamcrest.Matchers.not
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.odk.collect.android.benchmark.support.Benchmarker
+import org.odk.collect.android.benchmark.support.benchmark
+import org.odk.collect.android.support.TestDependencies
+import org.odk.collect.android.support.pages.MainMenuPage
+import org.odk.collect.android.support.rules.CollectTestRule
+import org.odk.collect.android.support.rules.TestRuleChain.chain
+import org.odk.collect.android.test.BuildConfig.ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL
+
+/**
+ * Benchmarks the performance of search() forms. [ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL] should be
+ * set to a project that contains the "100k Entities Filter search()" form.
+ *
+ * Devices that currently pass:
+ * - Fairphone 3
+ *
+ */
+
+@RunWith(AndroidJUnit4::class)
+class SearchBenchmarkTest {
+
+    private val rule = CollectTestRule(useDemoProject = false)
+
+    @get:Rule
+    var chain: RuleChain = chain(TestDependencies(true)).around(rule)
+
+    @Test
+    fun run() {
+        assertThat(
+            "Need to set ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL before running!",
+            ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL,
+            not(blankOrNullString())
+        )
+
+        val benchmarker = Benchmarker()
+
+        rule.startAtFirstLaunch()
+            .clickManuallyEnterProjectDetails()
+            .inputUrl(ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL)
+            .addProject()
+
+            .clickGetBlankForm()
+            .clickGetSelected()
+            .clickOK(MainMenuPage())
+
+            .clickFillBlankForm()
+            .benchmark("Loading form first time", 20, benchmarker) {
+                it.clickOnForm("100k Entities Filter search()")
+            }
+
+            .pressBackAndDiscardForm()
+            .clickFillBlankForm()
+            .benchmark("Loading form second time", 2, benchmarker) {
+                it.clickOnForm("100k Entities Filter search()")
+            }
+
+            .answerQuestion("Which value do you want to filter by?", "1024")
+            .benchmark("Filtering select", 2, benchmarker) {
+                it.swipeToNextQuestion("Filtered select")
+            }
+
+        benchmarker.assertResults()
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/support/Benchmarker.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/support/Benchmarker.kt
@@ -1,0 +1,63 @@
+package org.odk.collect.android.benchmark.support
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.lessThan
+import org.odk.collect.android.support.pages.Page
+import org.odk.collect.shared.TimeInMs
+
+class Benchmarker {
+    private val stopwatch = Stopwatch()
+    private val targets = mutableMapOf<String, Long>()
+
+    fun <T> benchmark(name: String, target: Long, action: () -> T): T {
+        targets[name] = target
+        return stopwatch.time(name) {
+            action()
+        }
+    }
+
+    fun assertResults() {
+        printResults()
+
+        targets.entries.forEach {
+            val time = stopwatch.getTime(it.key)
+            assertThat("\"${it.key}\" took ${time}s!", time, lessThan(it.value))
+        }
+    }
+
+    private fun printResults() {
+        println("Benchmark results:")
+        targets.keys.forEach {
+            println("$it: ${stopwatch.getTime(it)}s")
+        }
+    }
+}
+
+fun <T : Page<T>, Y : Page<Y>> Y.benchmark(
+    name: String,
+    target: Long,
+    benchmarker: Benchmarker,
+    action: (Y) -> T
+): T {
+    return benchmarker.benchmark(name, target) {
+        action(this)
+    }
+}
+
+private class Stopwatch {
+
+    private val times = mutableMapOf<String, Long>()
+
+    fun <T> time(name: String, action: () -> T): T {
+        val startTime = System.currentTimeMillis()
+        val result = action()
+        val endTime = System.currentTimeMillis()
+
+        times[name] = (endTime - startTime) / TimeInMs.ONE_SECOND
+        return result
+    }
+
+    fun getTime(name: String): Long {
+        return times[name]!!
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -263,6 +263,19 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
+    fun `#save supports properties with dots and dashes`() {
+        val repository = buildSubject()
+        val entity = Entity.New(
+            "things",
+            "1",
+            "One",
+            properties = listOf(Pair("a.property", "value"), Pair("a-property", "value"))
+        )
+        repository.save(entity)
+        assertThat(repository.getEntities("things")[0], sameEntityAs(entity))
+    }
+
+    @Test
     fun `#clear deletes all entities`() {
         val repository = buildSubject()
 

--- a/db/src/main/java/org/odk/collect/db/sqlite/CursorExt.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/CursorExt.kt
@@ -65,4 +65,17 @@ object CursorExt {
         val columnIndex = this.getColumnIndex(column)
         return this.getIntOrNull(columnIndex)
     }
+
+    /**
+     * Prevents doing repeated [Cursor.getColumnIndex] lookups and also works around the lack of
+     * support for column names including a "." there (due to the mysterious bug 903852).
+     *
+     * @see [SQLiteCursor source](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/database/sqlite/SQLiteCursor.java;l=178?q=sqlitecursor)
+     */
+    fun Cursor.rowToMap(): Map<String, String> {
+        return this.columnNames.foldIndexed(mutableMapOf()) { index, map, column ->
+            map[column] = this.getString(index)
+            map
+        }
+    }
 }

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -8,6 +8,7 @@ import org.odk.collect.entities.javarosa.spec.EntityAction
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
 import java.io.File
+import java.util.UUID
 
 object LocalEntityUseCases {
 
@@ -26,7 +27,8 @@ object LocalEntityUseCases {
                             id,
                             formEntity.label,
                             1,
-                            formEntity.properties
+                            formEntity.properties,
+                            branchId = UUID.randomUUID().toString()
                         )
 
                         entitiesRepository.save(entity)
@@ -72,7 +74,7 @@ object LocalEntityUseCases {
                 val existing = missingFromServer.remove(serverEntity.id)
 
                 if (existing == null || existing.version <= serverEntity.version) {
-                    newAndUpdated.add(serverEntity)
+                    newAndUpdated.add(serverEntity.copy(branchId = UUID.randomUUID().toString()))
                 } else if (existing.state == Entity.State.OFFLINE) {
                     val update = existing.copy(state = Entity.State.ONLINE)
                     newAndUpdated.add(update)
@@ -92,7 +94,7 @@ object LocalEntityUseCases {
     private fun parseEntityFromRecord(
         record: CSVRecord,
         list: String
-    ): Entity? {
+    ): Entity.New? {
         val map = record.toMap()
 
         val id = map.remove(EntityItemElement.ID)

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -93,7 +93,7 @@ object LocalEntityUseCases {
         record: CSVRecord,
         list: String
     ): Entity? {
-        val map = record.toMap().toMutableMap()
+        val map = record.toMap()
 
         val id = map.remove(EntityItemElement.ID)
         val label = map.remove(EntityItemElement.LABEL)
@@ -102,16 +102,12 @@ object LocalEntityUseCases {
             return null
         }
 
-        val properties = map.entries.fold(emptyList<Pair<String, String>>()) { properties, entry ->
-            properties + Pair(entry.key, entry.value)
-        }
-
         return Entity.New(
             list,
             id,
             label,
             version,
-            properties,
+            map.toList(),
             state = Entity.State.ONLINE,
             trunkVersion = version
         )

--- a/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
@@ -1,7 +1,5 @@
 package org.odk.collect.entities.storage
 
-import java.util.UUID
-
 sealed interface Entity {
     val list: String
     val id: String
@@ -20,7 +18,7 @@ sealed interface Entity {
         override val properties: List<Pair<String, String>> = emptyList(),
         override val state: State = State.OFFLINE,
         override val trunkVersion: Int? = null,
-        override val branchId: String = UUID.randomUUID().toString()
+        override val branchId: String = ""
     ) : Entity
 
     data class Saved(
@@ -32,7 +30,7 @@ sealed interface Entity {
         override val state: State = State.OFFLINE,
         val index: Int,
         override val trunkVersion: Int? = null,
-        override val branchId: String = UUID.randomUUID().toString()
+        override val branchId: String = ""
     ) : Entity
 
     enum class State {

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -142,6 +142,7 @@ class LocalEntityUseCasesTest {
         assertThat(songs[0].version, equalTo(2))
         assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
         assertThat(songs[0].trunkVersion, equalTo(2))
+        assertThat(songs[0].branchId, not(blankOrNullString()))
         assertThat(songs[0].branchId, not(equalTo(offline.branchId)))
     }
 
@@ -183,6 +184,7 @@ class LocalEntityUseCasesTest {
         assertThat(songs[0].version, equalTo(2))
         assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
         assertThat(songs[0].trunkVersion, equalTo(2))
+        assertThat(songs[0].branchId, not(blankOrNullString()))
         assertThat(songs[0].branchId, not(equalTo(offline.branchId)))
     }
 
@@ -204,6 +206,7 @@ class LocalEntityUseCasesTest {
         assertThat(songs[0].version, equalTo(3))
         assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
         assertThat(songs[0].trunkVersion, equalTo(3))
+        assertThat(songs[0].branchId, not(blankOrNullString()))
         assertThat(songs[0].branchId, not(equalTo(onlineBranched.branchId)))
     }
 


### PR DESCRIPTION
Closes #6344

This drops the benchmark target for first time entity form download to 25 seconds. As part of this work, I also fixed a bug related to special characters in property names.

#### Why is this the best possible solution? Were any other approaches considered?

I just needed to make a few tweaks to get down to 25 seconds. I chose this number due to the results of the new `SearchBenchmarkTest` which measure the performance of forms using `search()`. We'd expect the initial form load for `search()` forms and the initial download for entities forms to be roughly the same as they both insert the same number of rows into a SQLite DB.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This again changes the entity DB structure, so the app should be uninstalled before testing. The main changes here are all related to entity form download so that's the core area to focus on when testing.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
