### PR TITLE
Fix theme view specific themes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -58,9 +58,7 @@ class MainMenuActivity : LocalizedActivity() {
         val viewModelProvider = ViewModelProvider(this, viewModelFactory)
         currentProjectViewModel = viewModelProvider[CurrentProjectViewModel::class.java]
 
-        if (!FeatureFlags.NO_THEME_SETTING) {
-            ThemeUtils(this).setDarkModeForCurrentProject()
-        }
+        ThemeUtils(this).setDarkModeForCurrentProject()
 
         if (!currentProjectViewModel.hasCurrentProject()) {
             super.onCreate(null)

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -8,7 +8,6 @@ import org.odk.collect.android.R
 import org.odk.collect.android.activities.ActivityUtils
 import org.odk.collect.android.activities.CrashHandlerActivity
 import org.odk.collect.android.activities.FirstLaunchActivity
-import org.odk.collect.android.application.FeatureFlags
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.projects.ProjectSettingsDialog
 import org.odk.collect.android.utilities.ThemeUtils

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
@@ -29,6 +29,7 @@ import androidx.annotation.StyleRes;
 import androidx.appcompat.app.AppCompatDelegate;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.FeatureFlags;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.settings.SettingsProvider;
 import org.odk.collect.settings.keys.ProjectKeys;
@@ -89,7 +90,11 @@ public final class ThemeUtils {
     }
 
     public boolean isSystemTheme() {
-        return getPrefsTheme().equals(context.getString(org.odk.collect.strings.R.string.app_theme_system));
+        if (FeatureFlags.NO_THEME_SETTING) {
+            return true;
+        } else {
+            return getPrefsTheme().equals(context.getString(org.odk.collect.strings.R.string.app_theme_system));
+        }
     }
 
     public boolean isDarkTheme() {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
@@ -85,10 +85,6 @@ public final class ThemeUtils {
                 R.style.Theme_Collect_Light_Spinner_TimePicker_Dialog;
     }
 
-    public int getAccountPickerTheme() {
-        return isDarkTheme() ? 0 : 1;
-    }
-
     public boolean isSystemTheme() {
         if (FeatureFlags.NO_THEME_SETTING) {
             return true;


### PR DESCRIPTION
Closes #6555 

#### Why is this the best possible solution? Were any other approaches considered?

I realized the easiest thing to do here was just to simplify the implementation so we feature flag out the theme setting in `ThemeUtils`. This means the logic there can all stay intact, but we just end up ignoring the underlying setting and treat everything as if "system" was selected.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just mean that the view specific themes (spinners, dialogs and calendars etc) should all now follow the system regardless of the selected theme (on devices that had a previous version installed).

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
