### PR TITLE
Fixed the bug with linearlayout's divider in RTL

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
@@ -42,6 +42,8 @@ class FormEndView(
             listener.onSaveClicked(true)
         }
 
+        binding.divider.isVisible = binding.saveAsDraft.isVisible && binding.finalize.isVisible
+
         val shouldFormBeSentAutomatically = formEndViewModel.shouldFormBeSentAutomatically()
         if (shouldFormBeSentAutomatically) {
             binding.finalize.text = context.getString(org.odk.collect.strings.R.string.send)

--- a/collect_app/src/main/res/drawable/margin_standard_list_divider.xml
+++ b/collect_app/src/main/res/drawable/margin_standard_list_divider.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <size android:width="@dimen/margin_standard" />
-            <size android:height="@dimen/margin_standard" />
-        </shape>
-    </item>
-</layer-list>

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -95,8 +95,6 @@ the specific language governing permissions and limitations under the License.
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="64dp"
-            android:divider="@drawable/margin_standard_list_divider"
-            android:showDividers="middle"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -113,6 +111,11 @@ the specific language governing permissions and limitations under the License.
                 app:icon="@drawable/ic_save_menu_24"
                 app:iconGravity="textStart"
                 app:screenName="@string/form_end_screen" />
+
+            <Space
+                android:id="@+id/divider"
+                android:layout_width="@dimen/margin_standard"
+                android:layout_height="match_parent" />
 
             <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
                 android:id="@+id/finalize"


### PR DESCRIPTION
Closes #6362 

#### Why is this the best possible solution? Were any other approaches considered?
There’s a bug with the `LinearLayout` divider in RTL mode: https://issuetracker.google.com/issues/110104700 that causes this issue. Since it won’t be fixed, we’ll need an alternative to handle the spacing between buttons correctly. Switching to `ConstraintLayout` isn’t an option, as we deliberately used `LinearLayout` to address specific requirements (see https://github.com/getodk/collect/issues/5942). The easiest and safest solution for now is to show or hide a divider view programmatically.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test the display of the two buttons on the form end screen - `Save as draft` and `Finalize` (or `Send`, depending on settings). We don’t need to test their functionality, only the visual aspects:
- Ensure they display correctly in RTL mode.
- Check the layout when one button is missing (disabled in settings).
- Confirm that both buttons expand proportionally: https://github.com/getodk/collect/issues/5942
- Verify that the maximum width of the parent container is 640dp.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
