### PR TITLE
Prevent resetting finalized forms that modify entities

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/ResetProjectTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/ResetProjectTest.kt
@@ -3,7 +3,6 @@ package org.odk.collect.android.feature.settings
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
-import org.odk.collect.android.support.StubOpenRosaServer.EntityListItem
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.AccessControlPage
 import org.odk.collect.android.support.pages.FormEntryPage

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/ResetProjectTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/ResetProjectTest.kt
@@ -41,16 +41,12 @@ class ResetProjectTest {
     }
 
     @Test
-    fun canResetSavedFormsAndEntities() {
-        testDependencies.server.addForm("one-question-entity-registration.xml")
-        testDependencies.server.addForm(
-            "one-question-entity-update.xml",
-            listOf(EntityListItem("people.csv"))
-        )
+    fun canResetSavedForms() {
+        testDependencies.server.addForm("one-question.xml")
 
         rule.withMatchExactlyProject(testDependencies.server.url)
-            .startBlankForm("One Question Entity Registration")
-            .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("Name", "Logan Roy"))
+            .startBlankForm("One Question")
+            .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("what is your age", "34"))
 
             .openProjectSettingsDialog()
             .clickSettings()
@@ -62,11 +58,7 @@ class ResetProjectTest {
             .clickOKOnDialog(MainMenuPage())
 
             .clickDrafts()
-            .assertTextDoesNotExist("One Question Entity Registration")
-            .pressBack(MainMenuPage())
-
-            .startBlankForm("One Question Entity Update")
-            .assertTextDoesNotExist("Logan Roy")
+            .assertTextDoesNotExist("One Question")
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -190,7 +190,7 @@ class InstancesDataService(
         return projectDependencyModule.instancesLock.withLock { acquiredLock: Boolean ->
             if (acquiredLock) {
                 instancesRepository.all.forEach {
-                    if (it.canDeleteBeforeSend() || it.status != STATUS_COMPLETE && it.status != STATUS_SUBMISSION_FAILED) {
+                    if (it.canDelete()) {
                         instancesRepository.delete(it.dbId)
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -22,6 +22,8 @@ import org.odk.collect.androidshared.data.AppState
 import org.odk.collect.androidshared.data.getData
 import org.odk.collect.forms.Form
 import org.odk.collect.forms.instances.Instance
+import org.odk.collect.forms.instances.Instance.STATUS_COMPLETE
+import org.odk.collect.forms.instances.Instance.STATUS_SUBMISSION_FAILED
 import org.odk.collect.metadata.PropertyManager
 import org.odk.collect.projects.ProjectDependencyFactory
 import java.io.File
@@ -180,14 +182,18 @@ class InstancesDataService(
         }
     }
 
-    fun deleteAll(projectId: String): Boolean {
+    fun reset(projectId: String): Boolean {
         val projectDependencyModule =
             projectDependencyModuleFactory.create(projectId)
         val instancesRepository = projectDependencyModule.instancesRepository
 
         return projectDependencyModule.instancesLock.withLock { acquiredLock: Boolean ->
             if (acquiredLock) {
-                instancesRepository.deleteAll()
+                instancesRepository.all.forEach {
+                    if (it.canDeleteBeforeSend() || it.status != STATUS_COMPLETE && it.status != STATUS_SUBMISSION_FAILED) {
+                        instancesRepository.delete(it.dbId)
+                    }
+                }
                 update(projectId)
                 true
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectResetter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectResetter.kt
@@ -72,7 +72,7 @@ class ProjectResetter(
     private fun resetInstances() {
         entitiesRepositoryFactory.create(projectId).clear()
 
-        if (!instancesDataService.deleteAll(projectId) ||
+        if (!instancesDataService.reset(projectId) ||
             !deleteFolderContent(storagePaths.instancesDir)
         ) {
             failedResetActions.add(ResetAction.RESET_INSTANCES)

--- a/forms-test/src/main/java/org/odk/collect/formstest/InstanceFixtures.kt
+++ b/forms-test/src/main/java/org/odk/collect/formstest/InstanceFixtures.kt
@@ -12,7 +12,8 @@ object InstanceFixtures {
         displayName: String? = null,
         dbId: Long? = null,
         form: Form? = null,
-        deletedDate: Long? = null
+        deletedDate: Long? = null,
+        canDeleteBeforeSend: Boolean = true
     ): Instance {
         val instancesDir = TempFiles.createTempDir()
         return InstanceUtils.buildInstance("formId", "version", instancesDir.absolutePath)
@@ -26,7 +27,7 @@ object InstanceFixtures {
                 }
             }
             .deletedDate(deletedDate)
-            .canDeleteBeforeSend(true)
+            .canDeleteBeforeSend(canDeleteBeforeSend)
             .build()
     }
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -981,7 +981,7 @@
     <string name="select_all">Select All</string>
     <string name="clear_all">Clear All</string>
     <string name="reset_settings">All settings (internal settings, saved settings)</string>
-    <string name="reset_saved_forms">Saved forms and entities (instances folder, instances database, entities database)</string>
+    <string name="reset_saved_forms">Saved forms (instances folder, instances database)</string>
     <string name="reset_blank_forms">Blank forms (forms folder, forms database, itemsets database)</string>
     <string name="reset_layers">Map layers (layers folder)</string>
     <string name="reset_cache">Form load cache (.cache folder)</string>


### PR DESCRIPTION
Closes #6435

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here! I just piggy backed on the existing helpers added to determine whether a form can safely be deleted and added a new use case for resetting entities now the logic is more complex than just deleting everything.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just affects the saved form reset flow.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
