### PR TITLE
Fixed reading geometryXPath in FormMetadataParser

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParser.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParser.kt
@@ -117,7 +117,10 @@ object FormMetadataParser {
             if (geopointXPaths.contains(xpath)) {
                 return xpath
             } else if (child.childCount > 0 && !repeatXPaths.contains(xpath)) {
-                return getFirstPrimaryInstanceGeopointXPath(geopointXPaths, repeatXPaths, child, xpath)
+                val result = getFirstPrimaryInstanceGeopointXPath(geopointXPaths, repeatXPaths, child, xpath)
+                if (result != null) {
+                    return result
+                }
             }
         }
         return null

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParser.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParser.kt
@@ -109,17 +109,17 @@ object FormMetadataParser {
     ): String? {
         for (position in 0 until parentRoot.childCount) {
             val child = parentRoot.getElement(position) ?: continue
-            val xpath = if (parentXPath == null) {
+            val currentXPath = if (parentXPath == null) {
                 "/${parentRoot.name}/${child.name}"
             } else {
                 "$parentXPath/${child.name}"
             }
-            if (geopointXPaths.contains(xpath)) {
-                return xpath
-            } else if (child.childCount > 0 && !repeatXPaths.contains(xpath)) {
-                val result = getFirstPrimaryInstanceGeopointXPath(geopointXPaths, repeatXPaths, child, xpath)
-                if (result != null) {
-                    return result
+            if (geopointXPaths.contains(currentXPath)) {
+                return currentXPath
+            } else if (child.childCount > 0 && !repeatXPaths.contains(currentXPath)) {
+                val nestedXPath = getFirstPrimaryInstanceGeopointXPath(geopointXPaths, repeatXPaths, child, currentXPath)
+                if (nestedXPath != null) {
+                    return nestedXPath
                 }
             }
         }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParserTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParserTest.kt
@@ -286,6 +286,49 @@ class FormMetadataParserTest {
     }
 
     @Test
+    fun readMetadata_withGeopointInNonFirstGroup_returnsExpectedGeopointXPath() {
+        val formMetadata = readMetadata(
+            """
+                <?xml version="1.0"?>
+                <h:html xmlns:h="http://www.w3.org/1999/xhtml"
+                        xmlns="http://www.w3.org/2002/xforms">
+                    <h:head>
+                        <h:title>Two geopoints in group</h:title>
+                        <model>
+                            <instance>
+                                <data id="two-geopoints-group">
+                                    <my-group1>
+                                        <name />
+                                    </my-group1>
+                                    <my-group2>
+                                        <location />
+                                    </my-group2>
+                                </data>
+                            </instance>
+                            <bind nodeset="/data/my-group1/name" type="string" />
+                            <bind nodeset="/data/my-group2/location" type="geopoint" />
+                        </model>
+                    </h:head>
+                    <h:body>
+                        <group ref="/data/my-group1">
+                            <input ref="/data/my-group1/name">
+                                <label>Name</label>
+                            </input>
+                        </group>
+                        <group ref="/data/my-group2">
+                            <input ref="/data/my-group2/location">
+                                <label>Location</label>
+                            </input>
+                        </group>
+                    </h:body>
+                </h:html>
+            """.trimIndent().byteInputStream()
+        )
+
+        assertThat(formMetadata.geometryXPath, equalTo("/data/my-group2/location"))
+    }
+
+    @Test
     fun readMetadata_withGeopointInRepeat_returnsFirstGeopointXPathThatIsNotInsideRepeat() {
         val formMetadata = readMetadata(
             """


### PR DESCRIPTION
Closes #6450 

#### Why is this the best possible solution? Were any other approaches considered?
The problem here was a bug in a recursive function that returned a wrong (null) value too early.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We should test forms with geopoints (those that display the map icon in the form list) under different configurations. In this case, the issue was that while the geopoint existed, the form had two groups, and it was placed in the second one. It would be helpful to create several forms with multiple groups, including nested ones, to thoroughly test these scenarios.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
