### PR TITLE
Filter out case-insensitive duplicate properties

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -383,6 +383,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         val missingColumns = entity.properties
             .map { EntitiesTable.getPropertyColumn(it.first) }
             .filterNot { columnNames.contains(it) }
+            .distinctBy { it.lowercase() }
 
         if (missingColumns.isNotEmpty()) {
             databaseConnection.resetTransaction {

--- a/collect_app/src/test/java/org/odk/collect/android/entities/DatabaseEntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/DatabaseEntitiesRepositoryTest.kt
@@ -2,7 +2,6 @@ package org.odk.collect.android.entities
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,20 +35,5 @@ class DatabaseEntitiesRepositoryTest : EntitiesRepositoryTest() {
 
         repository.save("things", savedEntity)
         assertThat(repository.getEntities("things")[0], sameEntityAs(savedEntity))
-    }
-
-    @Test
-    fun `#save ignores case-insensitive duplicate properties`() {
-        val repository = buildSubject()
-        val entity = Entity.New(
-            "1",
-            "One",
-            properties = listOf(Pair("prop", "value"), Pair("Prop", "value"))
-        )
-
-        repository.save("things", entity)
-        val savedEntities = repository.getEntities("things")
-        assertThat(savedEntities[0].properties.size, equalTo(1))
-        assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/DatabaseEntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/DatabaseEntitiesRepositoryTest.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.entities
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,5 +36,20 @@ class DatabaseEntitiesRepositoryTest : EntitiesRepositoryTest() {
 
         repository.save("things", savedEntity)
         assertThat(repository.getEntities("things")[0], sameEntityAs(savedEntity))
+    }
+
+    @Test
+    fun `#save ignores case-insensitive duplicate properties`() {
+        val repository = buildSubject()
+        val entity = Entity.New(
+            "1",
+            "One",
+            properties = listOf(Pair("prop", "value"), Pair("Prop", "value"))
+        )
+
+        repository.save("things", entity)
+        val savedEntities = repository.getEntities("things")
+        assertThat(savedEntities[0].properties.size, equalTo(1))
+        assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -644,4 +644,19 @@ abstract class EntitiesRepositoryTest {
         repository.updateListHash("wine", "2024")
         assertThat(repository.getListHash("wine"), equalTo("2024"))
     }
+
+    @Test
+    fun `#save ignores case-insensitive duplicate properties`() {
+        val repository = buildSubject()
+        val entity = Entity.New(
+            "1",
+            "One",
+            properties = listOf(Pair("prop", "value"), Pair("Prop", "value"))
+        )
+
+        repository.save("things", entity)
+        val savedEntities = repository.getEntities("things")
+        assertThat(savedEntities[0].properties.size, equalTo(1))
+        assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
+    }
 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -123,7 +123,12 @@ class InMemEntitiesRepository : EntitiesRepository {
         lists.add(list)
         listProperties.getOrPut(list) {
             mutableSetOf()
-        }.addAll(entity.properties.map { it.first })
+        }.addAll(
+            entity
+                .properties
+                .distinctBy { it.first.lowercase() }
+                .map { it.first }
+        )
     }
 
     private fun mergeProperties(


### PR DESCRIPTION
Closes #6501 

#### Why is this the best possible solution? Were any other approaches considered?
The real issue here is that SQLite is case-insensitive, so attempting to add columns with names like `col` and `Col` results in an exception. I don't think we need to implement any special handling for this, as it doesn't make much sense to add such properties in the first place. Therefore, I believe filtering out duplicates is a good solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should be enough to test entities with duplicate properties like `col` and `Col`.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
