### PR TITLE
Log form and CSV instance sizes when loading

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -192,6 +192,8 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
         unzipMediaFiles(formMediaDir);
         setupReferenceManagerForForm(ReferenceManager.instance(), formMediaDir);
 
+        logFormDetails(formXml, formMediaDir);
+
         FormDef formDef = null;
         try {
             formDef = createFormDefFromCacheOrXml(form.getFormFilePath(), formXml);
@@ -276,6 +278,27 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
         return data;
     }
 
+    private void logFormDetails(File formFile, File formMediaDir) {
+        long formFileBytesSize = formFile.length();
+
+        long csvFileBytesSize = 0L;
+        File[] files = formMediaDir.listFiles();
+        if (files != null) {
+            for (File mediaFile : files) {
+                if (mediaFile.getName().endsWith(".csv")) {
+                    csvFileBytesSize += mediaFile.length();
+                }
+            }
+        }
+
+        Timber.i(
+                "Attempting to load from %s, file is %dB and has CSV files %dB",
+                formFile.getAbsolutePath(),
+                formFileBytesSize,
+                csvFileBytesSize
+        );
+    }
+
     private static void unzipMediaFiles(File formMediaDir) {
         File[] zipFiles = formMediaDir.listFiles(new FileFilter() {
             @Override
@@ -305,7 +328,6 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
         }
 
         // no binary, read from xml
-        Timber.i("Attempting to load from: %s", formXml.getAbsolutePath());
         final long start = System.currentTimeMillis();
         String lastSavedSrc = FileUtils.getOrCreateLastSavedSrc(formXml);
         FormDef formDefFromXml = XFormUtils.getFormFromFormXml(formPath, lastSavedSrc);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -293,13 +293,13 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
         }
 
         if (csvFileBytesSizes.isEmpty()) {
-            Timber.i(
+            Timber.w(
                     "Attempting to load from %s, file is %dB",
                     formFile.getAbsolutePath(),
                     formFileBytesSize
             );
         } else {
-            Timber.i(
+            Timber.w(
                     "Attempting to load from %s, file is %dB and has CSV files %s",
                     formFile.getAbsolutePath(),
                     formFileBytesSize,

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -67,6 +67,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -281,22 +282,30 @@ public class FormLoaderTask extends SchedulerAsyncTaskMimic<Void, String, FormLo
     private void logFormDetails(File formFile, File formMediaDir) {
         long formFileBytesSize = formFile.length();
 
-        long csvFileBytesSize = 0L;
+        List<String> csvFileBytesSizes = new ArrayList<>();
         File[] files = formMediaDir.listFiles();
         if (files != null) {
             for (File mediaFile : files) {
                 if (mediaFile.getName().endsWith(".csv")) {
-                    csvFileBytesSize += mediaFile.length();
+                    csvFileBytesSizes.add(mediaFile.length() + "B");
                 }
             }
         }
 
-        Timber.i(
-                "Attempting to load from %s, file is %dB and has CSV files %dB",
-                formFile.getAbsolutePath(),
-                formFileBytesSize,
-                csvFileBytesSize
-        );
+        if (csvFileBytesSizes.isEmpty()) {
+            Timber.i(
+                    "Attempting to load from %s, file is %dB",
+                    formFile.getAbsolutePath(),
+                    formFileBytesSize
+            );
+        } else {
+            Timber.i(
+                    "Attempting to load from %s, file is %dB and has CSV files %s",
+                    formFile.getAbsolutePath(),
+                    formFileBytesSize,
+                    String.join(", ", csvFileBytesSizes)
+            );
+        }
     }
 
     private static void unzipMediaFiles(File formMediaDir) {


### PR DESCRIPTION
This adds details to our logging during form load so we can know how large a form file, and it's CSV media files (which are probably instances are). This will let us know if OOM crashes are occurring for small forms or not (which we don't expect).