### PR TITLE
Don't require a label for Entity updates

### DIFF
--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -21,18 +21,20 @@ object LocalEntityUseCases {
         formEntities?.entities?.forEach { formEntity ->
             val id = formEntity.id
             val label = formEntity.label
-            if (id != null && !label.isNullOrEmpty()) {
+            if (id != null) {
                 when (formEntity.action) {
                     EntityAction.CREATE -> {
-                        val entity = Entity.New(
-                            id,
-                            label,
-                            1,
-                            formEntity.properties,
-                            branchId = UUID.randomUUID().toString()
-                        )
+                        if (!label.isNullOrEmpty()) {
+                            val entity = Entity.New(
+                                id,
+                                label,
+                                1,
+                                formEntity.properties,
+                                branchId = UUID.randomUUID().toString()
+                            )
 
-                        entitiesRepository.save(formEntity.dataset, entity)
+                            entitiesRepository.save(formEntity.dataset, entity)
+                        }
                     }
 
                     EntityAction.UPDATE -> {
@@ -41,7 +43,7 @@ object LocalEntityUseCases {
                             entitiesRepository.save(
                                 formEntity.dataset,
                                 existing.copy(
-                                    label = label,
+                                    label = if (label.isNullOrBlank()) existing.label else label,
                                     properties = formEntity.properties,
                                     version = existing.version + 1
                                 )

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -84,6 +84,54 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
+    fun `updateLocalEntitiesFromForm updates properties and does not change label on update if label is null`() {
+        entitiesRepository.save(
+            "things",
+            Entity.New(
+                "id",
+                "label",
+                version = 1,
+                properties = listOf("prop" to "value")
+            )
+        )
+
+        val formEntity =
+            FormEntity(EntityAction.UPDATE, "things", "id", null, listOf("prop" to "value 2"))
+        val formEntities = EntitiesExtra(listOf(formEntity))
+
+        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
+        val entities = entitiesRepository.getEntities("things")
+        assertThat(entities.size, equalTo(1))
+        assertThat(entities[0].label, equalTo("label"))
+        assertThat(entities[0].properties.size, equalTo(1))
+        assertThat(entities[0].properties[0], equalTo("prop" to "value 2"))
+    }
+
+    @Test
+    fun `updateLocalEntitiesFromForm updates properties and does not change label on update if label is empty`() {
+        entitiesRepository.save(
+            "things",
+            Entity.New(
+                "id",
+                "label",
+                version = 1,
+                properties = listOf("prop" to "value")
+            )
+        )
+
+        val formEntity =
+            FormEntity(EntityAction.UPDATE, "things", "id", "", listOf("prop" to "value 2"))
+        val formEntities = EntitiesExtra(listOf(formEntity))
+
+        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
+        val entities = entitiesRepository.getEntities("things")
+        assertThat(entities.size, equalTo(1))
+        assertThat(entities[0].label, equalTo("label"))
+        assertThat(entities[0].properties.size, equalTo(1))
+        assertThat(entities[0].properties[0], equalTo("prop" to "value 2"))
+    }
+
+    @Test
     fun `updateLocalEntitiesFromForm does not override trunk version or branchId on update`() {
         entitiesRepository.save(
             "things",
@@ -130,7 +178,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntitiesFromForm does not save entity that doesn't have a label`() {
+    fun `updateLocalEntitiesFromForm does not create entity that doesn't have a label`() {
         val formEntity =
             FormEntity(EntityAction.CREATE, "things", "1", null, emptyList())
         val formEntities = EntitiesExtra(listOf(formEntity))
@@ -141,7 +189,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntitiesFromForm does not save entity that has an empty label`() {
+    fun `updateLocalEntitiesFromForm does not create entity that has an empty label`() {
         val formEntity =
             FormEntity(EntityAction.CREATE, "things", "1", "", emptyList())
         val formEntities = EntitiesExtra(listOf(formEntity))


### PR DESCRIPTION
Closes #6511 

#### Why is this the best possible solution? Were any other approaches considered?
There’s nothing to discuss here, as no alternative solutions were considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Creating entities without labels should still not be possible, as before. However, when updating existing entities, if a label is missing or empty, the existing label should be retained.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used:
[entities_update.xlsx](https://github.com/user-attachments/files/17781213/entities_update.xlsx)
[entities_registration.xlsx](https://github.com/user-attachments/files/17781214/entities_registration.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
