### PR TITLE
Include DynamicPreloadExtra in formDef only if a form contains search or pulldata

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/DynamicPreloadXFormParserFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/DynamicPreloadXFormParserFactory.kt
@@ -2,7 +2,6 @@ package org.odk.collect.android.dynamicpreload
 
 import org.javarosa.core.model.FormDef
 import org.javarosa.core.model.QuestionDef
-import org.javarosa.core.util.externalizable.ExtUtil
 import org.javarosa.core.util.externalizable.Externalizable
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.xform.parse.IXFormParserFactory
@@ -51,23 +50,13 @@ class DynamicPreloadParseProcessor :
 
     override fun processFormDef(formDef: FormDef) {
         if (containsPullData || containsSearch) {
-            formDef.extras.put(DynamicPreloadExtra(true))
+            formDef.extras.put(DynamicPreloadExtra())
         }
     }
 }
 
-class DynamicPreloadExtra(usesDynamicPreload: Boolean) : Externalizable {
+class DynamicPreloadExtra : Externalizable {
+    override fun readExternal(`in`: DataInputStream?, pf: PrototypeFactory?) = Unit
 
-    constructor() : this(false)
-
-    var usesDynamicPreload = usesDynamicPreload
-        private set
-
-    override fun readExternal(`in`: DataInputStream?, pf: PrototypeFactory?) {
-        usesDynamicPreload = ExtUtil.read(`in`, Boolean::class.javaObjectType) as Boolean
-    }
-
-    override fun writeExternal(out: DataOutputStream?) {
-        ExtUtil.write(out, usesDynamicPreload)
-    }
+    override fun writeExternal(out: DataOutputStream?) = Unit
 }

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/DynamicPreloadXFormParserFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/DynamicPreloadXFormParserFactory.kt
@@ -50,7 +50,9 @@ class DynamicPreloadParseProcessor :
     }
 
     override fun processFormDef(formDef: FormDef) {
-        formDef.extras.put(DynamicPreloadExtra(containsPullData || containsSearch))
+        if (containsPullData || containsSearch) {
+            formDef.extras.put(DynamicPreloadExtra(true))
+        }
     }
 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUseCases.kt
@@ -16,7 +16,7 @@ object ExternalDataUseCases {
         isCancelled: Supplier<Boolean>,
         progressReporter: Consumer<Function<Resources, String>>
     ) {
-        if (form.extras.get(DynamicPreloadExtra::class.java)?.usesDynamicPreload != true) {
+        if (form.extras.get(DynamicPreloadExtra::class.java) == null) {
             return
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUseCases.kt
@@ -16,7 +16,7 @@ object ExternalDataUseCases {
         isCancelled: Supplier<Boolean>,
         progressReporter: Consumer<Function<Resources, String>>
     ) {
-        if (form.extras.get(DynamicPreloadExtra::class.java)?.usesDynamicPreload == false) {
+        if (form.extras.get(DynamicPreloadExtra::class.java)?.usesDynamicPreload != true) {
             return
         }
 

--- a/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/DynamicPreloadExtraTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/DynamicPreloadExtraTest.kt
@@ -1,7 +1,7 @@
 package org.odk.collect.android.dynamicpreload
 
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
 import org.javarosa.core.util.externalizable.ExtUtil
 import org.junit.Test
 
@@ -9,12 +9,12 @@ class DynamicPreloadExtraTest {
 
     @Test
     fun `can be externalized`() {
-        val extra = DynamicPreloadExtra(true)
+        val extra = DynamicPreloadExtra()
 
         val external = ExtUtil.serialize(extra)
         val deserialized =
             ExtUtil.deserialize(external, DynamicPreloadExtra::class.java) as DynamicPreloadExtra
 
-        assertThat(deserialized.usesDynamicPreload, equalTo(true))
+        assertThat(deserialized, instanceOf(DynamicPreloadExtra::class.java))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/DynamicPreloadParseProcessorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/DynamicPreloadParseProcessorTest.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.dynamicpreload
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
 import org.javarosa.core.model.FormDef
 import org.javarosa.core.model.QuestionDef
 import org.javarosa.xpath.expr.XPathExpression
@@ -14,50 +15,50 @@ class DynamicPreloadParseProcessorTest {
     private val processor = DynamicPreloadParseProcessor()
 
     @Test
-    fun `usesDynamicPreload is false when xpath does not contain pulldata`() {
+    fun `usesDynamicPreload is null when xpath does not contain pulldata`() {
         val formDef = FormDef()
 
         processor.processXPath(createNonPullDataExpression())
         processor.processFormDef(formDef)
         assertThat(
-            formDef.extras.get(DynamicPreloadExtra::class.java).usesDynamicPreload,
-            equalTo(false)
+            formDef.extras.get(DynamicPreloadExtra::class.java),
+            equalTo(null)
         )
     }
 
     @Test
-    fun `usesDynamicPreload is true when xpath does contain pulldata`() {
+    fun `usesDynamicPreload is not null when xpath does contain pulldata`() {
         val formDef = FormDef()
 
         processor.processXPath(createPullDataExpression())
         processor.processFormDef(formDef)
         assertThat(
-            formDef.extras.get(DynamicPreloadExtra::class.java).usesDynamicPreload,
-            equalTo(true)
+            formDef.extras.get(DynamicPreloadExtra::class.java),
+            instanceOf(DynamicPreloadExtra::class.java)
         )
     }
 
     @Test
-    fun `usesDynamicPreload is false when question appearance does not contain search`() {
+    fun `usesDynamicPreload is null when question appearance does not contain search`() {
         val formDef = FormDef()
 
         processor.processQuestion(createQuestion(appearance = "minimal"))
         processor.processFormDef(formDef)
         assertThat(
-            formDef.extras.get(DynamicPreloadExtra::class.java).usesDynamicPreload,
-            equalTo(false)
+            formDef.extras.get(DynamicPreloadExtra::class.java),
+            equalTo(null)
         )
     }
 
     @Test
-    fun `usesDynamicPreload is true when question appearance does contain search`() {
+    fun `usesDynamicPreload is not null when question appearance does contain search`() {
         val formDef = FormDef()
 
         processor.processQuestion(createQuestion(appearance = "search('fruits')"))
         processor.processFormDef(formDef)
         assertThat(
-            formDef.extras.get(DynamicPreloadExtra::class.java).usesDynamicPreload,
-            equalTo(true)
+            formDef.extras.get(DynamicPreloadExtra::class.java),
+            instanceOf(DynamicPreloadExtra::class.java)
         )
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/DynamicPreloadParseProcessorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/DynamicPreloadParseProcessorTest.kt
@@ -15,7 +15,7 @@ class DynamicPreloadParseProcessorTest {
     private val processor = DynamicPreloadParseProcessor()
 
     @Test
-    fun `usesDynamicPreload is null when xpath does not contain pulldata`() {
+    fun `DynamicPreloadExtra is null when xpath does not contain pulldata`() {
         val formDef = FormDef()
 
         processor.processXPath(createNonPullDataExpression())
@@ -27,7 +27,7 @@ class DynamicPreloadParseProcessorTest {
     }
 
     @Test
-    fun `usesDynamicPreload is not null when xpath does contain pulldata`() {
+    fun `DynamicPreloadExtra is not null when xpath does contain pulldata`() {
         val formDef = FormDef()
 
         processor.processXPath(createPullDataExpression())
@@ -39,7 +39,7 @@ class DynamicPreloadParseProcessorTest {
     }
 
     @Test
-    fun `usesDynamicPreload is null when question appearance does not contain search`() {
+    fun `DynamicPreloadExtra is null when question appearance does not contain search`() {
         val formDef = FormDef()
 
         processor.processQuestion(createQuestion(appearance = "minimal"))
@@ -51,7 +51,7 @@ class DynamicPreloadParseProcessorTest {
     }
 
     @Test
-    fun `usesDynamicPreload is not null when question appearance does contain search`() {
+    fun `DynamicPreloadExtra is not null when question appearance does contain search`() {
         val formDef = FormDef()
 
         processor.processQuestion(createQuestion(appearance = "search('fruits')"))

--- a/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/ExternalDataUseCasesTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/ExternalDataUseCasesTest.kt
@@ -25,7 +25,7 @@ class ExternalDataUseCasesTest {
     }
 
     @Test
-    fun `create() does not create a db file if the FormDef has not a DynamicPreloadExtra()`() {
+    fun `create() does not create a db file if the FormDef does not have a DynamicPreloadExtra`() {
         val form = FormDef()
 
         val mediaDir = TempFiles.createTempDir().also {
@@ -37,7 +37,7 @@ class ExternalDataUseCasesTest {
     }
 
     @Test
-    fun `create() creates a db file if the FormDef has a DynamicPreloadExtra()`() {
+    fun `create() creates a db file if the FormDef has a DynamicPreloadExtra`() {
         val form = FormDef().also {
             it.extras.put(DynamicPreloadExtra())
         }

--- a/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/ExternalDataUseCasesTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/ExternalDataUseCasesTest.kt
@@ -14,9 +14,7 @@ class ExternalDataUseCasesTest {
 
     @Test
     fun `create() does nothing if the form doesn't use dynamic preload`() {
-        val form = FormDef().also {
-            it.extras.put(DynamicPreloadExtra(false))
-        }
+        val form = FormDef()
 
         val mediaDir = TempFiles.createTempDir().also {
             File(it, "items.csv").writeText("name_key,name\nmango,Mango")
@@ -27,8 +25,23 @@ class ExternalDataUseCasesTest {
     }
 
     @Test
-    fun `create() works if the FormDef does not have a DynamicPreloadExtra()`() {
+    fun `create() does not create a db file if the FormDef has not a DynamicPreloadExtra()`() {
         val form = FormDef()
+
+        val mediaDir = TempFiles.createTempDir().also {
+            File(it, "items.csv").writeText("name_key,name\nmango,Mango")
+        }
+
+        ExternalDataUseCases.create(form, mediaDir, { false }, {})
+        assertThat(mediaDir.listFiles().size, equalTo(1))
+    }
+
+    @Test
+    fun `create() creates a db file if the FormDef has a DynamicPreloadExtra()`() {
+        val form = FormDef().also {
+            it.extras.put(DynamicPreloadExtra())
+        }
+
         val mediaDir = TempFiles.createTempDir().also {
             File(it, "items.csv").writeText("name_key,name\nmango,Mango")
         }
@@ -40,7 +53,7 @@ class ExternalDataUseCasesTest {
     @Test
     fun `create() leaves original CSV in place`() {
         val form = FormDef().also {
-            it.extras.put(DynamicPreloadExtra(true))
+            it.extras.put(DynamicPreloadExtra())
         }
 
         val mediaDir = TempFiles.createTempDir()


### PR DESCRIPTION
Closes #6447

In [issue #6446](https://github.com/getodk/collect/issues/6446), I mentioned that the problem with initializing `DynamicPreloadExtra` is likely not the main cause of the memory issues. However, when this exception is thrown, it indicates that we cannot read the form from cache and must load it from the file instead. This process consumes more memory and could be one of the factors contributing to the numerous out-of-memory issues we are experiencing.

#### Why is this the best possible solution? Were any other approaches considered?
As I mentioned in the issue, I cannot reproduce it and don’t fully understand why `DynamicPreloadExtra` sometimes cannot be instantiated, but I have some suspicions. Initially, I thought the issue might be related to ProGuard and the app shrinking process. We need an empty constructor to instantiate `DynamicPreloadExtra` using the `newInstance()` method in javarosa, and I wondered if that constructor had been removed. However, after installing the app version from the store, I didn’t encounter that exception, so that can’t be the cause.

Since this issue occurs for only some users, I suspect that `newInstance()` may have trouble creating an object from a Kotlin class. I know this sounds unusual, but after working on [issue #6364](https://github.com/getodk/collect/issues/6364), I have become more open to the idea that such unexpected issues can arise.

Although I can’t be certain about the root cause of the issue, I have a plan to at least mitigate it. For now, we add `DynamicPreloadExtra` to `formDef` regardless of whether a form uses `pulldata` or `search`. There is a true/false value that determines this, but I believe it is unnecessary. For instance, `EntityFormExtra` is only added if the form actually contains entities (see: [EntityFormParseProcessor.java#L63](https://github.com/getodk/collect/blob/master/entities/src/main/java/org/odk/collect/entities/javarosa/parse/EntityFormParseProcessor.java#L63)). I think `DynamicPreloadExtra` should operate in the same way and thanks to that it should not need to store any value. If it is present, it indicates that the form contains `search` or `pulldata`, if it is absent, then it does not.

If I’m correct that `newInstance()` may have difficulties creating objects from Kotlin classes, these changes might help, as the empty constructor is now the primary one. Could this have been the issue?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This requires testing forms with search/pulldata.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
