### PR TITLE
Allow deleting sent forms with entities

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteSavedFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteSavedFormTest.kt
@@ -10,6 +10,7 @@ import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.DeleteSavedFormPage
 import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.MainMenuPage
+import org.odk.collect.android.support.pages.SendFinalizedFormPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 import org.odk.collect.strings.R.string
@@ -44,15 +45,35 @@ class DeleteSavedFormTest {
     }
 
     @Test
-    fun whenFinalizedFormHasCreatedALocalEntity_doesNotAppearInListToDelete() {
+    fun whenFinalizedButNotSentFormHasCreatedALocalEntity_doesNotAppearInListToDelete() {
         testDependencies.server.addForm("one-question-entity-registration.xml")
 
         rule.withMatchExactlyProject(testDependencies.server.url)
+            // Drafts can be deleted
             .startBlankForm("One Question Entity Registration")
-            .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("Name", "Logan Roy"))
+            .fillOutAndSave(FormEntryPage.QuestionAndAnswer("Name", "Logan Roy"))
+            .clickDeleteSavedForm()
+            .assertText("One Question Entity Registration")
+            .pressBack(MainMenuPage())
 
+            // Finalized forms can not be deleted
+            .clickDrafts(1)
+            .clickOnForm("One Question Entity Registration")
+            .clickGoToEnd()
+            .clickFinalize()
             .clickDeleteSavedForm()
             .assertTextDoesNotExist("One Question Entity Registration")
+            .pressBack(MainMenuPage())
+
+            // Sent forms can be deleted
+            .clickSendFinalizedForm(1)
+            .clickSelectAll()
+            .clickSendSelected()
+            .clickOK(SendFinalizedFormPage())
+            .pressBack(MainMenuPage())
+            .clickDeleteSavedForm()
+            .assertText("One Question Entity Registration")
+            .pressBack(MainMenuPage())
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/savedformlist/DeleteSavedFormFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/savedformlist/DeleteSavedFormFragment.kt
@@ -36,7 +36,7 @@ class DeleteSavedFormFragment(
     private val multiSelectViewModel: MultiSelectViewModel<Instance> by viewModels {
         MultiSelectViewModel.Factory(
             savedFormListViewModel.formsToDisplay.map {
-                it.filter { instance -> instance.canDeleteBeforeSend() }
+                it.filter { instance -> instance.canDelete() }
                     .map { instance ->
                         SelectItem(
                             instance.dbId.toString(),

--- a/forms/src/main/java/org/odk/collect/forms/instances/Instance.java
+++ b/forms/src/main/java/org/odk/collect/forms/instances/Instance.java
@@ -229,6 +229,10 @@ public final class Instance {
         return canDeleteBeforeSend;
     }
 
+    public boolean canDelete() {
+        return canDeleteBeforeSend || !status.equals(Instance.STATUS_COMPLETE) && !status.equals(Instance.STATUS_SUBMISSION_FAILED);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/forms/src/test/java/org/odk/collect/forms/instances/InstanceTest.kt
+++ b/forms/src/test/java/org/odk/collect/forms/instances/InstanceTest.kt
@@ -11,4 +11,58 @@ class InstanceTest {
         val instance = Instance.Builder().build()
         assertThat(instance.canDeleteBeforeSend(), equalTo(true))
     }
+
+    @Test
+    fun `canDelete returns true if canDeleteBeforeSend is true no matter what the status is`() {
+        listOf(
+            Instance.STATUS_INCOMPLETE,
+            Instance.STATUS_INVALID,
+            Instance.STATUS_VALID,
+            Instance.STATUS_COMPLETE,
+            Instance.STATUS_SUBMISSION_FAILED,
+            Instance.STATUS_SUBMITTED
+        ).forEach { status ->
+            val instance = Instance
+                .Builder()
+                .status(status)
+                .canDeleteBeforeSend(true)
+                .build()
+
+            assertThat(instance.canDelete(), equalTo(true))
+        }
+    }
+
+    @Test
+    fun `canDelete returns true if canDeleteBeforeSend is false but form is not finalized or finalized but sent`() {
+        listOf(
+            Instance.STATUS_INCOMPLETE,
+            Instance.STATUS_INVALID,
+            Instance.STATUS_VALID,
+            Instance.STATUS_SUBMITTED
+        ).forEach { status ->
+            val instance = Instance
+                .Builder()
+                .status(status)
+                .canDeleteBeforeSend(false)
+                .build()
+
+            assertThat(instance.canDelete(), equalTo(true))
+        }
+    }
+
+    @Test
+    fun `canDelete returns false if canDeleteBeforeSend is false but form is finalized`() {
+        listOf(
+            Instance.STATUS_COMPLETE,
+            Instance.STATUS_SUBMISSION_FAILED
+        ).forEach { status ->
+            val instance = Instance
+                .Builder()
+                .status(status)
+                .canDeleteBeforeSend(false)
+                .build()
+
+            assertThat(instance.canDelete(), equalTo(false))
+        }
+    }
 }


### PR DESCRIPTION
Closes #6380 

#### Why is this the best possible solution? Were any other approaches considered?
I considered changing the instances database and renaming `CAN_DELETE_BEFORE_SEND` to a more generic `CAN_DELETE`, and updating the row after sending a form. However, this approach would be significantly more complex and riskier, so I decided to simply introduce a helper function `#canDelete` instead:

```java
public boolean canDelete() {
        return canDeleteBeforeSend || !status.equals(Instance.STATUS_COMPLETE) && 
              !status.equals(Instance.STATUS_SUBMISSION_FAILED);
}

```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should only adjust how we determine which forms can be deleted. Please test this filtering thoroughly with every possible form status to ensure it works correctly.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
