### PR TITLE
Fix bad queries after adding new propreties to entity list

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -267,10 +267,10 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             readableDatabase
                 .rawQuery(
                     """
-                SELECT *, i.$ROW_ID
-                FROM $list e, ${getRowIdTableName(list)} i
-                WHERE e._id = i._id AND i.$ROW_ID = ?
-                """.trimIndent(),
+                    SELECT *, i.$ROW_ID
+                    FROM $list e, ${getRowIdTableName(list)} i
+                    WHERE e._id = i._id AND i.$ROW_ID = ?
+                    """.trimIndent(),
                     arrayOf((index + 1).toString())
                 ).first {
                     mapCursorRowToEntity(list, it, it.getInt(ROW_ID))
@@ -321,18 +321,17 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             getLists().forEach {
                 writeableDatabase.execSQL(
                     """
-                DROP TABLE IF EXISTS ${getRowIdTableName(it)};
-                """.trimIndent()
+                    DROP TABLE IF EXISTS ${getRowIdTableName(it)};
+                    """.trimIndent()
                 )
 
                 writeableDatabase.execSQL(
                     """
-                CREATE TABLE ${getRowIdTableName(it)} AS SELECT _id FROM $it;
-                """.trimIndent()
+                    CREATE TABLE ${getRowIdTableName(it)} AS SELECT _id FROM $it;
+                    """.trimIndent()
                 )
             }
         }
-
     }
 
     private fun getRowIdTableName(it: String) = "${it}_row_numbers"
@@ -346,7 +345,6 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
                     selectionArgs = arrayOf(list)
                 ).use { it.count } > 0
         }
-
     }
 
     private fun createList(list: String) {
@@ -362,22 +360,22 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
 
                 execSQL(
                     """
-                CREATE TABLE IF NOT EXISTS $list (
-                    $_ID integer PRIMARY KEY,
-                    ${EntitiesTable.COLUMN_ID} text,
-                    ${EntitiesTable.COLUMN_LABEL} text,
-                    ${EntitiesTable.COLUMN_VERSION} integer,
-                    ${EntitiesTable.COLUMN_TRUNK_VERSION} integer,
-                    ${EntitiesTable.COLUMN_BRANCH_ID} text,
-                    ${EntitiesTable.COLUMN_STATE} integer NOT NULL
-                );
-                """.trimIndent()
+                    CREATE TABLE IF NOT EXISTS $list (
+                        $_ID integer PRIMARY KEY,
+                        ${EntitiesTable.COLUMN_ID} text,
+                        ${EntitiesTable.COLUMN_LABEL} text,
+                        ${EntitiesTable.COLUMN_VERSION} integer,
+                        ${EntitiesTable.COLUMN_TRUNK_VERSION} integer,
+                        ${EntitiesTable.COLUMN_BRANCH_ID} text,
+                        ${EntitiesTable.COLUMN_STATE} integer NOT NULL
+                    );
+                    """.trimIndent()
                 )
 
                 execSQL(
                     """
-                CREATE UNIQUE INDEX IF NOT EXISTS ${list}_unique_id_index ON $list (${EntitiesTable.COLUMN_ID});
-                """.trimIndent()
+                    CREATE UNIQUE INDEX IF NOT EXISTS ${list}_unique_id_index ON $list (${EntitiesTable.COLUMN_ID});
+                    """.trimIndent()
                 )
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -4,7 +4,6 @@ import android.content.ContentValues
 import android.content.Context
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
-import android.database.sqlite.SQLiteException
 import android.provider.BaseColumns._ID
 import androidx.core.database.sqlite.transaction
 import org.odk.collect.db.sqlite.CursorExt.first
@@ -360,14 +359,14 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
 
     private fun updatePropertyColumns(list: String, entity: Entity) {
         entity.properties.map { it.first }.forEach {
-            try {
+            if (!databaseConnection.readableDatabase.doesColumnExist(list, it)) {
                 databaseConnection.writeableDatabase.execSQL(
                     """
                     ALTER TABLE $list ADD "$it" text NOT NULL DEFAULT "";
                     """.trimIndent()
                 )
-            } catch (e: SQLiteException) {
-                // Ignored
+
+                databaseConnection.reset()
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -132,7 +132,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         }
 
         databaseConnection.withConnection {
-            writeableDatabase.update(
+            writableDatabase.update(
                 ListsTable.TABLE_NAME,
                 contentValues,
                 "${ListsTable.COLUMN_NAME} = ?",
@@ -184,10 +184,10 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
     override fun clear() {
         databaseConnection.withConnection {
             getLists().forEach {
-                writeableDatabase.delete(it)
+                writableDatabase.delete(it)
             }
 
-            writeableDatabase.delete(ListsTable.TABLE_NAME)
+            writableDatabase.delete(ListsTable.TABLE_NAME)
         }
     }
 
@@ -201,7 +201,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
     override fun delete(id: String) {
         databaseConnection.withConnection {
             getLists().forEach {
-                writeableDatabase.delete(
+                writableDatabase.delete(
                     it,
                     "${EntitiesTable.COLUMN_ID} = ?",
                     arrayOf(id)
@@ -317,13 +317,13 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
     private fun updateRowIdTables() {
         databaseConnection.withConnection {
             getLists().forEach {
-                writeableDatabase.execSQL(
+                writableDatabase.execSQL(
                     """
                     DROP TABLE IF EXISTS ${getRowIdTableName(it)};
                     """.trimIndent()
                 )
 
-                writeableDatabase.execSQL(
+                writableDatabase.execSQL(
                     """
                     CREATE TABLE ${getRowIdTableName(it)} AS SELECT _id FROM $it;
                     """.trimIndent()

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -391,13 +391,16 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             entity.properties.map { it.first }.filterNot { columnNames.contains(it) }
         if (missingColumns.isNotEmpty()) {
             databaseConnection.withConnection {
-                missingColumns.forEach {
-                    writeableDatabase.execSQL(
-                        """
-                        ALTER TABLE $list ADD "$it" text NOT NULL DEFAULT "";
-                        """.trimIndent()
-                    )
+                writeableDatabase.transaction {
+                    missingColumns.forEach {
+                        execSQL(
+                            """
+                            ALTER TABLE $list ADD "$it" text NOT NULL DEFAULT "";
+                            """.trimIndent()
+                        )
+                    }
                 }
+
 
                 reset()
             }

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -15,8 +15,8 @@ import org.odk.collect.db.sqlite.DatabaseMigrator
 import org.odk.collect.db.sqlite.SQLiteColumns.ROW_ID
 import org.odk.collect.db.sqlite.SQLiteDatabaseExt.delete
 import org.odk.collect.db.sqlite.SQLiteDatabaseExt.doesColumnExist
+import org.odk.collect.db.sqlite.SQLiteDatabaseExt.getColumnNames
 import org.odk.collect.db.sqlite.SQLiteDatabaseExt.query
-import org.odk.collect.db.sqlite.SQLiteUtils
 import org.odk.collect.db.sqlite.SynchronizedDatabaseConnection
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
@@ -379,7 +379,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
 
     private fun updatePropertyColumns(list: String, entity: Entity) {
         val columnNames = databaseConnection.withConnection {
-            SQLiteUtils.getColumnNames(readableDatabase, list)
+            readableDatabase.getColumnNames(list)
         }
 
         val missingColumns =

--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormsRepository.java
@@ -238,13 +238,13 @@ public class DatabaseFormsRepository implements FormsRepository {
     }
 
     private Long insertForm(ContentValues values) {
-        SQLiteDatabase writeableDatabase = databaseConnection.getWriteableDatabase();
-        return writeableDatabase.insertOrThrow(FORMS_TABLE_NAME, null, values);
+        SQLiteDatabase writableDatabase = databaseConnection.getWritableDatabase();
+        return writableDatabase.insertOrThrow(FORMS_TABLE_NAME, null, values);
     }
 
     private void updateForm(Long id, ContentValues values) {
-        SQLiteDatabase writeableDatabase = databaseConnection.getWriteableDatabase();
-        writeableDatabase.update(FORMS_TABLE_NAME, values, _ID + "=?", new String[]{String.valueOf(id)});
+        SQLiteDatabase writableDatabase = databaseConnection.getWritableDatabase();
+        writableDatabase.update(FORMS_TABLE_NAME, values, _ID + "=?", new String[]{String.valueOf(id)});
     }
 
     private void deleteForms(String selection, String[] selectionArgs) {
@@ -255,8 +255,8 @@ public class DatabaseFormsRepository implements FormsRepository {
             deleteFilesForForm(form);
         }
 
-        SQLiteDatabase writeableDatabase = databaseConnection.getWriteableDatabase();
-        writeableDatabase.delete(FORMS_TABLE_NAME, selection, selectionArgs);
+        SQLiteDatabase writableDatabase = databaseConnection.getWritableDatabase();
+        writableDatabase.delete(FORMS_TABLE_NAME, selection, selectionArgs);
     }
 
     @NotNull

--- a/collect_app/src/main/java/org/odk/collect/android/database/instances/DatabaseInstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/instances/DatabaseInstancesRepository.java
@@ -144,7 +144,7 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
     public void delete(Long id) {
         Instance instance = get(id);
 
-        databaseConnection.getWriteableDatabase().delete(
+        databaseConnection.getWritableDatabase().delete(
                 INSTANCES_TABLE_NAME,
                 _ID + "=?",
                 new String[]{String.valueOf(id)}
@@ -157,7 +157,7 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
     public void deleteAll() {
         List<Instance> instances = getAll();
 
-        databaseConnection.getWriteableDatabase().delete(
+        databaseConnection.getWritableDatabase().delete(
                 INSTANCES_TABLE_NAME,
                 null,
                 null
@@ -253,7 +253,7 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
     }
 
     private long insert(ContentValues values) {
-        return databaseConnection.getWriteableDatabase().insertOrThrow(
+        return databaseConnection.getWritableDatabase().insertOrThrow(
                 INSTANCES_TABLE_NAME,
                 null,
                 values
@@ -261,7 +261,7 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
     }
 
     private void update(Long instanceId, ContentValues values) {
-        databaseConnection.getWriteableDatabase().update(
+        databaseConnection.getWritableDatabase().update(
                 INSTANCES_TABLE_NAME,
                 values,
                 _ID + "=?",

--- a/collect_app/src/main/java/org/odk/collect/android/database/instances/InstanceDatabaseMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/instances/InstanceDatabaseMigrator.java
@@ -19,6 +19,7 @@ import static org.odk.collect.db.sqlite.SQLiteDatabaseExt.doesColumnExist;
 import android.database.sqlite.SQLiteDatabase;
 
 import org.odk.collect.db.sqlite.DatabaseMigrator;
+import org.odk.collect.db.sqlite.SQLiteDatabaseExt;
 import org.odk.collect.db.sqlite.SQLiteUtils;
 import org.odk.collect.forms.instances.Instance;
 
@@ -118,7 +119,7 @@ public class InstanceDatabaseMigrator implements DatabaseMigrator {
      * @param temporaryTableName    the name of the temporary table to use and then drop
      */
     private void dropObsoleteColumns(SQLiteDatabase db, String[] relevantColumns, String temporaryTableName) {
-        List<String> columns = SQLiteUtils.getColumnNames(db, INSTANCES_TABLE_NAME);
+        List<String> columns = SQLiteDatabaseExt.getColumnNames(db, INSTANCES_TABLE_NAME);
         columns.retainAll(Arrays.asList(relevantColumns));
         String[] columnsToKeep = columns.toArray(new String[0]);
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/savepoints/DatabaseSavepointsRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/savepoints/DatabaseSavepointsRepository.kt
@@ -66,7 +66,7 @@ class DatabaseSavepointsRepository(
         val values = getValuesFromSavepoint(savepoint, cachePath, instancesPath)
 
         databaseConnection
-            .writeableDatabase
+            .writableDatabase
             .insertOrThrow(SAVEPOINTS_TABLE_NAME, null, values)
     }
 
@@ -86,7 +86,7 @@ class DatabaseSavepointsRepository(
         }
 
         databaseConnection
-            .writeableDatabase
+            .writableDatabase
             .delete(SAVEPOINTS_TABLE_NAME, selection, selectionArgs)
 
         File(savepoint.savepointFilePath).delete()
@@ -98,7 +98,7 @@ class DatabaseSavepointsRepository(
         }
 
         databaseConnection
-            .writeableDatabase
+            .writableDatabase
             .delete(SAVEPOINTS_TABLE_NAME)
     }
 

--- a/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
@@ -67,10 +67,29 @@ open class DatabaseConnection @JvmOverloads constructor(
             }
         }
 
+    /**
+     * Closes the underlying connection and clears state so that subsequent accesses will create
+     * a new connection.
+     *
+     * This can be dangerous if the database is being access by multiple threads as the connection
+     * might be closed while a transaction is running or while another thread is using a
+     * [SQLiteDatabase] instance obtained via [writeableDatabase] or [readableDatabase]. Using
+     * [SynchronizedDatabaseConnection] is recommended in those scenarios.
+     */
     fun reset() {
         openHelpers.remove(databasePath)?.close()
     }
 
+    /**
+     * Access the database in a synchronized manner. This is not usually required, but should be
+     * used if a calls to [reset] will be made.
+     *
+     * Does not guarantee synchronized access if this or another [DatabaseConnection] for the
+     * same `.db` file uses [writeableDatabase] or [readableDatabase].
+     * [SynchronizedDatabaseConnection] can be used to ensure synchronized writes/reads to the
+     * underlying DB.
+     *
+     */
     fun <T> withSynchronizedConnection(block: DatabaseConnection.() -> T): T {
         return synchronized(dbHelper) {
             block(this)

--- a/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
@@ -64,6 +64,11 @@ open class DatabaseConnection @JvmOverloads constructor(
             }
         }
 
+    fun reset() {
+        val databasePath = path + File.separator + name
+        openHelpers.remove(databasePath)?.close()
+    }
+
     companion object {
 
         private val openHelpers = mutableMapOf<String, SQLiteOpenHelper>()

--- a/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
@@ -69,6 +69,12 @@ open class DatabaseConnection @JvmOverloads constructor(
         openHelpers.remove(databasePath)?.close()
     }
 
+    fun <T> withSynchronizedConnection(block: DatabaseConnection.() -> T): T {
+        return synchronized(dbHelper) {
+            block(this)
+        }
+    }
+
     companion object {
 
         private val openHelpers = mutableMapOf<String, SQLiteOpenHelper>()

--- a/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
@@ -26,7 +26,7 @@ open class DatabaseConnection @JvmOverloads constructor(
 
     private val databasePath = path + File.separator + name
 
-    val writeableDatabase: SQLiteDatabase
+    val writableDatabase: SQLiteDatabase
         get() {
             StrictMode.noteSlowCall("Accessing writable DB")
             return dbHelper.writableDatabase
@@ -73,7 +73,7 @@ open class DatabaseConnection @JvmOverloads constructor(
      *
      * This can be dangerous if the database is being access by multiple threads as the connection
      * might be closed while a transaction is running or while another thread is using a
-     * [SQLiteDatabase] instance obtained via [writeableDatabase] or [readableDatabase]. Using
+     * [SQLiteDatabase] instance obtained via [writableDatabase] or [readableDatabase]. Using
      * [SynchronizedDatabaseConnection] is recommended in those scenarios.
      */
     fun reset() {
@@ -85,10 +85,9 @@ open class DatabaseConnection @JvmOverloads constructor(
      * used if a calls to [reset] will be made.
      *
      * Does not guarantee synchronized access if this or another [DatabaseConnection] for the
-     * same `.db` file uses [writeableDatabase] or [readableDatabase].
+     * same `.db` file uses [writableDatabase] or [readableDatabase].
      * [SynchronizedDatabaseConnection] can be used to ensure synchronized writes/reads to the
      * underlying DB.
-     *
      */
     fun <T> withSynchronizedConnection(block: DatabaseConnection.() -> T): T {
         return synchronized(dbHelper) {

--- a/db/src/main/java/org/odk/collect/db/sqlite/SQLiteDatabaseExt.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SQLiteDatabaseExt.kt
@@ -23,6 +23,16 @@ object SQLiteDatabaseExt {
 
     @JvmStatic
     fun SQLiteDatabase.doesColumnExist(table: String, column: String): Boolean {
-        return SQLiteUtils.getColumnNames(this, table).contains(column)
+        return this.getColumnNames(table).contains(column)
+    }
+
+    @JvmStatic
+    fun SQLiteDatabase.getColumnNames(table: String): List<String> {
+        var columnNames: Array<String>
+        this.query(table, null, null, null, null, null, null).use { c ->
+            columnNames = c.columnNames
+        }
+
+        return columnNames.toList()
     }
 }

--- a/db/src/main/java/org/odk/collect/db/sqlite/SQLiteUtils.java
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SQLiteUtils.java
@@ -5,10 +5,6 @@ import static org.odk.collect.db.sqlite.SQLiteDatabaseExt.doesColumnExist;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 /**
  * @deprecated use {@link SQLiteDatabaseExt} instead.
  */
@@ -34,16 +30,6 @@ public final class SQLiteUtils {
         boolean foundTable = cursor.getCount() == 1;
         cursor.close();
         return foundTable;
-    }
-
-    public static List<String> getColumnNames(SQLiteDatabase db, String tableName) {
-        String[] columnNames;
-        try (Cursor c = db.query(tableName, null, null, null, null, null, null)) {
-            columnNames = c.getColumnNames();
-        }
-
-        // Build a full-featured ArrayList rather than the limited array-backed List from asList
-        return new ArrayList<>(Arrays.asList(columnNames));
     }
 
     public static void addColumn(SQLiteDatabase db, String table, String column, String type) {

--- a/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
@@ -1,8 +1,10 @@
 package org.odk.collect.db.sqlite
 
 import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import androidx.core.database.sqlite.transaction
 
-class SynchronizedDatabaseConnection constructor(
+class SynchronizedDatabaseConnection(
     context: Context,
     path: String,
     name: String,
@@ -19,5 +21,26 @@ class SynchronizedDatabaseConnection constructor(
 
     fun <T> withConnection(block: DatabaseConnection.() -> T): T {
         return databaseConnection.withSynchronizedConnection(block)
+    }
+
+    fun <T> transaction(
+        body: SQLiteDatabase.() -> T
+    ) {
+        return withConnection {
+            writeableDatabase.transaction {
+                body()
+            }
+        }
+    }
+
+    /**
+     * Runs a transaction and then calls [DatabaseConnection.reset]. Useful for transactions
+     * that will mutate the DB schema.
+     */
+    fun <T> resetTransaction(
+        body: SQLiteDatabase.() -> T
+    ) {
+        transaction(body)
+        databaseConnection.reset()
     }
 }

--- a/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
@@ -27,7 +27,7 @@ class SynchronizedDatabaseConnection(
         body: SQLiteDatabase.() -> T
     ) {
         return withConnection {
-            writeableDatabase.transaction {
+            writableDatabase.transaction {
                 body()
             }
         }

--- a/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
@@ -1,0 +1,23 @@
+package org.odk.collect.db.sqlite
+
+import android.content.Context
+
+class SynchronizedDatabaseConnection constructor(
+    context: Context,
+    path: String,
+    name: String,
+    migrator: DatabaseMigrator,
+    databaseVersion: Int
+) {
+    private val databaseConnection = DatabaseConnection(
+        context,
+        path,
+        name,
+        migrator,
+        databaseVersion
+    )
+
+    fun <T> withConnection(block: DatabaseConnection.() -> T): T {
+        return databaseConnection.withSynchronizedConnection(block)
+    }
+}


### PR DESCRIPTION
Closes #6396

#### Why is this the best possible solution? Were any other approaches considered?

As per the discussion in #6396, the conclusion was eventually made that the root cause was due to `ALTER TABLE` statements being executed in a shared database connection (`SqlLiteOpenHelper`). The solution here is to reset that connection (using a new `DatabaseConnetion#reset` method) so that follow-up queries do not end up getting incorrect/state data or data structures.

I've also added a new `SynchronizedDatabaseConnection` class that allows us to interact with `DatabaseConnection` in a synchornized way to stop prevent any problems that might come up from concurrent access combined with `reset()`. The reason for this is described in a comment on `reset()`:

```kotlin
/**
 * Closes the underlying connection and clears state so that subsequent accesses will create
 * a new connection.
 *
 * This can be dangerous if the database is being access by multiple threads as the connection
 * might be closed while a transaction is running or while another thread is using a
 * [SQLiteDatabase] instance obtained via [writeableDatabase] or [readableDatabase]. Using
 * [SynchronizedDatabaseConnection] is recommended in those scenarios.
 */
```

Using synchornized access for `DatabaseConnection` in `DatabaseEntitiesRepository` will theoretically have performance implications as two threads will not be able to simultaneously read from the DB. To some level this was already not possible (as `SqlLiteOpenHelper` serializes calls to the actual underlying database), but it will certainly expand the amount of "blocking" code. The real world impact for entities is basically non-existent as we're planning to remove concurrent form entry/form updates anyway in #6232 which would be the only situation that would benefit as far as I can tell. I think adding this lower level protection is important to reduce the risk of adding race conditions down the road.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should just fix the bug. Checking entity form downloads and form entry would be good here as this is a fairly low level change that could always have unforeseen consequences.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
