### PR TITLE
Fix leaking form session when viewing submission

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/ViewOnlyFormHierarchyActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/ViewOnlyFormHierarchyActivity.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.formhierarchy
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
+import androidx.activity.OnBackPressedCallback
 import org.javarosa.core.model.FormIndex
 import org.odk.collect.android.R
 import org.odk.collect.android.javarosawrapper.FormController
@@ -14,7 +15,16 @@ import org.odk.collect.android.javarosawrapper.FormController
 class ViewOnlyFormHierarchyActivity : FormHierarchyActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         onBackPressedCallback.remove()
+        onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                setResult(RESULT_OK)
+                finish()
+                val sessionId = intent.getStringExtra(EXTRA_SESSION_ID)!!
+                formSessionRepository.clear(sessionId)
+            }
+        })
     }
 
     /**
@@ -23,10 +33,7 @@ class ViewOnlyFormHierarchyActivity : FormHierarchyActivity() {
      */
     public override fun configureButtons(formController: FormController) {
         val exitButton = findViewById<Button>(R.id.exitButton)
-        exitButton.setOnClickListener {
-            setResult(RESULT_OK)
-            finish()
-        }
+        exitButton.setOnClickListener { onBackPressedDispatcher.onBackPressed() }
         exitButton.visibility = View.VISIBLE
         jumpBeginningButton.visibility = View.GONE
         jumpEndButton.visibility = View.GONE


### PR DESCRIPTION
Closes #6483

Memory usage when filling a form and then viewing the submission several times before the change:

<img width="1343" alt="Screenshot 2024-11-05 at 14 31 42" src="https://github.com/user-attachments/assets/7f81d8de-57f9-417c-b950-d5031a519f31">

...and after:

<img width="1344" alt="Screenshot 2024-11-05 at 14 34 06" src="https://github.com/user-attachments/assets/eb99f852-275a-46ad-962c-361ba900582e">

For some reason the axis on the left side makes the memory usage look pretty similar, but you can see from the "Total" number that that's not the case.

#### Why is this the best possible solution? Were any other approaches considered?

We'll want to solidify a fix with #5420, but this should provide a band-aid for the moment which hopefully prevents many OOMs in the wild.

I haven't written a test for this due to the fix being temporary and that it's hard to test the actual intention here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only area of the app affected is viewing submissions.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
