### PR TITLE
Set usesEntities to true if there is an entityList attachment in the manifest

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
@@ -168,7 +168,11 @@ public class ServerFormDownloader implements FormDownloader {
             if (newAttachmentsDetected) {
                 Form existingForm = formsRepository.getOneByPath(formFile.getAbsolutePath());
                 if (existingForm != null) {
-                    formsRepository.save(new Form.Builder(existingForm).lastDetectedAttachmentsUpdateDate(clock.get()).build());
+                    formsRepository.save(new Form.Builder(existingForm)
+                            .lastDetectedAttachmentsUpdateDate(clock.get())
+                            .usesEntities(entityAttachmentsDetected)
+                            .build()
+                    );
                 }
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
@@ -170,7 +170,16 @@ public class ServerFormDownloader implements FormDownloader {
                 if (existingForm != null) {
                     formsRepository.save(new Form.Builder(existingForm)
                             .lastDetectedAttachmentsUpdateDate(clock.get())
-                            .usesEntities(entityAttachmentsDetected)
+                            .build()
+                    );
+                }
+            }
+
+            if (entityAttachmentsDetected) {
+                Form existingForm = formsRepository.getOneByPath(formFile.getAbsolutePath());
+                if (existingForm != null) {
+                    formsRepository.save(new Form.Builder(existingForm)
+                            .usesEntities(true)
                             .build()
                     );
                 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormUseCasesTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormUseCasesTest.kt
@@ -179,7 +179,7 @@ class ServerFormUseCasesTest {
             mock()
         )
 
-        assertThat(result, equalTo(false))
+        assertThat(result, equalTo(MediaFilesDownloadResult(false, false)))
     }
 
     @Test
@@ -222,6 +222,6 @@ class ServerFormUseCasesTest {
             mock()
         )
 
-        assertThat(result, equalTo(false))
+        assertThat(result, equalTo(MediaFilesDownloadResult(false, false)))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/ServerFormDownloaderTest.java
@@ -818,6 +818,59 @@ public class ServerFormDownloaderTest {
         assertThat(form.usesEntities(), is(false));
     }
 
+    @Test
+    public void whenFormAlreadyDownloadedDoesNotHaveEntities_andHasNewMediaFilesWithEntities_downloadsAndMarkTheFormAsAFormThatUsesEntities() throws Exception {
+        String xform = createXFormBody("id", "version");
+        ServerFormDetails serverFormDetails = new ServerFormDetails(
+                "Form",
+                "http://downloadUrl",
+                "id",
+                "version",
+                Md5.getMd5Hash(new ByteArrayInputStream(xform.getBytes())),
+                true,
+                false,
+                new ManifestFile("", List.of(
+                        new MediaFile("file1", Md5.getMd5Hash(new ByteArrayInputStream("contents".getBytes())), "http://file1")
+                )));
+
+        FormSource formSource = mock(FormSource.class);
+        when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
+        when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents".getBytes()));
+
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), FormMetadataParser.INSTANCE, clock, entitiesRepository);
+
+        // Initial download
+        downloader.downloadForm(serverFormDetails, null, null);
+
+        List<Form> allForms = formsRepository.getAll();
+        assertThat(allForms.size(), is(1));
+        Form form = allForms.get(0);
+        assertThat(form.usesEntities(), is(false));
+
+        ServerFormDetails serverFormDetailsUpdatedMediaFile = new ServerFormDetails(
+                "Form",
+                "http://downloadUrl",
+                "id",
+                "version",
+                Md5.getMd5Hash(new ByteArrayInputStream(xform.getBytes())),
+                false,
+                false,
+                new ManifestFile("", List.of(
+                        new MediaFile("file1", Md5.getMd5Hash(new ByteArrayInputStream("contents-updated".getBytes())), "http://file1", true)
+                )));
+
+        when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
+        when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents-updated".getBytes()));
+
+        // Second download
+        downloader.downloadForm(serverFormDetailsUpdatedMediaFile, null, null);
+
+        allForms = formsRepository.getAll();
+        assertThat(allForms.size(), is(1));
+        form = allForms.get(0);
+        assertThat(form.usesEntities(), is(true));
+    }
+
     private String getFormFilesPath() {
         return formsDir.getAbsolutePath();
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/ServerFormDownloaderTest.java
@@ -819,7 +819,7 @@ public class ServerFormDownloaderTest {
     }
 
     @Test
-    public void whenFormAlreadyDownloadedDoesNotHaveEntities_andHasNewMediaFilesWithEntities_downloadsAndMarkTheFormAsAFormThatUsesEntities() throws Exception {
+    public void whenFormAlreadyDownloadedDoesNotHaveEntities_andOneOfTheAttachmentsBecomesMarkedAsAnEntityList_downloadsAndMarkTheFormAsAFormThatUsesEntities() throws Exception {
         String xform = createXFormBody("id", "version");
         ServerFormDetails serverFormDetails = new ServerFormDetails(
                 "Form",
@@ -856,11 +856,11 @@ public class ServerFormDownloaderTest {
                 false,
                 false,
                 new ManifestFile("", List.of(
-                        new MediaFile("file1", Md5.getMd5Hash(new ByteArrayInputStream("contents-updated".getBytes())), "http://file1", true)
+                        new MediaFile("file1", Md5.getMd5Hash(new ByteArrayInputStream("contents".getBytes())), "http://file1", true)
                 )));
 
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
-        when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents-updated".getBytes()));
+        when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents".getBytes()));
 
         // Second download
         downloader.downloadForm(serverFormDetailsUpdatedMediaFile, null, null);


### PR DESCRIPTION
Closes #6493 

#### Why is this the best possible solution? Were any other approaches considered?
As discussed in the comments and the issue, we need to mark forms downloaded before the upgrade as using entities if they indeed rely on entities. Doing this when new entities arrive seems to be the simplest and most effective approach.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This update modifies the database (specifically the useEntities column) when new entities are being downloaded to ensure that forms using entities are correctly marked, even if they existed prior to the introduction of this column. I don’t foresee any particular risks or areas needing additional careful testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
