### PR TITLE
Fixed deleting entities from lists with special characters

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -198,7 +198,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         databaseConnection.withConnection {
             getLists().forEach {
                 writableDatabase.delete(
-                    "`$it`",
+                    "\"$it\"",
                     "${EntitiesTable.COLUMN_ID} = ?",
                     arrayOf(id)
                 )

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -65,7 +65,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             entities.forEach { entity ->
                 val existing = if (listExists) {
                     query(
-                        "\"$list\"",
+                        quote(list),
                         "${EntitiesTable.COLUMN_ID} = ?",
                         arrayOf(entity.id)
                     ).first { mapCursorRowToEntity(it, 0) }
@@ -92,7 +92,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
                     }
 
                     update(
-                        "\"$list\"",
+                        quote(list),
                         contentValues,
                         "${EntitiesTable.COLUMN_ID} = ?",
                         arrayOf(entity.id)
@@ -110,7 +110,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
                     }
 
                     insertOrThrow(
-                        "\"$list\"",
+                        quote(list),
                         null,
                         contentValues
                     )
@@ -198,7 +198,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         databaseConnection.withConnection {
             getLists().forEach {
                 writableDatabase.delete(
-                    "\"$it\"",
+                    quote(it),
                     "${EntitiesTable.COLUMN_ID} = ?",
                     arrayOf(id)
                 )
@@ -377,7 +377,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
 
     private fun updatePropertyColumns(list: String, entity: Entity) {
         val columnNames = databaseConnection.withConnection {
-            readableDatabase.getColumnNames("\"$list\"")
+            readableDatabase.getColumnNames(quote(list))
         }
 
         val missingColumns = entity.properties
@@ -400,7 +400,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
 
     private fun addPropertiesToContentValues(contentValues: ContentValues, entity: Entity) {
         entity.properties.forEach { (name, value) ->
-            contentValues.put("\"${EntitiesTable.getPropertyColumn(name)}\"", value)
+            contentValues.put(quote(EntitiesTable.getPropertyColumn(name)), value)
         }
     }
 
@@ -450,6 +450,8 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             Entity.State.ONLINE -> 1
         }
     }
+
+    private fun quote(text: String) = "\"$text\""
 
     companion object {
         private const val DATABASE_VERSION = 2

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -198,7 +198,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         databaseConnection.withConnection {
             getLists().forEach {
                 writableDatabase.delete(
-                    it,
+                    "`$it`",
                     "${EntitiesTable.COLUMN_ID} = ?",
                     arrayOf(id)
                 )

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -429,6 +429,27 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
+    fun `#delete supports list names with dots and dashes`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New("1", "Léoville Barton 2008")
+
+        repository.save("wines.x", leoville)
+        repository.save("wines-x", leoville)
+
+        repository.delete("1")
+
+        assertThat(
+            repository.getEntities("wines.x").isEmpty(),
+            equalTo(true)
+        )
+        assertThat(
+            repository.getEntities("wines-x").isEmpty(),
+            equalTo(true)
+        )
+    }
+
+    @Test
     fun `#delete updates index values so that they are always in sequence and start at 0`() {
         val repository = buildSubject()
 


### PR DESCRIPTION
Closes #6559 

#### Why is this the best possible solution? Were any other approaches considered?
We need to quote the list name to make it possible to use special characters in table names in SQL. It's not the first issue like that so this approach is the same as it was before in the case of similar problems.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We’ve encountered issues with handling special characters in entities in other areas before, so this isn’t a new problem. Please test it as described in the issue (deleting entities), but keep in mind that this might not be the last case we’ll need to address.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with entities where lists contain special characters like `.` or `-`.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
