### PR TITLE
Do not clear the error state after syncing with storage

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormsDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormsDataService.kt
@@ -155,7 +155,7 @@ class FormsDataService(
                 }
 
                 syncWithDb(projectId)
-                finishSync(projectId, exception)
+                finishSyncWithServer(projectId, exception)
                 exception == null
             } else {
                 false
@@ -180,7 +180,7 @@ class FormsDataService(
                 startSync(projectId)
                 syncWithStorage(projectId)
                 syncWithDb(projectId)
-                finishSync(projectId)
+                finishSyncWithStorage(projectId)
             }
         }
     }
@@ -199,8 +199,12 @@ class FormsDataService(
         syncing.set(projectId, true)
     }
 
-    private fun finishSync(projectId: String, exception: FormSourceException? = null) {
+    private fun finishSyncWithServer(projectId: String, exception: FormSourceException? = null) {
         serverError.set(projectId, exception)
+        syncing.set(projectId, false)
+    }
+
+    private fun finishSyncWithStorage(projectId: String) {
         syncing.set(projectId, false)
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsDataServiceTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsDataServiceTest.kt
@@ -187,6 +187,17 @@ class FormsDataServiceTest {
     }
 
     @Test
+    fun `update() called after matchFormsWithServer() does not clear error state`() {
+        val error = FormSourceException.FetchError()
+        whenever(formSource.fetchFormList()).thenThrow(error)
+        formsDataService.matchFormsWithServer(project.uuid)
+
+        assertThat(formsDataService.getServerError(project.uuid).getOrAwaitValue(), equalTo(error))
+        formsDataService.update(project.uuid)
+        assertThat(formsDataService.getServerError(project.uuid).getOrAwaitValue(), equalTo(error))
+    }
+
+    @Test
     fun `matchFormsWithServer() notifies when called with default notify value`() {
         val error = FormSourceException.FetchError()
         whenever(formSource.fetchFormList()).thenThrow(error)


### PR DESCRIPTION
Closes #6500 

#### Why is this the best possible solution? Were any other approaches considered?
The issue was that syncing with storage would clear the error state, so if it was finished after a failed sync with the server, the error state was always reset. This left no indication (at least in the toolbar) that something had gone wrong. The solution was to avoid clearing the error state in that case as it was redundant (syncing with storage never adds any error sho it shouldn't clear it as well).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pull request should resolve the issue. I don't see any risks that need to be highlighted.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
