### PR TITLE
Fixed test

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
@@ -71,13 +71,7 @@ class OpenRosaResponseParserImplTest {
             .appendLine("</manifest>")
             .toString()
 
-        val doc = StringReader(response).use { reader ->
-            val parser = KXmlParser()
-            parser.setInput(reader)
-            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true)
-            Document().also { it.parse(parser) }
-        }
-
+        val doc = XFormParser.getXMLDocument(response.reader())
         val mediaFiles = OpenRosaResponseParserImpl().parseManifest(doc)!!
         assertThat(mediaFiles.size, equalTo(1))
         assertThat(mediaFiles[0].filename, equalTo("badgers.csv"))


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?
The test `parseManifest() sanitizes media file names` was recently added just before merging https://github.com/getodk/collect/pull/6356, where we reworked form parsing. However, since https://github.com/getodk/collect/pull/6356 was not rebased onto the master branch before merging, it didn't account for that test. We now need to address this in a separate pull request.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
