### PR TITLE
Log exceptions that happen during background tasks

### DIFF
--- a/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
@@ -45,5 +45,9 @@ interface Analytics {
         fun setUserProperty(name: String, value: String) {
             instance.setUserProperty(name, value)
         }
+
+        fun logNonFatal(throwable: Throwable) {
+            instance.logNonFatal(throwable)
+        }
     }
 }

--- a/async/src/main/java/org/odk/collect/async/TaskSpec.kt
+++ b/async/src/main/java/org/odk/collect/async/TaskSpec.kt
@@ -18,4 +18,9 @@ interface TaskSpec {
      * once instead of doing that after every single execution.
      */
     fun getTask(context: Context, inputData: Map<String, String>, isLastUniqueExecution: Boolean): Supplier<Boolean>
+
+    /**
+     * Called if an exception is thrown while executing the work.
+     */
+    fun onException(exception: Throwable)
 }

--- a/async/src/main/java/org/odk/collect/async/TaskSpecWorker.kt
+++ b/async/src/main/java/org/odk/collect/async/TaskSpecWorker.kt
@@ -24,16 +24,22 @@ class TaskSpecWorker(
         val spec = Class.forName(specClass).getConstructor().newInstance() as TaskSpec
 
         val stringInputData = inputData.keyValueMap.mapValues { it.value.toString() }
-        val completed =
-            spec.getTask(applicationContext, stringInputData, isLastUniqueExecution(spec)).get()
-        val maxRetries = spec.maxRetries
 
-        return if (completed) {
-            Result.success()
-        } else if (maxRetries == null || runAttemptCount < maxRetries) {
-            Result.retry()
-        } else {
-            Result.failure()
+        try {
+            val completed =
+                spec.getTask(applicationContext, stringInputData, isLastUniqueExecution(spec)).get()
+            val maxRetries = spec.maxRetries
+
+            return if (completed) {
+                Result.success()
+            } else if (maxRetries == null || runAttemptCount < maxRetries) {
+                Result.retry()
+            } else {
+                Result.failure()
+            }
+        } catch (t: Throwable) {
+            spec.onException(t)
+            return Result.failure()
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpec.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpec.kt
@@ -17,6 +17,7 @@ package org.odk.collect.android.backgroundwork
 
 import android.content.Context
 import androidx.work.BackoffPolicy
+import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.formmanagement.FormsDataService
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.async.TaskSpec
@@ -42,5 +43,9 @@ class AutoUpdateTaskSpec : TaskSpec {
                 throw IllegalArgumentException("No project ID provided!")
             }
         }
+    }
+
+    override fun onException(exception: Throwable) {
+        Analytics.logNonFatal(exception)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SendFormsTaskSpec.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SendFormsTaskSpec.kt
@@ -15,6 +15,7 @@ package org.odk.collect.android.backgroundwork
 
 import android.content.Context
 import androidx.work.BackoffPolicy
+import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.instancemanagement.InstancesDataService
 import org.odk.collect.async.TaskSpec
@@ -44,5 +45,9 @@ class SendFormsTaskSpec : TaskSpec {
                 throw IllegalArgumentException("No project ID provided!")
             }
         }
+    }
+
+    override fun onException(exception: Throwable) {
+        Analytics.logNonFatal(exception)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.backgroundwork
 
 import android.content.Context
 import androidx.work.BackoffPolicy
+import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.formmanagement.FormsDataService
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.async.TaskSpec
@@ -26,5 +27,9 @@ class SyncFormsTaskSpec : TaskSpec {
                 throw IllegalArgumentException("No project ID provided!")
             }
         }
+    }
+
+    override fun onException(exception: Throwable) {
+        Analytics.logNonFatal(exception)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -106,8 +106,17 @@ object ServerFormUseCases {
             }
 
             if (mediaFile.isEntityList) {
-                val entityListName = getEntityListFromFileName(mediaFile)
-                LocalEntityUseCases.updateLocalEntitiesFromServer(entityListName, tempMediaFile, entitiesRepository)
+                /**
+                 * We wrap and then rethrow exceptions that happen here to make them easier to
+                 * track in Crashlytics. This can be removed in the next release once any
+                 * unexpected exceptions "in the wild" are identified.
+                 */
+                try {
+                    val entityListName = getEntityListFromFileName(mediaFile)
+                    LocalEntityUseCases.updateLocalEntitiesFromServer(entityListName, tempMediaFile, entitiesRepository)
+                } catch (t: Throwable) {
+                    throw EntityListUpdateException(t)
+                }
             } else {
                 /**
                  * Track CSVs that have names that clash with entity lists in the project. If
@@ -143,3 +152,5 @@ object ServerFormUseCases {
         }
     }
 }
+
+class EntityListUpdateException(cause: Throwable) : Exception(cause)


### PR DESCRIPTION
Exceptions from our `TaskSpec` implementations will now be logged as non fatals to Crashlytics. Additionally, I've wrapped exceptions that occur during entity list updates in a specific exception so that it'll be easier to track them. 