### PR TITLE
Fixed the filtering of duplicate columns

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -383,7 +383,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         val missingColumns = entity.properties
             .map { EntitiesTable.getPropertyColumn(it.first) }
             .distinctBy { it.lowercase() }
-            .filterNot { columnNames.contains(it) }
+            .filterNot { columnName -> columnNames.any { it.equals(columnName, ignoreCase = true) } }
 
         if (missingColumns.isNotEmpty()) {
             databaseConnection.resetTransaction {

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -757,5 +757,14 @@ abstract class EntitiesRepositoryTest {
         savedEntities = repository.getEntities("things")
         assertThat(savedEntities[0].properties.size, equalTo(1))
         assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
+
+        /**
+         * Attempt to save again to ensure that duplicate properties are correctly compared,
+         * even if they appear in a different order.
+         */
+        repository.save("things", entity.copy(properties = listOf(Pair("Prop", "value"), Pair("prop", "value"))))
+        savedEntities = repository.getEntities("things")
+        assertThat(savedEntities[0].properties.size, equalTo(1))
+        assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -736,7 +736,7 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
-    fun `#save ignores case-insensitive duplicate properties`() {
+    fun `#save ignores case-insensitive duplicate new properties`() {
         val repository = buildSubject()
         val entity = Entity.New(
             "1",
@@ -745,24 +745,26 @@ abstract class EntitiesRepositoryTest {
         )
 
         repository.save("things", entity)
+        val savedEntities = repository.getEntities("things")
+        assertThat(savedEntities[0].properties.size, equalTo(1))
+        assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
+    }
+
+    @Test
+    fun `#save ignores case-insensitive duplicate properties if one of them has already been saved`() {
+        val repository = buildSubject()
+        val entity = Entity.New(
+            "1",
+            "One",
+            properties = listOf(Pair("prop", "value"))
+        )
+
+        repository.save("things", entity)
         var savedEntities = repository.getEntities("things")
         assertThat(savedEntities[0].properties.size, equalTo(1))
         assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
 
-        /**
-         * Attempt to save again to ensure that duplicate properties are correctly compared, not only
-         * within the current entity list, but also against properties already saved in the database.
-         */
-        repository.save("things", entity)
-        savedEntities = repository.getEntities("things")
-        assertThat(savedEntities[0].properties.size, equalTo(1))
-        assertThat(savedEntities[0].properties[0].first, equalTo("prop"))
-
-        /**
-         * Attempt to save again to ensure that duplicate properties are correctly compared,
-         * even if they appear in a different order.
-         */
-        repository.save("things", entity.copy(properties = listOf(Pair("Prop", "value"), Pair("prop", "value"))))
+        repository.save("things", entity.copy(properties = listOf(Pair("Prop", "value"))))
         savedEntities = repository.getEntities("things")
         assertThat(savedEntities[0].properties.size, equalTo(1))
         assertThat(savedEntities[0].properties[0].first, equalTo("prop"))

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -121,13 +121,15 @@ class InMemEntitiesRepository : EntitiesRepository {
 
     private fun updateLists(list: String, entity: Entity) {
         lists.add(list)
-        listProperties.getOrPut(list) {
+        val properties = listProperties.getOrPut(list) {
             mutableSetOf()
-        }.addAll(
+        }
+        properties.addAll(
             entity
                 .properties
-                .distinctBy { it.first.lowercase() }
                 .map { it.first }
+                .distinctBy { it.lowercase() }
+                .filterNot { properties.any { property -> property.equals(it, ignoreCase = true) } }
         )
     }
 


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?
It turns out that properties might come in different order causing the problem that my tests didn't take into account, see:
https://github.com/getodk/collect/pull/6543/files#diff-c1535b2e1da246141cdc344e2d23e0ec8897df03e4055fd171a82a64cd0907a4R762

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Just continue testing that yu started in https://github.com/getodk/collect/pull/6538.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
