### PR TITLE
Improved loading images with Glide

### DIFF
--- a/androidtest/src/main/java/org/odk/collect/androidtest/DrawableMatcher.kt
+++ b/androidtest/src/main/java/org/odk/collect/androidtest/DrawableMatcher.kt
@@ -39,13 +39,17 @@ object DrawableMatcher {
             }
 
             override fun matchesSafely(imageView: ImageView): Boolean {
+                if (match == null) {
+                    return false
+                }
+
                 val actual: Bitmap? = when (val drawable = imageView.drawable) {
                     is BitmapDrawable -> drawable.bitmap
-                    is PictureDrawable -> drawable.toBitmap()
+                    is PictureDrawable -> drawable.toBitmap(match.width, match.height)
                     else -> null
                 }
 
-                if (match == null || actual == null) {
+                if (actual == null) {
                     return false
                 } else {
                     val originalThreadPolicy = StrictMode.getThreadPolicy()

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/NoButtonsItem.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/NoButtonsItem.java
@@ -28,6 +28,7 @@ public class NoButtonsItem extends FrameLayout {
 
     public void setUpNoButtonsItem(File imageFile, String choiceText, String errorMsg, boolean isInGridView) {
         if (imageFile != null && imageFile.exists()) {
+            binding.imageView.layout(0, 0, 0, 0);
             binding.imageView.setVisibility(View.VISIBLE);
             if (isInGridView) {
                 imageLoader.loadImage(binding.imageView, imageFile, ImageView.ScaleType.FIT_CENTER, null);

--- a/image-loader/src/main/java/org/odk/collect/imageloader/GlideImageLoader.kt
+++ b/image-loader/src/main/java/org/odk/collect/imageloader/GlideImageLoader.kt
@@ -59,7 +59,6 @@ class GlideImageLoader : ImageLoader {
                     }
                 })
                 .apply(requestOptions)
-                .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
                 .into(imageView)
         } else {
             Glide.with(imageView)
@@ -88,7 +87,6 @@ class GlideImageLoader : ImageLoader {
                     }
                 })
                 .apply(requestOptions)
-                .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
                 .into(imageView)
         }
     }


### PR DESCRIPTION
Closes #6433
Closes #6434 

#### Why is this the best possible solution? Were any other approaches considered?
I believe I found a better solution for loading images with Glide and preventing resizing during filtering or scrolling by resetting the ImageView's layout bounds. This forces the layout system to remeasure and relayout the ImageView with the correct dimensions before Glide loads the image.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should resolve the issues mentioned above. However, since loading images can be tricky, I can't guarantee it as a foolproof fix. Please proceed with caution and thoroughly test image loading in the form-filling process.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
