### PR TITLE
Fixed the filtering of duplicate columns

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -382,8 +382,8 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
 
         val missingColumns = entity.properties
             .map { EntitiesTable.getPropertyColumn(it.first) }
-            .filterNot { columnNames.contains(it) }
             .distinctBy { it.lowercase() }
+            .filterNot { columnNames.contains(it) }
 
         if (missingColumns.isNotEmpty()) {
             databaseConnection.resetTransaction {

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -745,7 +745,16 @@ abstract class EntitiesRepositoryTest {
         )
 
         repository.save("things", entity)
-        val savedEntities = repository.getEntities("things")
+        var savedEntities = repository.getEntities("things")
+        assertThat(savedEntities[0].properties.size, equalTo(1))
+        assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
+
+        /**
+         * Attempt to save again to ensure that duplicate properties are correctly compared, not only
+         * within the current entity list, but also against properties already saved in the database.
+         */
+        repository.save("things", entity)
+        savedEntities = repository.getEntities("things")
         assertThat(savedEntities[0].properties.size, equalTo(1))
         assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
     }


### PR DESCRIPTION
Closes #6537 

#### Why is this the best possible solution? Were any other approaches considered?
Filtering out duplicate columns that we recently introduced worked well the first time, when no columns had been generated from properties. However, during subsequent saves, the comparison with already existing columns didn't work as expected.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pull request should resolve the issue. I don't see any risks that need to be highlighted.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
