### PR TITLE
Force glide to keep original image sizes

### DIFF
--- a/image-loader/src/main/java/org/odk/collect/imageloader/GlideImageLoader.kt
+++ b/image-loader/src/main/java/org/odk/collect/imageloader/GlideImageLoader.kt
@@ -83,6 +83,7 @@ class GlideImageLoader : ImageLoader {
                     }
                 })
                 .apply(requestOptions)
+                .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
                 .into(imageView)
         }
     }


### PR DESCRIPTION
Closes #6293 

#### Why is this the best possible solution? Were any other approaches considered?
I'm not sure why Glide alters the image sizes on subsequent loads (it might be a bug), but this change ensures they retain their original dimensions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that the bug is fixed and ensure images load correctly, not just in selects but also in image widgets - everywhere else images are used.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
