### PR TITLE
Do not proceed with LocalEntitiesFilterStrategy filtering if instanceId is null

### DIFF
--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -32,7 +32,7 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
         evaluationContext: EvaluationContext,
         next: Supplier<MutableList<TreeReference>>
     ): List<TreeReference> {
-        if (!dataAdapter.supportsInstance(sourceInstance.instanceId)) {
+        if (sourceInstance.instanceId == null || !dataAdapter.supportsInstance(sourceInstance.instanceId)) {
             return next.get()
         }
 

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -6,6 +6,7 @@ import org.hamcrest.Matchers.equalTo
 import org.javarosa.core.model.FormDef
 import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.condition.FilterStrategy
+import org.javarosa.core.model.data.IntegerData
 import org.javarosa.core.model.data.StringData
 import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.core.model.instance.TreeElement
@@ -14,6 +15,7 @@ import org.javarosa.form.api.FormEntryController
 import org.javarosa.form.api.FormEntryModel
 import org.javarosa.test.BindBuilderXFormsElement.bind
 import org.javarosa.test.Scenario
+import org.javarosa.test.XFormsElement
 import org.javarosa.test.XFormsElement.body
 import org.javarosa.test.XFormsElement.head
 import org.javarosa.test.XFormsElement.html
@@ -268,6 +270,44 @@ class LocalEntitiesFilterStrategyTest {
         )
 
         assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("Thing"))
+    }
+
+    @Test
+    fun `works correctly with filtering on a repeat`() {
+        val scenario = Scenario.init(
+            "Count people underage",
+            html(
+                head(
+                    title("Count people underage"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"count_people_underage\"",
+                                t("people",
+                                    t("name"),
+                                    t("age")
+                                ),
+                                t("total_underage")
+                            )
+                        ),
+                        bind("/data/people/name").type("string"),
+                        bind("/data/people/age").type("int"),
+                        bind("/data/question").type("string"),
+                        bind("/data/total_underage").type("string").calculate("count( /data/people [age&lt;18])")
+                    )
+                ),
+                body(
+                    XFormsElement.repeat("/data/people",
+                        input("/data/people/name"),
+                        input("/data/people/age")
+                    ),
+                    input("/data/total_underage")
+                )
+            ),
+            controllerSupplier
+        )
+
+        assertThat(scenario.answerOf<IntegerData>("/data/total_underage").value, equalTo(0))
     }
 
     @Test


### PR DESCRIPTION
Closes #6378 

#### Why is this the best possible solution? Were any other approaches considered?
We should check if instanceId is null and only if it is not should we proceed with `LocalEntitiesFilterStrategy`. When it comes to performing filtering on repeats it will be null and of course in this case `LocalEntitiesFilterStrategy` should not be used.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a pretty safe change so testing the scenario described in the issue should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
