### PR TITLE
Remove withIndex usage from flakey test

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.kt
@@ -150,8 +150,7 @@ class SendFinalizedFormTest {
 
             .clickSendFinalizedForm(2)
             .sortByDateNewestFirst()
-            .selectForm(0)
-            .selectForm(1)
+            .clickSelectAll()
             .clickSendSelected()
             .clickOK(SendFinalizedFormPage())
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/SendFinalizedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/SendFinalizedFormPage.java
@@ -10,6 +10,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.odk.collect.android.support.matchers.CustomMatchers.withIndex;
 
+import org.hamcrest.Matcher;
 import org.odk.collect.android.R;
 
 public class SendFinalizedFormPage extends Page<SendFinalizedFormPage> {
@@ -40,6 +41,10 @@ public class SendFinalizedFormPage extends Page<SendFinalizedFormPage> {
         return this;
     }
 
+    /**
+     * @deprecated uses the deprecated {@link org.odk.collect.android.support.matchers.CustomMatchers#withIndex(Matcher, int)})} helper.
+     */
+    @Deprecated
     public SendFinalizedFormPage selectForm(int index) {
         onView(withIndex(withId(androidx.appcompat.R.id.checkbox), index)).perform(click());
         return this;


### PR DESCRIPTION
This removes the deprecated `withIndex` method use from a flakey test. It appeared (from the video) the test was having problems clicking on the second form.