### PR TITLE
Fix property names clashing with DB column names

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -34,7 +34,7 @@ private object EntitiesTable {
     const val COLUMN_TRUNK_VERSION = "trunk_version"
     const val COLUMN_BRANCH_ID = "branch_id"
     const val COLUMN_STATE = "state"
-    const val COLUMN_PROPERTY_PREFIX = "prop_"
+    const val COLUMN_PROPERTY_PREFIX = "p_"
 
     fun getPropertyColumn(property: String) = "$COLUMN_PROPERTY_PREFIX$property"
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/DatabaseEntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/DatabaseEntitiesRepositoryTest.kt
@@ -2,9 +2,13 @@ package org.odk.collect.android.entities
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.odk.collect.android.database.entities.DatabaseEntitiesRepository
+import org.odk.collect.android.entities.support.EntitySameAsMatcher.Companion.sameEntityAs
 import org.odk.collect.entities.storage.EntitiesRepository
+import org.odk.collect.entities.storage.Entity
 import org.odk.collect.shared.TempFiles
 
 @RunWith(AndroidJUnit4::class)
@@ -14,5 +18,22 @@ class DatabaseEntitiesRepositoryTest : EntitiesRepositoryTest() {
             ApplicationProvider.getApplicationContext(),
             TempFiles.createTempDir().absolutePath
         )
+    }
+
+    @Test
+    fun `#save supports properties with db column names saving new entities and updating existing ones`() {
+        val repository = buildSubject()
+        val entity = Entity.New(
+            "1",
+            "One",
+            properties = listOf(Pair("_id", "value"), Pair("version", "value"))
+        )
+
+        repository.save("things", entity)
+        val savedEntity = repository.getEntities("things")[0]
+        assertThat(savedEntity, sameEntityAs(entity))
+
+        repository.save("things", savedEntity)
+        assertThat(repository.getEntities("things")[0], sameEntityAs(savedEntity))
     }
 }


### PR DESCRIPTION
Closes #6486

#### Why is this the best possible solution? Were any other approaches considered?

Other alternatives might have been to index properties in some way (in the `lists` table for example), but using a prefix felt like the simplest way to fix this to me. Even if a property clashes with the prefix (a property named `p_id` for example) we would still add/remove the prefix correctly as it's isolated to `DatabaseEntitiesRepository` (the previous example would end up with a column named `p_p_id`).

We also decided (on a call) to go with just clearing out the entities DB when upgrading rather than writing proper migration code. This mitigates any risk of migrating data incorrectly, and has minimal impact as the entities DB only exists for beta users at this time.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Along with fixing the bug, any local entities on device will be wiped. It's definitely worth playing with upgrades from the last beta to check this works as expected.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
