### PR TITLE
Set user property when there is a static CSV and entity list clash

### DIFF
--- a/async/src/main/java/org/odk/collect/async/TaskSpecWorker.kt
+++ b/async/src/main/java/org/odk/collect/async/TaskSpecWorker.kt
@@ -16,7 +16,7 @@ class TaskSpecWorker(
     override fun doWork(): Result {
         val cellularOnly = inputData.getBoolean(DATA_CELLULAR_ONLY, false)
         if (cellularOnly && connectivityProvider.currentNetwork != Scheduler.NetworkType.CELLULAR) {
-            Analytics.setUserProperty("EncounteredMeteredNonCellularInTasks", "true")
+            Analytics.setUserProperty("SawMeteredNonCellular", "true")
             return Result.retry()
         }
 


### PR DESCRIPTION
Closes #6455

As well as the case we're worried about this will also detect a couple that won't be a problem:
1. A secondary instance CSV that has a name like `people.csv` in a project that has a `people` entity list, but the instance ID is not `people` and so is safe (`static-people` for example).
2. A CSV that has a name like `people.csv` in a project that has a `people` entity list, but the CSV is not being used as the `src` for a secondary instance.

Both these cases should be very rare though. I've also updated the name of the user property we were using to track metered non-cellular connections as we'd forgotten to set the user property up on Firebase and the name we were using was too long (there is a 40-character limit).

