### PR TITLE
Allow null labels in follow up forms

### DIFF
--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -76,9 +76,12 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
 
         if (!partial) {
             name.value = StringData(entity.id)
-            label.value = StringData(entity.label)
             version.value = StringData(entity.version.toString())
             branchId.value = StringData(entity.branchId)
+
+            if (entity.label != null) {
+                label.value = StringData(entity.label)
+            }
 
             if (entity.trunkVersion != null) {
                 trunkVersion.value = StringData(entity.trunkVersion.toString())

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
@@ -171,4 +171,21 @@ class LocalEntitiesInstanceProviderTest {
         assertThat(second.getFirstChild("name")!!.value!!.value, equalTo("2"))
         assertThat(second.multiplicity, equalTo(1))
     }
+
+    @Test
+    fun `includes blank label version when it is null`() {
+        val entity =
+            Entity.New(
+                "1",
+                label = null
+            )
+        entitiesRepository.save("people", entity)
+
+        val parser = LocalEntitiesInstanceProvider { entitiesRepository }
+        val instance = parser.get("people", "people.csv")
+        assertThat(instance.numChildren, equalTo(1))
+
+        val item = instance.getChildAt(0)!!
+        assertThat(item.getFirstChild(EntityItemElement.LABEL)?.value, equalTo(null))
+    }
 }


### PR DESCRIPTION
Closes #6373
~~Blocked by #6376~~

#### Why is this the best possible solution? Were any other approaches considered?

This was very simple to fix! Another case of nullable values being transformed to the wrong thing in their `TreeElement` representation. I've opened [a PR against JavaRosa](https://github.com/getodk/javarosa/pull/794) to prevent us making the same mistake again.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue!

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
