### PR TITLE
Disable StrictMode for FormHiearchyActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -19,13 +19,10 @@ import static org.odk.collect.settings.keys.MetaKeys.KEY_GOOGLE_BUG_154855417_FI
 import android.app.Application;
 import android.content.Context;
 import android.content.res.Configuration;
-import android.os.Build;
-import android.os.StrictMode;
 
 import androidx.annotation.NonNull;
 
 import org.jetbrains.annotations.NotNull;
-import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.dynamicpreload.ExternalDataManager;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.injection.config.AppDependencyComponent;
@@ -36,13 +33,14 @@ import org.odk.collect.android.injection.config.CollectOsmDroidDependencyModule;
 import org.odk.collect.android.injection.config.CollectProjectsDependencyModule;
 import org.odk.collect.android.injection.config.CollectSelfieCameraDependencyModule;
 import org.odk.collect.android.injection.config.DaggerAppDependencyComponent;
+import org.odk.collect.android.utilities.CollectStrictMode;
 import org.odk.collect.android.utilities.FormsRepositoryProvider;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.androidshared.data.AppState;
 import org.odk.collect.androidshared.data.StateStore;
-import org.odk.collect.async.network.NetworkStateProvider;
 import org.odk.collect.androidshared.system.ExternalFilesUtils;
 import org.odk.collect.async.Scheduler;
+import org.odk.collect.async.network.NetworkStateProvider;
 import org.odk.collect.audiorecorder.AudioRecorderDependencyComponent;
 import org.odk.collect.audiorecorder.AudioRecorderDependencyComponentProvider;
 import org.odk.collect.audiorecorder.DaggerAudioRecorderDependencyComponent;
@@ -149,31 +147,9 @@ public class Collect extends Application implements
 
                     applicationComponent.applicationInitializer().initialize();
                     fixGoogleBug154855417();
-                    setupStrictMode();
+                    CollectStrictMode.enable();
                 }
         );
-    }
-
-    /**
-     * Enable StrictMode and log violations to the system log.
-     * This catches disk and network access on the main thread, as well as leaked SQLite
-     * cursors and unclosed resources.
-     */
-    private void setupStrictMode() {
-        if (BuildConfig.DEBUG) {
-            StrictMode.ThreadPolicy.Builder policyBuilder = new StrictMode.ThreadPolicy.Builder()
-                    .detectAll()
-                    .permitDiskReads()  // shared preferences are being read on main thread (`GetAndSubmitFormTest`)
-                    .permitDiskWrites() // files are being created on the fly (`GetAndSubmitFormTest`)
-                    .penaltyDeath();
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                policyBuilder.permitUnbufferedIo(); // `ObjectInputStream#readObject` calls
-            }
-
-            StrictMode.setThreadPolicy(policyBuilder
-                    .build());
-        }
     }
 
     private void setupDagger() {

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyActivity.java
@@ -60,6 +60,7 @@ import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.javarosawrapper.JavaRosaFormController;
 import org.odk.collect.android.projects.ProjectsDataService;
 import org.odk.collect.android.utilities.ApplicationConstants;
+import org.odk.collect.android.utilities.CollectStrictMode;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.FormsRepositoryProvider;
 import org.odk.collect.android.utilities.HtmlUtils;
@@ -212,6 +213,8 @@ public class FormHierarchyActivity extends LocalizedActivity implements DeleteRe
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        CollectStrictMode.disable();
+
         DaggerUtils.getComponent(this).inject(this);
 
         String sessionId = getIntent().getStringExtra(EXTRA_SESSION_ID);
@@ -923,5 +926,12 @@ public class FormHierarchyActivity extends LocalizedActivity implements DeleteRe
             goToPreviousEvent();
             goUpLevel();
         }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+
+        CollectStrictMode.enable();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyActivity.java
@@ -930,8 +930,7 @@ public class FormHierarchyActivity extends LocalizedActivity implements DeleteRe
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
-
         CollectStrictMode.enable();
+        super.onDestroy();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CollectStrictMode.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CollectStrictMode.kt
@@ -1,0 +1,31 @@
+package org.odk.collect.android.utilities
+
+import android.os.Build
+import android.os.StrictMode
+import android.os.StrictMode.ThreadPolicy
+import org.odk.collect.android.BuildConfig
+
+object CollectStrictMode {
+
+    @JvmStatic
+    fun enable() {
+        if (BuildConfig.DEBUG) {
+            val policyBuilder = ThreadPolicy.Builder()
+                .detectAll()
+                .permitDiskReads() // shared preferences are being read on main thread (`GetAndSubmitFormTest`)
+                .permitDiskWrites() // files are being created on the fly (`GetAndSubmitFormTest`)
+                .penaltyDeath()
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                policyBuilder.permitUnbufferedIo() // `ObjectInputStream#readObject` calls
+            }
+
+            StrictMode.setThreadPolicy(policyBuilder.build())
+        }
+    }
+
+    @JvmStatic
+    fun disable() {
+        StrictMode.setThreadPolicy(ThreadPolicy.Builder().permitCustomSlowCalls().build())
+    }
+}

--- a/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
@@ -16,7 +16,8 @@ class SynchronizedDatabaseConnection(
         path,
         name,
         migrator,
-        databaseVersion
+        databaseVersion,
+        true
     )
 
     fun <T> withConnection(block: DatabaseConnection.() -> T): T {


### PR DESCRIPTION
Closes #6397

#### Why is this the best possible solution? Were any other approaches considered?

While working on this, I discovered that we'd accidentally disabled StrictMode protection for `DatabaseEntitiesRepository`. Fortunately, it doesn't seem like we'd added any violations as I was able to add it back in without problems (other than the expected ones).

I'd initially thought about removing the blanket protection on the whole repository and just adding custom slow calls to some methods, but I realised I'd have to remove protection on pretty much all the `get...` methods to allow for different kinds of filters in the hierarchy. 

Instead, I've gone for an approach where StrictMode is disabled when the `FormHierarchyActivity` is created and then re-enabled when it is destroyed. This means we get full protection elsewhere, and only the "broken" code will have to change when we fix it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't affect users at all as the crashes/errors were only visible in debug. No need for testing here.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
