### PR TITLE
Fix closing notification drawer

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -98,7 +98,7 @@ class NotificationDrawer {
             device.pressBack()
         }
 
-        device.wait(Until.gone(By.text("Notifications")), 1000L)
+        device.wait(Until.gone(By.text("No notifications")), 1000L)
 
         isOpen = false
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -84,8 +84,8 @@ class NotificationDrawer {
         It appears that sometimes the notification drawer does not close automatically
         after clicking on a notification. This could be due to a bug in Android.
          */
-        val manage = device.findObject(By.text("Manage"))
-        if (manage != null) {
+        val manageButton = device.findObject(By.text("Manage"))
+        if (manageButton != null) {
             device.pressBack()
         }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -60,6 +60,7 @@ class NotificationDrawer {
         val actionElement = getExpandedElement(device, appName, actionText) ?: getExpandedElement(device, appName, actionText.uppercase())
         if (actionElement != null) {
             actionElement.click()
+            closeNotificationDrawerIfOpened()
             isOpen = false
         } else {
             throw AssertionError("Could not find \"$actionText\"")
@@ -99,7 +100,7 @@ class NotificationDrawer {
         }
 
         device.wait(Until.gone(By.text("No notifications")), 1000L)
-
+        closeNotificationDrawerIfOpened()
         isOpen = false
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -88,12 +88,6 @@ class NotificationDrawer {
         }
     }
 
-    fun pressBack() {
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        device.pressBack()
-        isOpen = false
-    }
-
     fun clearAll() {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         val clearAll = device.findObject(By.text("Clear all"))
@@ -101,7 +95,7 @@ class NotificationDrawer {
             clearAll.click()
         } else {
             // "Clear all" doesn't exist because there are notifications to clear - just press back
-            pressBack()
+            device.pressBack()
         }
 
         device.wait(Until.gone(By.text("Notifications")), 1000L)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -10,6 +10,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.odk.collect.shared.TimeInMs
 import org.odk.collect.testshared.WaitFor.waitFor
 
 class NotificationDrawer {
@@ -79,16 +80,7 @@ class NotificationDrawer {
     ): D {
         val device = waitForNotification(appName, title)
         device.findObject(By.text(title)).click()
-
-        /*
-        It appears that sometimes the notification drawer does not close automatically
-        after clicking on a notification. This could be due to a bug in Android.
-         */
-        val manageButton = device.findObject(By.text("Manage"))
-        if (manageButton != null) {
-            device.pressBack()
-        }
-
+        closeNotificationDrawerIfOpened()
         isOpen = false
 
         return waitFor {
@@ -162,6 +154,19 @@ class NotificationDrawer {
                 `is`(true)
             )
             device
+        }
+    }
+
+    /*
+    It appears that sometimes the notification drawer does not close automatically
+    after clicking on a notification. This could be due to a bug in Android.
+    */
+    private fun closeNotificationDrawerIfOpened() {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        device.wait(Until.hasObject(By.text("Manage")), TimeInMs.ONE_SECOND)
+        val manageButton = device.findObject(By.text("Manage"))
+        if (manageButton != null) {
+            device.pressBack()
         }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -158,9 +158,8 @@ class NotificationDrawer {
      */
     private fun closeNotificationDrawerIfOpened() {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        device.wait(Until.hasObject(By.text("Manage")), TimeInMs.ONE_SECOND)
-        val manageButton = device.findObject(By.text("Manage"))
-        if (manageButton != null) {
+        val isManageButtonGone = device.wait(Until.gone(By.text("Manage")), TimeInMs.THREE_SECONDS)
+        if (!isManageButtonGone) {
             device.pressBack()
         }
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -79,6 +79,12 @@ class NotificationDrawer {
     ): D {
         val device = waitForNotification(appName, title)
         device.findObject(By.text(title)).click()
+
+        val manage = device.findObject(By.text("Manage"))
+        if (manage != null) {
+            device.pressBack()
+        }
+
         isOpen = false
 
         return waitFor {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -152,10 +152,10 @@ class NotificationDrawer {
         }
     }
 
-    /*
-    It appears that sometimes the notification drawer does not close automatically
-    after clicking on a notification. This could be due to a bug in Android.
-    */
+    /**
+     * It appears that sometimes the notification drawer does not close automatically when it should
+     * such as after clicking on a notification or its action. This could be due to a bug in Android.
+     */
     private fun closeNotificationDrawerIfOpened() {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         device.wait(Until.hasObject(By.text("Manage")), TimeInMs.ONE_SECOND)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -80,6 +80,10 @@ class NotificationDrawer {
         val device = waitForNotification(appName, title)
         device.findObject(By.text(title)).click()
 
+        /*
+        It appears that sometimes the notification drawer does not close automatically
+        after clicking on a notification. This could be due to a bug in Android.
+         */
         val manage = device.findObject(By.text("Manage"))
         if (manage != null) {
             device.pressBack()

--- a/shared/src/main/java/org/odk/collect/shared/TimeInMs.kt
+++ b/shared/src/main/java/org/odk/collect/shared/TimeInMs.kt
@@ -2,6 +2,7 @@ package org.odk.collect.shared
 
 object TimeInMs {
     const val ONE_SECOND = 1000L
+    const val THREE_SECONDS = 3000L
     const val ONE_MINUTE = 60000L
     const val ONE_HOUR = 3600000L
     const val ONE_DAY = 86400000L


### PR DESCRIPTION
Closes #6391 

#### Why is this the best possible solution? Were any other approaches considered?
As I said in my comment:

`It appears that sometimes the notification drawer does not close automatically when it should such as after clicking on a notification or its action. This could be due to a bug in Android.`

I hope this fixes the issue but we can't be sure so we will see.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
