### PR TITLE
Remove Multidex usages

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -15,7 +15,6 @@ object Dependencies {
     const val androidx_appcompat = "androidx.appcompat:appcompat:1.7.0"
     const val androidx_work_runtime = "androidx.work:work-runtime:${Versions.work}"
     const val androidx_exinterface = "androidx.exifinterface:exifinterface:1.3.7"
-    const val androidx_multidex = "androidx.multidex:multidex:2.0.1"
     const val androidx_preference_ktx = "androidx.preference:preference-ktx:1.2.1"
     const val androidx_fragment_ktx = "androidx.fragment:fragment-ktx:${Versions.androidx_fragment}"
     const val android_material = "com.google.android.material:material:1.12.0"
@@ -85,6 +84,5 @@ object Dependencies {
     const val okhttp3_mockwebserver = "com.squareup.okhttp3:mockwebserver:${Versions.okhttp3}"
     const val hamcrest = "org.hamcrest:hamcrest:2.2"
     const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
-    const val robolectric_shadows_multidex = "org.robolectric:shadows-multidex:${Versions.robolectric}"
     const val uiautomator = "androidx.test.uiautomator:uiautomator:2.3.0"
 }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -82,7 +82,6 @@ android {
         versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()
         versionName getVersionName()
         testInstrumentationRunner('androidx.test.runner.AndroidJUnitRunner')
-        multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
         archivesBaseName = 'ODK-Collect'
     }
@@ -280,7 +279,6 @@ dependencies {
     implementation Dependencies.androidx_appcompat
     implementation Dependencies.androidx_work_runtime
 
-    implementation Dependencies.androidx_multidex
     implementation Dependencies.androidx_preference_ktx
     implementation Dependencies.androidx_fragment_ktx
 
@@ -363,7 +361,6 @@ dependencies {
 
     testImplementation Dependencies.androidx_test_ext_junit
     testImplementation Dependencies.androidx_arch_core_testing
-    testImplementation Dependencies.robolectric_shadows_multidex
     testImplementation Dependencies.okhttp3_mockwebserver
     testImplementation Dependencies.squareup_okhttp_tls
 

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -23,7 +23,6 @@ import android.os.Build;
 import android.os.StrictMode;
 
 import androidx.annotation.NonNull;
-import androidx.multidex.MultiDex;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.BuildConfig;
@@ -135,16 +134,6 @@ public class Collect extends Application implements
 
     public void setExternalDataManager(ExternalDataManager externalDataManager) {
         this.externalDataManager = externalDataManager;
-    }
-
-    /*
-        Adds support for multidex support library. For more info check out the link below,
-        https://developer.android.com/studio/build/multidex.html
-    */
-    @Override
-    protected void attachBaseContext(Context base) {
-        super.attachBaseContext(base);
-        MultiDex.install(this);
     }
 
     @Override


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?

Since the min SDK is 21, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should be transparent to users and developers alike.

#### Do we need any specific form for testing your changes? If so, please attach one.

No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
