### PR TITLE
Fixed removing savepoints on finalize

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
@@ -88,4 +88,16 @@ public class EncryptedFormTest {
                 .clickDrafts()
                 .checkInstanceState("encrypted-no-instanceID", Instance.STATUS_INCOMPLETE);
     }
+
+    @Test
+    public void instanceOfEncryptedFormWithoutInstanceID_doesNotLeaveSavepointOnFinalization() {
+        rule.startAtMainMenu()
+                .copyForm("encrypted-no-instanceID.xml")
+                .startBlankForm("encrypted-no-instanceID")
+                .clickGoToArrow()
+                .clickGoToEnd()
+                .clickFinalize()
+                .checkIsToastWithMessageDisplayed("This form does not specify an instanceID. You must specify one to enable encryption. Form has not been saved as finalized.")
+                .startBlankForm("encrypted-no-instanceID");
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -2,6 +2,7 @@ package org.odk.collect.android.formentry.saving;
 
 import static org.odk.collect.android.tasks.SaveFormToDisk.SAVED;
 import static org.odk.collect.android.tasks.SaveFormToDisk.SAVED_AND_EXIT;
+import static org.odk.collect.android.tasks.SaveFormToDisk.SAVE_ERROR;
 import static org.odk.collect.shared.strings.StringUtils.isBlank;
 
 import android.net.Uri;
@@ -256,7 +257,7 @@ public class FormSaveViewModel extends ViewModel implements MaterialProgressDial
             return;
         }
 
-        if (taskResult.getSaveResult() == SAVED || taskResult.getSaveResult() == SAVED_AND_EXIT) {
+        if (taskResult.getSaveResult() != SAVE_ERROR) {
             removeSavepoint(form.getDbId(), instance != null ? instance.getDbId() : null);
         }
 
@@ -284,7 +285,7 @@ public class FormSaveViewModel extends ViewModel implements MaterialProgressDial
                 break;
             }
 
-            case SaveFormToDisk.SAVE_ERROR: {
+            case SAVE_ERROR: {
                 formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.SAVE_ERROR, true, clock.get());
                 saveResult.setValue(new SaveResult(SaveResult.State.SAVE_ERROR, saveRequest, taskResult.getSaveErrorMessage()));
                 break;


### PR DESCRIPTION
Closes #6285 

#### Why is this the best possible solution? Were any other approaches considered?
If an error occurs while finalizing a form that requires encryption, the form is saved as a draft. In this case, the existing savepoint should be removed. That's why I have achieved by improving the logic in 
https://github.com/getodk/collect/pull/6427/files#diff-ace02871a97e4eac36ebcb210c7538fc66f3d712ff27ae490e423efecbfddbd9R260

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test that savepoints are properly removed when saving a form, whether it's during finalization or while the user is filling out the form and clicks the save icon. I can't think of anything else that could be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
