### PR TITLE
Remember last zoom level on a map

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -32,6 +32,8 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
 
     override fun setCenter(center: MapPoint?, animate: Boolean) {}
 
+    override fun zoomToCurrentLocation(center: MapPoint?) {}
+
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {}
 
     override fun zoomToPoint(center: MapPoint?, zoom: Double, animate: Boolean) {}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -45,7 +45,7 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
     override fun zoomToPoint(center: MapPoint?, zoom: Double, animate: Boolean) {}
 
     override fun zoomToBoundingBox(
-        points: MutableIterable<MapPoint>?,
+        points: Iterable<MapPoint>?,
         scaleFactor: Double,
         animate: Boolean
     ) {}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -22,11 +22,7 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         readyListener?.onReady(this)
     }
 
-    override fun getZoomLevelSetByUser(): Float? {
-        return null
-    }
-
-    override fun setZoomLevelSetByUser(zoomLevel: Float?) {}
+    override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {}
 
     override fun getCenter(): MapPoint {
         return MapPoint(0.0, 0.0)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -27,8 +27,6 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
     override val mapFragmentDelegate: MapFragmentDelegate
         get() = mock()
 
-    override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {}
-
     override fun getCenter(): MapPoint {
         return MapPoint(0.0, 0.0)
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -3,8 +3,10 @@ package org.odk.collect.android.support
 import android.os.Handler
 import android.os.Looper
 import androidx.fragment.app.Fragment
+import org.mockito.Mockito.mock
 import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapFragment
+import org.odk.collect.maps.MapFragmentDelegate
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.maps.markers.MarkerDescription
@@ -22,6 +24,9 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         readyListener?.onReady(this)
     }
 
+    override val mapFragmentDelegate: MapFragmentDelegate
+        get() = mock()
+
     override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {}
 
     override fun getCenter(): MapPoint {
@@ -33,8 +38,6 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
     }
 
     override fun setCenter(center: MapPoint?, animate: Boolean) {}
-
-    override fun zoomToCurrentLocation(center: MapPoint?) {}
 
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {}
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -22,6 +22,12 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         readyListener?.onReady(this)
     }
 
+    override fun getZoomLevelSetByUser(): Float? {
+        return null
+    }
+
+    override fun setZoomLevelSetByUser(zoomLevel: Float?) {}
+
     override fun getCenter(): MapPoint {
         return MapPoint(0.0, 0.0)
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
@@ -1,8 +1,10 @@
 package org.odk.collect.android.widgets.support
 
 import androidx.fragment.app.Fragment
+import org.mockito.Mockito.mock
 import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapFragment
+import org.odk.collect.maps.MapFragmentDelegate
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.maps.markers.MarkerDescription
@@ -16,6 +18,9 @@ class NoOpMapFragment : Fragment(), MapFragment {
     ) {
     }
 
+    override val mapFragmentDelegate: MapFragmentDelegate
+        get() = mock()
+
     override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {}
 
     override fun getCenter(): MapPoint {
@@ -27,9 +32,6 @@ class NoOpMapFragment : Fragment(), MapFragment {
     }
 
     override fun setCenter(center: MapPoint?, animate: Boolean) {
-    }
-
-    override fun zoomToCurrentLocation(center: MapPoint?) {
     }
 
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
@@ -27,6 +27,9 @@ class NoOpMapFragment : Fragment(), MapFragment {
     override fun setCenter(center: MapPoint?, animate: Boolean) {
     }
 
+    override fun zoomToCurrentLocation(center: MapPoint?) {
+    }
+
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
@@ -44,7 +44,7 @@ class NoOpMapFragment : Fragment(), MapFragment {
     }
 
     override fun zoomToBoundingBox(
-        points: MutableIterable<MapPoint>?,
+        points: Iterable<MapPoint>?,
         scaleFactor: Double,
         animate: Boolean
     ) {
@@ -54,7 +54,7 @@ class NoOpMapFragment : Fragment(), MapFragment {
         TODO("Not yet implemented")
     }
 
-    override fun addMarkers(markers: MutableList<MarkerDescription>?): MutableList<Int> {
+    override fun addMarkers(markers: List<MarkerDescription>): MutableList<Int> {
         TODO("Not yet implemented")
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
@@ -21,8 +21,6 @@ class NoOpMapFragment : Fragment(), MapFragment {
     override val mapFragmentDelegate: MapFragmentDelegate
         get() = mock()
 
-    override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {}
-
     override fun getCenter(): MapPoint {
         TODO("Not yet implemented")
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
@@ -16,12 +16,7 @@ class NoOpMapFragment : Fragment(), MapFragment {
     ) {
     }
 
-    override fun getZoomLevelSetByUser(): Float? {
-        return null
-    }
-
-    override fun setZoomLevelSetByUser(zoomLevel: Float?) {
-    }
+    override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {}
 
     override fun getCenter(): MapPoint {
         TODO("Not yet implemented")

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
@@ -16,6 +16,13 @@ class NoOpMapFragment : Fragment(), MapFragment {
     ) {
     }
 
+    override fun getZoomLevelSetByUser(): Float? {
+        return null
+    }
+
+    override fun setZoomLevelSetByUser(zoomLevel: Float?) {
+    }
+
     override fun getCenter(): MapPoint {
         TODO("Not yet implemented")
     }

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
@@ -238,7 +238,7 @@ public class GeoPointMapActivity extends LocalizedActivity {
 
         // Focuses on marked location
         zoomButton.setEnabled(false);
-        zoomButton.setOnClickListener(v -> map.zoomToPoint(map.getGpsLocation(), true));
+        zoomButton.setOnClickListener(v -> map.zoomToCurrentLocation(map.getGpsLocation()));
 
         // Menu Layer Toggle
         findViewById(R.id.layer_menu).setOnClickListener(v -> {
@@ -354,7 +354,7 @@ public class GeoPointMapActivity extends LocalizedActivity {
             }
 
             if (!foundFirstLocation) {
-                map.zoomToPoint(map.getGpsLocation(), true);
+                map.zoomToCurrentLocation(map.getGpsLocation());
                 foundFirstLocation = true;
             }
 

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
@@ -270,7 +270,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
         });
 
         zoomButton = findViewById(R.id.zoom);
-        zoomButton.setOnClickListener(v -> map.zoomToPoint(map.getGpsLocation(), true));
+        zoomButton.setOnClickListener(v -> map.zoomToCurrentLocation(map.getGpsLocation()));
 
         List<MapPoint> points = new ArrayList<>();
         Intent intent = getIntent();
@@ -412,7 +412,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
     private void onGpsLocationReady(MapFragment map) {
         // Don't zoom to current location if a user is manually entering points
         if (getWindow().isActive() && (!inputActive || recordingEnabled)) {
-            map.zoomToPoint(map.getGpsLocation(), true);
+            map.zoomToCurrentLocation(map.getGpsLocation());
         }
         updateUi();
     }

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -189,7 +189,7 @@ class SelectionMapFragment(
         map = newMapFragment
 
         binding.zoomToLocation.setMultiClickSafeOnClickListener {
-            map.zoomToPoint(map.gpsLocation, true)
+            map.zoomToCurrentLocation(map.gpsLocation)
         }
 
         binding.zoomToBounds.setMultiClickSafeOnClickListener {
@@ -368,7 +368,7 @@ class SelectionMapFragment(
                 map.zoomToBoundingBox(points, 0.8, false)
             } else {
                 map.setGpsLocationListener { point ->
-                    map.zoomToPoint(point, true)
+                    map.zoomToCurrentLocation(point)
                     map.setGpsLocationListener(null)
                 }
             }

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -189,7 +189,7 @@ class SelectionMapFragment(
         map = newMapFragment
 
         binding.zoomToLocation.setMultiClickSafeOnClickListener {
-            map.zoomToCurrentLocation(map.gpsLocation)
+            map.zoomToCurrentLocation(map.getGpsLocation())
         }
 
         binding.zoomToBounds.setMultiClickSafeOnClickListener {
@@ -312,7 +312,7 @@ class SelectionMapFragment(
                         val point = item.point
 
                         if (maintainZoom) {
-                            map.zoomToPoint(MapPoint(point.latitude, point.longitude), map.zoom, true)
+                            map.zoomToPoint(MapPoint(point.latitude, point.longitude), map.getZoom(), true)
                         } else {
                             map.zoomToPoint(MapPoint(point.latitude, point.longitude), true)
                         }

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -346,7 +346,7 @@ class SelectionMapFragmentTest {
         whenever(data.getMappableItems()).doReturn(MutableLiveData(emptyList()))
 
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
-        map.onZoomLevelChangedByUserListener(10f)
+        map.setZoomLevel(10f)
         map.ready()
 
         assertThat(map.hasCenter(), equalTo(false))

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -328,7 +328,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `zooms to current location when there are no items`() {
+    fun `zooms to current location with default zoom level when there are no items and there is no zoom level saved`() {
         whenever(data.getMappableItems()).doReturn(MutableLiveData(emptyList()))
 
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
@@ -339,6 +339,21 @@ class SelectionMapFragmentTest {
         map.setLocation(MapPoint(1.0, 2.0))
         assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
         assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
+    }
+
+    @Test
+    fun `zooms to current location with saved zoom level when there are no items and there is last zoom level set by user saved`() {
+        whenever(data.getMappableItems()).doReturn(MutableLiveData(emptyList()))
+
+        launcherRule.launchInContainer(SelectionMapFragment::class.java)
+        map.zoomLevelSetByUser = 10f
+        map.ready()
+
+        assertThat(map.hasCenter(), equalTo(false))
+
+        map.setLocation(MapPoint(1.0, 2.0))
+        assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
+        assertThat(map.zoom, equalTo(10.0))
     }
 
     @Test

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -338,7 +338,7 @@ class SelectionMapFragmentTest {
 
         map.setLocation(MapPoint(1.0, 2.0))
         assertThat(map.getCenter(), equalTo(MapPoint(1.0, 2.0)))
-        assertThat(map.getZoom(), equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
+        assertThat(map.getZoom(), equalTo(MapFragment.POINT_ZOOM.toDouble()))
     }
 
     @Test
@@ -400,7 +400,7 @@ class SelectionMapFragmentTest {
         onView(withId(R.id.zoom_to_location)).perform(click())
 
         assertThat(map.getCenter(), equalTo(MapPoint(40.181389, 44.514444)))
-        assertThat(map.getZoom(), equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
+        assertThat(map.getZoom(), equalTo(MapFragment.POINT_ZOOM.toDouble()))
     }
 
     @Test
@@ -733,7 +733,7 @@ class SelectionMapFragmentTest {
         map.ready()
 
         assertThat(map.getCenter(), equalTo(items[1].toMapPoint()))
-        assertThat(map.getZoom(), equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
+        assertThat(map.getZoom(), equalTo(MapFragment.POINT_ZOOM.toDouble()))
     }
 
     @Test

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -297,7 +297,7 @@ class SelectionMapFragmentTest {
         map.setCenter(MapPoint(12.3, 45.6), false)
         map.ready()
 
-        assertThat(map.center, equalTo(MapPoint(12.3, 45.6)))
+        assertThat(map.getCenter(), equalTo(MapPoint(12.3, 45.6)))
     }
 
     @Test
@@ -324,7 +324,7 @@ class SelectionMapFragmentTest {
         assertThat(map.hasCenter(), equalTo(false))
 
         map.setLocation(MapPoint(1.0, 2.0))
-        assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
+        assertThat(map.getCenter(), equalTo(MapPoint(1.0, 2.0)))
     }
 
     @Test
@@ -337,8 +337,8 @@ class SelectionMapFragmentTest {
         assertThat(map.hasCenter(), equalTo(false))
 
         map.setLocation(MapPoint(1.0, 2.0))
-        assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
-        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
+        assertThat(map.getCenter(), equalTo(MapPoint(1.0, 2.0)))
+        assertThat(map.getZoom(), equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
     }
 
     @Test
@@ -346,14 +346,14 @@ class SelectionMapFragmentTest {
         whenever(data.getMappableItems()).doReturn(MutableLiveData(emptyList()))
 
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
-        map.zoomLevelSetByUser = 10f
+        map.onZoomLevelChangedByUserListener(10f)
         map.ready()
 
         assertThat(map.hasCenter(), equalTo(false))
 
         map.setLocation(MapPoint(1.0, 2.0))
-        assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
-        assertThat(map.zoom, equalTo(10.0))
+        assertThat(map.getCenter(), equalTo(MapPoint(1.0, 2.0)))
+        assertThat(map.getZoom(), equalTo(10.0))
     }
 
     @Test
@@ -366,10 +366,10 @@ class SelectionMapFragmentTest {
         assertThat(map.hasCenter(), equalTo(false))
 
         map.setLocation(MapPoint(1.0, 2.0))
-        assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
+        assertThat(map.getCenter(), equalTo(MapPoint(1.0, 2.0)))
 
         map.setLocation(MapPoint(3.0, 4.0))
-        assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
+        assertThat(map.getCenter(), equalTo(MapPoint(1.0, 2.0)))
     }
 
     @Test
@@ -399,8 +399,8 @@ class SelectionMapFragmentTest {
         map.setLocation(MapPoint(40.181389, 44.514444))
         onView(withId(R.id.zoom_to_location)).perform(click())
 
-        assertThat(map.center, equalTo(MapPoint(40.181389, 44.514444)))
-        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
+        assertThat(map.getCenter(), equalTo(MapPoint(40.181389, 44.514444)))
+        assertThat(map.getZoom(), equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
     }
 
     @Test
@@ -463,8 +463,8 @@ class SelectionMapFragmentTest {
         map.zoomToPoint(MapPoint(55.0, 66.0), 2.0, false)
 
         map.clickOnFeature(1)
-        assertThat(map.center, equalTo(items[1].toMapPoint()))
-        assertThat(map.zoom, equalTo(2.0))
+        assertThat(map.getCenter(), equalTo(items[1].toMapPoint()))
+        assertThat(map.getZoom(), equalTo(2.0))
     }
 
     @Test
@@ -499,7 +499,7 @@ class SelectionMapFragmentTest {
         map.ready()
 
         map.clickOnFeatureId(map.getFeatureId(listOf((items[1] as MappableSelectItem.MappableSelectPoint).point)))
-        assertThat(map.center, equalTo((items[1] as MappableSelectItem.MappableSelectPoint).point))
+        assertThat(map.getCenter(), equalTo((items[1] as MappableSelectItem.MappableSelectPoint).point))
     }
 
     @Test
@@ -732,8 +732,8 @@ class SelectionMapFragmentTest {
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
 
-        assertThat(map.center, equalTo(items[1].toMapPoint()))
-        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
+        assertThat(map.getCenter(), equalTo(items[1].toMapPoint()))
+        assertThat(map.getZoom(), equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
     }
 
     @Test
@@ -748,7 +748,7 @@ class SelectionMapFragmentTest {
         map.ready()
 
         map.setLocation(MapPoint(1.0, 2.0))
-        assertThat(map.center, equalTo(items[1].toMapPoint()))
+        assertThat(map.getCenter(), equalTo(items[1].toMapPoint()))
     }
 
     @Test

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -42,6 +42,13 @@ class FakeMapFragment : Fragment(), MapFragment {
         readyListener?.onReady(this)
     }
 
+    override fun getZoomLevelSetByUser(): Float? {
+        return null
+    }
+
+    override fun setZoomLevelSetByUser(zoomLevel: Float?) {
+    }
+
     override fun getCenter(): MapPoint {
         return center ?: DEFAULT_CENTER
     }

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -51,10 +51,6 @@ class FakeMapFragment : Fragment(), MapFragment {
         readyListener?.onReady(this)
     }
 
-    override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {
-        zoomLevelSetByUser = zoomLevel
-    }
-
     override fun getCenter(): MapPoint {
         return center ?: MapFragment.INITIAL_CENTER
     }
@@ -266,5 +262,9 @@ class FakeMapFragment : Fragment(), MapFragment {
 
     fun getPolygons(): List<PolygonDescription> {
         return polygons.values.toList()
+    }
+
+    fun setZoomLevel(zoomLevel: Float?) {
+        zoomLevelSetByUser = zoomLevel
     }
 }

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -30,6 +30,7 @@ class FakeMapFragment : Fragment(), MapFragment {
     private val polygons = mutableMapOf<Int, PolygonDescription>()
     private var hasCenter = false
     private val featureIds = mutableListOf<Int>()
+    private var zoomLevelSetByUser: Float? = null
 
     override fun init(
         readyListener: ReadyListener?,
@@ -43,10 +44,11 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     override fun getZoomLevelSetByUser(): Float? {
-        return null
+        return zoomLevelSetByUser
     }
 
     override fun setZoomLevelSetByUser(zoomLevel: Float?) {
+        zoomLevelSetByUser = zoomLevel
     }
 
     override fun getCenter(): MapPoint {
@@ -63,6 +65,7 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     override fun zoomToCurrentLocation(center: MapPoint?) {
+        zoomToPoint(center, zoomLevelSetByUser?.toDouble() ?: DEFAULT_POINT_ZOOM, true)
     }
 
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -1,11 +1,14 @@
 package org.odk.collect.geo.support
 
 import androidx.fragment.app.Fragment
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragment.FeatureListener
 import org.odk.collect.maps.MapFragment.PointListener
 import org.odk.collect.maps.MapFragment.ReadyListener
+import org.odk.collect.maps.MapFragmentDelegate
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.maps.markers.MarkerDescription
@@ -39,6 +42,11 @@ class FakeMapFragment : Fragment(), MapFragment {
         this.readyListener = readyListener
     }
 
+    override val mapFragmentDelegate: MapFragmentDelegate
+        get() = mock<MapFragmentDelegate?>().also {
+            whenever(it.zoomLevel).thenReturn(zoomLevelSetByUser)
+        }
+
     fun ready() {
         readyListener?.onReady(this)
     }
@@ -48,7 +56,7 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     override fun getCenter(): MapPoint {
-        return center ?: DEFAULT_CENTER
+        return center ?: MapFragment.INITIAL_CENTER
     }
 
     override fun getZoom(): Double {
@@ -60,14 +68,10 @@ class FakeMapFragment : Fragment(), MapFragment {
         hasCenter = true
     }
 
-    override fun zoomToCurrentLocation(center: MapPoint?) {
-        zoomToPoint(center, zoomLevelSetByUser?.toDouble() ?: DEFAULT_POINT_ZOOM, true)
-    }
-
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {
         zoomBoundingBox = null
         this.center = center
-        this.zoom = DEFAULT_POINT_ZOOM
+        this.zoom = MapFragment.POINT_ZOOM.toDouble()
         hasCenter = true
     }
 
@@ -262,18 +266,5 @@ class FakeMapFragment : Fragment(), MapFragment {
 
     fun getPolygons(): List<PolygonDescription> {
         return polygons.values.toList()
-    }
-
-    companion object {
-        /**
-         * The value returned if the map has had no center set or has had `null` pass to
-         * [setCenter]
-         */
-        val DEFAULT_CENTER = MapPoint(-1.0, -1.0)
-
-        /**
-         * The value used to zoom when [zoomToPoint] is called without a zoom level
-         */
-        const val DEFAULT_POINT_ZOOM = -1.0
     }
 }

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -43,11 +43,7 @@ class FakeMapFragment : Fragment(), MapFragment {
         readyListener?.onReady(this)
     }
 
-    override fun getZoomLevelSetByUser(): Float? {
-        return zoomLevelSetByUser
-    }
-
-    override fun setZoomLevelSetByUser(zoomLevel: Float?) {
+    override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {
         zoomLevelSetByUser = zoomLevel
     }
 

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -55,6 +55,9 @@ class FakeMapFragment : Fragment(), MapFragment {
         hasCenter = true
     }
 
+    override fun zoomToCurrentLocation(center: MapPoint?) {
+    }
+
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {
         zoomBoundingBox = null
         this.center = center

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -83,17 +83,19 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     override fun zoomToBoundingBox(
-        points: Iterable<MapPoint>,
+        points: Iterable<MapPoint>?,
         scaleFactor: Double,
         animate: Boolean
     ) {
-        center = null
-        zoom = 0.0
-        zoomBoundingBox = Pair(
-            points.toList(), // Clone list to prevent original changing captured values
-            scaleFactor
-        )
-        hasCenter = true
+        points?.let {
+            center = null
+            zoom = 0.0
+            zoomBoundingBox = Pair(
+                it.toList(), // Clone list to prevent original changing captured values
+                scaleFactor
+            )
+            hasCenter = true
+        }
     }
 
     override fun addMarker(markerDescription: MarkerDescription): Int {

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -223,6 +223,17 @@ public class GoogleMapFragment extends Fragment implements
         super.onDestroy();
     }
 
+    @Nullable
+    @Override
+    public Float getZoomLevelSetByUser() {
+        return null;
+    }
+
+    @Override
+    public void setZoomLevelSetByUser(@Nullable Float zoomLevel) {
+
+    }
+
     @Override public @NonNull MapPoint getCenter() {
         if (map == null) {  // during Robolectric tests, map will be null
             return INITIAL_CENTER;

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -275,7 +275,11 @@ public class GoogleMapFragment extends Fragment implements
 
     @Override
     public void zoomToCurrentLocation(@Nullable MapPoint center) {
-        zoomToPoint(center, POINT_ZOOM, true);
+        zoomToPoint(
+                center,
+                lastZoomLevelChangedByUser != null ? lastZoomLevelChangedByUser : POINT_ZOOM,
+                true
+        );
     }
 
     @Override public void zoomToPoint(@Nullable MapPoint center, boolean animate) {

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -98,9 +98,8 @@ public class GoogleMapFragment extends Fragment implements
     private final MapFragmentDelegate mapFragmentDelegate = new MapFragmentDelegate(
             this,
             this::createConfigurator,
-            () -> {
-                return settingsProvider.getUnprotectedSettings();
-            },
+            () -> settingsProvider.getUnprotectedSettings(),
+            () -> settingsProvider.getMetaSettings(),
             this::onConfigChanged
     );
 

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -127,7 +127,6 @@ public class GoogleMapFragment extends Fragment implements
     private TileOverlay referenceOverlay;
     private boolean hasCenter;
     private boolean isUserZooming;
-    private @Nullable Float lastZoomLevelChangedByUser;
 
     @Override
     public void init(@Nullable ReadyListener readyListener, @Nullable ErrorListener errorListener) {
@@ -181,7 +180,7 @@ public class GoogleMapFragment extends Fragment implements
             googleMap.setOnCameraIdleListener(() -> {
                 scaleView.update(googleMap.getCameraPosition().zoom, googleMap.getCameraPosition().target.latitude);
                 if (isUserZooming) {
-                    lastZoomLevelChangedByUser = googleMap.getCameraPosition().zoom;
+                    onZoomLevelChangedByUserListener(googleMap.getCameraPosition().zoom);
                     isUserZooming = false;
                 }
             });
@@ -236,15 +235,9 @@ public class GoogleMapFragment extends Fragment implements
         super.onDestroy();
     }
 
-    @Nullable
     @Override
-    public Float getZoomLevelSetByUser() {
-        return lastZoomLevelChangedByUser;
-    }
-
-    @Override
-    public void setZoomLevelSetByUser(@Nullable Float zoomLevel) {
-        lastZoomLevelChangedByUser = zoomLevel;
+    public void onZoomLevelChangedByUserListener(@Nullable Float zoomLevel) {
+        mapFragmentDelegate.onZoomLevelChangedByUserListener(zoomLevel);
     }
 
     @Override public @NonNull MapPoint getCenter() {
@@ -275,9 +268,10 @@ public class GoogleMapFragment extends Fragment implements
 
     @Override
     public void zoomToCurrentLocation(@Nullable MapPoint center) {
+        Float zoomLevel = mapFragmentDelegate.getZoomLevel();
         zoomToPoint(
                 center,
-                lastZoomLevelChangedByUser != null ? lastZoomLevelChangedByUser : POINT_ZOOM,
+                zoomLevel != null ? zoomLevel : POINT_ZOOM,
                 true
         );
     }

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -250,6 +250,11 @@ public class GoogleMapFragment extends Fragment implements
         return map.getCameraPosition().zoom;
     }
 
+    @Override
+    public void zoomToCurrentLocation(@Nullable MapPoint center) {
+        zoomToPoint(center, POINT_ZOOM, true);
+    }
+
     @Override public void zoomToPoint(@Nullable MapPoint center, boolean animate) {
         zoomToPoint(center, POINT_ZOOM, animate);
     }

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -171,7 +171,7 @@ public class GoogleMapFragment extends Fragment implements
             googleMap.setMyLocationEnabled(false);
             googleMap.setMinZoomPreference(1);
             googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(
-                    toLatLng(INITIAL_CENTER), INITIAL_ZOOM));
+                    toLatLng(MapFragment.Companion.getINITIAL_CENTER()), INITIAL_ZOOM));
             googleMap.setOnCameraMoveListener(() -> scaleView.update(googleMap.getCameraPosition().zoom, googleMap.getCameraPosition().target.latitude));
             googleMap.setOnCameraMoveStartedListener(reason -> {
                 if (reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE) {
@@ -249,7 +249,7 @@ public class GoogleMapFragment extends Fragment implements
 
     @Override public @NonNull MapPoint getCenter() {
         if (map == null) {  // during Robolectric tests, map will be null
-            return INITIAL_CENTER;
+            return MapFragment.Companion.getINITIAL_CENTER();
         }
         LatLng target = map.getCameraPosition().target;
         return new MapPoint(target.latitude, target.longitude);
@@ -297,7 +297,7 @@ public class GoogleMapFragment extends Fragment implements
         hasCenter = true;
     }
 
-    @Override public void zoomToBoundingBox(Iterable<MapPoint> points, double scaleFactor, boolean animate) {
+    @Override public void zoomToBoundingBox(@Nullable Iterable<MapPoint> points, double scaleFactor, boolean animate) {
         if (map == null) {  // during Robolectric tests, map will be null
             return;
         }
@@ -728,7 +728,7 @@ public class GoogleMapFragment extends Fragment implements
         );
     }
 
-    private static float getIconAnchorValueX(@IconAnchor String iconAnchor) {
+    private static float getIconAnchorValueX(@MapFragment.Companion.IconAnchor String iconAnchor) {
         switch (iconAnchor) {
             case BOTTOM:
             default:
@@ -736,7 +736,7 @@ public class GoogleMapFragment extends Fragment implements
         }
     }
 
-    private static float getIconAnchorValueY(@IconAnchor String iconAnchor) {
+    private static float getIconAnchorValueY(@MapFragment.Companion.IconAnchor String iconAnchor) {
         switch (iconAnchor) {
             case BOTTOM:
                 return 1.0f;

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -180,7 +180,7 @@ public class GoogleMapFragment extends Fragment implements
             googleMap.setOnCameraIdleListener(() -> {
                 scaleView.update(googleMap.getCameraPosition().zoom, googleMap.getCameraPosition().target.latitude);
                 if (isUserZooming) {
-                    onZoomLevelChangedByUserListener(googleMap.getCameraPosition().zoom);
+                    mapFragmentDelegate.onZoomLevelChangedByUserListener(googleMap.getCameraPosition().zoom);
                     isUserZooming = false;
                 }
             });
@@ -239,11 +239,6 @@ public class GoogleMapFragment extends Fragment implements
     @Override
     public MapFragmentDelegate getMapFragmentDelegate() {
         return mapFragmentDelegate;
-    }
-
-    @Override
-    public void onZoomLevelChangedByUserListener(@Nullable Float zoomLevel) {
-        mapFragmentDelegate.onZoomLevelChangedByUserListener(zoomLevel);
     }
 
     @Override public @NonNull MapPoint getCenter() {

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -235,6 +235,12 @@ public class GoogleMapFragment extends Fragment implements
         super.onDestroy();
     }
 
+    @NonNull
+    @Override
+    public MapFragmentDelegate getMapFragmentDelegate() {
+        return mapFragmentDelegate;
+    }
+
     @Override
     public void onZoomLevelChangedByUserListener(@Nullable Float zoomLevel) {
         mapFragmentDelegate.onZoomLevelChangedByUserListener(zoomLevel);
@@ -264,16 +270,6 @@ public class GoogleMapFragment extends Fragment implements
             return INITIAL_ZOOM;
         }
         return map.getCameraPosition().zoom;
-    }
-
-    @Override
-    public void zoomToCurrentLocation(@Nullable MapPoint center) {
-        Float zoomLevel = mapFragmentDelegate.getZoomLevel();
-        zoomToPoint(
-                center,
-                zoomLevel != null ? zoomLevel : POINT_ZOOM,
-                true
-        );
     }
 
     @Override public void zoomToPoint(@Nullable MapPoint center, boolean animate) {

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -125,6 +125,7 @@ public class GoogleMapFragment extends Fragment implements
     private int mapType;
     private File referenceLayerFile;
     private TileOverlay referenceOverlay;
+    private float currentZoomLevel;
     private boolean hasCenter;
     private boolean isUserZooming;
 
@@ -180,9 +181,13 @@ public class GoogleMapFragment extends Fragment implements
             googleMap.setOnCameraIdleListener(() -> {
                 scaleView.update(googleMap.getCameraPosition().zoom, googleMap.getCameraPosition().target.latitude);
                 if (isUserZooming) {
-                    mapFragmentDelegate.onZoomLevelChangedByUserListener(googleMap.getCameraPosition().zoom);
+                    float newZoomLevel = googleMap.getCameraPosition().zoom;
+                    if (newZoomLevel != currentZoomLevel) {
+                        mapFragmentDelegate.onZoomLevelChangedByUserListener(googleMap.getCameraPosition().zoom);
+                    }
                     isUserZooming = false;
                 }
+                currentZoomLevel = googleMap.getCameraPosition().zoom;
             });
             loadReferenceOverlay();
 

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapUtils.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapUtils.kt
@@ -18,7 +18,7 @@ object MapUtils {
         pointAnnotationManager: PointAnnotationManager,
         point: MapPoint,
         draggable: Boolean,
-        @MapFragment.IconAnchor iconAnchor: String,
+        @MapFragment.Companion.IconAnchor iconAnchor: String,
         iconDrawableId: Int,
         context: Context
     ): PointAnnotation {
@@ -53,7 +53,7 @@ object MapUtils {
         return pointAnnotationManager.create(pointAnnotationOptionsList)
     }
 
-    private fun getIconAnchorValue(@MapFragment.IconAnchor iconAnchor: String): IconAnchor {
+    private fun getIconAnchorValue(@MapFragment.Companion.IconAnchor iconAnchor: String): IconAnchor {
         return when (iconAnchor) {
             MapFragment.BOTTOM -> IconAnchor.BOTTOM
             else -> IconAnchor.CENTER

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -107,7 +107,7 @@ class MapboxMapFragment :
     private var clientWantsLocationUpdates = false
     private var topStyleLayerId: String? = null
     private val locationCallback = MapboxLocationCallback(this)
-    private var mapFragmentDelegate = MapFragmentDelegate(
+    override val mapFragmentDelegate = MapFragmentDelegate(
         this,
         { MapboxMapConfigurator() },
         { settingsProvider.getUnprotectedSettings() },
@@ -261,14 +261,6 @@ class MapboxMapFragment :
         }
 
         hasCenter = true
-    }
-
-    override fun zoomToCurrentLocation(center: MapPoint?) {
-        zoomToPoint(
-            center,
-            mapFragmentDelegate.zoomLevel?.toDouble() ?: MapFragment.POINT_ZOOM.toDouble(),
-            true
-        )
     }
 
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -173,7 +173,7 @@ class MapboxMapFragment :
                     override fun onScaleBegin(detector: StandardScaleGestureDetector) = Unit
 
                     override fun onScaleEnd(detector: StandardScaleGestureDetector) {
-                        onZoomLevelChangedByUserListener(cameraState.zoom.toFloat())
+                        mapFragmentDelegate.onZoomLevelChangedByUserListener(cameraState.zoom.toFloat())
                     }
                 })
             }
@@ -240,10 +240,6 @@ class MapboxMapFragment :
             }
             loadReferenceOverlay()
         }
-    }
-
-    override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {
-        mapFragmentDelegate.onZoomLevelChangedByUserListener(zoomLevel)
     }
 
     override fun getCenter(): MapPoint {

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -230,6 +230,13 @@ class MapboxMapFragment :
         }
     }
 
+    override fun getZoomLevelSetByUser(): Float? {
+        return null
+    }
+
+    override fun setZoomLevelSetByUser(zoomLevel: Float?) {
+    }
+
     override fun getCenter(): MapPoint {
         val point = mapboxMap.cameraState.center
         return MapPoint(point.latitude(), point.longitude())

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -246,6 +246,10 @@ class MapboxMapFragment :
         hasCenter = true
     }
 
+    override fun zoomToCurrentLocation(center: MapPoint?) {
+        zoomToPoint(center, MapFragment.POINT_ZOOM.toDouble(), true)
+    }
+
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {
         zoomToPoint(center, MapFragment.POINT_ZOOM.toDouble(), animate)
     }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.startup.AppInitializer
 import com.google.android.gms.location.LocationListener
+import com.mapbox.android.gestures.StandardScaleGestureDetector
 import com.mapbox.geojson.Point
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapView
@@ -41,8 +42,10 @@ import com.mapbox.maps.plugin.annotation.generated.createPolylineAnnotationManag
 import com.mapbox.maps.plugin.compass.compass
 import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
+import com.mapbox.maps.plugin.gestures.OnScaleListener
 import com.mapbox.maps.plugin.gestures.addOnMapClickListener
 import com.mapbox.maps.plugin.gestures.addOnMapLongClickListener
+import com.mapbox.maps.plugin.gestures.addOnScaleListener
 import com.mapbox.maps.plugin.locationcomponent.location
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -113,6 +116,7 @@ class MapboxMapFragment :
     )
 
     private var hasCenter = false
+    private var lastZoomLevelChangedByUser: Float? = null
 
     private val settingsProvider: SettingsProvider by lazy {
         (requireActivity().applicationContext as ObjectProviderHost).getObjectProvider().provide(SettingsProvider::class.java)
@@ -164,6 +168,15 @@ class MapboxMapFragment :
             .apply {
                 addOnMapClickListener(this@MapboxMapFragment)
                 addOnMapLongClickListener(this@MapboxMapFragment)
+                addOnScaleListener(object : OnScaleListener {
+                    override fun onScale(detector: StandardScaleGestureDetector) = Unit
+
+                    override fun onScaleBegin(detector: StandardScaleGestureDetector) = Unit
+
+                    override fun onScaleEnd(detector: StandardScaleGestureDetector) {
+                        zoomLevelSetByUser = cameraState.zoom.toFloat()
+                    }
+                })
             }
 
         polylineAnnotationManager = mapView
@@ -231,10 +244,11 @@ class MapboxMapFragment :
     }
 
     override fun getZoomLevelSetByUser(): Float? {
-        return null
+        return lastZoomLevelChangedByUser
     }
 
     override fun setZoomLevelSetByUser(zoomLevel: Float?) {
+        lastZoomLevelChangedByUser = zoomLevel
     }
 
     override fun getCenter(): MapPoint {

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -108,6 +108,7 @@ class MapboxMapFragment :
         this,
         { MapboxMapConfigurator() },
         { settingsProvider.getUnprotectedSettings() },
+        { settingsProvider.getMetaSettings() },
         this::onConfigChanged
     )
 

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -116,7 +116,6 @@ class MapboxMapFragment :
     )
 
     private var hasCenter = false
-    private var lastZoomLevelChangedByUser: Float? = null
 
     private val settingsProvider: SettingsProvider by lazy {
         (requireActivity().applicationContext as ObjectProviderHost).getObjectProvider().provide(SettingsProvider::class.java)
@@ -174,7 +173,7 @@ class MapboxMapFragment :
                     override fun onScaleBegin(detector: StandardScaleGestureDetector) = Unit
 
                     override fun onScaleEnd(detector: StandardScaleGestureDetector) {
-                        lastZoomLevelChangedByUser = cameraState.zoom.toFloat()
+                        onZoomLevelChangedByUserListener(cameraState.zoom.toFloat())
                     }
                 })
             }
@@ -243,12 +242,8 @@ class MapboxMapFragment :
         }
     }
 
-    override fun getZoomLevelSetByUser(): Float? {
-        return lastZoomLevelChangedByUser
-    }
-
-    override fun setZoomLevelSetByUser(zoomLevel: Float?) {
-        lastZoomLevelChangedByUser = zoomLevel
+    override fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {
+        mapFragmentDelegate.onZoomLevelChangedByUserListener(zoomLevel)
     }
 
     override fun getCenter(): MapPoint {
@@ -271,7 +266,7 @@ class MapboxMapFragment :
     override fun zoomToCurrentLocation(center: MapPoint?) {
         zoomToPoint(
             center,
-            lastZoomLevelChangedByUser?.toDouble() ?: MapFragment.POINT_ZOOM.toDouble(),
+            mapFragmentDelegate.zoomLevel?.toDouble() ?: MapFragment.POINT_ZOOM.toDouble(),
             true
         )
     }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -269,7 +269,11 @@ class MapboxMapFragment :
     }
 
     override fun zoomToCurrentLocation(center: MapPoint?) {
-        zoomToPoint(center, MapFragment.POINT_ZOOM.toDouble(), true)
+        zoomToPoint(
+            center,
+            lastZoomLevelChangedByUser?.toDouble() ?: MapFragment.POINT_ZOOM.toDouble(),
+            true
+        )
     }
 
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -174,7 +174,7 @@ class MapboxMapFragment :
                     override fun onScaleBegin(detector: StandardScaleGestureDetector) = Unit
 
                     override fun onScaleEnd(detector: StandardScaleGestureDetector) {
-                        zoomLevelSetByUser = cameraState.zoom.toFloat()
+                        lastZoomLevelChangedByUser = cameraState.zoom.toFloat()
                     }
                 })
             }

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.java
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.java
@@ -61,8 +61,15 @@ public interface MapFragment {
 
     void init(@Nullable ReadyListener readyListener, @Nullable ErrorListener errorListener);
 
+    /**
+     * Gets the current zoom level if it has been changed by the user through gestures.
+     * Programmatic zoom changes will not be considered.
+     */
     @Nullable Float getZoomLevelSetByUser();
 
+    /**
+     * Sets the remembered zoom level changed by the user through gestures.
+     */
     void setZoomLevelSetByUser(@Nullable Float zoomLevel);
 
     /** Gets the point currently shown at the center of the map view. */

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.java
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.java
@@ -77,6 +77,13 @@ public interface MapFragment {
     void setCenter(@Nullable MapPoint center, boolean animate);
 
     /**
+     * Centers the map view on the current location, zooming in to the last zoom level set by the
+     * user if available, or to a close-up level deemed appropriate by
+     * the implementation, possibly with animation.
+     */
+    void zoomToCurrentLocation(@Nullable MapPoint center);
+
+    /**
      * Centers the map view on the given point, zooming in to a close-up level
      * deemed appropriate by the implementation, possibly with animation.
      */

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.java
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.java
@@ -61,6 +61,10 @@ public interface MapFragment {
 
     void init(@Nullable ReadyListener readyListener, @Nullable ErrorListener errorListener);
 
+    @Nullable Float getZoomLevelSetByUser();
+
+    void setZoomLevelSetByUser(@Nullable Float zoomLevel);
+
     /** Gets the point currently shown at the center of the map view. */
     @NonNull MapPoint getCenter();
 

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
@@ -27,16 +27,7 @@ import org.odk.collect.maps.markers.MarkerIconDescription
 interface MapFragment {
     fun init(readyListener: ReadyListener?, errorListener: ErrorListener?)
 
-    /**
-     * Gets the current zoom level if it has been changed by the user through gestures.
-     * Programmatic zoom changes will not be considered.
-     */
-    fun getZoomLevelSetByUser(): Float?
-
-    /**
-     * Sets the remembered zoom level changed by the user through gestures.
-     */
-    fun setZoomLevelSetByUser(zoomLevel: Float?)
+    fun onZoomLevelChangedByUserListener(zoomLevel: Float?)
 
     /** Gets the point currently shown at the center of the map view.  */
     fun getCenter(): MapPoint

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
@@ -29,8 +29,6 @@ interface MapFragment {
 
     fun init(readyListener: ReadyListener?, errorListener: ErrorListener?)
 
-    fun onZoomLevelChangedByUserListener(zoomLevel: Float?)
-
     /** Gets the point currently shown at the center of the map view.  */
     fun getCenter(): MapPoint
 

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
@@ -25,6 +25,8 @@ import org.odk.collect.maps.markers.MarkerIconDescription
  * even though the geo widgets only use one kind of feature at a time.
  */
 interface MapFragment {
+    val mapFragmentDelegate: MapFragmentDelegate
+
     fun init(readyListener: ReadyListener?, errorListener: ErrorListener?)
 
     fun onZoomLevelChangedByUserListener(zoomLevel: Float?)
@@ -49,7 +51,13 @@ interface MapFragment {
      * user if available, or to a close-up level deemed appropriate by
      * the implementation, possibly with animation.
      */
-    fun zoomToCurrentLocation(center: MapPoint?)
+    fun zoomToCurrentLocation(center: MapPoint?) {
+        zoomToPoint(
+            center,
+            mapFragmentDelegate.zoomLevel?.toDouble() ?: POINT_ZOOM.toDouble(),
+            true
+        )
+    }
 
     /**
      * Centers the map view on the given point, zooming in to a close-up level

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
@@ -1,29 +1,8 @@
-/*
- * Copyright (C) 2018 Nafundi
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
+package org.odk.collect.maps
 
-package org.odk.collect.maps;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringDef;
-
-import org.odk.collect.maps.markers.MarkerDescription;
-import org.odk.collect.maps.markers.MarkerIconDescription;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.util.List;
+import androidx.annotation.StringDef
+import org.odk.collect.maps.markers.MarkerDescription
+import org.odk.collect.maps.markers.MarkerIconDescription
 
 /**
  * Interface for a Fragment that renders a map view.  The plan is to have one
@@ -45,66 +24,53 @@ import java.util.List;
  * three distinct modes), the map always supports all three kinds of features,
  * even though the geo widgets only use one kind of feature at a time.
  */
-public interface MapFragment {
-    MapPoint INITIAL_CENTER = new MapPoint(0, -30);
-    float INITIAL_ZOOM = 2;
-    float POINT_ZOOM = 16;
-
-    String KEY_REFERENCE_LAYER = "REFERENCE_LAYER";
-
-    @Retention(RetentionPolicy.SOURCE)
-    @StringDef({BOTTOM, CENTER})
-    @interface IconAnchor {}
-
-    String CENTER = "center";
-    String BOTTOM = "bottom";
-
-    void init(@Nullable ReadyListener readyListener, @Nullable ErrorListener errorListener);
+interface MapFragment {
+    fun init(readyListener: ReadyListener?, errorListener: ErrorListener?)
 
     /**
      * Gets the current zoom level if it has been changed by the user through gestures.
      * Programmatic zoom changes will not be considered.
      */
-    @Nullable Float getZoomLevelSetByUser();
+    fun getZoomLevelSetByUser(): Float?
 
     /**
      * Sets the remembered zoom level changed by the user through gestures.
      */
-    void setZoomLevelSetByUser(@Nullable Float zoomLevel);
+    fun setZoomLevelSetByUser(zoomLevel: Float?)
 
-    /** Gets the point currently shown at the center of the map view. */
-    @NonNull MapPoint getCenter();
+    /** Gets the point currently shown at the center of the map view.  */
+    fun getCenter(): MapPoint
 
     /**
      * Gets the current zoom level.  For maps that only support zooming by
      * powers of 2, the zoom level will always be an integer.
      */
-    double getZoom();
+    fun getZoom(): Double
 
     /**
      * Centers the map view on the given point, leaving zoom level unchanged,
      * possibly with animation.
      */
-    void setCenter(@Nullable MapPoint center, boolean animate);
+    fun setCenter(center: MapPoint?, animate: Boolean)
 
     /**
      * Centers the map view on the current location, zooming in to the last zoom level set by the
      * user if available, or to a close-up level deemed appropriate by
      * the implementation, possibly with animation.
      */
-    void zoomToCurrentLocation(@Nullable MapPoint center);
+    fun zoomToCurrentLocation(center: MapPoint?)
 
     /**
      * Centers the map view on the given point, zooming in to a close-up level
      * deemed appropriate by the implementation, possibly with animation.
      */
-    void zoomToPoint(@Nullable MapPoint center, boolean animate);
+    fun zoomToPoint(center: MapPoint?, animate: Boolean)
 
     /**
      * Centers the map view on the given point with a zoom level as close as
      * possible to the given zoom level, possibly with animation.
      */
-    void zoomToPoint(@Nullable MapPoint center, double zoom, boolean animate);
+    fun zoomToPoint(center: MapPoint?, zoom: Double, animate: Boolean)
 
     /**
      * Adjusts the map's viewport to enclose all of the given points, possibly
@@ -114,65 +80,65 @@ public interface MapFragment {
      * to occupy at most 80% of the width and 80% of the height of the viewport,
      * ensuring a margin of at least 10% on all sides.
      */
-    void zoomToBoundingBox(Iterable<MapPoint> points, double scaleFactor, boolean animate);
+    fun zoomToBoundingBox(points: Iterable<MapPoint>?, scaleFactor: Double, animate: Boolean)
 
     /**
      * Adds a marker to the map at the given location. If draggable is true,
      * the user will be able to drag the marker to change its location.
      * Returns a positive integer, the featureId for the newly added shape.
      */
-    int addMarker(MarkerDescription markerDescription);
+    fun addMarker(markerDescription: MarkerDescription): Int
 
-    List<Integer> addMarkers(List<MarkerDescription> markers);
+    fun addMarkers(markers: List<MarkerDescription>): List<Int>
 
-    /** Sets the icon for a marker. */
-    void setMarkerIcon(int featureId, MarkerIconDescription markerIconDescription);
+    /** Sets the icon for a marker.  */
+    fun setMarkerIcon(featureId: Int, markerIconDescription: MarkerIconDescription)
 
-    /** Gets the location of an existing marker. */
-    MapPoint getMarkerPoint(int featureId);
+    /** Gets the location of an existing marker.  */
+    fun getMarkerPoint(featureId: Int): MapPoint?
 
     /**
      * Adds a polyline to the map with the given sequence of vertices.
      * The vertices will have handles that can be dragged by the user.
      * Returns a positive integer, the featureId for the newly added shape.
      */
-    int addPolyLine(LineDescription lineDescription);
+    fun addPolyLine(lineDescription: LineDescription): Int
 
     /**
      * Adds a polygon to the map with given sequence of vertices. * Returns a positive integer,
      * the featureId for the newly added shape.
      */
-    int addPolygon(PolygonDescription polygonDescription);
+    fun addPolygon(polygonDescription: PolygonDescription): Int
 
-    /** Appends a vertex to the polyline or polygon specified by featureId. */
-    void appendPointToPolyLine(int featureId, @NonNull MapPoint point);
+    /** Appends a vertex to the polyline or polygon specified by featureId.  */
+    fun appendPointToPolyLine(featureId: Int, point: MapPoint)
 
     /**
      * Removes the last vertex of the polyline or polygon specified by featureId.
      * If there are no vertices, does nothing.
      */
-    void removePolyLineLastPoint(int featureId);
+    fun removePolyLineLastPoint(featureId: Int)
 
     /**
      * Returns the vertices of the polyline or polygon specified by featureId, or an
      * empty list if the featureId does not identify an existing polyline or polygon.
      */
-    @NonNull List<MapPoint> getPolyLinePoints(int featureId);
+    fun getPolyLinePoints(featureId: Int): List<MapPoint>
 
-    /** Removes all map features from the map. */
-    void clearFeatures();
+    /** Removes all map features from the map.  */
+    fun clearFeatures()
 
-    /** Sets or clears the callback for a click on the map. */
-    void setClickListener(@Nullable PointListener listener);
+    /** Sets or clears the callback for a click on the map.  */
+    fun setClickListener(listener: PointListener?)
 
-    /** Sets or clears the callback for a long press on the map. */
-    void setLongPressListener(@Nullable PointListener listener);
+    /** Sets or clears the callback for a long press on the map.  */
+    fun setLongPressListener(listener: PointListener?)
 
-    /** Sets or clears the callback for a click on a feature. */
-    void setFeatureClickListener(@Nullable FeatureListener listener);
+    /** Sets or clears the callback for a click on a feature.  */
+    fun setFeatureClickListener(listener: FeatureListener?)
 
-    /** Sets or clears the callback for when a drag is completed. */
-    void setDragEndListener(@Nullable FeatureListener listener);
+    /** Sets or clears the callback for when a drag is completed.  */
+    fun setDragEndListener(listener: FeatureListener?)
 
     /**
      * Enables/disables GPS tracking.  While enabled, the GPS location is shown
@@ -180,13 +146,13 @@ public interface MapFragment {
      * runOnGpsLocationReady(), and every GPS fix will invoke the callback set
      * by setGpsLocationListener().
      */
-    void setGpsLocationEnabled(boolean enabled);
+    fun setGpsLocationEnabled(enabled: Boolean)
 
-    /** Gets the last GPS location fix, or null if there hasn't been one. */
-    @Nullable MapPoint getGpsLocation();
+    /** Gets the last GPS location fix, or null if there hasn't been one.  */
+    fun getGpsLocation(): MapPoint?
 
-    /** Gets the provider of the last fix, or null if there hasn't been one. */
-    @Nullable String getLocationProvider();
+    /** Gets the provider of the last fix, or null if there hasn't been one.  */
+    fun getLocationProvider(): String?
 
     /**
      * Queues a callback to be invoked on the UI thread as soon as a GPS fix is
@@ -196,35 +162,49 @@ public interface MapFragment {
      * Activities that set callbacks should call setGpsLocationEnabled(false)
      * in their onStop() or onDestroy() methods, to prevent invalid callbacks.
      */
-    void runOnGpsLocationReady(@NonNull ReadyListener listener);
+    fun runOnGpsLocationReady(listener: ReadyListener)
 
     /**
      * Sets or clears the callback for GPS location updates.  This callback
      * will only be invoked while GPS is enabled with setGpsLocationEnabled().
      */
-    void setGpsLocationListener(@Nullable PointListener listener);
+    fun setGpsLocationListener(listener: PointListener?)
 
-    void setRetainMockAccuracy(boolean retainMockAccuracy);
+    fun setRetainMockAccuracy(retainMockAccuracy: Boolean)
 
     /**
-     * @return true if the {@link MapFragment} center has already been set (by {@link MapFragment#zoomToPoint(MapPoint, boolean)} for instance).
+     * @return true if the [MapFragment] center has already been set (by [MapFragment.zoomToPoint] for instance).
      */
-    boolean hasCenter();
+    fun hasCenter(): Boolean
 
-    interface ErrorListener {
-        void onError();
+    fun interface ErrorListener {
+        fun onError()
     }
 
-    interface ReadyListener {
-        void onReady(@NonNull MapFragment mapFragment);
+    fun interface ReadyListener {
+        fun onReady(mapFragment: MapFragment)
     }
 
-    interface PointListener {
-        void onPoint(@NonNull MapPoint point);
+    fun interface PointListener {
+        fun onPoint(point: MapPoint)
     }
 
-    interface FeatureListener {
-        void onFeature(int featureId);
+    fun interface FeatureListener {
+        fun onFeature(featureId: Int)
     }
 
+    companion object {
+        val INITIAL_CENTER: MapPoint = MapPoint(0.0, -30.0)
+        const val INITIAL_ZOOM: Float = 2f
+        const val POINT_ZOOM: Float = 16f
+
+        const val KEY_REFERENCE_LAYER: String = "REFERENCE_LAYER"
+
+        @Retention(AnnotationRetention.SOURCE)
+        @StringDef(BOTTOM, CENTER)
+        annotation class IconAnchor
+
+        const val CENTER: String = "center"
+        const val BOTTOM: String = "bottom"
+    }
 }

--- a/maps/src/main/java/org/odk/collect/maps/MapFragmentDelegate.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragmentDelegate.kt
@@ -19,6 +19,8 @@ class MapFragmentDelegate(
     private val metaSettings by lazy { metaSettingsProvider() }
 
     private var savedInstanceState: Bundle? = null
+    var zoomLevel: Float? = null
+        private set
 
     fun onCreate(savedInstanceState: Bundle?) {
         this.savedInstanceState = savedInstanceState
@@ -37,15 +39,15 @@ class MapFragmentDelegate(
 
     fun onStart() {
         if (metaSettings.contains(LAST_KNOWN_ZOOM_LEVEL)) {
-            mapFragment.setZoomLevelSetByUser(metaSettings.getFloat(LAST_KNOWN_ZOOM_LEVEL))
+            zoomLevel = metaSettings.getFloat(LAST_KNOWN_ZOOM_LEVEL)
         }
         onConfigChanged.accept(configurator.buildConfig(unprotectedSettings))
         unprotectedSettings.registerOnSettingChangeListener(this)
     }
 
     fun onStop() {
-        if (mapFragment.getZoomLevelSetByUser() != null) {
-            metaSettings.save(LAST_KNOWN_ZOOM_LEVEL, mapFragment.getZoomLevelSetByUser())
+        if (zoomLevel != null) {
+            metaSettings.save(LAST_KNOWN_ZOOM_LEVEL, zoomLevel)
         }
         unprotectedSettings.unregisterOnSettingChangeListener(this)
     }
@@ -53,6 +55,10 @@ class MapFragmentDelegate(
     fun onSaveInstanceState(outState: Bundle) {
         outState.putParcelable(MAP_CENTER_KEY, mapFragment.getCenter())
         outState.putDouble(MAP_ZOOM_KEY, mapFragment.getZoom())
+    }
+
+    fun onZoomLevelChangedByUserListener(zoomLevel: Float?) {
+        this.zoomLevel = zoomLevel
     }
 
     override fun onSettingChanged(key: String) {

--- a/maps/src/main/java/org/odk/collect/maps/MapFragmentDelegate.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragmentDelegate.kt
@@ -36,12 +36,13 @@ class MapFragmentDelegate(
     }
 
     fun onStart() {
+        mapFragment.setZoomLevelSetByUser(metaSettings.getFloat(LAST_KNOWN_ZOOM_LEVEL))
         onConfigChanged.accept(configurator.buildConfig(unprotectedSettings))
         unprotectedSettings.registerOnSettingChangeListener(this)
     }
 
     fun onStop() {
-        metaSettings.save(LAST_KNOWN_ZOOM_LEVEL, "")
+        metaSettings.save(LAST_KNOWN_ZOOM_LEVEL, mapFragment.zoomLevelSetByUser)
         unprotectedSettings.unregisterOnSettingChangeListener(this)
     }
 

--- a/maps/src/main/java/org/odk/collect/maps/MapFragmentDelegate.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragmentDelegate.kt
@@ -44,15 +44,15 @@ class MapFragmentDelegate(
     }
 
     fun onStop() {
-        if (mapFragment.zoomLevelSetByUser != null) {
-            metaSettings.save(LAST_KNOWN_ZOOM_LEVEL, mapFragment.zoomLevelSetByUser)
+        if (mapFragment.getZoomLevelSetByUser() != null) {
+            metaSettings.save(LAST_KNOWN_ZOOM_LEVEL, mapFragment.getZoomLevelSetByUser())
         }
         unprotectedSettings.unregisterOnSettingChangeListener(this)
     }
 
     fun onSaveInstanceState(outState: Bundle) {
-        outState.putParcelable(MAP_CENTER_KEY, mapFragment.center)
-        outState.putDouble(MAP_ZOOM_KEY, mapFragment.zoom)
+        outState.putParcelable(MAP_CENTER_KEY, mapFragment.getCenter())
+        outState.putDouble(MAP_ZOOM_KEY, mapFragment.getZoom())
     }
 
     override fun onSettingChanged(key: String) {

--- a/maps/src/main/java/org/odk/collect/maps/MapFragmentDelegate.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragmentDelegate.kt
@@ -36,13 +36,17 @@ class MapFragmentDelegate(
     }
 
     fun onStart() {
-        mapFragment.setZoomLevelSetByUser(metaSettings.getFloat(LAST_KNOWN_ZOOM_LEVEL))
+        if (metaSettings.contains(LAST_KNOWN_ZOOM_LEVEL)) {
+            mapFragment.setZoomLevelSetByUser(metaSettings.getFloat(LAST_KNOWN_ZOOM_LEVEL))
+        }
         onConfigChanged.accept(configurator.buildConfig(unprotectedSettings))
         unprotectedSettings.registerOnSettingChangeListener(this)
     }
 
     fun onStop() {
-        metaSettings.save(LAST_KNOWN_ZOOM_LEVEL, mapFragment.zoomLevelSetByUser)
+        if (mapFragment.zoomLevelSetByUser != null) {
+            metaSettings.save(LAST_KNOWN_ZOOM_LEVEL, mapFragment.zoomLevelSetByUser)
+        }
         unprotectedSettings.unregisterOnSettingChangeListener(this)
     }
 

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerDescription.kt
@@ -6,7 +6,6 @@ import org.odk.collect.maps.MapPoint
 data class MarkerDescription(
     val point: MapPoint,
     val isDraggable: Boolean,
-    @get:MapFragment.IconAnchor @param:MapFragment.IconAnchor
-    val iconAnchor: String,
+    @MapFragment.Companion.IconAnchor val iconAnchor: String,
     val iconDescription: MarkerIconDescription
 )

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -201,7 +201,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         map.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.NEVER);
         map.setMinZoomLevel(2.0);
         map.setMaxZoomLevel(22.0);
-        map.getController().setCenter(toGeoPoint(INITIAL_CENTER));
+        map.getController().setCenter(toGeoPoint(MapFragment.Companion.getINITIAL_CENTER()));
         map.getController().setZoom((int) INITIAL_ZOOM);
         map.setTilesScaledToDpi(true);
         map.setFlingEnabled(false);
@@ -313,7 +313,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     }
 
     @Override
-    public void zoomToBoundingBox(Iterable<MapPoint> points, double scaleFactor, boolean animate) {
+    public void zoomToBoundingBox(@Nullable Iterable<MapPoint> points, double scaleFactor, boolean animate) {
         if (points != null) {
             int count = 0;
             List<GeoPoint> geoPoints = new ArrayList<>();
@@ -684,7 +684,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         return marker;
     }
 
-    private float getIconAnchorValueX(@IconAnchor String iconAnchor) {
+    private float getIconAnchorValueX(@MapFragment.Companion.IconAnchor String iconAnchor) {
         switch (iconAnchor) {
             case BOTTOM:
             default:
@@ -692,7 +692,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         }
     }
 
-    private float getIconAnchorValueY(@IconAnchor String iconAnchor) {
+    private float getIconAnchorValueY(@MapFragment.Companion.IconAnchor String iconAnchor) {
         switch (iconAnchor) {
             case BOTTOM:
                 return Marker.ANCHOR_BOTTOM;

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -228,6 +228,16 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         return view;
     }
 
+    @Nullable
+    @Override
+    public Float getZoomLevelSetByUser() {
+        return null;
+    }
+
+    @Override
+    public void setZoomLevelSetByUser(@Nullable Float zoomLevel) {
+    }
+
     @Override
     public @NonNull
     MapPoint getCenter() {

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -209,7 +209,12 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
             @Override
             public boolean onZoom(ZoomEvent event) {
                 if (!isSystemZooming) {
-                    onZoomLevelChangedByUserListener((float) event.getZoomLevel());
+                    float zoomLevel = (float) event.getZoomLevel();
+                    if (zoomLevel < 2) {
+                        mapFragmentDelegate.onZoomLevelChangedByUserListener(2f);
+                    } else {
+                        mapFragmentDelegate.onZoomLevelChangedByUserListener(zoomLevel);
+                    }
                 }
                 return false;
             }
@@ -247,15 +252,6 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     @Override
     public MapFragmentDelegate getMapFragmentDelegate() {
         return mapFragmentDelegate;
-    }
-
-    @Override
-    public void onZoomLevelChangedByUserListener(@Nullable Float zoomLevel) {
-        if (zoomLevel != null && zoomLevel < 2) {
-            mapFragmentDelegate.onZoomLevelChangedByUserListener(2f);
-        } else {
-            mapFragmentDelegate.onZoomLevelChangedByUserListener(zoomLevel);
-        }
     }
 
     @Override

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -132,7 +132,6 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     private TilesOverlay referenceOverlay;
     private boolean hasCenter;
     private boolean isSystemZooming;
-    private @Nullable Float lastZoomLevelChangedByUser;
 
     @Override
     public void init(@Nullable ReadyListener readyListener, @Nullable ErrorListener errorListener) {
@@ -210,7 +209,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
             @Override
             public boolean onZoom(ZoomEvent event) {
                 if (!isSystemZooming) {
-                    lastZoomLevelChangedByUser = (float) event.getZoomLevel();
+                    onZoomLevelChangedByUserListener((float) event.getZoomLevel());
                 }
                 return false;
             }
@@ -244,18 +243,12 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         return view;
     }
 
-    @Nullable
     @Override
-    public Float getZoomLevelSetByUser() {
-        return lastZoomLevelChangedByUser;
-    }
-
-    @Override
-    public void setZoomLevelSetByUser(@Nullable Float zoomLevel) {
+    public void onZoomLevelChangedByUserListener(@Nullable Float zoomLevel) {
         if (zoomLevel != null && zoomLevel < 2) {
-            lastZoomLevelChangedByUser = 2f;
+            mapFragmentDelegate.onZoomLevelChangedByUserListener(2f);
         } else {
-            lastZoomLevelChangedByUser = zoomLevel;
+            mapFragmentDelegate.onZoomLevelChangedByUserListener(zoomLevel);
         }
     }
 
@@ -285,9 +278,10 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
 
     @Override
     public void zoomToCurrentLocation(@Nullable MapPoint center) {
+        Float zoomLevel = mapFragmentDelegate.getZoomLevel();
         zoomToPoint(
                 center,
-                lastZoomLevelChangedByUser != null ? lastZoomLevelChangedByUser : POINT_ZOOM,
+                zoomLevel != null ? zoomLevel : POINT_ZOOM,
                 true
         );
     }

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -252,6 +252,11 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     }
 
     @Override
+    public void zoomToCurrentLocation(@Nullable MapPoint center) {
+        zoomToPoint(center, POINT_ZOOM, true);
+    }
+
+    @Override
     public void zoomToPoint(@Nullable MapPoint center, boolean animate) {
         zoomToPoint(center, POINT_ZOOM, animate);
     }

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -110,6 +110,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
             this,
             () -> mapConfigurator,
             () -> settingsProvider.getUnprotectedSettings(),
+            () -> settingsProvider.getMetaSettings(),
             this::onConfigChanged
     );
 

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -285,7 +285,11 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
 
     @Override
     public void zoomToCurrentLocation(@Nullable MapPoint center) {
-        zoomToPoint(center, POINT_ZOOM, true);
+        zoomToPoint(
+                center,
+                lastZoomLevelChangedByUser != null ? lastZoomLevelChangedByUser : POINT_ZOOM,
+                true
+        );
     }
 
     @Override

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -243,6 +243,12 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         return view;
     }
 
+    @NonNull
+    @Override
+    public MapFragmentDelegate getMapFragmentDelegate() {
+        return mapFragmentDelegate;
+    }
+
     @Override
     public void onZoomLevelChangedByUserListener(@Nullable Float zoomLevel) {
         if (zoomLevel != null && zoomLevel < 2) {
@@ -274,16 +280,6 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     @Override
     public double getZoom() {
         return map.getZoomLevel();
-    }
-
-    @Override
-    public void zoomToCurrentLocation(@Nullable MapPoint center) {
-        Float zoomLevel = mapFragmentDelegate.getZoomLevel();
-        zoomToPoint(
-                center,
-                zoomLevel != null ? zoomLevel : POINT_ZOOM,
-                true
-        );
     }
 
     @Override

--- a/settings/src/main/java/org/odk/collect/settings/keys/MetaKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/MetaKeys.kt
@@ -13,4 +13,5 @@ object MetaKeys {
     const val LAST_USED_PEN_COLOR = "last_used_pen_color"
     const val PERMISSIONS_REQUESTED = "permissions_requested"
     const val DRAFTS_PILLS_EDUCATION_SHOWN = "drafts_pills_education_shown"
+    const val LAST_KNOWN_ZOOM_LEVEL = "last_known_zoom_level"
 }


### PR DESCRIPTION
Closes #6136

#### Why is this the best possible solution? Were any other approaches considered?
I don't think there's much to discuss here, as the implementation feels pretty natural, and I didn't explore alternative solutions. I extended the interface to handle the last set zoom level and decided to save it in meta prefs, which seemed like the most logical location.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Instead of zooming to the current location with a default zoom level, the map now remembers the last zoom level set by the user and applies it. This change requires testing both automatic and manual zooming to the current location, as well as zooming to a group of points or a single point. This change should apply exclusively to zooming to the current location.

Please check the boundary zoom levels.
**Google**: 2 - 22
**Mapbox**: 0 - 22
**OSM**: 2-22

Some of the code has been converted from java to kotllin so please also test the functionality that geo questions offer.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
