### PR TITLE
Optimize redownloading entity forms

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -78,18 +78,18 @@ class EntitiesBenchmarkTest {
 
             .clickOK(MainMenuPage())
             .clickFillBlankForm()
-            .benchmark("Loading form first time", 5, benchmarker) {
+            .benchmark("Loading form first time", 2, benchmarker) {
                 it.clickOnForm("100k Entities Filter")
             }
 
             .pressBackAndDiscardForm()
             .clickFillBlankForm()
-            .benchmark("Loading form second time", 5, benchmarker) {
+            .benchmark("Loading form second time", 2, benchmarker) {
                 it.clickOnForm("100k Entities Filter")
             }
 
             .answerQuestion("Which value do you want to filter by?", "1024")
-            .benchmark("Filtering select", 5, benchmarker) {
+            .benchmark("Filtering select", 3, benchmarker) {
                 it.swipeToNextQuestion("Filtered select")
             }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -66,7 +66,7 @@ class EntitiesBenchmarkTest {
             .clickOKOnDialog(MainMenuPage())
 
             .clickGetBlankForm()
-            .benchmark("Downloading form with http cache", 35, benchmarker) {
+            .benchmark("Downloading form with http cache", 25, benchmarker) {
                 it.clickGetSelected()
             }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -25,6 +25,7 @@ import org.odk.collect.strings.R
  *
  * Devices that currently pass:
  * - Fairphone 3
+ * - Pixel 3
  *
  */
 
@@ -66,7 +67,7 @@ class EntitiesBenchmarkTest {
             .clickOKOnDialog(MainMenuPage())
 
             .clickGetBlankForm()
-            .benchmark("Downloading form with http cache", 25, benchmarker) {
+            .benchmark("Downloading form with http cache", 40, benchmarker) {
                 it.clickGetSelected()
             }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -66,13 +66,13 @@ class EntitiesBenchmarkTest {
             .clickOKOnDialog(MainMenuPage())
 
             .clickGetBlankForm()
-            .benchmark("Downloading form with http cache", 25, benchmarker) {
+            .benchmark("Downloading form with http cache", 35, benchmarker) {
                 it.clickGetSelected()
             }
 
             .clickOK(MainMenuPage())
             .clickGetBlankForm()
-            .benchmark("Downloading form second time with http cache", 35, benchmarker) {
+            .benchmark("Downloading form second time with http cache", 5, benchmarker) {
                 it.clickGetSelected()
             }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -72,7 +72,7 @@ class EntitiesBenchmarkTest {
 
             .clickOK(MainMenuPage())
             .clickGetBlankForm()
-            .benchmark("Downloading form second time with http cache", 75, benchmarker) {
+            .benchmark("Downloading form second time with http cache", 35, benchmarker) {
                 it.clickGetSelected()
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -135,12 +135,12 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             .foldAndClose(emptySet()) { set, cursor -> set + cursor.getString(ListsTable.COLUMN_NAME) }
     }
 
-    override fun updateListMD5(list: String, md5: String) {
+    override fun updateListVersion(list: String, version: String) {
         createList(list)
         updateRowIdTables()
 
         val contentValues = ContentValues().also {
-            it.put(ListsTable.MD5, md5)
+            it.put(ListsTable.MD5, version)
         }
 
         databaseConnection
@@ -153,7 +153,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             )
     }
 
-    override fun getListMD5(list: String): String? {
+    override fun getListVersion(list: String): String? {
         return databaseConnection
             .readableDatabase
             .query(ListsTable.TABLE_NAME, "${ListsTable.COLUMN_NAME} = ?", arrayOf(list))

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -136,9 +136,6 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
     }
 
     override fun updateListVersion(list: String, version: String) {
-        createList(list)
-        updateRowIdTables()
-
         val contentValues = ContentValues().also {
             it.put(ListsTable.MD5, version)
         }

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -23,9 +23,9 @@ import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
 
 private object ListsTable {
-    const val MD5 = "md5"
     const val TABLE_NAME = "lists"
     const val COLUMN_NAME = "name"
+    const val COLUMN_VERSION = "version"
 }
 
 private object EntitiesTable {
@@ -129,7 +129,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
 
     override fun updateListVersion(list: String, version: String) {
         val contentValues = ContentValues().also {
-            it.put(ListsTable.MD5, version)
+            it.put(ListsTable.COLUMN_VERSION, version)
         }
 
         databaseConnection
@@ -146,7 +146,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         return databaseConnection
             .readableDatabase
             .query(ListsTable.TABLE_NAME, "${ListsTable.COLUMN_NAME} = ?", arrayOf(list))
-            .first { it.getStringOrNull(ListsTable.MD5) }
+            .first { it.getStringOrNull(ListsTable.COLUMN_VERSION) }
     }
 
     override fun getEntities(list: String): List<Entity.Saved> {
@@ -435,7 +435,7 @@ private class EntitiesDatabaseMigrator :
             CREATE TABLE IF NOT EXISTS ${ListsTable.TABLE_NAME} (
                     $_ID integer PRIMARY KEY, 
                     ${ListsTable.COLUMN_NAME} text NOT NULL,
-                    ${ListsTable.MD5} text
+                    ${ListsTable.COLUMN_VERSION} text
             );
             """.trimIndent()
         )

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -83,9 +83,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
                         it.put(EntitiesTable.COLUMN_BRANCH_ID, entity.branchId)
                         it.put(EntitiesTable.COLUMN_STATE, convertStateToInt(state))
 
-                        entity.properties.forEach { (name, value) ->
-                            it.put(name, value)
-                        }
+                        addPropertiesToContentValues(it, entity)
                     }
 
                     update(
@@ -103,9 +101,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
                         it.put(EntitiesTable.COLUMN_BRANCH_ID, entity.branchId)
                         it.put(EntitiesTable.COLUMN_STATE, convertStateToInt(entity.state))
 
-                        entity.properties.forEach { (name, value) ->
-                            it.put("\"$name\"", value)
-                        }
+                        addPropertiesToContentValues(it, entity)
                     }
 
                     insertOrThrow(
@@ -423,6 +419,12 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         return when (state) {
             Entity.State.OFFLINE -> 0
             Entity.State.ONLINE -> 1
+        }
+    }
+
+    private fun addPropertiesToContentValues(contentValues: ContentValues, entity: Entity) {
+        entity.properties.forEach { (name, value) ->
+            contentValues.put("\"$name\"", value)
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -25,7 +25,7 @@ import org.odk.collect.entities.storage.Entity
 private object ListsTable {
     const val TABLE_NAME = "lists"
     const val COLUMN_NAME = "name"
-    const val COLUMN_VERSION = "version"
+    const val COLUMN_HASH = "hash"
 }
 
 private object EntitiesTable {
@@ -123,9 +123,9 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             .foldAndClose(emptySet()) { set, cursor -> set + cursor.getString(ListsTable.COLUMN_NAME) }
     }
 
-    override fun updateListVersion(list: String, version: String) {
+    override fun updateListHash(list: String, hash: String) {
         val contentValues = ContentValues().also {
-            it.put(ListsTable.COLUMN_VERSION, version)
+            it.put(ListsTable.COLUMN_HASH, hash)
         }
 
         databaseConnection
@@ -138,11 +138,11 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             )
     }
 
-    override fun getListVersion(list: String): String? {
+    override fun getListHash(list: String): String? {
         return databaseConnection
             .readableDatabase
             .query(ListsTable.TABLE_NAME, "${ListsTable.COLUMN_NAME} = ?", arrayOf(list))
-            .first { it.getStringOrNull(ListsTable.COLUMN_VERSION) }
+            .first { it.getStringOrNull(ListsTable.COLUMN_HASH) }
     }
 
     override fun getEntities(list: String): List<Entity.Saved> {
@@ -437,7 +437,7 @@ private class EntitiesDatabaseMigrator :
             CREATE TABLE IF NOT EXISTS ${ListsTable.TABLE_NAME} (
                     $_ID integer PRIMARY KEY, 
                     ${ListsTable.COLUMN_NAME} text NOT NULL,
-                    ${ListsTable.COLUMN_VERSION} text
+                    ${ListsTable.COLUMN_HASH} text
             );
             """.trimIndent()
         )

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -49,24 +49,22 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
     )
 
     override fun save(vararg entities: Entity) {
-        val existingLists = getLists()
-        val createdLists = mutableListOf<String>()
-        val modifiedList = mutableListOf<String>()
+        val first = entities.first()
+        val list = first.list
+        val listExists = listExists(list)
+        if (!listExists) {
+            createList(list)
+        }
+
+        updatePropertyColumns(first)
 
         databaseConnection.writeableDatabase.transaction {
             entities.forEach { entity ->
-                val list = entity.list
-                if (!existingLists.contains(list) && !createdLists.contains(list)) {
-                    createList(list)
-                    createdLists.add(list)
+                if (entity.list != list) {
+                    throw IllegalArgumentException()
                 }
 
-                if (!modifiedList.contains(list)) {
-                    updatePropertyColumns(entity)
-                    modifiedList.add(list)
-                }
-
-                val existing = if (existingLists.contains(list)) {
+                val existing = if (listExists) {
                     query(
                         list,
                         "${EntitiesTable.COLUMN_ID} = ?",

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -49,6 +49,10 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
     )
 
     override fun save(list: String, vararg entities: Entity) {
+        if (entities.isEmpty()) {
+            return
+        }
+
         val listExists = listExists(list)
         if (!listExists) {
             createList(list)

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/LocalFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/LocalFormUseCases.kt
@@ -8,7 +8,7 @@ import org.odk.collect.androidshared.utils.Validator
 import org.odk.collect.forms.Form
 import org.odk.collect.forms.FormsRepository
 import org.odk.collect.forms.instances.InstancesRepository
-import org.odk.collect.shared.strings.Md5
+import org.odk.collect.shared.strings.Md5.getMd5Hash
 import org.odk.collect.strings.localization.getLocalizedString
 import timber.log.Timber
 import java.io.File
@@ -75,7 +75,7 @@ object LocalFormUseCases {
                         // remove it from the list of forms (we only want forms
                         // we haven't added at the end)
                         formsToAdd.remove(sqlFile)
-                        val md5Computed = Md5.getMd5Hash(sqlFile)
+                        val md5Computed = sqlFile.getMd5Hash()
                         if (md5Computed == null || md5 == null || md5Computed != md5) {
                             // Probably someone overwrite the file on the sdcard
                             // So re-parse it and update it's information

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -12,7 +12,7 @@ import org.odk.collect.forms.FormSourceException
 import org.odk.collect.forms.FormsRepository
 import org.odk.collect.forms.MediaFile
 import org.odk.collect.shared.locks.ChangeLock
-import org.odk.collect.shared.strings.Md5
+import org.odk.collect.shared.strings.Md5.getMd5Hash
 import java.io.File
 import java.io.IOException
 
@@ -92,14 +92,14 @@ object ServerFormUseCases {
             val existingFile = searchForExistingMediaFile(formsRepository, formToDownload, mediaFile)
             existingFile.also {
                 if (it != null) {
-                    if (Md5.getMd5Hash(it).contentEquals(mediaFile.hash)) {
+                    if (it.getMd5Hash().contentEquals(mediaFile.hash)) {
                         FileUtils.copyFile(it, tempMediaFile)
                     } else {
-                        val existingFileHash = Md5.getMd5Hash(it)
+                        val existingFileHash = it.getMd5Hash()
                         val file = formSource.fetchMediaFile(mediaFile.downloadUrl)
                         FileUtils.interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
 
-                        if (!Md5.getMd5Hash(tempMediaFile).contentEquals(existingFileHash)) {
+                        if (!tempMediaFile.getMd5Hash().contentEquals(existingFileHash)) {
                             atLeastOneNewMediaFileDetected = true
                         }
                     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
@@ -128,7 +128,7 @@ open class ServerFormsDetailsFetcher(
         }
 
         return localMediaFiles.any {
-            newMediaFile.hash == getMd5Hash(it)
+            newMediaFile.hash == it.getMd5Hash()
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -252,7 +252,7 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
-    fun `#save supports properties with dots and dashes`() {
+    fun `#save supports properties with dots and dashes when saving new entities and updating existing ones`() {
         val repository = buildSubject()
         val entity = Entity.New(
             "1",
@@ -264,7 +264,6 @@ abstract class EntitiesRepositoryTest {
         val savedEntity = repository.getEntities("things")[0]
         assertThat(savedEntity, sameEntityAs(entity))
 
-        // Check update works as well
         repository.save("things", savedEntity)
         assertThat(repository.getEntities("things")[0], sameEntityAs(savedEntity))
     }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -269,7 +269,7 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
-    fun `#save with no entities works`() {
+    fun `#save does not create a list when no entities are provided`() {
         val repository = buildSubject()
         repository.save("blah")
         assertThat(repository.getLists(), equalTo(emptySet()))

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -4,6 +4,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
+import org.junit.Assert.fail
 import org.junit.Test
 import org.odk.collect.android.entities.support.EntitySameAsMatcher.Companion.sameEntityAs
 import org.odk.collect.entities.storage.EntitiesRepository
@@ -276,6 +277,21 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
+    fun `#save throws an exception when used to save multiple lists`() {
+        val repository = buildSubject()
+
+        val wine = Entity.New("wine", "1", "1")
+        val whisky = Entity.New("whisky", "2", "2")
+
+        try {
+            repository.save(wine, whisky)
+            fail()
+        } catch (e: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
     fun `#clear deletes all entities`() {
         val repository = buildSubject()
 
@@ -300,11 +316,11 @@ abstract class EntitiesRepositoryTest {
     fun `#save can save multiple entities`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008")
-        val whisky = Entity.New("whiskys", "2", "Lagavulin 16")
-        repository.save(wine, whisky)
+        val wine1 = Entity.New("wines", "1", "Léoville Barton 2008")
+        val wine2 = Entity.New("wines", "2", "Chateau Pontet Canet")
+        repository.save(wine1, wine2)
 
-        assertThat(repository.getLists(), containsInAnyOrder("wines", "whiskys"))
+        assertThat(repository.getEntities("wines").size, equalTo(2))
     }
 
     @Test
@@ -440,7 +456,8 @@ abstract class EntitiesRepositoryTest {
 
         val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
         val ardbeg = Entity.New("whisky", "2", "Ardbeg 10")
-        repository.save(leoville, ardbeg)
+        repository.save(leoville)
+        repository.save(ardbeg)
 
         assertThat(repository.getById("whisky", "1"), equalTo(null))
     }
@@ -573,7 +590,8 @@ abstract class EntitiesRepositoryTest {
             properties = listOf("vintage" to "1983")
         )
 
-        repository.save(leoville, dows)
+        repository.save(leoville)
+        repository.save(dows)
         assertThat(repository.getAllByProperty("wines", "vintage", "1983"), equalTo(emptyList()))
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -4,7 +4,6 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
-import org.junit.Assert.fail
 import org.junit.Test
 import org.odk.collect.android.entities.support.EntitySameAsMatcher.Companion.sameEntityAs
 import org.odk.collect.entities.storage.EntitiesRepository
@@ -18,10 +17,10 @@ abstract class EntitiesRepositoryTest {
     fun `#getLists returns lists for saved entities`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008")
-        val whisky = Entity.New("whiskys", "2", "Lagavulin 16")
-        repository.save(wine)
-        repository.save(whisky)
+        val wine = Entity.New("1", "Léoville Barton 2008")
+        val whisky = Entity.New("2", "Lagavulin 16")
+        repository.save("wines", wine)
+        repository.save("whiskys", whisky)
 
         assertThat(repository.getLists(), containsInAnyOrder("wines", "whiskys"))
     }
@@ -37,7 +36,6 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val wine = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             version = 2,
@@ -45,15 +43,14 @@ abstract class EntitiesRepositoryTest {
         )
 
         val whisky = Entity.New(
-            "whiskys",
             "2",
             "Lagavulin 16",
             version = 3,
             trunkVersion = 1
         )
 
-        repository.save(wine)
-        repository.save(whisky)
+        repository.save("wines", wine)
+        repository.save("whiskys", whisky)
 
         val wines = repository.getEntities("wines")
         assertThat(wines.size, equalTo(1))
@@ -69,15 +66,14 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val wine = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             trunkVersion = 1
         )
-        repository.save(wine)
+        repository.save("wines", wine)
 
         val updatedWine = wine.copy(label = "Léoville Barton 2009", version = 2)
-        repository.save(updatedWine)
+        repository.save("wines", updatedWine)
 
         val wines = repository.getEntities("wines")
         assertThat(wines, contains(sameEntityAs(updatedWine)))
@@ -87,11 +83,11 @@ abstract class EntitiesRepositoryTest {
     fun `#save creates entity with matching id in different list`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008", version = 1)
-        repository.save(wine)
+        val wine = Entity.New("1", "Léoville Barton 2008", version = 1)
+        repository.save("wines", wine)
 
-        val updatedWine = Entity.New("whisky", wine.id, "Edradour 10", version = 2)
-        repository.save(updatedWine)
+        val updatedWine = Entity.New(wine.id, "Edradour 10", version = 2)
+        repository.save("whisky", updatedWine)
 
         val wines = repository.getEntities("wines")
         assertThat(wines, contains(sameEntityAs(wine)))
@@ -103,11 +99,11 @@ abstract class EntitiesRepositoryTest {
     fun `#save updates existing entity with matching id and version`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008", version = 1)
-        repository.save(wine)
+        val wine = Entity.New("1", "Léoville Barton 2008", version = 1)
+        repository.save("wines", wine)
 
         val updatedWine = wine.copy(label = "Léoville Barton 2009")
-        repository.save(updatedWine)
+        repository.save("wines", updatedWine)
 
         val wines = repository.getEntities("wines")
         assertThat(wines, contains(sameEntityAs(updatedWine)))
@@ -117,11 +113,11 @@ abstract class EntitiesRepositoryTest {
     fun `#save updates state on existing entity when it is offline`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008", state = Entity.State.OFFLINE)
-        repository.save(wine)
+        val wine = Entity.New("1", "Léoville Barton 2008", state = Entity.State.OFFLINE)
+        repository.save("wines", wine)
 
         val updatedWine = wine.copy(state = Entity.State.ONLINE)
-        repository.save(updatedWine)
+        repository.save("wines", updatedWine)
 
         val wines = repository.getEntities("wines")
         assertThat(wines, contains(sameEntityAs(updatedWine)))
@@ -131,11 +127,11 @@ abstract class EntitiesRepositoryTest {
     fun `#save does not update state on existing entity when it is online`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008", state = Entity.State.ONLINE)
-        repository.save(wine)
+        val wine = Entity.New("1", "Léoville Barton 2008", state = Entity.State.ONLINE)
+        repository.save("wines", wine)
 
         val updatedWine = wine.copy(state = Entity.State.OFFLINE)
-        repository.save(updatedWine)
+        repository.save("wines", updatedWine)
 
         val wines = repository.getEntities("wines")
         assertThat(wines, contains(sameEntityAs(wine)))
@@ -146,22 +142,20 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val wine = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("window" to "2019-2038"),
             version = 1
         )
-        repository.save(wine)
+        repository.save("wines", wine)
 
         val updatedWine = Entity.New(
-            "wines",
             wine.id,
             "Léoville Barton 2008",
             properties = listOf("score" to "92"),
             version = 2
         )
-        repository.save(updatedWine)
+        repository.save("wines", updatedWine)
 
         val wines = repository.getEntities("wines")
         assertThat(wines.size, equalTo(1))
@@ -173,22 +167,20 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val wine = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("window" to "2019-2038"),
             version = 1
         )
-        repository.save(wine)
+        repository.save("wines", wine)
 
         val otherWine = Entity.New(
-            "wines",
             "2",
             "Léoville Barton 2009",
             properties = listOf("score" to "92"),
             version = 2
         )
-        repository.save(otherWine)
+        repository.save("wines", otherWine)
 
         val wines = repository.getEntities("wines")
         assertThat(wines.size, equalTo(2))
@@ -201,22 +193,20 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val wine = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("window" to "2019-2038"),
             version = 1
         )
-        repository.save(wine)
+        repository.save("wines", wine)
 
         val updatedWine = Entity.New(
-            "wines",
             wine.id,
             "Léoville Barton 2008",
             properties = listOf("window" to "2019-2042"),
             version = 2
         )
-        repository.save(updatedWine)
+        repository.save("wines", updatedWine)
 
         val wines = repository.getEntities("wines")
         assertThat(wines.size, equalTo(1))
@@ -228,22 +218,20 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val wine = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("window" to "2019-2038"),
             version = 1
         )
-        repository.save(wine)
+        repository.save("wines", wine)
 
         val updatedWine = Entity.New(
-            "wines",
             wine.id,
             null,
             properties = listOf("window" to "2019-2042"),
             version = 2
         )
-        repository.save(updatedWine)
+        repository.save("wines", updatedWine)
 
         val wines = repository.getEntities("wines")
         assertThat(wines.size, equalTo(1))
@@ -259,7 +247,7 @@ abstract class EntitiesRepositoryTest {
         repository.addList("blah")
         assertThat(repository.getLists(), containsInAnyOrder("wines", "blah"))
 
-        repository.save(Entity.New("wines", "blah", "Blah"))
+        repository.save("wines", Entity.New("blah", "Blah"))
         assertThat(repository.getLists(), containsInAnyOrder("wines", "blah"))
     }
 
@@ -267,38 +255,22 @@ abstract class EntitiesRepositoryTest {
     fun `#save supports properties with dots and dashes`() {
         val repository = buildSubject()
         val entity = Entity.New(
-            "things",
             "1",
             "One",
             properties = listOf(Pair("a.property", "value"), Pair("a-property", "value"))
         )
-        repository.save(entity)
+        repository.save("things", entity)
         assertThat(repository.getEntities("things")[0], sameEntityAs(entity))
-    }
-
-    @Test
-    fun `#save throws an exception when used to save multiple lists`() {
-        val repository = buildSubject()
-
-        val wine = Entity.New("wine", "1", "1")
-        val whisky = Entity.New("whisky", "2", "2")
-
-        try {
-            repository.save(wine, whisky)
-            fail()
-        } catch (e: IllegalArgumentException) {
-            // expected
-        }
     }
 
     @Test
     fun `#clear deletes all entities`() {
         val repository = buildSubject()
 
-        val wine = Entity.New("wines", "1", "Léoville Barton 2008")
-        val whisky = Entity.New("whiskys", "2", "Lagavulin 16")
-        repository.save(wine)
-        repository.save(whisky)
+        val wine = Entity.New("1", "Léoville Barton 2008")
+        val whisky = Entity.New("2", "Lagavulin 16")
+        repository.save("wines", wine)
+        repository.save("whiskys", whisky)
 
         repository.clear()
         assertThat(repository.getLists().size, equalTo(0))
@@ -316,20 +288,20 @@ abstract class EntitiesRepositoryTest {
     fun `#save can save multiple entities`() {
         val repository = buildSubject()
 
-        val wine1 = Entity.New("wines", "1", "Léoville Barton 2008")
-        val wine2 = Entity.New("wines", "2", "Chateau Pontet Canet")
-        repository.save(wine1, wine2)
+        val wine1 = Entity.New("1", "Léoville Barton 2008")
+        val wine2 = Entity.New("2", "Chateau Pontet Canet")
+        repository.save("wines", wine1, wine2)
 
         assertThat(repository.getEntities("wines").size, equalTo(2))
     }
 
     @Test
     fun `#save assigns an index to each entity in insert order when saving multiple entities`() {
-        val first = Entity.New("wines", "1", "Léoville Barton 2008")
-        val second = Entity.New("wines", "2", "Pontet Canet 2014")
+        val first = Entity.New("1", "Léoville Barton 2008")
+        val second = Entity.New("2", "Pontet Canet 2014")
 
         val repository = buildSubject()
-        repository.save(first, second)
+        repository.save("wines", first, second)
 
         val entities = repository.getEntities("wines")
         assertThat(entities[0].index, equalTo(0))
@@ -338,12 +310,12 @@ abstract class EntitiesRepositoryTest {
 
     @Test
     fun `#save assigns an index to each entity in insert order when saving single entities`() {
-        val first = Entity.New("wines", "1", "Léoville Barton 2008")
-        val second = Entity.New("wines", "2", "Pontet Canet 2014")
+        val first = Entity.New("1", "Léoville Barton 2008")
+        val second = Entity.New("2", "Pontet Canet 2014")
 
         val repository = buildSubject()
-        repository.save(first)
-        repository.save(second)
+        repository.save("wines", first)
+        repository.save("wines", second)
 
         val entities = repository.getEntities("wines")
         assertThat(entities[0].index, equalTo(0))
@@ -354,13 +326,13 @@ abstract class EntitiesRepositoryTest {
     fun `#save does not change index when updating an existing entity`() {
         val repository = buildSubject()
 
-        val first = Entity.New("wines", "1", "Léoville Barton 2008")
-        val second = Entity.New("wines", "2", "Pontet Canet 2014")
-        repository.save(first, second)
+        val first = Entity.New("1", "Léoville Barton 2008")
+        val second = Entity.New("2", "Pontet Canet 2014")
+        repository.save("wines", first, second)
         assertThat(repository.getEntities("wines")[0].index, equalTo(0))
 
         val updatedWine = first.copy(label = "Léoville Barton 2009")
-        repository.save(updatedWine)
+        repository.save("wines", updatedWine)
 
         assertThat(repository.getEntities("wines")[0].index, equalTo(0))
     }
@@ -388,9 +360,9 @@ abstract class EntitiesRepositoryTest {
     fun `#delete removes an entity`() {
         val repository = buildSubject()
 
-        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
-        val canet = Entity.New("wines", "2", "Pontet-Canet 2014")
-        repository.save(leoville, canet)
+        val leoville = Entity.New("1", "Léoville Barton 2008")
+        val canet = Entity.New("2", "Pontet-Canet 2014")
+        repository.save("wines", leoville, canet)
 
         repository.delete("1")
 
@@ -404,10 +376,10 @@ abstract class EntitiesRepositoryTest {
     fun `#delete updates index values so that they are always in sequence and start at 0`() {
         val repository = buildSubject()
 
-        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
-        val canet = Entity.New("wines", "2", "Pontet-Canet 2014")
-        val gloria = Entity.New("wines", "3", "Chateau Gloria 2016")
-        repository.save(leoville, canet, gloria)
+        val leoville = Entity.New("1", "Léoville Barton 2008")
+        val canet = Entity.New("2", "Pontet-Canet 2014")
+        val gloria = Entity.New("3", "Chateau Gloria 2016")
+        repository.save("wines", leoville, canet, gloria)
 
         repository.delete("1")
 
@@ -415,7 +387,7 @@ abstract class EntitiesRepositoryTest {
         assertThat(wines[0].index, equalTo(0))
         assertThat(wines[1].index, equalTo(1))
 
-        repository.save(leoville)
+        repository.save("wines", leoville)
         wines = repository.getEntities("wines")
         assertThat(wines[0].index, equalTo(0))
         assertThat(wines[1].index, equalTo(1))
@@ -426,9 +398,9 @@ abstract class EntitiesRepositoryTest {
     fun `#getById returns entities with matching id`() {
         val repository = buildSubject()
 
-        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
-        val canet = Entity.New("wines", "2", "Pontet-Canet 2014")
-        repository.save(leoville, canet)
+        val leoville = Entity.New("1", "Léoville Barton 2008")
+        val canet = Entity.New("2", "Pontet-Canet 2014")
+        repository.save("wines", leoville, canet)
 
         val wines = repository.getEntities("wines")
 
@@ -443,9 +415,9 @@ abstract class EntitiesRepositoryTest {
     fun `#getById returns null when there are no matches`() {
         val repository = buildSubject()
 
-        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
-        val canet = Entity.New("wines", "2", "Pontet-Canet 2014")
-        repository.save(leoville, canet)
+        val leoville = Entity.New("1", "Léoville Barton 2008")
+        val canet = Entity.New("2", "Pontet-Canet 2014")
+        repository.save("wines", leoville, canet)
 
         assertThat(repository.getById("wines", "3"), equalTo(null))
     }
@@ -454,10 +426,10 @@ abstract class EntitiesRepositoryTest {
     fun `#getById returns null when there is a match in a different list`() {
         val repository = buildSubject()
 
-        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
-        val ardbeg = Entity.New("whisky", "2", "Ardbeg 10")
-        repository.save(leoville)
-        repository.save(ardbeg)
+        val leoville = Entity.New("1", "Léoville Barton 2008")
+        val ardbeg = Entity.New("2", "Ardbeg 10")
+        repository.save("wines", leoville)
+        repository.save("whisky", ardbeg)
 
         assertThat(repository.getById("whisky", "1"), equalTo(null))
     }
@@ -473,20 +445,18 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val leoville = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("vintage" to "2008")
         )
 
         val canet = Entity.New(
-            "wines",
             "2",
             "Pontet-Canet 2014",
             properties = listOf("vintage" to "2014")
         )
 
-        repository.save(leoville, canet)
+        repository.save("wines", leoville, canet)
 
         val wines = repository.getEntities("wines")
         assertThat(
@@ -500,21 +470,19 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val leoville = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("vintage" to "2008")
         )
 
         val canet = Entity.New(
-            "wines",
             "2",
             "Pontet-Canet 2014",
             properties = listOf("score" to "93")
         )
 
-        repository.save(leoville)
-        repository.save(canet)
+        repository.save("wines", leoville)
+        repository.save("wines", canet)
 
         val allByProperty = repository.getAllByProperty("wines", "score", "")
         assertThat(allByProperty.size, equalTo(1))
@@ -526,13 +494,12 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val leoville = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("vintage" to "2008")
         )
 
-        repository.save(leoville)
+        repository.save("wines", leoville)
         assertThat(repository.getAllByProperty("wines", "score", "").size, equalTo(1))
     }
 
@@ -541,13 +508,12 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val leoville = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("vintage" to "2008")
         )
 
-        repository.save(leoville)
+        repository.save("wines", leoville)
         assertThat(repository.getAllByProperty("wines", "score", "92").size, equalTo(0))
     }
 
@@ -556,20 +522,18 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val leoville = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("vintage" to "2008")
         )
 
         val canet = Entity.New(
-            "wines",
             "2",
             "Pontet-Canet 2014",
             properties = listOf("vintage" to "2014")
         )
 
-        repository.save(leoville, canet)
+        repository.save("wines", leoville, canet)
         assertThat(repository.getAllByProperty("wines", "vintage", "2024"), equalTo(emptyList()))
     }
 
@@ -578,20 +542,18 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         val leoville = Entity.New(
-            "wines",
             "1",
             "Léoville Barton 2008",
             properties = listOf("vintage" to "2008")
         )
         val dows = Entity.New(
-            "ports",
             "2",
             "Dow's 1983",
             properties = listOf("vintage" to "1983")
         )
 
-        repository.save(leoville)
-        repository.save(dows)
+        repository.save("wines", leoville)
+        repository.save("ports", dows)
         assertThat(repository.getAllByProperty("wines", "vintage", "1983"), equalTo(emptyList()))
     }
 
@@ -619,12 +581,12 @@ abstract class EntitiesRepositoryTest {
     fun `#getCount returns number of entities in list`() {
         val repository = buildSubject()
 
-        val leoville = Entity.New("wines", "1", "Léoville Barton 2008")
-        val dows = Entity.New("wines", "2", "Dow's 1983")
-        repository.save(leoville, dows)
+        val leoville = Entity.New("1", "Léoville Barton 2008")
+        val dows = Entity.New("2", "Dow's 1983")
+        repository.save("wines", leoville, dows)
 
-        val springbank = Entity.New("whiskys", "1", "Springbank 10")
-        repository.save(springbank)
+        val springbank = Entity.New("1", "Springbank 10")
+        repository.save("whiskys", springbank)
 
         assertThat(repository.getCount("wines"), equalTo(2))
         assertThat(repository.getCount("whiskys"), equalTo(1))
@@ -634,9 +596,9 @@ abstract class EntitiesRepositoryTest {
     fun `#getByIndex returns matching entity`() {
         val repository = buildSubject()
 
-        val springbank = Entity.New("whiskys", "1", "Springbank 10")
-        val aultmore = Entity.New("whiskys", "2", "Aultmore 12")
-        repository.save(springbank, aultmore)
+        val springbank = Entity.New("1", "Springbank 10")
+        val aultmore = Entity.New("2", "Aultmore 12")
+        repository.save("whiskys", springbank, aultmore)
 
         val aultmoreIndex = repository.getEntities("whiskys").first { it.id == aultmore.id }.index
         assertThat(repository.getByIndex("whiskys", aultmoreIndex), sameEntityAs(aultmore))

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -269,6 +269,13 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
+    fun `#save with no entities works`() {
+        val repository = buildSubject()
+        repository.save("blah")
+        assertThat(repository.getLists(), equalTo(emptySet()))
+    }
+
+    @Test
     fun `#clear deletes all entities`() {
         val repository = buildSubject()
 

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -259,8 +259,14 @@ abstract class EntitiesRepositoryTest {
             "One",
             properties = listOf(Pair("a.property", "value"), Pair("a-property", "value"))
         )
+
         repository.save("things", entity)
-        assertThat(repository.getEntities("things")[0], sameEntityAs(entity))
+        val savedEntity = repository.getEntities("things")[0]
+        assertThat(savedEntity, sameEntityAs(entity))
+
+        // Check update works as well
+        repository.save("things", savedEntity)
+        assertThat(repository.getEntities("things")[0], sameEntityAs(savedEntity))
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -629,7 +629,7 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
 
         repository.addList("wine")
-        repository.updateListVersion("wine", "2024")
-        assertThat(repository.getListVersion("wine"), equalTo("2024"))
+        repository.updateListHash("wine", "2024")
+        assertThat(repository.getListHash("wine"), equalTo("2024"))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -637,4 +637,13 @@ abstract class EntitiesRepositoryTest {
 
         assertThat(repository.getByIndex("wine", 0), equalTo(null))
     }
+
+    @Test
+    fun `#getListVersion returns list version`() {
+        val repository = buildSubject()
+
+        repository.addList("wine")
+        repository.updateListVersion("wine", "2024")
+        assertThat(repository.getListVersion("wine"), equalTo("2024"))
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsDataServiceTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsDataServiceTest.kt
@@ -240,7 +240,7 @@ class FormsDataServiceTest {
                     "http://$formId",
                     formId,
                     formVersion,
-                    getMd5Hash(updatedXForm),
+                    updatedXForm.getMd5Hash(),
                     "blah",
                     null
                 )

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormUseCasesTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormUseCasesTest.kt
@@ -23,7 +23,7 @@ import org.odk.collect.formstest.FormFixtures
 import org.odk.collect.formstest.FormUtils
 import org.odk.collect.formstest.InMemFormsRepository
 import org.odk.collect.shared.TempFiles
-import org.odk.collect.shared.strings.Md5
+import org.odk.collect.shared.strings.Md5.getMd5Hash
 import org.odk.collect.testshared.BooleanChangeLock
 import java.io.File
 
@@ -187,7 +187,7 @@ class ServerFormUseCasesTest {
         formsRepository.save(form2)
 
         // Set up same media file on server
-        val existingMediaFileHash = Md5.getMd5Hash(File(form2.formMediaPath, "file"))!!
+        val existingMediaFileHash = File(form2.formMediaPath, "file").getMd5Hash()!!
         val mediaFile = MediaFile("file", existingMediaFileHash, "downloadUrl")
         val manifestFile = ManifestFile(null, listOf(mediaFile))
         val serverFormDetails =

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -57,7 +57,7 @@ object LocalEntityUseCases {
         serverList: File,
         entitiesRepository: EntitiesRepository
     ) {
-        val listVersion = Md5.getMd5Hash(serverList)
+        val listVersion = getListVersion(serverList)
         val existingListVersion = entitiesRepository.getListVersion(list)
         if (listVersion == existingListVersion) {
             return
@@ -107,7 +107,11 @@ object LocalEntityUseCases {
             entitiesRepository.save(*newAndUpdated.toTypedArray())
         }
 
-        entitiesRepository.updateListVersion(list, listVersion!!)
+        entitiesRepository.updateListVersion(list, listVersion)
+    }
+
+    private fun getListVersion(serverList: File): String {
+        return "md5:${Md5.getMd5Hash(serverList)!!}"
     }
 
     private fun parseEntityFromRecord(

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -24,7 +24,6 @@ object LocalEntityUseCases {
                 when (formEntity.action) {
                     EntityAction.CREATE -> {
                         val entity = Entity.New(
-                            formEntity.dataset,
                             id,
                             formEntity.label,
                             1,
@@ -32,13 +31,14 @@ object LocalEntityUseCases {
                             branchId = UUID.randomUUID().toString()
                         )
 
-                        entitiesRepository.save(entity)
+                        entitiesRepository.save(formEntity.dataset, entity)
                     }
 
                     EntityAction.UPDATE -> {
                         val existing = entitiesRepository.getById(formEntity.dataset, formEntity.id)
                         if (existing != null) {
                             entitiesRepository.save(
+                                formEntity.dataset,
                                 existing.copy(
                                     label = formEntity.label,
                                     properties = formEntity.properties,
@@ -104,7 +104,7 @@ object LocalEntityUseCases {
         }
 
         if (newAndUpdated.isNotEmpty()) {
-            entitiesRepository.save(*newAndUpdated.toTypedArray())
+            entitiesRepository.save(list, *newAndUpdated.toTypedArray())
         }
 
         entitiesRepository.updateListVersion(list, listVersion)
@@ -128,7 +128,6 @@ object LocalEntityUseCases {
         }
 
         return Entity.New(
-            list,
             id,
             label,
             version,

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -117,10 +117,7 @@ object LocalEntityUseCases {
             }
         }
 
-        if (newAndUpdated.isNotEmpty()) {
-            entitiesRepository.save(list, *newAndUpdated.toTypedArray())
-        }
-
+        entitiesRepository.save(list, *newAndUpdated.toTypedArray())
         entitiesRepository.updateListVersion(list, listVersion)
     }
 

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -93,7 +93,7 @@ object LocalEntityUseCases {
                         )
                     )
                 } else if (existing.version <= serverEntity.version) {
-                    if (existing.isDirty()) {
+                    if (existing.isDirty() || serverEntity.version > existing.version) {
                         val update = existing.copy(
                             label = serverEntity.label,
                             version = serverEntity.version,

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -57,9 +57,9 @@ object LocalEntityUseCases {
         serverList: File,
         entitiesRepository: EntitiesRepository
     ) {
-        val listVersion = getListVersion(serverList)
-        val existingListVersion = entitiesRepository.getListVersion(list)
-        if (listVersion == existingListVersion) {
+        val listHash = getListHash(serverList)
+        val existingListVersion = entitiesRepository.getListHash(list)
+        if (listHash == existingListVersion) {
             return
         }
 
@@ -118,10 +118,10 @@ object LocalEntityUseCases {
         }
 
         entitiesRepository.save(list, *newAndUpdated.toTypedArray())
-        entitiesRepository.updateListVersion(list, listVersion)
+        entitiesRepository.updateListHash(list, listHash)
     }
 
-    private fun getListVersion(serverList: File): String {
+    private fun getListHash(serverList: File): String {
         return "md5:${Md5.getMd5Hash(serverList)!!}"
     }
 

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -57,9 +57,9 @@ object LocalEntityUseCases {
         serverList: File,
         entitiesRepository: EntitiesRepository
     ) {
-        val listMD5 = Md5.getMd5Hash(serverList)
-        val existingListMD5 = entitiesRepository.getListMD5(list)
-        if (listMD5 == existingListMD5) {
+        val listVersion = Md5.getMd5Hash(serverList)
+        val existingListVersion = entitiesRepository.getListVersion(list)
+        if (listVersion == existingListVersion) {
             return
         }
 
@@ -107,7 +107,7 @@ object LocalEntityUseCases {
             entitiesRepository.save(*newAndUpdated.toTypedArray())
         }
 
-        entitiesRepository.updateListMD5(list, listMD5!!)
+        entitiesRepository.updateListVersion(list, listVersion!!)
     }
 
     private fun parseEntityFromRecord(

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -92,7 +92,20 @@ object LocalEntityUseCases {
                             branchId = UUID.randomUUID().toString()
                         )
                     )
-                } else if (existing.version <= serverEntity.version) {
+                } else if (existing.version < serverEntity.version) {
+                    val update = existing.copy(
+                        label = serverEntity.label,
+                        version = serverEntity.version,
+                        properties = serverEntity.properties.toList(),
+                        state = Entity.State.ONLINE,
+                        branchId = UUID.randomUUID().toString(),
+                        trunkVersion = serverEntity.version
+                    )
+                    newAndUpdated.add(update)
+                } else if (
+                    existing.version == serverEntity.version &&
+                    serverEntity.version != existing.trunkVersion
+                ) {
                     val update = existing.copy(
                         label = serverEntity.label,
                         version = serverEntity.version,

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -92,26 +92,18 @@ object LocalEntityUseCases {
                             branchId = UUID.randomUUID().toString()
                         )
                     )
-                } else if (existing.version < serverEntity.version) {
-                    val update = existing.copy(
-                        label = serverEntity.label,
-                        version = serverEntity.version,
-                        properties = serverEntity.properties.toList(),
-                        state = Entity.State.ONLINE,
-                        branchId = UUID.randomUUID().toString(),
-                        trunkVersion = serverEntity.version
-                    )
-                    newAndUpdated.add(update)
-                } else if (
-                    existing.version == serverEntity.version &&
-                    serverEntity.version != existing.trunkVersion
-                ) {
-                    val update = existing.copy(
-                        state = Entity.State.ONLINE,
-                        branchId = UUID.randomUUID().toString(),
-                        trunkVersion = serverEntity.version
-                    )
-                    newAndUpdated.add(update)
+                } else if (existing.version <= serverEntity.version) {
+                    if (existing.isDirty()) {
+                        val update = existing.copy(
+                            label = serverEntity.label,
+                            version = serverEntity.version,
+                            properties = serverEntity.properties.toList(),
+                            state = Entity.State.ONLINE,
+                            branchId = UUID.randomUUID().toString(),
+                            trunkVersion = serverEntity.version
+                        )
+                        newAndUpdated.add(update)
+                    }
                 } else if (existing.state == Entity.State.OFFLINE) {
                     val update = existing.copy(state = Entity.State.ONLINE)
                     newAndUpdated.add(update)

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -77,7 +77,7 @@ object LocalEntityUseCases {
         val newAndUpdated = ArrayList<Entity>()
         csvParser.use {
             it.forEach { record ->
-                val serverEntity = parseEntityFromRecord(record, list) ?: return
+                val serverEntity = parseEntityFromRecord(record) ?: return
                 val existing = missingFromServer.remove(serverEntity.id)
 
                 if (existing == null || existing.version < serverEntity.version) {
@@ -114,10 +114,7 @@ object LocalEntityUseCases {
         return "md5:${Md5.getMd5Hash(serverList)!!}"
     }
 
-    private fun parseEntityFromRecord(
-        record: CSVRecord,
-        list: String
-    ): Entity.New? {
+    private fun parseEntityFromRecord(record: CSVRecord): Entity.New? {
         val map = record.toMap()
 
         val id = map.remove(EntityItemElement.ID)

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -7,7 +7,7 @@ import org.odk.collect.entities.javarosa.parse.EntityItemElement
 import org.odk.collect.entities.javarosa.spec.EntityAction
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
-import org.odk.collect.shared.strings.Md5
+import org.odk.collect.shared.strings.Md5.getMd5Hash
 import java.io.File
 import java.util.UUID
 
@@ -122,7 +122,7 @@ object LocalEntityUseCases {
     }
 
     private fun getListHash(serverList: File): String {
-        return "md5:${Md5.getMd5Hash(serverList)!!}"
+        return "md5:${serverList.getMd5Hash()!!}"
     }
 
     private fun parseEntityFromRecord(record: CSVRecord): ServerEntity? {

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -107,9 +107,6 @@ object LocalEntityUseCases {
                     serverEntity.version != existing.trunkVersion
                 ) {
                     val update = existing.copy(
-                        label = serverEntity.label,
-                        version = serverEntity.version,
-                        properties = serverEntity.properties.toList(),
                         state = Entity.State.ONLINE,
                         branchId = UUID.randomUUID().toString(),
                         trunkVersion = serverEntity.version

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -7,6 +7,7 @@ import org.odk.collect.entities.javarosa.parse.EntityItemElement
 import org.odk.collect.entities.javarosa.spec.EntityAction
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
+import org.odk.collect.shared.strings.Md5
 import java.io.File
 import java.util.UUID
 
@@ -56,6 +57,14 @@ object LocalEntityUseCases {
         serverList: File,
         entitiesRepository: EntitiesRepository
     ) {
+        val listMD5 = Md5.getMd5Hash(serverList)
+        val existingListMD5 = entitiesRepository.getListMD5(list)
+        if (listMD5 == existingListMD5) {
+            return
+        } else {
+            entitiesRepository.updateListMD5(list, listMD5!!)
+        }
+
         val csvParser = try {
             SecondaryInstanceCSVParserBuilder()
                 .path(serverList.absolutePath)

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -92,17 +92,11 @@ object LocalEntityUseCases {
                             branchId = UUID.randomUUID().toString()
                         )
                     )
-                } else if (existing.version <= serverEntity.version) {
-                    if (existing.isDirty() || serverEntity.version > existing.version) {
-                        val update = existing.copy(
-                            label = serverEntity.label,
-                            version = serverEntity.version,
-                            properties = serverEntity.properties.toList(),
-                            state = Entity.State.ONLINE,
-                            branchId = UUID.randomUUID().toString(),
-                            trunkVersion = serverEntity.version
-                        )
-                        newAndUpdated.add(update)
+                } else if (existing.version < serverEntity.version) {
+                    newAndUpdated.add(serverEntity.updateLocal(existing))
+                } else if (existing.version == serverEntity.version) {
+                    if (existing.isDirty()) {
+                        newAndUpdated.add(serverEntity.updateLocal(existing))
                     }
                 } else if (existing.state == Entity.State.OFFLINE) {
                     val update = existing.copy(state = Entity.State.ONLINE)
@@ -148,5 +142,16 @@ private data class ServerEntity(
     val id: String,
     val label: String,
     val version: Int,
-    val properties: Map<String, String>
-)
+    val properties: Map<String, String>) {
+
+    fun updateLocal(local: Entity.Saved): Entity.Saved {
+        return local.copy(
+            label = this.label,
+            version = this.version,
+            properties = this.properties.toList(),
+            state = Entity.State.ONLINE,
+            branchId = UUID.randomUUID().toString(),
+            trunkVersion = this.version
+        )
+    }
+}

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -61,8 +61,6 @@ object LocalEntityUseCases {
         val existingListMD5 = entitiesRepository.getListMD5(list)
         if (listMD5 == existingListMD5) {
             return
-        } else {
-            entitiesRepository.updateListMD5(list, listMD5!!)
         }
 
         val csvParser = try {
@@ -108,6 +106,8 @@ object LocalEntityUseCases {
         if (newAndUpdated.isNotEmpty()) {
             entitiesRepository.save(*newAndUpdated.toTypedArray())
         }
+
+        entitiesRepository.updateListMD5(list, listMD5!!)
     }
 
     private fun parseEntityFromRecord(

--- a/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
@@ -11,6 +11,6 @@ interface EntitiesRepository {
     fun getById(list: String, id: String): Entity.Saved?
     fun getAllByProperty(list: String, property: String, value: String): List<Entity.Saved>
     fun getByIndex(list: String, index: Int): Entity.Saved?
-    fun updateListVersion(list: String, version: String)
-    fun getListVersion(list: String): String?
+    fun updateListHash(list: String, hash: String)
+    fun getListHash(list: String): String?
 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
@@ -1,7 +1,7 @@
 package org.odk.collect.entities.storage
 
 interface EntitiesRepository {
-    fun save(vararg entities: Entity)
+    fun save(list: String, vararg entities: Entity)
     fun getLists(): Set<String>
     fun getEntities(list: String): List<Entity.Saved>
     fun getCount(list: String): Int

--- a/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
@@ -11,6 +11,6 @@ interface EntitiesRepository {
     fun getById(list: String, id: String): Entity.Saved?
     fun getAllByProperty(list: String, property: String, value: String): List<Entity.Saved>
     fun getByIndex(list: String, index: Int): Entity.Saved?
-    fun updateListMD5(list: String, md5: String)
-    fun getListMD5(list: String): String?
+    fun updateListVersion(list: String, version: String)
+    fun getListVersion(list: String): String?
 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/EntitiesRepository.kt
@@ -11,4 +11,6 @@ interface EntitiesRepository {
     fun getById(list: String, id: String): Entity.Saved?
     fun getAllByProperty(list: String, property: String, value: String): List<Entity.Saved>
     fun getByIndex(list: String, index: Int): Entity.Saved?
+    fun updateListMD5(list: String, md5: String)
+    fun getListMD5(list: String): String?
 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
@@ -1,7 +1,6 @@
 package org.odk.collect.entities.storage
 
 sealed interface Entity {
-    val list: String
     val id: String
     val label: String?
     val version: Int
@@ -11,7 +10,6 @@ sealed interface Entity {
     val branchId: String
 
     data class New(
-        override val list: String,
         override val id: String,
         override val label: String?,
         override val version: Int = 1,
@@ -22,7 +20,6 @@ sealed interface Entity {
     ) : Entity
 
     data class Saved(
-        override val list: String,
         override val id: String,
         override val label: String?,
         override val version: Int = 1,
@@ -46,7 +43,6 @@ sealed interface Entity {
 
     private fun convertToNew(entity: Entity): New {
         return New(
-            entity.list,
             entity.id,
             entity.label,
             entity.version,

--- a/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
@@ -8,7 +8,9 @@ sealed interface Entity {
     val state: State
 
     /**
-     * The server version (from an entity list CSV) this is based on.
+     * The server version (from an entity list CSV) this is based on. This should only be updated
+     * when updating an entity from the server where as [version] should be incremented whenever
+     * there is a local change.
      */
     val trunkVersion: Int?
 

--- a/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
@@ -6,7 +6,16 @@ sealed interface Entity {
     val version: Int
     val properties: List<Pair<String, String>>
     val state: State
+
+    /**
+     * The server version (from an entity list CSV) this is based on.
+     */
     val trunkVersion: Int?
+
+    /**
+     * The offline "branch" identifier. Should be updated whenever the local version is modified
+     * from the latest server version.
+     */
     val branchId: String
 
     fun isDirty(): Boolean {

--- a/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/Entity.kt
@@ -9,6 +9,10 @@ sealed interface Entity {
     val trunkVersion: Int?
     val branchId: String
 
+    fun isDirty(): Boolean {
+        return version != trunkVersion
+    }
+
     data class New(
         override val id: String,
         override val label: String?,

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -67,6 +67,14 @@ class InMemEntitiesRepository : EntitiesRepository {
         return getEntities(list).firstOrNull { it.index == index }
     }
 
+    override fun updateListMD5(list: String, md5: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getListMD5(list: String): String? {
+        TODO("Not yet implemented")
+    }
+
     override fun save(vararg entities: Entity) {
         entities.forEach { entity ->
             updateLists(entity)

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -67,11 +67,11 @@ class InMemEntitiesRepository : EntitiesRepository {
         return getEntities(list).firstOrNull { it.index == index }
     }
 
-    override fun updateListMD5(list: String, md5: String) {
+    override fun updateListVersion(list: String, version: String) {
         TODO("Not yet implemented")
     }
 
-    override fun getListMD5(list: String): String? {
+    override fun getListVersion(list: String): String? {
         TODO("Not yet implemented")
     }
 

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -77,7 +77,13 @@ class InMemEntitiesRepository : EntitiesRepository {
     }
 
     override fun save(vararg entities: Entity) {
+        val list = entities.first().list
+
         entities.forEach { entity ->
+            if (entity.list != list) {
+                throw IllegalArgumentException()
+            }
+
             updateLists(entity)
             val existing = this.entities.find { it.id == entity.id && it.list == entity.list }
 

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -70,11 +70,11 @@ class InMemEntitiesRepository : EntitiesRepository {
         return getEntities(list).firstOrNull { it.index == index }
     }
 
-    override fun updateListVersion(list: String, version: String) {
-        listVersions[list] = version
+    override fun updateListHash(list: String, hash: String) {
+        listVersions[list] = hash
     }
 
-    override fun getListVersion(list: String): String? {
+    override fun getListHash(list: String): String? {
         return listVersions[list]
     }
 

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -5,20 +5,20 @@ class InMemEntitiesRepository : EntitiesRepository {
     private val lists = mutableSetOf<String>()
     private val listProperties = mutableMapOf<String, MutableSet<String>>()
     private val listVersions = mutableMapOf<String, String>()
-    private val entities = mutableListOf<Entity.New>()
+    private val entities = mutableMapOf<String, MutableList<Entity.New>>()
 
     override fun getLists(): Set<String> {
         return lists
     }
 
     override fun getEntities(list: String): List<Entity.Saved> {
-        return entities.filter { it.list == list }.mapIndexed { index, entity ->
+        val entities = entities[list] ?: emptyList()
+        return entities.mapIndexed { index, entity ->
             Entity.Saved(
-                entity.list,
                 entity.id,
                 entity.label,
                 entity.version,
-                buildProperties(entity),
+                buildProperties(list, entity),
                 entity.state,
                 index,
                 entity.trunkVersion,
@@ -41,7 +41,9 @@ class InMemEntitiesRepository : EntitiesRepository {
     }
 
     override fun delete(id: String) {
-        entities.removeIf { it.id == id }
+        entities.forEach { (_, list) ->
+            list.removeIf { it.id == id }
+        }
     }
 
     override fun getById(list: String, id: String): Entity.Saved? {
@@ -76,16 +78,12 @@ class InMemEntitiesRepository : EntitiesRepository {
         return listVersions[list]
     }
 
-    override fun save(vararg entities: Entity) {
-        val list = entities.first().list
+    override fun save(list: String, vararg entities: Entity) {
+        val entityList = this.entities.getOrPut(list) { mutableListOf() }
 
         entities.forEach { entity ->
-            if (entity.list != list) {
-                throw IllegalArgumentException()
-            }
-
-            updateLists(entity)
-            val existing = this.entities.find { it.id == entity.id && it.list == entity.list }
+            updateLists(list, entity)
+            val existing = entityList.find { it.id == entity.id }
 
             if (existing != null) {
                 val state = when (existing.state) {
@@ -93,10 +91,9 @@ class InMemEntitiesRepository : EntitiesRepository {
                     Entity.State.ONLINE -> Entity.State.ONLINE
                 }
 
-                this.entities.remove(existing)
-                this.entities.add(
+                entityList.remove(existing)
+                entityList.add(
                     Entity.New(
-                        entity.list,
                         entity.id,
                         entity.label ?: existing.label,
                         version = entity.version,
@@ -107,9 +104,8 @@ class InMemEntitiesRepository : EntitiesRepository {
                     )
                 )
             } else {
-                this.entities.add(
+                entityList.add(
                     Entity.New(
-                        entity.list,
                         entity.id,
                         entity.label,
                         entity.version,
@@ -123,9 +119,9 @@ class InMemEntitiesRepository : EntitiesRepository {
         }
     }
 
-    private fun updateLists(entity: Entity) {
-        lists.add(entity.list)
-        listProperties.getOrPut(entity.list) {
+    private fun updateLists(list: String, entity: Entity) {
+        lists.add(list)
+        listProperties.getOrPut(list) {
             mutableSetOf()
         }.addAll(entity.properties.map { it.first })
     }
@@ -142,8 +138,8 @@ class InMemEntitiesRepository : EntitiesRepository {
         return existingProperties.map { Pair(it.key, it.value) }
     }
 
-    private fun buildProperties(entity: Entity.New): List<Pair<String, String>> {
-        return listProperties[entity.list]?.map { property ->
+    private fun buildProperties(list: String, entity: Entity.New): List<Pair<String, String>> {
+        return listProperties[list]?.map { property ->
             Pair(
                 property,
                 entity.properties.find { it.first == property }?.second ?: ""

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -4,6 +4,7 @@ class InMemEntitiesRepository : EntitiesRepository {
 
     private val lists = mutableSetOf<String>()
     private val listProperties = mutableMapOf<String, MutableSet<String>>()
+    private val listVersions = mutableMapOf<String, String>()
     private val entities = mutableListOf<Entity.New>()
 
     override fun getLists(): Set<String> {
@@ -68,11 +69,11 @@ class InMemEntitiesRepository : EntitiesRepository {
     }
 
     override fun updateListVersion(list: String, version: String) {
-        TODO("Not yet implemented")
+        listVersions[list] = version
     }
 
     override fun getListVersion(list: String): String? {
-        TODO("Not yet implemented")
+        return listVersions[list]
     }
 
     override fun save(vararg entities: Entity) {

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -153,7 +153,24 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer overrides offline version if the online version is newer`() {
-        val offline = Entity.New("noah", "Noa", 1)
+        val offline = Entity.New("noah", "Noa", 1, trunkVersion = 1)
+        entitiesRepository.save("songs", offline)
+        val csv = createEntityList(Entity.New("noah", "Noah", 2))
+
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
+        val songs = entitiesRepository.getEntities("songs")
+        assertThat(songs.size, equalTo(1))
+        assertThat(songs[0].label, equalTo("Noah"))
+        assertThat(songs[0].version, equalTo(2))
+        assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
+        assertThat(songs[0].trunkVersion, equalTo(2))
+        assertThat(songs[0].branchId, not(blankOrNullString()))
+        assertThat(songs[0].branchId, not(equalTo(offline.branchId)))
+    }
+
+    @Test
+    fun `updateLocalEntitiesFromServer overrides offline version if the online version is newer and the offline version is dirty`() {
+        val offline = Entity.New("noah", "Noa", 1, trunkVersion = null)
         entitiesRepository.save("songs", offline)
         val csv = createEntityList(Entity.New("noah", "Noah", 2))
 

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -306,7 +306,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntitiesFromServer accesses entities repo only twice when saving multiple entities`() {
+    fun `updateLocalEntitiesFromServer accesses entities repo only 4 times when saving multiple entities`() {
         val csv = createEntityList(
             Entity.New("songs", "noah", "Noah"),
             Entity.New("songs", "seven-trumpets", "Seven Trumpets")
@@ -314,7 +314,7 @@ class LocalEntityUseCasesTest {
 
         val entitiesRepository = MeasurableEntitiesRepository(entitiesRepository)
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
-        assertThat(entitiesRepository.accesses, equalTo(2))
+        assertThat(entitiesRepository.accesses, equalTo(4))
     }
 
     @Test
@@ -461,5 +461,15 @@ private class MeasurableEntitiesRepository(private val wrapped: EntitiesReposito
     override fun getByIndex(list: String, index: Int): Entity.Saved? {
         accesses += 1
         return wrapped.getByIndex(list, index)
+    }
+
+    override fun updateListVersion(list: String, version: String) {
+        accesses += 1
+        wrapped.updateListVersion(list, version)
+    }
+
+    override fun getListVersion(list: String): String? {
+        accesses += 1
+        return wrapped.getListVersion(list)
     }
 }

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -7,7 +7,6 @@ import org.hamcrest.Matchers.blankOrNullString
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
-import org.junit.Ignore
 import org.junit.Test
 import org.odk.collect.entities.javarosa.finalization.EntitiesExtra
 import org.odk.collect.entities.javarosa.finalization.FormEntity

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -42,6 +42,7 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromForm increments version on update`() {
         entitiesRepository.save(
+            "things",
             Entity.New(
                 "id",
                 "label",
@@ -62,6 +63,7 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromForm updates properties on update`() {
         entitiesRepository.save(
+            "things",
             Entity.New(
                 "id",
                 "label",
@@ -84,6 +86,7 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromForm does not override trunk version or branchId on update`() {
         entitiesRepository.save(
+            "things",
             Entity.New(
                 "id",
                 "label",
@@ -129,7 +132,7 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromServer overrides offline version if the online version is newer`() {
         val offline = Entity.New("noah", "Noa", 1)
-        entitiesRepository.save(offline)
+        entitiesRepository.save("songs", offline)
         val csv = createEntityList(Entity.New("noah", "Noah", 2))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
@@ -146,7 +149,7 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromServer updates state if the online version is older`() {
         val offline = Entity.New("noah", "Noah", 2)
-        entitiesRepository.save(offline)
+        entitiesRepository.save("songs", offline)
         val csv = createEntityList(Entity.New("noah", "Noa", 1))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
@@ -162,7 +165,7 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromServer overrides offline version if the online version is the same`() {
         val offline = Entity.New("noah", "Noah", 2)
-        entitiesRepository.save(offline)
+        entitiesRepository.save("songs", offline)
         val csv = createEntityList(
             Entity.New(
                 "noah",
@@ -201,13 +204,13 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromServer updates trunkVersion, branchId and state if the online version catches up to an offline branch`() {
         val offline = Entity.New("noah", "Noah", 2)
-        entitiesRepository.save(offline)
+        entitiesRepository.save("songs", offline)
 
         val csv1 = createEntityList(Entity.New("noah", "Noah", 2))
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv1, entitiesRepository)
 
         val onlineBranched = Entity.New("noah", "Noah", 3)
-        entitiesRepository.save(onlineBranched)
+        entitiesRepository.save("songs", onlineBranched)
         val csv2 = createEntityList(Entity.New("noah", "Noah", 3))
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv2, entitiesRepository)
 
@@ -222,7 +225,7 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer ignores properties not in offline version from older online version`() {
-        entitiesRepository.save(Entity.New("noah", "Noah", 3))
+        entitiesRepository.save("songs", Entity.New("noah", "Noah", 3))
         val csv =
             createEntityList(Entity.New("noah", "Noah", 2, listOf(Pair("length", "6:38"))))
 
@@ -235,6 +238,7 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromServer overrides properties in offline version from newer list version`() {
         entitiesRepository.save(
+            "songs",
             Entity.New("noah", "Noah", 1, listOf(Pair("length", "6:38")))
         )
         val csv =
@@ -315,7 +319,7 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer does not remove offline entities that are not in online entities`() {
-        entitiesRepository.save(Entity.New("noah", "Noah"))
+        entitiesRepository.save("songs", Entity.New("noah", "Noah"))
         val csv = createEntityList(Entity.New("cathedrals", "Cathedrals"))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
@@ -325,7 +329,7 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer removes offline entity that was in online list, but isn't any longer`() {
-        entitiesRepository.save(Entity.New("cathedrals", "Cathedrals"))
+        entitiesRepository.save("songs", Entity.New("cathedrals", "Cathedrals"))
 
         val firstCsv = createEntityList(Entity.New("cathedrals", "Cathedrals"))
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", firstCsv, entitiesRepository)
@@ -340,7 +344,7 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer removes offline entity that was updated in online list, but isn't any longer`() {
-        entitiesRepository.save(Entity.New("cathedrals", "Cathedrals", version = 1))
+        entitiesRepository.save("songs", Entity.New("cathedrals", "Cathedrals", version = 1))
 
         val firstCsv =
             createEntityList(Entity.New("cathedrals", "Cathedrals (A Song)", version = 2))
@@ -405,10 +409,10 @@ private class MeasurableEntitiesRepository(private val wrapped: EntitiesReposito
     var savedEntities: Int = 0
         private set
 
-    override fun save(vararg entities: Entity) {
+    override fun save(list: String, vararg entities: Entity) {
         accesses += 1
         savedEntities += entities.size
-        wrapped.save(*entities)
+        wrapped.save(list, *entities)
     }
 
     override fun getLists(): Set<String> {

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -328,18 +328,6 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntitiesFromServer accesses entities repo only 4 times when saving multiple entities`() {
-        val csv = createEntityList(
-            Entity.New("noah", "Noah"),
-            Entity.New("seven-trumpets", "Seven Trumpets")
-        )
-
-        val entitiesRepository = MeasurableEntitiesRepository(entitiesRepository)
-        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
-        assertThat(entitiesRepository.accesses, equalTo(4))
-    }
-
-    @Test
     fun `updateLocalEntitiesFromServer does not remove offline entities that are not in online entities`() {
         entitiesRepository.save("songs", Entity.New("noah", "Noah"))
         val csv = createEntityList(Entity.New("cathedrals", "Cathedrals"))

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -43,7 +43,6 @@ class LocalEntityUseCasesTest {
     fun `updateLocalEntitiesFromForm increments version on update`() {
         entitiesRepository.save(
             Entity.New(
-                "things",
                 "id",
                 "label",
                 version = 1
@@ -64,7 +63,6 @@ class LocalEntityUseCasesTest {
     fun `updateLocalEntitiesFromForm updates properties on update`() {
         entitiesRepository.save(
             Entity.New(
-                "things",
                 "id",
                 "label",
                 version = 1,
@@ -87,7 +85,6 @@ class LocalEntityUseCasesTest {
     fun `updateLocalEntitiesFromForm does not override trunk version or branchId on update`() {
         entitiesRepository.save(
             Entity.New(
-                "things",
                 "id",
                 "label",
                 version = 1,
@@ -131,9 +128,9 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer overrides offline version if the online version is newer`() {
-        val offline = Entity.New("songs", "noah", "Noa", 1)
+        val offline = Entity.New("noah", "Noa", 1)
         entitiesRepository.save(offline)
-        val csv = createEntityList(Entity.New("songs", "noah", "Noah", 2))
+        val csv = createEntityList(Entity.New("noah", "Noah", 2))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
@@ -148,9 +145,9 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer updates state if the online version is older`() {
-        val offline = Entity.New("songs", "noah", "Noah", 2)
+        val offline = Entity.New("noah", "Noah", 2)
         entitiesRepository.save(offline)
-        val csv = createEntityList(Entity.New("songs", "noah", "Noa", 1))
+        val csv = createEntityList(Entity.New("noah", "Noa", 1))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
@@ -164,11 +161,10 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer overrides offline version if the online version is the same`() {
-        val offline = Entity.New("songs", "noah", "Noah", 2)
+        val offline = Entity.New("noah", "Noah", 2)
         entitiesRepository.save(offline)
         val csv = createEntityList(
             Entity.New(
-                "songs",
                 "noah",
                 "Noa",
                 2,
@@ -192,27 +188,27 @@ class LocalEntityUseCasesTest {
     fun `updateLocalEntitiesFromServer does not write to repository if online and local are exactly the same`() {
         val entitiesRepository = MeasurableEntitiesRepository(entitiesRepository)
 
-        val local = Entity.New("songs", "noah", "Noah", 2, properties = listOf("length" to "4:33"))
+        val local = Entity.New("noah", "Noah", 2, properties = listOf("length" to "4:33"))
         val csv1 = createEntityList(local)
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv1, entitiesRepository)
         assertThat(entitiesRepository.savedEntities, equalTo(1))
 
-        val csv2 = createEntityList(local, Entity.New("songs", "perception", "Perception"))
+        val csv2 = createEntityList(local, Entity.New("perception", "Perception"))
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv2, entitiesRepository)
         assertThat(entitiesRepository.savedEntities, equalTo(2))
     }
 
     @Test
     fun `updateLocalEntitiesFromServer updates trunkVersion, branchId and state if the online version catches up to an offline branch`() {
-        val offline = Entity.New("songs", "noah", "Noah", 2)
+        val offline = Entity.New("noah", "Noah", 2)
         entitiesRepository.save(offline)
 
-        val csv1 = createEntityList(Entity.New("songs", "noah", "Noah", 2))
+        val csv1 = createEntityList(Entity.New("noah", "Noah", 2))
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv1, entitiesRepository)
 
-        val onlineBranched = Entity.New("songs", "noah", "Noah", 3)
+        val onlineBranched = Entity.New("noah", "Noah", 3)
         entitiesRepository.save(onlineBranched)
-        val csv2 = createEntityList(Entity.New("songs", "noah", "Noah", 3))
+        val csv2 = createEntityList(Entity.New("noah", "Noah", 3))
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv2, entitiesRepository)
 
         val songs = entitiesRepository.getEntities("songs")
@@ -226,9 +222,9 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer ignores properties not in offline version from older online version`() {
-        entitiesRepository.save(Entity.New("songs", "noah", "Noah", 3))
+        entitiesRepository.save(Entity.New("noah", "Noah", 3))
         val csv =
-            createEntityList(Entity.New("songs", "noah", "Noah", 2, listOf(Pair("length", "6:38"))))
+            createEntityList(Entity.New("noah", "Noah", 2, listOf(Pair("length", "6:38"))))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
@@ -239,10 +235,10 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromServer overrides properties in offline version from newer list version`() {
         entitiesRepository.save(
-            Entity.New("songs", "noah", "Noah", 1, listOf(Pair("length", "6:38")))
+            Entity.New("noah", "Noah", 1, listOf(Pair("length", "6:38")))
         )
         val csv =
-            createEntityList(Entity.New("songs", "noah", "Noah", 2, listOf(Pair("length", "4:58"))))
+            createEntityList(Entity.New("noah", "Noah", 2, listOf(Pair("length", "4:58"))))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
@@ -289,7 +285,7 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer adds online entity when its label is blank`() {
-        val csv = createEntityList(Entity.New("songs", "cathedrals", label = ""))
+        val csv = createEntityList(Entity.New("cathedrals", label = ""))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
@@ -308,8 +304,8 @@ class LocalEntityUseCasesTest {
     @Test
     fun `updateLocalEntitiesFromServer accesses entities repo only 4 times when saving multiple entities`() {
         val csv = createEntityList(
-            Entity.New("songs", "noah", "Noah"),
-            Entity.New("songs", "seven-trumpets", "Seven Trumpets")
+            Entity.New("noah", "Noah"),
+            Entity.New("seven-trumpets", "Seven Trumpets")
         )
 
         val entitiesRepository = MeasurableEntitiesRepository(entitiesRepository)
@@ -319,8 +315,8 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer does not remove offline entities that are not in online entities`() {
-        entitiesRepository.save(Entity.New("songs", "noah", "Noah"))
-        val csv = createEntityList(Entity.New("songs", "cathedrals", "Cathedrals"))
+        entitiesRepository.save(Entity.New("noah", "Noah"))
+        val csv = createEntityList(Entity.New("cathedrals", "Cathedrals"))
 
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
         val songs = entitiesRepository.getEntities("songs")
@@ -329,12 +325,12 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer removes offline entity that was in online list, but isn't any longer`() {
-        entitiesRepository.save(Entity.New("songs", "cathedrals", "Cathedrals"))
+        entitiesRepository.save(Entity.New("cathedrals", "Cathedrals"))
 
-        val firstCsv = createEntityList(Entity.New("songs", "cathedrals", "Cathedrals"))
+        val firstCsv = createEntityList(Entity.New("cathedrals", "Cathedrals"))
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", firstCsv, entitiesRepository)
 
-        val secondCsv = createEntityList(Entity.New("songs", "noah", "Noah"))
+        val secondCsv = createEntityList(Entity.New("noah", "Noah"))
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", secondCsv, entitiesRepository)
 
         val songs = entitiesRepository.getEntities("songs")
@@ -344,10 +340,10 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer removes offline entity that was updated in online list, but isn't any longer`() {
-        entitiesRepository.save(Entity.New("songs", "cathedrals", "Cathedrals", version = 1))
+        entitiesRepository.save(Entity.New("cathedrals", "Cathedrals", version = 1))
 
         val firstCsv =
-            createEntityList(Entity.New("songs", "cathedrals", "Cathedrals (A Song)", version = 2))
+            createEntityList(Entity.New("cathedrals", "Cathedrals (A Song)", version = 2))
         LocalEntityUseCases.updateLocalEntitiesFromServer("songs", firstCsv, entitiesRepository)
 
         val secondCsv = createEntityList()

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -190,14 +190,16 @@ class LocalEntityUseCasesTest {
 
     @Test
     fun `updateLocalEntitiesFromServer does not write to repository if online and local are exactly the same`() {
-        val local = Entity.New("songs", "noah", "Noah", 2, properties = listOf("length" to "4:33"))
-        val csv = createEntityList(local)
-        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
-
         val entitiesRepository = MeasurableEntitiesRepository(entitiesRepository)
-        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
 
-        assertThat(entitiesRepository.accesses, equalTo(1))
+        val local = Entity.New("songs", "noah", "Noah", 2, properties = listOf("length" to "4:33"))
+        val csv1 = createEntityList(local)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv1, entitiesRepository)
+        assertThat(entitiesRepository.savedEntities, equalTo(1))
+
+        val csv2 = createEntityList(local, Entity.New("songs", "perception", "Perception"))
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv2, entitiesRepository)
+        assertThat(entitiesRepository.savedEntities, equalTo(2))
     }
 
     @Test
@@ -404,8 +406,12 @@ private class MeasurableEntitiesRepository(private val wrapped: EntitiesReposito
     var accesses: Int = 0
         private set
 
+    var savedEntities: Int = 0
+        private set
+
     override fun save(vararg entities: Entity) {
         accesses += 1
+        savedEntities += entities.size
         wrapped.save(*entities)
     }
 

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -211,7 +211,6 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    @Ignore
     fun `updateLocalEntitiesFromServer does not write to repository if online and local are exactly the same`() {
         val entitiesRepository = MeasurableEntitiesRepository(entitiesRepository)
 

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -4,7 +4,6 @@ import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVPrinter
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.blankOrNullString
-import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.Test
@@ -182,31 +181,6 @@ class LocalEntityUseCasesTest {
         assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
         assertThat(songs[0].trunkVersion, equalTo(null))
         assertThat(songs[0].branchId, equalTo(offline.branchId))
-    }
-
-    @Test
-    fun `updateLocalEntitiesFromServer overrides offline version if the online version is the same`() {
-        val offline = Entity.New("noah", "Noah", 2)
-        entitiesRepository.save("songs", offline)
-        val csv = createEntityList(
-            Entity.New(
-                "noah",
-                "Noa",
-                2,
-                properties = listOf("length" to "4:33")
-            )
-        )
-
-        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
-        val songs = entitiesRepository.getEntities("songs")
-        assertThat(songs.size, equalTo(1))
-        assertThat(songs[0].label, equalTo("Noa"))
-        assertThat(songs[0].properties, containsInAnyOrder("length" to "4:33"))
-        assertThat(songs[0].version, equalTo(2))
-        assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
-        assertThat(songs[0].trunkVersion, equalTo(2))
-        assertThat(songs[0].branchId, not(blankOrNullString()))
-        assertThat(songs[0].branchId, not(equalTo(offline.branchId)))
     }
 
     @Test

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -485,13 +485,13 @@ private class MeasurableEntitiesRepository(private val wrapped: EntitiesReposito
         return wrapped.getByIndex(list, index)
     }
 
-    override fun updateListVersion(list: String, version: String) {
+    override fun updateListHash(list: String, hash: String) {
         accesses += 1
-        wrapped.updateListVersion(list, version)
+        wrapped.updateListHash(list, hash)
     }
 
-    override fun getListVersion(list: String): String? {
+    override fun getListHash(list: String): String? {
         accesses += 1
-        return wrapped.getListVersion(list)
+        return wrapped.getListHash(list)
     }
 }

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -7,6 +7,7 @@ import org.hamcrest.Matchers.blankOrNullString
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
+import org.junit.Ignore
 import org.junit.Test
 import org.odk.collect.entities.javarosa.finalization.EntitiesExtra
 import org.odk.collect.entities.javarosa.finalization.FormEntity
@@ -130,6 +131,28 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
+    fun `updateLocalEntitiesFromServer saves entity from server`() {
+        val csv = createEntityList(
+            Entity.New(
+                "noah",
+                "Noah",
+                2,
+                properties = listOf("property" to "value")
+            )
+        )
+
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
+        val songs = entitiesRepository.getEntities("songs")
+        assertThat(songs.size, equalTo(1))
+        assertThat(songs[0].label, equalTo("Noah"))
+        assertThat(songs[0].version, equalTo(2))
+        assertThat(songs[0].properties, equalTo(listOf("property" to "value")))
+        assertThat(songs[0].state, equalTo(Entity.State.ONLINE))
+        assertThat(songs[0].trunkVersion, equalTo(2))
+        assertThat(songs[0].branchId, not(blankOrNullString()))
+    }
+
+    @Test
     fun `updateLocalEntitiesFromServer overrides offline version if the online version is newer`() {
         val offline = Entity.New("noah", "Noa", 1)
         entitiesRepository.save("songs", offline)
@@ -188,6 +211,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
+    @Ignore
     fun `updateLocalEntitiesFromServer does not write to repository if online and local are exactly the same`() {
         val entitiesRepository = MeasurableEntitiesRepository(entitiesRepository)
 

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -189,6 +189,18 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
+    fun `updateLocalEntitiesFromServer does not write to repository if online and local are exactly the same`() {
+        val local = Entity.New("songs", "noah", "Noah", 2, properties = listOf("length" to "4:33"))
+        val csv = createEntityList(local)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
+
+        val entitiesRepository = MeasurableEntitiesRepository(entitiesRepository)
+        LocalEntityUseCases.updateLocalEntitiesFromServer("songs", csv, entitiesRepository)
+
+        assertThat(entitiesRepository.accesses, equalTo(1))
+    }
+
+    @Test
     fun `updateLocalEntitiesFromServer updates trunkVersion, branchId and state if the online version catches up to an offline branch`() {
         val offline = Entity.New("songs", "noah", "Noah", 2)
         entitiesRepository.save(offline)
@@ -441,6 +453,7 @@ private class MeasurableEntitiesRepository(private val wrapped: EntitiesReposito
     }
 
     override fun getByIndex(list: String, index: Int): Entity.Saved? {
+        accesses += 1
         return wrapped.getByIndex(list, index)
     }
 }

--- a/entities/src/test/java/org/odk/collect/entities/browser/EntityItemViewTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/browser/EntityItemViewTest.kt
@@ -21,7 +21,6 @@ class EntityItemViewTest {
         val view = EntityItemView(context)
         view.setEntity(
             Entity.Saved(
-                "songs",
                 "1",
                 "S.D.O.S",
                 properties = listOf(Pair("name", "S.D.O.S"), Pair("length", "2:50")),
@@ -36,7 +35,7 @@ class EntityItemViewTest {
     @Test
     fun `shows offline pill when entity is offline`() {
         val view = EntityItemView(context)
-        val entity = Entity.Saved("songs", "1", "S.D.O.S", index = 0)
+        val entity = Entity.Saved("1", "S.D.O.S", index = 0)
 
         view.setEntity(entity.copy(state = Entity.State.OFFLINE))
         assertThat(view.binding.offlinePill.isVisible, equalTo(true))
@@ -48,7 +47,7 @@ class EntityItemViewTest {
     @Test
     fun `shows id and version`() {
         val view = EntityItemView(context)
-        val entity = Entity.Saved("songs", "1", "S.D.O.S", version = 11, index = 0)
+        val entity = Entity.Saved("1", "S.D.O.S", version = 11, index = 0)
 
         view.setEntity(entity.copy(state = Entity.State.OFFLINE))
         assertThat(view.binding.id.text, equalTo("${entity.id} (${entity.version})"))

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
@@ -20,7 +20,7 @@ class LocalEntitiesInstanceProviderTest {
                 "Shiv Roy",
                 properties = listOf(Pair("age", "35"), Pair("born", "England"))
             )
-        entitiesRepository.save(entity)
+        entitiesRepository.save("people", entity)
 
         val parser = LocalEntitiesInstanceProvider { entitiesRepository }
         val instance = parser.get("people", "people.csv")
@@ -40,7 +40,7 @@ class LocalEntitiesInstanceProviderTest {
                 "Shiv Roy",
                 version = 1
             )
-        entitiesRepository.save(entity)
+        entitiesRepository.save("people", entity)
 
         val parser = LocalEntitiesInstanceProvider { entitiesRepository }
         val instance = parser.get("people", "people.csv")
@@ -59,7 +59,7 @@ class LocalEntitiesInstanceProviderTest {
                 "Shiv Roy",
                 trunkVersion = 1
             )
-        entitiesRepository.save(entity)
+        entitiesRepository.save("people", entity)
 
         val parser = LocalEntitiesInstanceProvider { entitiesRepository }
         val instance = parser.get("people", "people.csv")
@@ -78,7 +78,7 @@ class LocalEntitiesInstanceProviderTest {
                 "Shiv Roy",
                 branchId = "branch-1"
             )
-        entitiesRepository.save(entity)
+        entitiesRepository.save("people", entity)
 
         val parser = LocalEntitiesInstanceProvider { entitiesRepository }
         val instance = parser.get("people", "people.csv")
@@ -100,7 +100,7 @@ class LocalEntitiesInstanceProviderTest {
                 "Shiv Roy",
                 trunkVersion = null
             )
-        entitiesRepository.save(entity)
+        entitiesRepository.save("people", entity)
 
         val parser = LocalEntitiesInstanceProvider { entitiesRepository }
         val instance = parser.get("people", "people.csv")
@@ -126,7 +126,7 @@ class LocalEntitiesInstanceProviderTest {
                 version = 1
             )
         )
-        entitiesRepository.save(*entity)
+        entitiesRepository.save("people", *entity)
 
         val parser = LocalEntitiesInstanceProvider { entitiesRepository }
         val instance = parser.get("people", "people.csv", true)
@@ -158,7 +158,7 @@ class LocalEntitiesInstanceProviderTest {
         )
 
         val repository = InMemEntitiesRepository()
-        repository.save(*entities)
+        repository.save("people", *entities)
 
         val parser = LocalEntitiesInstanceProvider { repository }
         val instance = parser.get("people", "people.csv", false)

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
@@ -16,7 +16,6 @@ class LocalEntitiesInstanceProviderTest {
     fun `includes properties in local entity elements`() {
         val entity =
             Entity.New(
-                "people",
                 "1",
                 "Shiv Roy",
                 properties = listOf(Pair("age", "35"), Pair("born", "England"))
@@ -37,7 +36,6 @@ class LocalEntitiesInstanceProviderTest {
     fun `includes version in local entity elements`() {
         val entity =
             Entity.New(
-                "people",
                 "1",
                 "Shiv Roy",
                 version = 1
@@ -57,7 +55,6 @@ class LocalEntitiesInstanceProviderTest {
     fun `includes trunk version in local entity elements`() {
         val entity =
             Entity.New(
-                "people",
                 "1",
                 "Shiv Roy",
                 trunkVersion = 1
@@ -77,7 +74,6 @@ class LocalEntitiesInstanceProviderTest {
     fun `includes branch id in local entity elements`() {
         val entity =
             Entity.New(
-                "people",
                 "1",
                 "Shiv Roy",
                 branchId = "branch-1"
@@ -100,7 +96,6 @@ class LocalEntitiesInstanceProviderTest {
     fun `includes blank trunk version when it is null`() {
         val entity =
             Entity.New(
-                "people",
                 "1",
                 "Shiv Roy",
                 trunkVersion = null
@@ -119,14 +114,12 @@ class LocalEntitiesInstanceProviderTest {
     fun `partial parse returns elements without values for first item and just item for others`() {
         val entity = arrayOf(
             Entity.New(
-                "people",
                 "1",
                 "Shiv Roy",
                 properties = listOf(Pair("age", "35")),
                 version = 1
             ),
             Entity.New(
-                "people",
                 "2",
                 "Kendall Roy",
                 properties = listOf(Pair("age", "40")),
@@ -155,12 +148,10 @@ class LocalEntitiesInstanceProviderTest {
     fun `uses entity index for multiplicity`() {
         val entities = arrayOf(
             Entity.New(
-                "people",
                 "1",
                 "Shiv Roy"
             ),
             Entity.New(
-                "people",
                 "2",
                 "Kendall Roy"
             )

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -66,8 +66,8 @@ class LocalEntitiesFilterStrategyTest {
 
     @Test
     fun `returns matching nodes when entity matches name`() {
-        entitiesRepository.save(Entity.New("thing1", "Thing 1"))
-        entitiesRepository.save(Entity.New("thing2", "Thing 2"))
+        entitiesRepository.save("things", Entity.New("thing1", "Thing 1"))
+        entitiesRepository.save("things", Entity.New("thing2", "Thing 2"))
 
         val scenario = Scenario.init(
             "Secondary instance form",
@@ -102,6 +102,7 @@ class LocalEntitiesFilterStrategyTest {
     @Test
     fun `replaces partial elements when entity matches name`() {
         entitiesRepository.save(
+            "things",
             Entity.New("thing", "Thing"),
             Entity.New("other", "Other")
         )
@@ -171,7 +172,7 @@ class LocalEntitiesFilterStrategyTest {
 
     @Test
     fun `works correctly with name != expressions`() {
-        entitiesRepository.save(Entity.New("thing", "Thing"))
+        entitiesRepository.save("things", Entity.New("thing", "Thing"))
 
         val scenario = Scenario.init(
             "Secondary instance form",
@@ -204,7 +205,7 @@ class LocalEntitiesFilterStrategyTest {
 
     @Test
     fun `works correctly with non eq name expressions`() {
-        entitiesRepository.save(Entity.New("thing", "Thing"))
+        entitiesRepository.save("things", Entity.New("thing", "Thing"))
 
         val scenario = Scenario.init(
             "Secondary instance form",
@@ -272,6 +273,7 @@ class LocalEntitiesFilterStrategyTest {
     @Test
     fun `returns matching nodes when entity matches property`() {
         entitiesRepository.save(
+            "things",
             Entity.New(
                 "thing1",
                 "Thing1",
@@ -325,6 +327,7 @@ class LocalEntitiesFilterStrategyTest {
     @Test
     fun `replaces partial elements when entity matches property`() {
         entitiesRepository.save(
+            "things",
             Entity.New(
                 "thing1",
                 "Thing1",
@@ -367,6 +370,7 @@ class LocalEntitiesFilterStrategyTest {
     @Test
     fun `works correctly with label = expressions`() {
         entitiesRepository.save(
+            "things",
             Entity.New(
                 "thing1",
                 "Thing1",
@@ -409,6 +413,7 @@ class LocalEntitiesFilterStrategyTest {
     @Test
     fun `works correctly with version = expressions`() {
         entitiesRepository.save(
+            "things",
             Entity.New(
                 "thing1",
                 "Thing1",

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -66,8 +66,8 @@ class LocalEntitiesFilterStrategyTest {
 
     @Test
     fun `returns matching nodes when entity matches name`() {
-        entitiesRepository.save(Entity.New("things", "thing1", "Thing 1"))
-        entitiesRepository.save(Entity.New("things", "thing2", "Thing 2"))
+        entitiesRepository.save(Entity.New("thing1", "Thing 1"))
+        entitiesRepository.save(Entity.New("thing2", "Thing 2"))
 
         val scenario = Scenario.init(
             "Secondary instance form",
@@ -102,8 +102,8 @@ class LocalEntitiesFilterStrategyTest {
     @Test
     fun `replaces partial elements when entity matches name`() {
         entitiesRepository.save(
-            Entity.New("things", "thing", "Thing"),
-            Entity.New("things", "other", "Other")
+            Entity.New("thing", "Thing"),
+            Entity.New("other", "Other")
         )
 
         Scenario.init(
@@ -171,7 +171,7 @@ class LocalEntitiesFilterStrategyTest {
 
     @Test
     fun `works correctly with name != expressions`() {
-        entitiesRepository.save(Entity.New("things", "thing", "Thing"))
+        entitiesRepository.save(Entity.New("thing", "Thing"))
 
         val scenario = Scenario.init(
             "Secondary instance form",
@@ -204,7 +204,7 @@ class LocalEntitiesFilterStrategyTest {
 
     @Test
     fun `works correctly with non eq name expressions`() {
-        entitiesRepository.save(Entity.New("things", "thing", "Thing"))
+        entitiesRepository.save(Entity.New("thing", "Thing"))
 
         val scenario = Scenario.init(
             "Secondary instance form",
@@ -273,19 +273,16 @@ class LocalEntitiesFilterStrategyTest {
     fun `returns matching nodes when entity matches property`() {
         entitiesRepository.save(
             Entity.New(
-                "things",
                 "thing1",
                 "Thing1",
                 properties = listOf("property" to "value")
             ),
             Entity.New(
-                "things",
                 "thing2",
                 "Thing2",
                 properties = listOf("property" to "value")
             ),
             Entity.New(
-                "things",
                 "other",
                 "Other",
                 properties = listOf("property" to "other")
@@ -329,7 +326,6 @@ class LocalEntitiesFilterStrategyTest {
     fun `replaces partial elements when entity matches property`() {
         entitiesRepository.save(
             Entity.New(
-                "things",
                 "thing1",
                 "Thing1",
                 properties = listOf("property" to "value")
@@ -372,7 +368,6 @@ class LocalEntitiesFilterStrategyTest {
     fun `works correctly with label = expressions`() {
         entitiesRepository.save(
             Entity.New(
-                "things",
                 "thing1",
                 "Thing1",
                 properties = listOf("property" to "value")
@@ -415,7 +410,6 @@ class LocalEntitiesFilterStrategyTest {
     fun `works correctly with version = expressions`() {
         entitiesRepository.save(
             Entity.New(
-                "things",
                 "thing1",
                 "Thing1",
                 version = 2,

--- a/shared/src/main/java/org/odk/collect/shared/strings/Md5.kt
+++ b/shared/src/main/java/org/odk/collect/shared/strings/Md5.kt
@@ -13,15 +13,15 @@ object Md5 {
 
     @JvmStatic
     @JvmOverloads
-    fun getMd5Hash(string: String, bufSize: Int = 16 * 1024): String? {
-        return getMd5Hash(string.byteInputStream(), bufSize)
+    fun String.getMd5Hash(bufSize: Int = 16 * 1024): String? {
+        return getMd5Hash(this.byteInputStream(), bufSize)
     }
 
     @JvmStatic
     @JvmOverloads
-    fun getMd5Hash(file: File, bufSize: Int = 16 * 1024): String? {
+    fun File.getMd5Hash(bufSize: Int = 16 * 1024): String? {
         val inputStream: InputStream = try {
-            FileInputStream(file)
+            FileInputStream(this)
         } catch (e: FileNotFoundException) {
             return null
         }

--- a/shared/src/test/java/org/odk/collect/shared/Md5Test.kt
+++ b/shared/src/test/java/org/odk/collect/shared/Md5Test.kt
@@ -1,8 +1,9 @@
 package org.odk.collect.shared
 
-import org.junit.Assert
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.Test
-import org.odk.collect.shared.strings.Md5
+import org.odk.collect.shared.strings.Md5.getMd5Hash
 import java.io.File
 import java.io.FileWriter
 
@@ -20,7 +21,7 @@ class Md5Test {
 
         for (bufSize in listOf(1, contents.length - 1, contents.length, 64 * 1024)) {
             val expectedResult = "bc6e6f16b8a077ef5fbc8d59d0b931b9" // From md5 command-line utility
-            Assert.assertEquals(expectedResult, Md5.getMd5Hash(tempFile, bufSize))
+            assertThat(tempFile.getMd5Hash(bufSize), equalTo(expectedResult))
         }
     }
 }


### PR DESCRIPTION
Closes #6344
Closes #6389
~~Blocked by #6372~~

#### Why is this the best possible solution? Were any other approaches considered?

There are two keys changes here that lower subsequent download times (with or without changes):

- Entities that haven't changed aren't saved to the database as an update any longer
- Entity list CSVs that exactly match the previously processed list are not reprocessed


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The main changes and risks are again all around form update for entity follow-up and update forms.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
