### PR TITLE
Remove Generic Exception prefix for form submission errors

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -215,8 +215,7 @@ public class InstanceServerUploader extends InstanceUploader {
             }
 
         } catch (Exception e) {
-            throw new FormUploadException(FAIL + "Generic Exception: "
-                    + (e.getMessage() != null ? e.getMessage() : e.toString()));
+            throw new FormUploadException(e.getMessage() != null ? e.getMessage() : e.toString());
         }
 
         markSubmissionComplete(instance);


### PR DESCRIPTION
This is a pet peeve of mine that I'm hoping will be an easy accept. I am annoyed every time I see "Error: Generic Exception: Error: <some error>" It looks like a mistake. I have never seen an error for which "Error: Generic Exception" added any information.

| Before | After |
|--------|------|
|![Screenshot_20241121_113101](https://github.com/user-attachments/assets/6021b777-1a74-468f-8f38-46be71bb8bda) | ![Screenshot_20241121_113909](https://github.com/user-attachments/assets/44480c4b-ab77-41dd-b295-4e5bd1cefb83) |

#### Why is this the best possible solution? Were any other approaches considered?
I considered only removing the `Error:` prefix but I really don't think `Generic Exception` adds anything either.

I didn't add any tests. I verified that there are no tests that expect that text currently.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The biggest risk would be that there's an exception without any error message at all. But I think seeing the exception name, which the `toString` should give us, is way more useful than the static "Generic Exception" text.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] added or modified tests for any new or changed behavior
       there were no existing tests so it feels ok to leave as-is.
- [ ] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
       I don't see any reason to run connected tests for this change.
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
