### PR TITLE
Reset savepoints when resetting instances

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectResetter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectResetter.kt
@@ -68,7 +68,9 @@ class ProjectResetter(
     }
 
     private fun resetInstances() {
-        if (!instancesDataService.reset(projectId)) {
+        if (instancesDataService.reset(projectId)) {
+            savepointsRepositoryProvider.create(projectId).deleteAll()
+        } else {
             failedResetActions.add(ResetAction.RESET_INSTANCES)
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectResetterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectResetterTest.kt
@@ -198,9 +198,10 @@ class ProjectResetterTest {
     }
 
     @Test
-    fun `Reset instances does not clear instances if the instances database is locked`() {
+    fun `Reset instances does not clear instances and savepoints if the instances database is locked`() {
         saveTestInstanceFiles(currentProjectId)
         setupTestInstancesDatabase(currentProjectId)
+        setupTestSavepointsDatabase(currentProjectId)
 
         (changeLockProvider.create(currentProjectId).instancesLock as ThreadSafeBooleanChangeLock).tryLock()
         val failedResetActions = projectResetter.reset(listOf(ProjectResetter.ResetAction.RESET_INSTANCES))
@@ -208,12 +209,14 @@ class ProjectResetterTest {
 
         assertEquals(1, instancesRepositoryProvider.create(currentProjectId).all.size)
         assertTestInstanceFiles(currentProjectId)
+        assertEquals(1, savepointsRepositoryProvider.create(currentProjectId).getAll().size)
     }
 
     @Test
-    fun `Reset instances clears instances for current project`() {
+    fun `Reset instances clears instances and savepoints for current project`() {
         saveTestInstanceFiles(currentProjectId)
         setupTestInstancesDatabase(currentProjectId)
+        setupTestSavepointsDatabase(anotherProjectId)
         val instancesRepository = instancesRepositoryProvider.create(currentProjectId)
         val instance = instancesRepository.all[0]
 
@@ -221,17 +224,20 @@ class ProjectResetterTest {
 
         assertEquals(0, instancesRepository.all.size)
         assertEquals(false, File(instance.instanceFilePath).parentFile.exists())
+        assertEquals(1, savepointsRepositoryProvider.create(anotherProjectId).getAll().size)
     }
 
     @Test
-    fun `Reset instances does not clear instances for another projects`() {
+    fun `Reset instances does not clear instances and savepoints for another projects`() {
         saveTestInstanceFiles(anotherProjectId)
         setupTestInstancesDatabase(anotherProjectId)
+        setupTestSavepointsDatabase(anotherProjectId)
 
         resetAppState(listOf(ProjectResetter.ResetAction.RESET_INSTANCES))
 
         assertEquals(1, instancesRepositoryProvider.create(anotherProjectId).all.size)
         assertTestInstanceFiles(anotherProjectId)
+        assertEquals(1, savepointsRepositoryProvider.create(anotherProjectId).getAll().size)
     }
 
     @Test


### PR DESCRIPTION
Closes #6331 

#### Why is this the best possible solution? Were any other approaches considered?
When resetting saved forms, we should also reset savepoints, as they are essentially saved forms too, making it logical to reset them together.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I believe it should just fix the issue. I can't think of any big risk here so during testing we can focus on resetting saved forms. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
