### PR TITLE
Clear TilesOverlay correctly when not needed anymore

### DIFF
--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -550,6 +550,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     private void loadReferenceOverlay() {
         if (referenceOverlay != null) {
             map.getOverlays().remove(referenceOverlay);
+            referenceOverlay.onDetach(map);
             referenceOverlay = null;
         }
         if (referenceLayerFile != null) {


### PR DESCRIPTION
Closes #6281

#### Why is this the best possible solution? Were any other approaches considered?
We need to call `onDetach` on `TilesOverlay` when switching between layers to ensure that registered receivers are properly unregistered. Otherwise, only the last registered receiver will be unregistered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue. I don't think there is any big risk here. An important thing that I have mentioned in the issue as well is that this leak only happens with `Open Street Maps`.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
