### PR TITLE
Fixed importing savepoints

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/SavepointsImporter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/SavepointsImporter.kt
@@ -52,7 +52,9 @@ class SavepointsImporter(
                 val formFileName = File(form.formFilePath).name.substringBeforeLast(".xml")
 
                 cacheDir.listFiles { file ->
-                    val match = """${formFileName}_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})(.xml.save)""".toRegex().matchEntire(file.name)
+                    val match = """${Regex.escape(formFileName)}_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})(.xml.save)"""
+                        .toRegex()
+                        .matchEntire(file.name)
                     match != null
                 }?.forEach { savepointFile ->
                     if (savepointFile.lastModified() > form.date) {

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/SavepointsImporterTest.kt
@@ -127,6 +127,27 @@ class SavepointsImporterTest {
     }
 
     @Test
+    fun formFileNameShouldBeEscapedAndTreatedAsLiteralTextToAvoidPatternSyntaxException() {
+        val form1Name = "sampleForm("
+
+        // create blank forms
+        val blankForm1 = createBlankForm(project, form1Name, "1")
+
+        // create savepoints
+        val savepointFile1 = createFileInCache(project, "${form1Name}_2024-04-10_01-35-41.xml.save")
+
+        // trigger importing
+        savepointsImporter.run()
+
+        // verify import
+        val savepoints = savepointsRepository.getAll()
+        val expectedSavepoint1 =
+            Savepoint(blankForm1.dbId, null, savepointFile1.absolutePath, "${storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, project.uuid)}/${form1Name}_2024-04-10_01-35-41/${form1Name}_2024-04-10_01-35-41.xml")
+
+        assertThat(savepoints, contains(expectedSavepoint1))
+    }
+
+    @Test
     fun ifThereAreMultipleVersionsOfTheSameBlankFormWithSavepoints_allSavepointsShouldBeImported() {
         val form1Name = "sampleForm"
         val form2Name = "sampleForm_1"


### PR DESCRIPTION
Closes #6405 

#### Why is this the best possible solution? Were any other approaches considered?
There is not much to discuss here. The form name should be escaped so that it is treated as literal text when used in a regular expression pattern.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I've only modified the regex used to identify savepoints associated with the given form names. This change shouldn't affect the existing implementation, it simply resolves the issue.

Here are the apks for testing: https://drive.google.com/file/d/14hDAkrEGU6MoGZsj3cJDorib9KnuEZzL/view?usp=sharing

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
