### PR TITLE
Order entities by insertion

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -284,6 +284,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
                     SELECT *, i.$ROW_ID
                     FROM $list e, ${getRowIdTableName(list)} i
                     WHERE e._id = i._id
+                    ORDER BY i.$ROW_ID
                     """.trimIndent(),
                     null
                 )
@@ -301,6 +302,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
                 SELECT *, i.$ROW_ID
                 FROM $list e, ${getRowIdTableName(list)} i
                 WHERE e._id = i._id AND $selectionColumn = ?
+                ORDER BY i.$ROW_ID
                 """.trimIndent(),
                 arrayOf(selectionArg)
             )

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -327,7 +327,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
 
                 writableDatabase.execSQL(
                     """
-                    CREATE TABLE ${getRowIdTableName(it)} AS SELECT _id FROM $it;
+                    CREATE TABLE ${getRowIdTableName(it)} AS SELECT _id FROM $it ORDER BY _id;
                     """.trimIndent()
                 )
             }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -309,15 +309,21 @@ abstract class EntitiesRepositoryTest {
 
     @Test
     fun `#save assigns an index to each entity in insert order when saving multiple entities`() {
-        val first = Entity.New("1", "Léoville Barton 2008")
-        val second = Entity.New("2", "Pontet Canet 2014")
+        /**
+         * first and second have alphabetically out of order IDs/names here so that any indexing on
+         * them is tested. We'd likely never see this fail if they were ordered.
+         */
+        val first = Entity.New("2", "B")
+        val second = Entity.New("1", "A")
 
         val repository = buildSubject()
         repository.save("wines", first, second)
 
         val entities = repository.getEntities("wines")
         assertThat(entities[0].index, equalTo(0))
+        assertThat(entities[0].id, equalTo(first.id))
         assertThat(entities[1].index, equalTo(1))
+        assertThat(entities[1].id, equalTo(second.id))
     }
 
     @Test


### PR DESCRIPTION
This makes sure entities are in insertion order (from the CSV and locally) by changing the way we generate `index` so that it's ordered. It appeared that `index` ordering was based on entity `id` which would appear "random" (as they would usually be UUIDs).

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I've already checked that `EntitiesBenchmarkTest` still passes so it seems like we're ok in terms of performance. Other than that, I think the main thing is to check that the entities are always in the "expected" order in selects (filtered and unfiltered).

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
