### PR TITLE
Add support for pulldata with local entities

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -34,7 +34,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.1.0"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.9"
-    const val javarosa_online = "org.getodk:javarosa:5.0.0-SNAPSHOT-30ef2a9"
+    const val javarosa_online = "org.getodk:javarosa:5.0.0-SNAPSHOT-6ce1352"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val javarosa = javarosa_online
     const val karumi_dexter = "com.karumi:dexter:6.2.3"

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataPullTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataPullTest.kt
@@ -3,7 +3,9 @@ package org.odk.collect.android.feature.formentry.dynamicpreload
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
-import org.odk.collect.android.support.rules.FormEntryActivityTestRule
+import org.odk.collect.android.support.StubOpenRosaServer.MediaFileItem
+import org.odk.collect.android.support.TestDependencies
+import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 
 /**
@@ -12,16 +14,18 @@ import org.odk.collect.android.support.rules.TestRuleChain.chain
  */
 class DynamicPreLoadedDataPullTest {
 
-    private val rule = FormEntryActivityTestRule()
+    private val rule = CollectTestRule(useDemoProject = false)
+    private val testDependencies = TestDependencies()
 
     @get:Rule
-    val copyFormChain: RuleChain = chain()
-        .around(rule)
+    val chain: RuleChain = chain(testDependencies).around(rule)
 
     @Test
     fun canUsePullDataFunctionToPullDataFromCSV() {
-        rule.setUpProjectAndCopyForm("pull_data.xml", listOf("fruits.csv"))
-            .fillNewForm("pull_data.xml", "pull_data")
+        testDependencies.server.addForm("pull_data.xml", listOf(MediaFileItem("fruits.csv")))
+
+        rule.withMatchExactlyProject(testDependencies.server.url)
+            .startBlankForm("pull_data")
             .assertText("The fruit Mango is pulled csv data.")
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataPullTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/dynamicpreload/DynamicPreLoadedDataPullTest.kt
@@ -3,8 +3,10 @@ package org.odk.collect.android.feature.formentry.dynamicpreload
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
+import org.odk.collect.android.support.StubOpenRosaServer.EntityListItem
 import org.odk.collect.android.support.StubOpenRosaServer.MediaFileItem
 import org.odk.collect.android.support.TestDependencies
+import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 
@@ -27,5 +29,23 @@ class DynamicPreLoadedDataPullTest {
         rule.withMatchExactlyProject(testDependencies.server.url)
             .startBlankForm("pull_data")
             .assertText("The fruit Mango is pulled csv data.")
+    }
+
+    @Test
+    fun canUsePullDataFunctionToPullDataFromLocalEntities() {
+        testDependencies.server.addForm("one-question-entity-registration.xml")
+        testDependencies.server.addForm(
+            "entity-update-pulldata.xml",
+            listOf(EntityListItem("people.csv"))
+        )
+
+        rule.withMatchExactlyProject(testDependencies.server.url)
+            .startBlankForm("One Question Entity Registration")
+            .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("Name", "Logan Roy"))
+
+            .startBlankForm("Entity Update Pull Data")
+            .clickOnText("Logan Roy")
+            .swipeToNextQuestion("Name")
+            .assertText("Logan Roy")
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -8,6 +8,7 @@ import org.odk.collect.android.dynamicpreload.ExternalDataManagerImpl
 import org.odk.collect.android.dynamicpreload.handler.ExternalDataHandlerPull
 import org.odk.collect.android.tasks.FormLoaderTask.FormEntryControllerFactory
 import org.odk.collect.entities.javarosa.filter.LocalEntitiesFilterStrategy
+import org.odk.collect.entities.javarosa.filter.PullDataFunctionHandler
 import org.odk.collect.entities.javarosa.finalization.EntityFormFinalizationProcessor
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.settings.keys.ProjectKeys
@@ -25,7 +26,8 @@ class CollectFormEntryControllerFactory(
         }
 
         return FormEntryController(FormEntryModel(formDef)).also {
-            it.addFunctionHandler(ExternalDataHandlerPull(externalDataManager))
+            val externalDataHandlerPull = ExternalDataHandlerPull(externalDataManager)
+            it.addFunctionHandler(PullDataFunctionHandler(entitiesRepository, externalDataHandlerPull))
             it.addPostProcessor(EntityFormFinalizationProcessor())
 
             if (settings.getBoolean(ProjectKeys.KEY_LOCAL_ENTITIES)) {

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -22,7 +22,7 @@ import java.util.function.Supplier
 class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
     FilterStrategy {
 
-    private val dataAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
+    private val instanceAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
 
     override fun filter(
         sourceInstance: DataInstance<*>,
@@ -32,7 +32,7 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
         evaluationContext: EvaluationContext,
         next: Supplier<MutableList<TreeReference>>
     ): List<TreeReference> {
-        if (sourceInstance.instanceId == null || !dataAdapter.supportsInstance(sourceInstance.instanceId)) {
+        if (sourceInstance.instanceId == null || !instanceAdapter.supportsInstance(sourceInstance.instanceId)) {
             return next.get()
         }
 
@@ -43,7 +43,7 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
                     val child = candidate.nodeSide.steps[0].name.name
                     val value = candidate.evalContextSide(sourceInstance, evaluationContext)
 
-                    val results = dataAdapter.queryEq(
+                    val results = instanceAdapter.queryEq(
                         sourceInstance.instanceId,
                         child,
                         value as String

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
@@ -11,7 +11,7 @@ class PullDataFunctionHandler(
     private val fallback: IFunctionHandler? = null
 ) : IFunctionHandler {
 
-    private val entitiesDataAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
+    private val instanceAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
 
     override fun getName(): String {
         return NAME
@@ -35,8 +35,8 @@ class PullDataFunctionHandler(
         val filterChild = XPathFuncExpr.toString(args[2])
         val filterValue = XPathFuncExpr.toString(args[3])
 
-        return if (entitiesDataAdapter.supportsInstance(instanceId)) {
-            entitiesDataAdapter.queryEq(instanceId, filterChild, filterValue)!!.firstOrNull()
+        return if (instanceAdapter.supportsInstance(instanceId)) {
+            instanceAdapter.queryEq(instanceId, filterChild, filterValue)!!.firstOrNull()
                 ?.getFirstChild(child)?.value?.value ?: ""
         } else {
             fallback?.eval(args, ec) ?: ""

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
@@ -1,0 +1,48 @@
+package org.odk.collect.entities.javarosa.filter
+
+import org.javarosa.core.model.condition.EvaluationContext
+import org.javarosa.core.model.condition.IFunctionHandler
+import org.javarosa.xpath.expr.XPathFuncExpr
+import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceAdapter
+import org.odk.collect.entities.storage.EntitiesRepository
+
+class PullDataFunctionHandler(
+    entitiesRepository: EntitiesRepository,
+    private val fallback: IFunctionHandler
+) : IFunctionHandler {
+
+    private val entitiesDataAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
+
+    override fun getName(): String {
+        return NAME
+    }
+
+    override fun getPrototypes(): List<Array<Class<Any>>> {
+        return emptyList()
+    }
+
+    override fun rawArgs(): Boolean {
+        return true
+    }
+
+    override fun realTime(): Boolean {
+        return false
+    }
+
+    override fun eval(args: Array<Any>, ec: EvaluationContext): Any {
+        val instanceId = XPathFuncExpr.toString(args[0])
+        val child = XPathFuncExpr.toString(args[1])
+        val filterChild = XPathFuncExpr.toString(args[2])
+        val filterValue = XPathFuncExpr.toString(args[3])
+
+        return if (entitiesDataAdapter.supportsInstance(instanceId)) {
+            entitiesDataAdapter.queryEq(instanceId, filterChild, filterValue)!!.firstOrNull()?.getFirstChild(child)?.value?.value ?: ""
+        } else {
+            fallback.eval(args, ec)
+        }
+    }
+
+    companion object {
+        private const val NAME = "pulldata"
+    }
+}

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
@@ -8,7 +8,7 @@ import org.odk.collect.entities.storage.EntitiesRepository
 
 class PullDataFunctionHandler(
     entitiesRepository: EntitiesRepository,
-    private val fallback: IFunctionHandler
+    private val fallback: IFunctionHandler? = null
 ) : IFunctionHandler {
 
     private val entitiesDataAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
@@ -36,9 +36,10 @@ class PullDataFunctionHandler(
         val filterValue = XPathFuncExpr.toString(args[3])
 
         return if (entitiesDataAdapter.supportsInstance(instanceId)) {
-            entitiesDataAdapter.queryEq(instanceId, filterChild, filterValue)!!.firstOrNull()?.getFirstChild(child)?.value?.value ?: ""
+            entitiesDataAdapter.queryEq(instanceId, filterChild, filterValue)!!.firstOrNull()
+                ?.getFirstChild(child)?.value?.value ?: ""
         } else {
-            fallback.eval(args, ec)
+            fallback?.eval(args, ec) ?: ""
         }
     }
 

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -40,7 +40,7 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
 
     fun queryEq(instanceId: String, child: String, value: String): List<TreeElement>? {
         return when {
-            child == "name" -> {
+            child == EntityItemElement.ID -> {
                 val entity = entitiesRepository.getById(
                     instanceId,
                     value
@@ -53,9 +53,14 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
                 }
             }
 
-            child == "label" -> {
+            child == EntityItemElement.LABEL -> {
                 val entities = entitiesRepository.getEntities(instanceId)
                 entities.filter { it.label == value }.map { convertToElement(it, false) }
+            }
+
+            child == EntityItemElement.VERSION -> {
+                val entities = entitiesRepository.getEntities(instanceId)
+                entities.filter { it.version == value.toInt() }.map { convertToElement(it, false) }
             }
 
             !listOf(EntityItemElement.LABEL, EntityItemElement.VERSION).contains(child) -> {

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -63,6 +63,16 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
                 entities.filter { it.version == value.toInt() }.map { convertToElement(it, false) }
             }
 
+            child == EntityItemElement.TRUNK_VERSION -> {
+                val entities = entitiesRepository.getEntities(instanceId)
+                entities.filter { it.trunkVersion == value.toInt() }.map { convertToElement(it, false) }
+            }
+
+            child == EntityItemElement.BRANCH_ID -> {
+                val entities = entitiesRepository.getEntities(instanceId)
+                entities.filter { it.branchId == value }.map { convertToElement(it, false) }
+            }
+
             !listOf(EntityItemElement.LABEL, EntityItemElement.VERSION).contains(child) -> {
                 val entities = entitiesRepository.getAllByProperty(
                     instanceId,

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -23,7 +23,7 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
 
                 0.until(count).map {
                     if (it == 0) {
-                        convertToElement(first, true)
+                        convertToElement(first)
                     } else {
                         TreeElement("item", it, true)
                     }
@@ -33,7 +33,7 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
             }
         } else {
             entitiesRepository.getEntities(instanceId).map { entity ->
-                convertToElement(entity, false)
+                convertToElement(entity)
             }
         }
     }
@@ -47,7 +47,7 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
                 )
 
                 if (entity != null) {
-                    listOf(convertToElement(entity, false))
+                    listOf(convertToElement(entity))
                 } else {
                     emptyList()
                 }
@@ -76,7 +76,7 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
                     value
                 )
 
-                entities.map { convertToElement(it, false) }
+                entities.map { convertToElement(it) }
             }
         }
     }
@@ -86,31 +86,29 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
         filter: (Entity.Saved) -> Boolean
     ): List<TreeElement> {
         val entities = entitiesRepository.getEntities(list)
-        return entities.filter(filter).map { convertToElement(it, false) }
+        return entities.filter(filter).map { convertToElement(it) }
     }
 
-    private fun convertToElement(entity: Entity.Saved, partial: Boolean): TreeElement {
+    private fun convertToElement(entity: Entity.Saved): TreeElement {
         val name = TreeElement(EntityItemElement.ID)
         val label = TreeElement(EntityItemElement.LABEL)
         val version = TreeElement(EntityItemElement.VERSION)
         val trunkVersion = TreeElement(EntityItemElement.TRUNK_VERSION)
         val branchId = TreeElement(EntityItemElement.BRANCH_ID)
 
-        if (!partial) {
-            name.value = StringData(entity.id)
-            version.value = StringData(entity.version.toString())
-            branchId.value = StringData(entity.branchId)
+        name.value = StringData(entity.id)
+        version.value = StringData(entity.version.toString())
+        branchId.value = StringData(entity.branchId)
 
-            if (entity.label != null) {
-                label.value = StringData(entity.label)
-            }
-
-            if (entity.trunkVersion != null) {
-                trunkVersion.value = StringData(entity.trunkVersion.toString())
-            }
+        if (entity.label != null) {
+            label.value = StringData(entity.label)
         }
 
-        val item = TreeElement("item", entity.index, partial)
+        if (entity.trunkVersion != null) {
+            trunkVersion.value = StringData(entity.trunkVersion.toString())
+        }
+
+        val item = TreeElement("item", entity.index, false)
         item.addChild(name)
         item.addChild(label)
         item.addChild(version)
@@ -119,11 +117,7 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
 
         entity.properties.forEach { property ->
             val propertyElement = TreeElement(property.first)
-
-            if (!partial) {
-                propertyElement.value = StringData(property.second)
-            }
-
+            propertyElement.value = StringData(property.second)
             item.addChild(propertyElement)
         }
 

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -53,6 +53,11 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
                 }
             }
 
+            child == "label" -> {
+                val entities = entitiesRepository.getEntities(instanceId)
+                entities.filter { it.label == value }.map { convertToElement(it, false) }
+            }
+
             !listOf(EntityItemElement.LABEL, EntityItemElement.VERSION).contains(child) -> {
                 val entities = entitiesRepository.getAllByProperty(
                     instanceId,

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/intance/LocalEntitiesInstanceAdapter.kt
@@ -54,26 +54,22 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
             }
 
             child == EntityItemElement.LABEL -> {
-                val entities = entitiesRepository.getEntities(instanceId)
-                entities.filter { it.label == value }.map { convertToElement(it, false) }
+                filterAndConvertEntities(instanceId) { it.label == value }
             }
 
             child == EntityItemElement.VERSION -> {
-                val entities = entitiesRepository.getEntities(instanceId)
-                entities.filter { it.version == value.toInt() }.map { convertToElement(it, false) }
+                filterAndConvertEntities(instanceId) { it.version == value.toInt() }
             }
 
             child == EntityItemElement.TRUNK_VERSION -> {
-                val entities = entitiesRepository.getEntities(instanceId)
-                entities.filter { it.trunkVersion == value.toInt() }.map { convertToElement(it, false) }
+                filterAndConvertEntities(instanceId) { it.trunkVersion == value.toInt() }
             }
 
             child == EntityItemElement.BRANCH_ID -> {
-                val entities = entitiesRepository.getEntities(instanceId)
-                entities.filter { it.branchId == value }.map { convertToElement(it, false) }
+                filterAndConvertEntities(instanceId) { it.branchId == value }
             }
 
-            !listOf(EntityItemElement.LABEL, EntityItemElement.VERSION).contains(child) -> {
+            else -> {
                 val entities = entitiesRepository.getAllByProperty(
                     instanceId,
                     child,
@@ -82,9 +78,15 @@ class LocalEntitiesInstanceAdapter(private val entitiesRepository: EntitiesRepos
 
                 entities.map { convertToElement(it, false) }
             }
-
-            else -> null
         }
+    }
+
+    private fun filterAndConvertEntities(
+        list: String,
+        filter: (Entity.Saved) -> Boolean
+    ): List<TreeElement> {
+        val entities = entitiesRepository.getEntities(list)
+        return entities.filter(filter).map { convertToElement(it, false) }
     }
 
     private fun convertToElement(entity: Entity.Saved, partial: Boolean): TreeElement {

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/LocalEntitiesInstanceProviderTest.kt
@@ -111,7 +111,7 @@ class LocalEntitiesInstanceProviderTest {
     }
 
     @Test
-    fun `partial parse returns elements without values for first item and just item for others`() {
+    fun `partial parse returns the full first item and just item for others`() {
         val entity = arrayOf(
             Entity.New(
                 "1",
@@ -133,11 +133,9 @@ class LocalEntitiesInstanceProviderTest {
         assertThat(instance.numChildren, equalTo(2))
 
         val item1 = instance.getChildAt(0)!!
-        assertThat(item1.isPartial, equalTo(true))
+        assertThat(item1.isPartial, equalTo(false))
         assertThat(item1.numChildren, equalTo(6))
-        0.until(item1.numChildren).forEach {
-            assertThat(item1.getChildAt(it).value?.value, equalTo(null))
-        }
+        assertThat(item1.getFirstChild("name")!!.value!!.value, equalTo("1"))
 
         val item2 = instance.getChildAt(1)!!
         assertThat(item2.isPartial, equalTo(true))

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandlerTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandlerTest.kt
@@ -1,0 +1,104 @@
+package org.odk.collect.entities.javarosa.filter
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.javarosa.core.model.data.StringData
+import org.javarosa.form.api.FormEntryController
+import org.javarosa.form.api.FormEntryModel
+import org.javarosa.test.BindBuilderXFormsElement.bind
+import org.javarosa.test.Scenario
+import org.javarosa.test.XFormsElement.body
+import org.javarosa.test.XFormsElement.head
+import org.javarosa.test.XFormsElement.html
+import org.javarosa.test.XFormsElement.input
+import org.javarosa.test.XFormsElement.mainInstance
+import org.javarosa.test.XFormsElement.model
+import org.javarosa.test.XFormsElement.t
+import org.javarosa.test.XFormsElement.title
+import org.junit.Test
+import org.odk.collect.entities.storage.Entity
+import org.odk.collect.entities.storage.InMemEntitiesRepository
+
+class PullDataFunctionHandlerTest {
+
+    @Test
+    fun `returns empty string when there are no matching results`() {
+        val entitiesRepository = InMemEntitiesRepository()
+        entitiesRepository.addList("things")
+
+        val scenario = Scenario.init(
+            "Pull data form",
+            html(
+                head(
+                    title("Pull data form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"pull-data-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("pulldata('things', 'label', 'name', 'blah')")
+                    )
+                ),
+                body(
+                    input("/data/question"),
+                    input("/data/calculate")
+                )
+            )
+        ) { formDef ->
+            FormEntryController(FormEntryModel(formDef)).also {
+                it.addFunctionHandler(PullDataFunctionHandler(entitiesRepository))
+            }
+        }
+
+        assertThat(scenario.answerOf<StringData>("/data/calculate"), equalTo(null))
+    }
+
+    @Test
+    fun `returns first match when there are multiple`() {
+        val entitiesRepository = InMemEntitiesRepository()
+        entitiesRepository.save(
+            "things",
+            Entity.New("one", "One", properties = listOf(Pair("property", "value")))
+        )
+        entitiesRepository.save(
+            "things",
+            Entity.New("two", "Two", properties = listOf(Pair("property", "value")))
+        )
+
+        val scenario = Scenario.init(
+            "Pull data form",
+            html(
+                head(
+                    title("Pull data form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"pull-data-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("pulldata('things', 'label', 'property', 'value')")
+                    )
+                ),
+                body(
+                    input("/data/question"),
+                    input("/data/calculate")
+                )
+            )
+        ) { formDef ->
+            FormEntryController(FormEntryModel(formDef)).also {
+                it.addFunctionHandler(PullDataFunctionHandler(entitiesRepository))
+            }
+        }
+
+        assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("One"))
+    }
+}

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/instance/LocalEntitiesInstanceAdapterTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/instance/LocalEntitiesInstanceAdapterTest.kt
@@ -1,0 +1,22 @@
+package org.odk.collect.entities.javarosa.instance
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceAdapter
+import org.odk.collect.entities.storage.Entity
+import org.odk.collect.entities.storage.InMemEntitiesRepository
+
+class LocalEntitiesInstanceAdapterTest {
+
+    @Test
+    fun `#queryEq supports label`() {
+        val entitiesRepository = InMemEntitiesRepository()
+        entitiesRepository.save("things", Entity.New("thing1", "Thing 1"))
+        entitiesRepository.save("things", Entity.New("thing2", "Thing 2"))
+
+        val instanceAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
+        val results = instanceAdapter.queryEq("things", "label", "Thing 2")
+        assertThat(results!!.first().getFirstChild("name")!!.value!!.value, equalTo("thing2"))
+    }
+}

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/instance/LocalEntitiesInstanceAdapterTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/instance/LocalEntitiesInstanceAdapterTest.kt
@@ -18,7 +18,8 @@ class LocalEntitiesInstanceAdapterTest {
 
         val instanceAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
         val results = instanceAdapter.queryEq("things", EntityItemElement.LABEL, "Thing 2")
-        assertThat(results!!.first().getFirstChild("name")!!.value!!.value, equalTo("thing2"))
+        assertThat(results!!.size, equalTo(1))
+        assertThat(results.first().getFirstChild("name")!!.value!!.value, equalTo("thing2"))
     }
 
     @Test
@@ -29,6 +30,31 @@ class LocalEntitiesInstanceAdapterTest {
 
         val instanceAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
         val results = instanceAdapter.queryEq("things", EntityItemElement.VERSION, "2")
-        assertThat(results!!.first().getFirstChild("name")!!.value!!.value, equalTo("thing2"))
+        assertThat(results!!.size, equalTo(1))
+        assertThat(results.first().getFirstChild("name")!!.value!!.value, equalTo("thing2"))
+    }
+
+    @Test
+    fun `#queryEq supports __trunkVersion`() {
+        val entitiesRepository = InMemEntitiesRepository()
+        entitiesRepository.save("things", Entity.New("thing1", "Thing 1", trunkVersion = 1))
+        entitiesRepository.save("things", Entity.New("thing2", "Thing 2", trunkVersion = 2))
+
+        val instanceAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
+        val results = instanceAdapter.queryEq("things", EntityItemElement.TRUNK_VERSION, "2")
+        assertThat(results!!.size, equalTo(1))
+        assertThat(results.first().getFirstChild("name")!!.value!!.value, equalTo("thing2"))
+    }
+
+    @Test
+    fun `#queryEq supports __branchId`() {
+        val entitiesRepository = InMemEntitiesRepository()
+        entitiesRepository.save("things", Entity.New("thing1", "Thing 1", branchId = "branch1"))
+        entitiesRepository.save("things", Entity.New("thing2", "Thing 2", branchId = "branch2"))
+
+        val instanceAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
+        val results = instanceAdapter.queryEq("things", EntityItemElement.BRANCH_ID, "branch2")
+        assertThat(results!!.size, equalTo(1))
+        assertThat(results.first().getFirstChild("name")!!.value!!.value, equalTo("thing2"))
     }
 }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/instance/LocalEntitiesInstanceAdapterTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/instance/LocalEntitiesInstanceAdapterTest.kt
@@ -4,6 +4,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceAdapter
+import org.odk.collect.entities.javarosa.parse.EntityItemElement
 import org.odk.collect.entities.storage.Entity
 import org.odk.collect.entities.storage.InMemEntitiesRepository
 
@@ -16,7 +17,18 @@ class LocalEntitiesInstanceAdapterTest {
         entitiesRepository.save("things", Entity.New("thing2", "Thing 2"))
 
         val instanceAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
-        val results = instanceAdapter.queryEq("things", "label", "Thing 2")
+        val results = instanceAdapter.queryEq("things", EntityItemElement.LABEL, "Thing 2")
+        assertThat(results!!.first().getFirstChild("name")!!.value!!.value, equalTo("thing2"))
+    }
+
+    @Test
+    fun `#queryEq supports __version`() {
+        val entitiesRepository = InMemEntitiesRepository()
+        entitiesRepository.save("things", Entity.New("thing1", "Thing 1", version = 1))
+        entitiesRepository.save("things", Entity.New("thing2", "Thing 2", version = 2))
+
+        val instanceAdapter = LocalEntitiesInstanceAdapter(entitiesRepository)
+        val results = instanceAdapter.queryEq("things", EntityItemElement.VERSION, "2")
         assertThat(results!!.first().getFirstChild("name")!!.value!!.value, equalTo("thing2"))
     }
 }

--- a/test-forms/src/main/resources/forms/entity-update-pulldata.xml
+++ b/test-forms/src/main/resources/forms/entity-update-pulldata.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:entities="http://www.opendatakit.org/xforms/entities">
+	<h:head>
+		<h:title>Entity Update Pull Data</h:title>
+		<model odk:xforms-version="1.0.0" entities:entities-version="2024.1.0">
+			<instance>
+				<data id="entity_update_pull_data" version="1">
+					<selected_person/>
+					<person/>
+					<name/>
+					<meta>
+						<instanceID/>
+						<instanceName/>
+						<entity dataset="people" update="true" id="" baseVersion="" trunkVersion="" branchId="">
+							<label/>
+						</entity>
+					</meta>
+				</data>
+			</instance>
+
+			<instance id="people" src="jr://file-csv/people.csv"/>
+
+			<bind nodeset="/data/selected_person" type="string" calculate="pulldata('people', 'full_name', 'name', /data/person)"/>
+			<bind nodeset="/data/person" type="string"/>
+			<bind nodeset="/data/name" type="string" calculate="pulldata('people', 'full_name', 'name', /data/person)" entities:saveto="full_name"/>
+
+			<bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+
+			<bind nodeset="/data/meta/entity/@id" type="string" calculate="/data/person"/>
+			<bind calculate="/data/name" nodeset="/data/meta/entity/label" type="string"/>
+			<bind nodeset="/data/meta/entity/@baseVersion" calculate="instance('people')/root/item[name=/data/person]/__version" type="string"/>
+			<bind nodeset="/data/meta/entity/@trunkVersion" calculate="instance('people')/root/item[name=/data/person]/__trunkVersion" type="string"/>
+			<bind nodeset="/data/meta/entity/@branchId" calculate="instance('people')/root/item[name=/data/person]/__branchId" type="string"/>
+		</model>
+	</h:head>
+	<h:body>
+		<select1 ref="/data/person">
+			<label>Select person</label>
+			<itemset nodeset="instance('people')/root/item">
+				<value ref="name"/>
+				<label ref="label"/>
+			</itemset>
+			<setvalue event="xforms-value-changed" ref="/data/name" value="/data/selected_person" />
+		</select1>
+		<input ref="/data/name">
+			<label>Name</label>
+		</input>
+	</h:body>
+</h:html>


### PR DESCRIPTION
Closes #6443
~~Blocked by https://github.com/getodk/javarosa/pull/802~~

#### Why is this the best possible solution? Were any other approaches considered?

I'd initially wanted to implement this by just executing a dynamically built XPath expression, but this proved tricky as JavaRosa currently doesn't attach secondary instances that aren't referenced by an `instance` expression. This would mean that a form that contained **only** a `pulldata` referencing an entity list wouldn't work (as the external instance would never be parsed and attached to the main instance). We'll look to move to the originally intended implementation in the next release as part of https://github.com/getodk/collect/issues/6454.

Instead, I've ended up using the `LocalEntityInstanceAdapter` in a similar way to `LocalEntityFilterStrategy` with modifications so that it now supports querying any child of an entity item (like `label` for example). This new support doesn't add anything significant in the way of optimisation however: queries for children like `label` work by just loading every entity in the list from the DB and then performing an in-mem filter. This limits the amount of work we do to just support `pulldata`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The big risks here will be to all `pulldata` forms (including ones that use with entities obviously) and to entity filters in forms in general.

One thing to note: I've not extended the instance "normalising" that `pulldata` does to entity lists. For normal secondary instances, `pulldata` would let you use the wrong case for the name or add `.csv` to the end. We'll discuss if we want to maintain this (currently undocumented) behaviour separately.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
