### PR TITLE
Block settings that restart the app when in form entry

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FillBlankFormWithRepeatGroupTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FillBlankFormWithRepeatGroupTest.kt
@@ -25,7 +25,7 @@ class FillBlankFormWithRepeatGroupTest {
             .copyForm("TestRepeat.xml")
             .startBlankForm("TestRepeat")
             .clickOptionsIcon()
-            .clickGeneralSettings()
+            .clickProjectSettings()
             .clickOnUserInterface()
             .clickNavigation()
             .clickUseSwipesAndButtons()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormNavigationTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormNavigationTest.kt
@@ -18,7 +18,6 @@ package org.odk.collect.android.feature.formentry
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
-import org.odk.collect.android.R
 import org.odk.collect.android.support.pages.AccessControlPage
 import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.MainMenuPage
@@ -111,7 +110,7 @@ class FormNavigationTest {
 
             // change settings to 'Horizontal swipes' mode'
             .clickOptionsIcon()
-            .clickGeneralSettings()
+            .clickProjectSettings()
             .clickOnUserInterface()
             .clickNavigation()
             .clickSwipes()
@@ -124,7 +123,7 @@ class FormNavigationTest {
 
             // change settings to 'Forward/backward buttons' mode'
             .clickOptionsIcon()
-            .clickGeneralSettings()
+            .clickProjectSettings()
             .clickOnUserInterface()
             .clickNavigation()
             .clickUseNavigationButtons()
@@ -138,7 +137,7 @@ class FormNavigationTest {
 
             // change settings to 'Swipes and buttons' mode'
             .clickOptionsIcon()
-            .clickGeneralSettings()
+            .clickProjectSettings()
             .clickOnUserInterface()
             .clickNavigation()
             .clickUseSwipesAndButtons()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormStylingTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormStylingTest.kt
@@ -3,7 +3,6 @@ package org.odk.collect.android.feature.formentry
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
-import org.odk.collect.android.R
 import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.ProjectSettingsPage
@@ -58,7 +57,7 @@ class FormStylingTest {
             .startBlankForm(FORM_NAME)
             .assertText("Guidance text")
             .clickOptionsIcon()
-            .clickGeneralSettings()
+            .clickProjectSettings()
             .openFormManagement()
             .openShowGuidanceForQuestions()
             .clickOnString(org.odk.collect.strings.R.string.guidance_yes_collapsed)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -69,7 +69,7 @@ class AuditTest {
             .startBlankForm("One Question Audit Track Changes")
             .fillOut(FormEntryPage.QuestionAndAnswer("What is your age?", "31"))
             .clickOptionsIcon()
-            .clickGeneralSettings()
+            .clickProjectSettings()
 
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
         assertThat(auditLog[1].get("event"), equalTo("question"))

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/FormEntrySettingsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/FormEntrySettingsTest.kt
@@ -1,0 +1,33 @@
+package org.odk.collect.android.feature.settings
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.odk.collect.android.support.rules.CollectTestRule
+import org.odk.collect.android.support.rules.TestRuleChain
+import org.odk.collect.strings.R
+
+@RunWith(AndroidJUnit4::class)
+class FormEntrySettingsTest {
+
+    private val rule = CollectTestRule()
+
+    @get:Rule
+    val chain: RuleChain = TestRuleChain.chain().around(rule)
+
+    @Test
+    fun settingsThatResetAppAreBlocked() {
+        rule.startAtMainMenu()
+            .copyForm("one-question.xml")
+            .startBlankForm("One Question")
+            .clickOptionsIcon()
+            .clickProjectSettings()
+            .assertDisabled(R.string.project_management_section_title)
+
+            .clickOnUserInterface()
+            .assertDisabled(R.string.app_theme)
+            .assertDisabled(R.string.language)
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -174,7 +174,7 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return clickOptionsIcon(org.odk.collect.strings.R.string.project_settings);
     }
 
-    public ProjectSettingsPage clickGeneralSettings() {
+    public ProjectSettingsPage clickProjectSettings() {
         onView(withText(getTranslatedString(org.odk.collect.strings.R.string.project_settings))).perform(click());
         return new ProjectSettingsPage().assertOnPage();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -127,9 +127,6 @@ import org.odk.collect.android.formentry.saving.SaveFormProgressDialogFragment;
 import org.odk.collect.android.formhierarchy.FormHierarchyActivity;
 import org.odk.collect.android.formhierarchy.ViewOnlyFormHierarchyActivity;
 import org.odk.collect.android.fragments.MediaLoadingFragment;
-import org.odk.collect.android.utilities.ChangeLockProvider;
-import org.odk.collect.android.widgets.datetime.pickers.CustomDatePickerDialog;
-import org.odk.collect.android.widgets.datetime.pickers.CustomTimePickerDialog;
 import org.odk.collect.android.fragments.dialogs.LocationProvidersDisabledDialog;
 import org.odk.collect.android.fragments.dialogs.NumberPickerDialog;
 import org.odk.collect.android.fragments.dialogs.RankingWidgetDialog;
@@ -145,7 +142,6 @@ import org.odk.collect.android.listeners.AdvanceToNextListener;
 import org.odk.collect.android.listeners.FormLoaderListener;
 import org.odk.collect.android.listeners.WidgetValueChangedListener;
 import org.odk.collect.android.logic.ImmutableDisplayableQuestion;
-import org.odk.collect.android.mainmenu.MainMenuActivity;
 import org.odk.collect.android.projects.ProjectsDataService;
 import org.odk.collect.android.savepoints.SavepointListener;
 import org.odk.collect.android.savepoints.SavepointTask;
@@ -154,6 +150,7 @@ import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.tasks.FormLoaderTask;
 import org.odk.collect.android.tasks.SaveFormIndexTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
+import org.odk.collect.android.utilities.ChangeLockProvider;
 import org.odk.collect.android.utilities.ContentUriHelper;
 import org.odk.collect.android.utilities.ControllableLifecyleOwner;
 import org.odk.collect.android.utilities.ExternalAppIntentProvider;
@@ -163,8 +160,10 @@ import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.SavepointsRepositoryProvider;
 import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.SoftKeyboardController;
-import org.odk.collect.android.widgets.datetime.DateTimeWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
+import org.odk.collect.android.widgets.datetime.DateTimeWidget;
+import org.odk.collect.android.widgets.datetime.pickers.CustomDatePickerDialog;
+import org.odk.collect.android.widgets.datetime.pickers.CustomTimePickerDialog;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.items.SelectOneFromMapDialogFragment;
 import org.odk.collect.android.widgets.range.RangePickerDecimalWidget;
@@ -1792,23 +1791,12 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 if (fec != null) {
                     loadingComplete(formLoaderTask, formLoaderTask.getFormDef(), null);
                 } else {
-                    DialogFragmentUtils.dismissDialog(FormLoadingDialogFragment.class, getSupportFragmentManager());
-                    FormLoaderTask t = formLoaderTask;
-                    formLoaderTask = null;
-                    t.cancel();
-                    t.destroy();
-                    // there is no formController -- fire MainMenu activity?
-                    Timber.w("Starting MainMenuActivity because formController is null/formLoaderTask not null");
-                    startActivity(new Intent(this, MainMenuActivity.class));
+                    throw new IllegalStateException("Null formController!");
                 }
             }
         } else {
             if (formController == null && !identityPromptViewModel.requiresIdentityToContinue().getValue()) {
-                // there is no formController -- fire MainMenu activity?
-                Timber.w("Starting MainMenuActivity because formController is null/formLoaderTask is null");
-                startActivity(new Intent(this, MainMenuActivity.class));
-                exit();
-                return;
+                throw new IllegalStateException("Null formController!");
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuProvider.kt
@@ -110,8 +110,9 @@ class FormEntryMenuProvider(
                     showIfNotShowing(RecordingWarningDialogFragment::class.java, activity.supportFragmentManager)
                 } else {
                     formEntryViewModel.updateAnswersForScreen(answersProvider.answers, false)
-                    val pref = Intent(activity, ProjectPreferencesActivity::class.java)
-                    activity.startActivityForResult(pref, ApplicationConstants.RequestCodes.CHANGE_SETTINGS)
+                    val intent = Intent(activity, ProjectPreferencesActivity::class.java)
+                    intent.putExtra(ProjectPreferencesActivity.EXTRA_IN_FORM_ENTRY, true)
+                    activity.startActivityForResult(intent, ApplicationConstants.RequestCodes.CHANGE_SETTINGS)
                 }
                 true
             }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectPreferencesActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectPreferencesActivity.kt
@@ -22,6 +22,7 @@ import org.odk.collect.android.fragments.dialogs.MovingBackwardsDialog.MovingBac
 import org.odk.collect.android.fragments.dialogs.ResetSettingsResultDialog.ResetSettingsResultDialogListener
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.mainmenu.MainMenuActivity
+import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.metadata.PropertyManager
 import org.odk.collect.strings.localization.LocalizedActivity
 import javax.inject.Inject
@@ -37,6 +38,12 @@ class ProjectPreferencesActivity :
     lateinit var propertyManager: PropertyManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        supportFragmentManager.fragmentFactory = FragmentFactoryBuilder()
+            .forClass(ProjectPreferencesFragment::class.java) {
+                ProjectPreferencesFragment(intent.getBooleanExtra(EXTRA_IN_FORM_ENTRY, false))
+            }
+            .build()
+
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_preferences_layout)
         DaggerUtils.getComponent(this).inject(this)
@@ -67,4 +74,8 @@ class ProjectPreferencesActivity :
     }
 
     fun isInstanceStateSaved() = isInstanceStateSaved
+
+    companion object {
+        const val EXTRA_IN_FORM_ENTRY = "in_form_entry"
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectPreferencesFragment.kt
@@ -23,6 +23,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.preference.Preference
 import org.odk.collect.android.R
 import org.odk.collect.android.injection.DaggerUtils
@@ -33,7 +34,7 @@ import org.odk.collect.androidshared.data.Consumable
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
 
-class ProjectPreferencesFragment :
+class ProjectPreferencesFragment(private val inFormEntry: Boolean) :
     BaseProjectPreferencesFragment(),
     Preference.OnPreferenceClickListener {
 
@@ -68,6 +69,10 @@ class ProjectPreferencesFragment :
         findPreference<Preference>(CHANGE_ADMIN_PASSWORD_PREFERENCE_KEY)!!.onPreferenceClickListener = this
         findPreference<Preference>(PROJECT_MANAGEMENT_PREFERENCE_KEY)!!.onPreferenceClickListener = this
         findPreference<Preference>(ACCESS_CONTROL_PREFERENCE_KEY)!!.onPreferenceClickListener = this
+
+        if (inFormEntry) {
+            findPreference<Preference>(PROJECT_MANAGEMENT_PREFERENCE_KEY)!!.isEnabled = false
+        }
     }
 
     override fun onPreferenceClick(preference: Preference): Boolean {
@@ -75,7 +80,12 @@ class ProjectPreferencesFragment :
             when (preference.key) {
                 PROTOCOL_PREFERENCE_KEY -> displayPreferences(ServerPreferencesFragment())
                 PROJECT_DISPLAY_PREFERENCE_KEY -> displayPreferences(ProjectDisplayPreferencesFragment())
-                USER_INTERFACE_PREFERENCE_KEY -> displayPreferences(UserInterfacePreferencesFragment())
+                USER_INTERFACE_PREFERENCE_KEY -> {
+                    val fragment = UserInterfacePreferencesFragment()
+                    fragment.arguments =
+                        bundleOf(UserInterfacePreferencesFragment.ARG_IN_FORM_ENTRY to inFormEntry)
+                    displayPreferences(fragment)
+                }
                 MAPS_PREFERENCE_KEY -> displayPreferences(MapsPreferencesFragment())
                 FORM_MANAGEMENT_PREFERENCE_KEY -> displayPreferences(FormManagementPreferencesFragment())
                 USER_AND_DEVICE_IDENTITY_PREFERENCE_KEY -> displayPreferences(IdentityPreferencesFragment())

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectPreferencesFragment.kt
@@ -67,11 +67,10 @@ class ProjectPreferencesFragment(private val inFormEntry: Boolean) :
         findPreference<Preference>(EXPERIMENTAL_PREFERENCE_KEY)!!.onPreferenceClickListener = this
         findPreference<Preference>(UNLOCK_PROTECTED_SETTINGS_PREFERENCE_KEY)!!.onPreferenceClickListener = this
         findPreference<Preference>(CHANGE_ADMIN_PASSWORD_PREFERENCE_KEY)!!.onPreferenceClickListener = this
-        findPreference<Preference>(PROJECT_MANAGEMENT_PREFERENCE_KEY)!!.onPreferenceClickListener = this
         findPreference<Preference>(ACCESS_CONTROL_PREFERENCE_KEY)!!.onPreferenceClickListener = this
-
-        if (inFormEntry) {
-            findPreference<Preference>(PROJECT_MANAGEMENT_PREFERENCE_KEY)!!.also {
+        findPreference<Preference>(PROJECT_MANAGEMENT_PREFERENCE_KEY)!!.also {
+            it.onPreferenceClickListener = this
+            if (inFormEntry) {
                 it.isEnabled = false
                 it.setSummary(org.odk.collect.strings.R.string.setting_not_available_during_form_entry)
             }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectPreferencesFragment.kt
@@ -71,7 +71,10 @@ class ProjectPreferencesFragment(private val inFormEntry: Boolean) :
         findPreference<Preference>(ACCESS_CONTROL_PREFERENCE_KEY)!!.onPreferenceClickListener = this
 
         if (inFormEntry) {
-            findPreference<Preference>(PROJECT_MANAGEMENT_PREFERENCE_KEY)!!.isEnabled = false
+            findPreference<Preference>(PROJECT_MANAGEMENT_PREFERENCE_KEY)!!.also {
+                it.isEnabled = false
+                it.setSummary(org.odk.collect.strings.R.string.setting_not_available_during_form_entry)
+            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/UserInterfacePreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/UserInterfacePreferencesFragment.java
@@ -22,25 +22,35 @@ import static org.odk.collect.settings.keys.ProjectKeys.KEY_NAVIGATION;
 
 import android.content.Context;
 import android.os.Bundle;
+
 import androidx.preference.ListPreference;
+
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.mainmenu.MainMenuActivity;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.version.VersionInformation;
+
 import java.util.ArrayList;
 import java.util.TreeMap;
+
 import javax.inject.Inject;
 
 public class UserInterfacePreferencesFragment extends BaseProjectPreferencesFragment {
 
+    public static final String ARG_IN_FORM_ENTRY = "in_form_entry";
+
     @Inject
     VersionInformation versionInformation;
+
+    private boolean inFormEntry;
 
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
         DaggerUtils.getComponent(context).inject(this);
+
+        inFormEntry = requireArguments().getBoolean(ARG_IN_FORM_ENTRY);
     }
 
     @Override
@@ -58,16 +68,20 @@ public class UserInterfacePreferencesFragment extends BaseProjectPreferencesFrag
         final ListPreference pref = findPreference(KEY_APP_THEME);
 
         if (pref != null) {
-            pref.setSummary(pref.getEntry());
-            pref.setOnPreferenceChangeListener((preference, newValue) -> {
-                int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
-                String entry = (String) ((ListPreference) preference).getEntries()[index];
-                if (pref.getEntry() == null || !pref.getEntry().equals(entry)) {
-                    preference.setSummary(entry);
-                    startActivityAndCloseAllOthers(getActivity(), MainMenuActivity.class);
-                }
-                return true;
-            });
+            if (!inFormEntry) {
+                pref.setSummary(pref.getEntry());
+                pref.setOnPreferenceChangeListener((preference, newValue) -> {
+                    int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
+                    String entry = (String) ((ListPreference) preference).getEntries()[index];
+                    if (pref.getEntry() == null || !pref.getEntry().equals(entry)) {
+                        preference.setSummary(entry);
+                        startActivityAndCloseAllOthers(getActivity(), MainMenuActivity.class);
+                    }
+                    return true;
+                });
+            } else {
+                pref.setEnabled(false);
+            }
         }
     }
 
@@ -103,31 +117,35 @@ public class UserInterfacePreferencesFragment extends BaseProjectPreferencesFrag
         final ListPreference pref = findPreference(KEY_APP_LANGUAGE);
 
         if (pref != null) {
-            TreeMap<String, String> languageList = LocaleHelper.languageList();
-            ArrayList<String> entryValues = new ArrayList<>();
-            entryValues.add(0, "");
-            entryValues.addAll(languageList.values());
-            pref.setEntryValues(entryValues.toArray(new String[0]));
-            ArrayList<String> entries = new ArrayList<>();
-            entries.add(0, getActivity().getResources()
-                    .getString(org.odk.collect.strings.R.string.use_device_language));
-            entries.addAll(languageList.keySet());
-            pref.setEntries(entries.toArray(new String[0]));
-            if (pref.getValue() == null) {
-                //set Default value to "Use phone locale"
-                pref.setValueIndex(0);
+            if (!inFormEntry) {
+                TreeMap<String, String> languageList = LocaleHelper.languageList();
+                ArrayList<String> entryValues = new ArrayList<>();
+                entryValues.add(0, "");
+                entryValues.addAll(languageList.values());
+                pref.setEntryValues(entryValues.toArray(new String[0]));
+                ArrayList<String> entries = new ArrayList<>();
+                entries.add(0, getActivity().getResources()
+                        .getString(org.odk.collect.strings.R.string.use_device_language));
+                entries.addAll(languageList.keySet());
+                pref.setEntries(entries.toArray(new String[0]));
+                if (pref.getValue() == null) {
+                    //set Default value to "Use phone locale"
+                    pref.setValueIndex(0);
+                }
+                pref.setSummary(pref.getEntry());
+                pref.setOnPreferenceChangeListener((preference, newValue) -> {
+                    int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
+                    String entry = (String) ((ListPreference) preference).getEntries()[index];
+                    preference.setSummary(entry);
+
+                    settingsProvider.getUnprotectedSettings().save(KEY_APP_LANGUAGE, newValue.toString());
+
+                    startActivityAndCloseAllOthers(getActivity(), MainMenuActivity.class);
+                    return true;
+                });
+            } else {
+                pref.setEnabled(false);
             }
-            pref.setSummary(pref.getEntry());
-            pref.setOnPreferenceChangeListener((preference, newValue) -> {
-                int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
-                String entry = (String) ((ListPreference) preference).getEntries()[index];
-                preference.setSummary(entry);
-
-                settingsProvider.getUnprotectedSettings().save(KEY_APP_LANGUAGE, newValue.toString());
-
-                startActivityAndCloseAllOthers(getActivity(), MainMenuActivity.class);
-                return true;
-            });
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/UserInterfacePreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/UserInterfacePreferencesFragment.java
@@ -81,6 +81,7 @@ public class UserInterfacePreferencesFragment extends BaseProjectPreferencesFrag
                 });
             } else {
                 pref.setEnabled(false);
+                pref.setSummary(org.odk.collect.strings.R.string.setting_not_available_during_form_entry);
             }
         }
     }
@@ -145,6 +146,7 @@ public class UserInterfacePreferencesFragment extends BaseProjectPreferencesFrag
                 });
             } else {
                 pref.setEnabled(false);
+                pref.setSummary(org.odk.collect.strings.R.string.setting_not_available_during_form_entry);
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/UserInterfacePreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/UserInterfacePreferencesFragment.java
@@ -50,7 +50,10 @@ public class UserInterfacePreferencesFragment extends BaseProjectPreferencesFrag
         super.onAttach(context);
         DaggerUtils.getComponent(context).inject(this);
 
-        inFormEntry = requireArguments().getBoolean(ARG_IN_FORM_ENTRY);
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            inFormEntry = arguments.getBoolean(ARG_IN_FORM_ENTRY);
+        }
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/ProjectPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/ProjectPreferencesFragmentTest.kt
@@ -16,6 +16,7 @@ import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.preferences.ProjectPreferencesViewModel
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.utilities.AdminPasswordProvider
+import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.settings.keys.ProtectedProjectKeys
 import org.odk.collect.shared.settings.Settings
@@ -30,8 +31,13 @@ class ProjectPreferencesFragmentTest {
     }
     private val projectPreferencesViewModel = ProjectPreferencesViewModel(adminPasswordProvider)
 
+    private val fragmentFactory = FragmentFactoryBuilder()
+        .forClass(ProjectPreferencesFragment::class) {
+            ProjectPreferencesFragment(false)
+        }.build()
+
     @get:Rule
-    val launcherRule = FragmentScenarioLauncherRule()
+    val launcherRule = FragmentScenarioLauncherRule(defaultFactory = fragmentFactory)
 
     @Before
     fun setup() {

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -949,6 +949,9 @@
     <!-- Label for an item displayed in the project settings menu to indicate that settings are unlocked -->
     <string name="settings_unlocked">Settings unlocked</string>
 
+    <!-- Summary on setting that's currently not available because the user has entered settings from form entry -->
+    <string name="setting_not_available_during_form_entry">Setting not available during form entry</string>
+
     <!--
      ##############################################
      # PROTECTED SETTINGS


### PR DESCRIPTION
Closes #6482

I've also cleaned up a couple of cases in `FormFillingActivity` that would return to the main menu in rare states.

#### Why is this the best possible solution? Were any other approaches considered?

As discussed in the issue and elsewhere, we decided to go with blocking these settings during form entry for now as reworking locking would be better to after #5420.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The main things to check here are that the user is not able to access settings that reproduce the bug.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
