### PR TITLE
Remove redundant files cleaning during resetting saved forms

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectResetter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectResetter.kt
@@ -68,9 +68,7 @@ class ProjectResetter(
     }
 
     private fun resetInstances() {
-        if (!instancesDataService.reset(projectId) ||
-            !deleteFolderContent(storagePaths.instancesDir)
-        ) {
+        if (!instancesDataService.reset(projectId)) {
             failedResetActions.add(ResetAction.RESET_INSTANCES)
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstancesDataServiceTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstancesDataServiceTest.kt
@@ -30,6 +30,7 @@ import org.odk.collect.projects.ProjectDependencyFactory
 import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.shared.locks.ThreadSafeBooleanChangeLock
 import org.odk.collect.shared.settings.InMemSettings
+import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class InstancesDataServiceTest {
@@ -129,5 +130,7 @@ class InstancesDataServiceTest {
         assertThat(remainingInstances.size, equalTo(2))
         assertThat(remainingInstances.any { it.status == STATUS_COMPLETE }, equalTo(true))
         assertThat(remainingInstances.any { it.status == STATUS_SUBMISSION_FAILED }, equalTo(true))
+        assertThat(File(remainingInstances[0].instanceFilePath).parentFile?.exists(), equalTo(true))
+        assertThat(File(remainingInstances[1].instanceFilePath).parentFile?.exists(), equalTo(true))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectResetterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectResetterTest.kt
@@ -214,11 +214,13 @@ class ProjectResetterTest {
     fun `Reset instances clears instances for current project`() {
         saveTestInstanceFiles(currentProjectId)
         setupTestInstancesDatabase(currentProjectId)
+        val instancesRepository = instancesRepositoryProvider.create(currentProjectId)
+        val instance = instancesRepository.all[0]
 
         resetAppState(listOf(ProjectResetter.ResetAction.RESET_INSTANCES))
 
-        assertEquals(0, instancesRepositoryProvider.create(currentProjectId).all.size)
-        assertFolderEmpty(storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, currentProjectId))
+        assertEquals(0, instancesRepository.all.size)
+        assertEquals(false, File(instance.instanceFilePath).parentFile.exists())
     }
 
     @Test


### PR DESCRIPTION
Closes #6475 

#### Why is this the best possible solution? Were any other approaches considered?
We don't need the file cleaning that removes all instance directories, as when we reset specific instances (those that can be deleted), their files are removed automatically. See: https://github.com/getodk/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/database/instances/DatabaseInstancesRepository.java#L153

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We should test it in the same way as [this pull request](https://github.com/getodk/collect/pull/6460), as this is a fix for that specific PR.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
