### PR TITLE
Don't require OpenGL 3.0

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/OpenGLVersionChecker.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/OpenGLVersionChecker.kt
@@ -1,0 +1,28 @@
+package org.odk.collect.androidshared.system
+
+import android.app.ActivityManager
+import android.content.Context
+
+/**
+ * Checks if the device supports the given OpenGL ES version.
+ *
+ * Note: This approach may not be 100% reliable because `reqGlEsVersion` indicates
+ * the highest version of OpenGL ES that the device's hardware is guaranteed to support
+ * at runtime. However, it might not always reflect the actual version available.
+ *
+ * For a more reliable method, refer to https://developer.android.com/develop/ui/views/graphics/opengl/about-opengl#version-check.
+ * This recommended approach is more complex to implement but offers better accuracy.
+ */
+object OpenGLVersionChecker {
+    @JvmStatic
+    fun isOpenGLv2Supported(context: Context): Boolean {
+        return (context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager)
+            .deviceConfigurationInfo.reqGlEsVersion >= 0x20000
+    }
+
+    @JvmStatic
+    fun isOpenGLv3Supported(context: Context): Boolean {
+        return (context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager)
+            .deviceConfigurationInfo.reqGlEsVersion >= 0x30000
+    }
+}

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@ the specific language governing permissions and limitations under the License.
     <uses-feature
         android:name="android.hardware.wifi"
         android:required="false" />
+    <uses-feature
+        android:glEsVersion="0x00030000"
+        android:required="false" />
 
     <!-- Dangerous permissions -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapConfigurator.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapConfigurator.java
@@ -4,7 +4,6 @@ import static org.odk.collect.androidshared.ui.PrefUtils.createListPref;
 import static org.odk.collect.androidshared.ui.PrefUtils.getInt;
 import static kotlin.collections.SetsKt.setOf;
 
-import android.app.ActivityManager;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -14,6 +13,7 @@ import androidx.preference.Preference;
 
 import com.google.android.gms.maps.GoogleMap;
 
+import org.odk.collect.androidshared.system.OpenGLVersionChecker;
 import org.odk.collect.androidshared.system.PlayServicesChecker;
 import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.maps.MapConfigurator;
@@ -57,8 +57,7 @@ public class GoogleMapConfigurator implements MapConfigurator {
     private static boolean isGoogleMapsSdkAvailable(Context context) {
         // The Google Maps SDK for Android requires OpenGL ES version 2.
         // See https://developers.google.com/maps/documentation/android-sdk/config
-        return ((ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE))
-                .getDeviceConfigurationInfo().reqGlEsVersion >= 0x20000;
+        return OpenGLVersionChecker.isOpenGLv2Supported(context);
     }
 
     @Override public void showUnavailableMessage(Context context) {

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapConfigurator.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapConfigurator.java
@@ -55,8 +55,10 @@ public class GoogleMapConfigurator implements MapConfigurator {
     }
 
     private static boolean isGoogleMapsSdkAvailable(Context context) {
-        // The Google Maps SDK for Android requires OpenGL ES version 2.
-        // See https://developers.google.com/maps/documentation/android-sdk/config
+        /*
+         * The Google Maps SDK for Android requires OpenGL ES version 2.
+         * See: https://developers.google.com/maps/documentation/android-sdk/config
+         */
         return OpenGLVersionChecker.isOpenGLv2Supported(context);
     }
 

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapConfigurator.java
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapConfigurator.java
@@ -10,6 +10,7 @@ import androidx.preference.Preference;
 
 import com.mapbox.maps.Style;
 
+import org.odk.collect.androidshared.system.OpenGLVersionChecker;
 import org.odk.collect.androidshared.ui.PrefUtils;
 import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.maps.MapConfigurator;
@@ -42,8 +43,9 @@ public class MapboxMapConfigurator implements MapConfigurator {
     }
 
     @Override public boolean isAvailable(Context context) {
-        // If the app builds that means mapbox is available
-        return true;
+        // The Mapbox SDK for Android requires OpenGL ES version 3.
+        // See https://github.com/mapbox/mapbox-maps-android/blob/main/CHANGELOG.md#1100-november-29-2023
+        return OpenGLVersionChecker.isOpenGLv3Supported(context);
     }
 
     @Override public void showUnavailableMessage(Context context) {

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapConfigurator.java
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapConfigurator.java
@@ -43,8 +43,10 @@ public class MapboxMapConfigurator implements MapConfigurator {
     }
 
     @Override public boolean isAvailable(Context context) {
-        // The Mapbox SDK for Android requires OpenGL ES version 3.
-        // See https://github.com/mapbox/mapbox-maps-android/blob/main/CHANGELOG.md#1100-november-29-2023
+        /*
+         * The Mapbox SDK for Android requires OpenGL ES version 3.
+         * See: https://github.com/mapbox/mapbox-maps-android/blob/main/CHANGELOG.md#1100-november-29-2023
+         */
         return OpenGLVersionChecker.isOpenGLv3Supported(context);
     }
 


### PR DESCRIPTION
Closes #6410 

#### Why is this the best possible solution? Were any other approaches considered?
As I said in the comment:
```
/**
 * Checks if the device supports the given OpenGL ES version.
 *
 * Note: This approach may not be 100% reliable because `reqGlEsVersion` indicates
 * the highest version of OpenGL ES that the device's hardware is guaranteed to support
 * at runtime. However, it might not always reflect the actual version available.
 *
 * For a more reliable method, refer to https://developer.android.com/develop/ui/views/graphics/opengl/about-opengl#version-check.
 * This recommended approach is more complex to implement but offers better accuracy.
 */
```

The way I check OpenGL versions might not be the best one but for now, our main goal is to check if:
```
   <uses-feature
        android:glEsVersion="0x00030000"
        android:required="false" />
```

will let us make OpenGL 3.0 not required. If the way of checking versions is not reliable we will see crashes or receive reports from users and then we can fix it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
@dbemke @srujner @WKobus do we have any device with OpenGL 2.0? You can check it using adb:
`adb shell dumpsys SurfaceFlinger | grep "OpenGL`

if not we can just check that using Mapbox is still available in settings as it was before.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
