### PR TITLE
Log filter times during form entry

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/ToastUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/ToastUtils.kt
@@ -24,26 +24,24 @@ object ToastUtils {
 
     @JvmStatic
     fun showShortToast(message: String) {
-        showToast(application, message)
+        showToast(message)
     }
 
     @JvmStatic
     fun showShortToast(messageResource: Int) {
         showToast(
-            application,
             application.getLocalizedString(messageResource)
         )
     }
 
     @JvmStatic
     fun showLongToast(message: String) {
-        showToast(application, message, Toast.LENGTH_LONG)
+        showToast(message, Toast.LENGTH_LONG)
     }
 
     @JvmStatic
     fun showLongToast(messageResource: Int) {
         showToast(
-            application,
             application.getLocalizedString(messageResource),
             Toast.LENGTH_LONG
         )
@@ -69,7 +67,6 @@ object ToastUtils {
     }
 
     private fun showToast(
-        application: Application,
         message: String,
         duration: Int = Toast.LENGTH_SHORT
     ) {

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/ToastUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/ToastUtils.kt
@@ -2,7 +2,6 @@ package org.odk.collect.androidshared.ui
 
 import android.app.Activity
 import android.app.Application
-import android.content.Context
 import android.os.Build
 import android.view.Gravity
 import android.view.ViewGroup
@@ -21,30 +20,31 @@ object ToastUtils {
     private var recordedToasts = mutableListOf<String>()
 
     private lateinit var lastToast: Toast
+    private lateinit var application: Application
 
     @JvmStatic
-    fun showShortToast(context: Context, message: String) {
-        showToast(context.applicationContext as Application, message)
+    fun showShortToast(message: String) {
+        showToast(application, message)
     }
 
     @JvmStatic
-    fun showShortToast(context: Context, messageResource: Int) {
+    fun showShortToast(messageResource: Int) {
         showToast(
-            context.applicationContext as Application,
-            context.getLocalizedString(messageResource)
+            application,
+            application.getLocalizedString(messageResource)
         )
     }
 
     @JvmStatic
-    fun showLongToast(context: Context, message: String) {
-        showToast(context.applicationContext as Application, message, Toast.LENGTH_LONG)
+    fun showLongToast(message: String) {
+        showToast(application, message, Toast.LENGTH_LONG)
     }
 
     @JvmStatic
-    fun showLongToast(context: Context, messageResource: Int) {
+    fun showLongToast(messageResource: Int) {
         showToast(
-            context.applicationContext as Application,
-            context.getLocalizedString(messageResource),
+            application,
+            application.getLocalizedString(messageResource),
             Toast.LENGTH_LONG
         )
     }
@@ -63,13 +63,18 @@ object ToastUtils {
         return copy
     }
 
+    @JvmStatic
+    fun setApplication(application: Application) {
+        this.application = application
+    }
+
     private fun showToast(
-        context: Application,
+        application: Application,
         message: String,
         duration: Int = Toast.LENGTH_SHORT
     ) {
         hideLastToast()
-        lastToast = Toast.makeText(context, message, duration)
+        lastToast = Toast.makeText(application, message, duration)
         lastToast.show()
 
         if (recordToasts) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -273,7 +273,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
      */
     private void downloadFormList() {
         if (!connectivityProvider.isDeviceOnline()) {
-            ToastUtils.showShortToast(this, org.odk.collect.strings.R.string.no_connection);
+            ToastUtils.showShortToast(org.odk.collect.strings.R.string.no_connection);
 
             if (viewModel.isDownloadOnlyMode()) {
                 setReturnResult(false, getString(org.odk.collect.strings.R.string.no_connection), viewModel.getFormResults());
@@ -408,7 +408,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
             downloadFormsTask.execute(filesToDownload);
         } else {
-            ToastUtils.showShortToast(this, org.odk.collect.strings.R.string.noselect_error);
+            ToastUtils.showShortToast(org.odk.collect.strings.R.string.noselect_error);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -865,7 +865,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         if (intent == null && requestCode != RequestCodes.DRAW_IMAGE && requestCode != RequestCodes.ANNOTATE_IMAGE
                 && requestCode != RequestCodes.SIGNATURE_CAPTURE && requestCode != RequestCodes.IMAGE_CAPTURE) {
             Timber.d("The intent has a null value for requestCode: %s", requestCode);
-            showLongToast(this, getString(org.odk.collect.strings.R.string.null_intent_value));
+            showLongToast(getString(org.odk.collect.strings.R.string.null_intent_value));
             return;
         }
 
@@ -978,7 +978,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                             waitingForDataRegistry.cancelWaitingForData();
                         } catch (Exception e) {
                             Timber.e(e);
-                            ToastUtils.showLongToast(this, currentViewIfODKView.getContext().getString(org.odk.collect.strings.R.string.error_attaching_binary_file,
+                            ToastUtils.showLongToast(currentViewIfODKView.getContext().getString(org.odk.collect.strings.R.string.error_attaching_binary_file,
                                     e.getMessage()));
                         }
                         set = true;
@@ -1552,7 +1552,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
         // save current answer
         if (current) {
             if (!formEntryViewModel.updateAnswersForScreen(getAnswers(), complete)) {
-                showShortToast(this, org.odk.collect.strings.R.string.data_saved_error);
+                showShortToast(org.odk.collect.strings.R.string.data_saved_error);
                 return false;
             }
         }
@@ -1584,7 +1584,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 if (result.getRequest().viewExiting()) {
                     finishAndReturnInstance();
                 } else {
-                    showShortToast(this, org.odk.collect.strings.R.string.data_saved_ok);
+                    showShortToast(org.odk.collect.strings.R.string.data_saved_ok);
                 }
 
                 formSessionRepository.update(sessionId, formSaveViewModel.getInstance());
@@ -1604,7 +1604,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                     message = getString(org.odk.collect.strings.R.string.data_saved_error);
                 }
 
-                showLongToast(this, message);
+                showLongToast(message);
                 formSaveViewModel.resumeFormEntry();
                 break;
 
@@ -1612,7 +1612,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                 DialogFragmentUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
                 DialogFragmentUtils.dismissDialog(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
 
-                showLongToast(this, String.format(getString(org.odk.collect.strings.R.string.encryption_error_message),
+                showLongToast(String.format(getString(org.odk.collect.strings.R.string.encryption_error_message),
                         result.getMessage()));
                 finishAndReturnInstance();
                 formSaveViewModel.resumeFormEntry();
@@ -1954,7 +1954,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
             boolean hasUsedSavepoint = task.hasUsedSavepoint();
 
             if (hasUsedSavepoint) {
-                runOnUiThread(() -> showLongToast(this, org.odk.collect.strings.R.string.savepoint_used));
+                runOnUiThread(() -> showLongToast(org.odk.collect.strings.R.string.savepoint_used));
             }
 
             if (formController.getInstanceFile() == null) {
@@ -1992,7 +1992,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
                         formEntryViewModel.refresh();
 
                         if (warningMsg != null) {
-                            showLongToast(this, warningMsg);
+                            showLongToast(warningMsg);
                             Timber.w(warningMsg);
                         }
                     }
@@ -2050,7 +2050,7 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
             }
         } else {
             Timber.e(new Error("FormController is null"));
-            showLongToast(this, org.odk.collect.strings.R.string.loading_form_failed);
+            showLongToast(org.odk.collect.strings.R.string.loading_form_failed);
             exit();
         }
     }
@@ -2129,14 +2129,14 @@ public class FormFillingActivity extends LocalizedActivity implements AnimationL
     @Override
     public void onSavePointError(String errorMessage) {
         if (errorMessage != null && errorMessage.trim().length() > 0) {
-            showLongToast(this, getString(org.odk.collect.strings.R.string.save_point_error, errorMessage));
+            showLongToast(getString(org.odk.collect.strings.R.string.save_point_error, errorMessage));
         }
     }
 
     @Override
     public void onSaveFormIndexError(String errorMessage) {
         if (errorMessage != null && errorMessage.trim().length() > 0) {
-            showLongToast(this, getString(org.odk.collect.strings.R.string.save_point_error, errorMessage));
+            showLongToast(getString(org.odk.collect.strings.R.string.save_point_error, errorMessage));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.kt
@@ -10,6 +10,7 @@ import org.odk.collect.android.application.Collect
 import org.odk.collect.android.application.initialization.upgrade.UpgradeInitializer
 import org.odk.collect.android.entities.EntitiesRepositoryProvider
 import org.odk.collect.android.projects.ProjectsDataService
+import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.metadata.PropertyManager
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.SettingsProvider
@@ -49,6 +50,7 @@ class ApplicationInitializer(
     }
 
     private fun initializeFrameworks() {
+        ToastUtils.setApplication(context)
         initializeLogging()
         AppInitializer.getInstance(context).initializeComponent(JodaTimeInitializer::class.java)
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeMenuProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeMenuProvider.kt
@@ -62,7 +62,6 @@ class QRCodeMenuProvider internal constructor(
                 photoPickerIntent.type = "image/*"
                 intentLauncher.launchForResult(activity, photoPickerIntent, SELECT_PHOTO) {
                     showShortToast(
-                        activity,
                         activity.getString(
                             org.odk.collect.strings.R.string.activity_not_found,
                             activity.getString(org.odk.collect.strings.R.string.choose_image)

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeScannerFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeScannerFragment.kt
@@ -56,7 +56,6 @@ class QRCodeScannerFragment : BarCodeScannerFragment() {
                 }
 
                 showLongToast(
-                    requireContext(),
                     getString(org.odk.collect.strings.R.string.successfully_imported_settings)
                 )
                 ActivityUtils.startActivityAndCloseAllOthers(
@@ -66,14 +65,12 @@ class QRCodeScannerFragment : BarCodeScannerFragment() {
             }
 
             SettingsImportingResult.INVALID_SETTINGS -> showLongToast(
-                requireContext(),
                 getString(
                     org.odk.collect.strings.R.string.invalid_qrcode
                 )
             )
 
             SettingsImportingResult.GD_PROJECT -> showLongToast(
-                requireContext(),
                 getString(org.odk.collect.strings.R.string.settings_with_gd_protocol)
             )
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -471,11 +471,11 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
             } catch (ExternalParamsException e) {
                 Timber.e(e, "ExternalParamsException");
 
-                ToastUtils.showShortToast(getContext(), e.getMessage());
+                ToastUtils.showShortToast(e.getMessage());
             } catch (ActivityNotFoundException e) {
                 Timber.d(e, "ActivityNotFoundExcept");
 
-                ToastUtils.showShortToast(getContext(), errorString);
+                ToastUtils.showShortToast(errorString);
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListMenuProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListMenuProvider.kt
@@ -89,11 +89,11 @@ class BlankFormListMenuProvider(
                 if (networkStateProvider?.isDeviceOnline == true) {
                     viewModel.syncWithServer().observe(activity) { success: Boolean ->
                         if (success) {
-                            ToastUtils.showShortToast(activity, org.odk.collect.strings.R.string.form_update_succeeded)
+                            ToastUtils.showShortToast(org.odk.collect.strings.R.string.form_update_succeeded)
                         }
                     }
                 } else {
-                    ToastUtils.showShortToast(activity, org.odk.collect.strings.R.string.no_connection)
+                    ToastUtils.showShortToast(org.odk.collect.strings.R.string.no_connection)
                 }
                 true
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -3,8 +3,13 @@ package org.odk.collect.android.formmanagement
 import android.os.Handler
 import android.os.Looper
 import org.javarosa.core.model.FormDef
+import org.javarosa.core.model.condition.EvaluationContext
+import org.javarosa.core.model.condition.FilterStrategy
+import org.javarosa.core.model.instance.DataInstance
+import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.form.api.FormEntryController
 import org.javarosa.form.api.FormEntryModel
+import org.javarosa.xpath.expr.XPathExpression
 import org.odk.collect.android.application.Collect
 import org.odk.collect.android.dynamicpreload.ExternalDataManagerImpl
 import org.odk.collect.android.dynamicpreload.handler.ExternalDataHandlerPull
@@ -16,6 +21,7 @@ import org.odk.collect.entities.javarosa.finalization.EntityFormFinalizationProc
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.shared.settings.Settings
 import java.io.File
+import java.util.function.Supplier
 
 class CollectFormEntryControllerFactory(
     private val entitiesRepository: EntitiesRepository,
@@ -37,18 +43,29 @@ class CollectFormEntryControllerFactory(
             )
             it.addPostProcessor(EntityFormFinalizationProcessor())
 
-            it.addFilterStrategy { sourceInstance, nodeSet, predicate, children, evaluationContext, next ->
-                val startTime = System.currentTimeMillis()
-                val result = next.get()
-
-                val filterTime = System.currentTimeMillis() - startTime
-                Handler(Looper.getMainLooper()).post {
-                    ToastUtils.showShortToast("Filter took ${filterTime / 1000.0}s")
-                }
-
-                result
-            }
+            it.addFilterStrategy(LoggingFilterStrategy())
             it.addFilterStrategy(LocalEntitiesFilterStrategy(entitiesRepository))
         }
+    }
+}
+
+private class LoggingFilterStrategy : FilterStrategy {
+    override fun filter(
+        sourceInstance: DataInstance<*>,
+        nodeSet: TreeReference,
+        predicate: XPathExpression,
+        children: MutableList<TreeReference>,
+        evaluationContext: EvaluationContext,
+        next: Supplier<MutableList<TreeReference>>
+    ): MutableList<TreeReference> {
+        val startTime = System.currentTimeMillis()
+        val result = next.get()
+
+        val filterTime = System.currentTimeMillis() - startTime
+        Handler(Looper.getMainLooper()).post {
+            ToastUtils.showShortToast("Filter took ${filterTime / 1000.0}s")
+        }
+
+        return result
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -23,6 +23,7 @@ import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.shared.settings.Settings
 import java.io.File
 import java.util.function.Supplier
+import kotlin.system.measureTimeMillis
 
 class CollectFormEntryControllerFactory(
     private val entitiesRepository: EntitiesRepository,
@@ -62,10 +63,8 @@ private class LoggingFilterStrategy : FilterStrategy {
         evaluationContext: EvaluationContext,
         next: Supplier<MutableList<TreeReference>>
     ): MutableList<TreeReference> {
-        val startTime = System.currentTimeMillis()
-        val result = next.get()
-
-        val filterTime = System.currentTimeMillis() - startTime
+        val result: MutableList<TreeReference>
+        val filterTime = measureTimeMillis { result = next.get() }
         Handler(Looper.getMainLooper()).post {
             ToastUtils.showShortToast("Filter took ${filterTime / 1000.0}s")
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -19,6 +19,7 @@ import org.odk.collect.entities.javarosa.filter.LocalEntitiesFilterStrategy
 import org.odk.collect.entities.javarosa.filter.PullDataFunctionHandler
 import org.odk.collect.entities.javarosa.finalization.EntityFormFinalizationProcessor
 import org.odk.collect.entities.storage.EntitiesRepository
+import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.shared.settings.Settings
 import java.io.File
 import java.util.function.Supplier
@@ -43,7 +44,10 @@ class CollectFormEntryControllerFactory(
             )
             it.addPostProcessor(EntityFormFinalizationProcessor())
 
-            it.addFilterStrategy(LoggingFilterStrategy())
+            if (settings.getBoolean(ProjectKeys.KEY_DEBUG_FILTERS)) {
+                it.addFilterStrategy(LoggingFilterStrategy())
+            }
+
             it.addFilterStrategy(LocalEntitiesFilterStrategy(entitiesRepository))
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -1,9 +1,7 @@
 package org.odk.collect.android.formmanagement
 
-import android.app.Application
 import android.os.Handler
 import android.os.Looper
-import android.widget.Toast
 import org.javarosa.core.model.FormDef
 import org.javarosa.form.api.FormEntryController
 import org.javarosa.form.api.FormEntryModel
@@ -11,6 +9,7 @@ import org.odk.collect.android.application.Collect
 import org.odk.collect.android.dynamicpreload.ExternalDataManagerImpl
 import org.odk.collect.android.dynamicpreload.handler.ExternalDataHandlerPull
 import org.odk.collect.android.tasks.FormLoaderTask.FormEntryControllerFactory
+import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.entities.javarosa.filter.LocalEntitiesFilterStrategy
 import org.odk.collect.entities.javarosa.filter.PullDataFunctionHandler
 import org.odk.collect.entities.javarosa.finalization.EntityFormFinalizationProcessor
@@ -19,7 +18,6 @@ import org.odk.collect.shared.settings.Settings
 import java.io.File
 
 class CollectFormEntryControllerFactory(
-    private val application: Application,
     private val entitiesRepository: EntitiesRepository,
     private val settings: Settings
 ) :
@@ -44,10 +42,8 @@ class CollectFormEntryControllerFactory(
                 val result = next.get()
 
                 val filterTime = System.currentTimeMillis() - startTime
-
                 Handler(Looper.getMainLooper()).post {
-                    Toast.makeText(application, "Filter took ${filterTime / 1000.0}s", Toast.LENGTH_SHORT)
-                        .show()
+                    ToastUtils.showShortToast("Filter took ${filterTime / 1000.0}s")
                 }
 
                 result

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -13,6 +13,7 @@ import org.javarosa.xpath.expr.XPathExpression
 import org.odk.collect.android.application.Collect
 import org.odk.collect.android.dynamicpreload.ExternalDataManagerImpl
 import org.odk.collect.android.dynamicpreload.handler.ExternalDataHandlerPull
+import org.odk.collect.android.preferences.SettingsExt.getExperimentalOptIn
 import org.odk.collect.android.tasks.FormLoaderTask.FormEntryControllerFactory
 import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.entities.javarosa.filter.LocalEntitiesFilterStrategy
@@ -45,7 +46,7 @@ class CollectFormEntryControllerFactory(
             )
             it.addPostProcessor(EntityFormFinalizationProcessor())
 
-            if (settings.getBoolean(ProjectKeys.KEY_DEBUG_FILTERS)) {
+            if (settings.getExperimentalOptIn(ProjectKeys.KEY_DEBUG_FILTERS)) {
                 it.addFilterStrategy(LoggingFilterStrategy())
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
@@ -99,7 +99,7 @@ public abstract class BarCodeScannerFragment extends Fragment implements Decorat
             try {
                 handleScanningResult(barcodeResult);
             } catch (IOException | DataFormatException | IllegalArgumentException e) {
-                ToastUtils.showShortToast(requireContext(), getString(org.odk.collect.strings.R.string.invalid_qrcode));
+                ToastUtils.showShortToast(getString(org.odk.collect.strings.R.string.invalid_qrcode));
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -23,6 +23,7 @@ import org.odk.collect.analytics.BlockableFirebaseAnalytics;
 import org.odk.collect.analytics.NoopAnalytics;
 import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.application.CollectSettingsChangeHandler;
 import org.odk.collect.android.application.MapboxClassInstanceCreator;
 import org.odk.collect.android.application.initialization.AnalyticsInitializer;
@@ -616,6 +617,6 @@ public class AppDependencyModule {
     public FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory(ProjectsDataService projectsDataService, EntitiesRepositoryProvider entitiesRepositoryProvider, SettingsProvider settingsProvider) {
         String projectId = projectsDataService.requireCurrentProject().getUuid();
         EntitiesRepository entitiesRepository = entitiesRepositoryProvider.create(projectId);
-        return new CollectFormEntryControllerFactory(entitiesRepository, settingsProvider.getUnprotectedSettings(projectId));
+        return new CollectFormEntryControllerFactory(Collect.getInstance(), entitiesRepository, settingsProvider.getUnprotectedSettings(projectId));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -23,7 +23,6 @@ import org.odk.collect.analytics.BlockableFirebaseAnalytics;
 import org.odk.collect.analytics.NoopAnalytics;
 import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.application.CollectSettingsChangeHandler;
 import org.odk.collect.android.application.MapboxClassInstanceCreator;
 import org.odk.collect.android.application.initialization.AnalyticsInitializer;
@@ -617,6 +616,6 @@ public class AppDependencyModule {
     public FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory(ProjectsDataService projectsDataService, EntitiesRepositoryProvider entitiesRepositoryProvider, SettingsProvider settingsProvider) {
         String projectId = projectsDataService.requireCurrentProject().getUuid();
         EntitiesRepository entitiesRepository = entitiesRepositoryProvider.create(projectId);
-        return new CollectFormEntryControllerFactory(Collect.getInstance(), entitiesRepository, settingsProvider.getUnprotectedSettings(projectId));
+        return new CollectFormEntryControllerFactory(entitiesRepository, settingsProvider.getUnprotectedSettings(projectId));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -107,7 +107,6 @@ class InstancesDataService(
                 val formMediaDir = File(form.formMediaPath)
                 val formEntryController =
                     CollectFormEntryControllerFactory(
-                        Collect.getInstance(),
                         entitiesRepository,
                         projectDependencyModule.generalSettings
                     ).create(formDef, formMediaDir)

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -107,6 +107,7 @@ class InstancesDataService(
                 val formMediaDir = File(form.formMediaPath)
                 val formEntryController =
                     CollectFormEntryControllerFactory(
+                        Collect.getInstance(),
                         entitiesRepository,
                         projectDependencyModule.generalSettings
                     ).create(formDef, formMediaDir)

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/send/InstanceUploaderListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/send/InstanceUploaderListActivity.java
@@ -170,12 +170,12 @@ public class InstanceUploaderListActivity extends LocalizedActivity implements
 
     public void onUploadButtonsClicked() {
         if (!connectivityProvider.isDeviceOnline()) {
-            ToastUtils.showShortToast(this, org.odk.collect.strings.R.string.no_connection);
+            ToastUtils.showShortToast(org.odk.collect.strings.R.string.no_connection);
             return;
         }
 
         if (autoSendOngoing) {
-            ToastUtils.showShortToast(this, org.odk.collect.strings.R.string.send_in_progress);
+            ToastUtils.showShortToast(org.odk.collect.strings.R.string.send_in_progress);
             return;
         }
 
@@ -187,7 +187,7 @@ public class InstanceUploaderListActivity extends LocalizedActivity implements
             multiSelectViewModel.unselectAll();
         } else {
             // no items selected
-            ToastUtils.showLongToast(this, org.odk.collect.strings.R.string.noselect_error);
+            ToastUtils.showLongToast(org.odk.collect.strings.R.string.noselect_error);
         }
     }
 
@@ -376,7 +376,7 @@ public class InstanceUploaderListActivity extends LocalizedActivity implements
         Cursor c = (Cursor) listView.getAdapter().getItem(position);
         boolean encryptedForm = !Boolean.parseBoolean(c.getString(c.getColumnIndex(DatabaseInstanceColumns.CAN_EDIT_WHEN_COMPLETE)));
         if (encryptedForm) {
-            ToastUtils.showLongToast(this, org.odk.collect.strings.R.string.encrypted_form);
+            ToastUtils.showLongToast(org.odk.collect.strings.R.string.encrypted_form);
         } else {
             long instanceId = c.getLong(c.getColumnIndex(DatabaseInstanceColumns._ID));
             Intent intent = FormFillingIntentFactory.editInstanceIntent(this, projectsDataService.requireCurrentProject().getUuid(), instanceId);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.android.preferences
 
 import com.google.android.gms.maps.GoogleMap
+import org.odk.collect.android.BuildConfig
 import org.odk.collect.android.application.Collect
 import org.odk.collect.android.widgets.utilities.QuestionFontSizeUtils
 import org.odk.collect.settings.keys.ProjectKeys
@@ -51,7 +52,7 @@ object Defaults {
             hashMap[ProjectKeys.KEY_GOOGLE_MAP_STYLE] = GoogleMap.MAP_TYPE_NORMAL.toString()
             hashMap[ProjectKeys.KEY_MAPBOX_MAP_STYLE] = "mapbox://styles/mapbox/streets-v11"
             // experimental_preferences.xml
-            hashMap[ProjectKeys.KEY_DEBUG_FILTERS] = false
+            hashMap[ProjectKeys.KEY_DEBUG_FILTERS] = BuildConfig.BUILD_TYPE == "selfSignedRelease"
             return hashMap
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
@@ -50,6 +50,8 @@ object Defaults {
             hashMap[ProjectKeys.KEY_USGS_MAP_STYLE] = "topographic"
             hashMap[ProjectKeys.KEY_GOOGLE_MAP_STYLE] = GoogleMap.MAP_TYPE_NORMAL.toString()
             hashMap[ProjectKeys.KEY_MAPBOX_MAP_STYLE] = "mapbox://styles/mapbox/streets-v11"
+            // experimental_preferences.xml
+            hashMap[ProjectKeys.KEY_DEBUG_FILTERS] = false
             return hashMap
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/SettingsExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/SettingsExt.kt
@@ -1,0 +1,17 @@
+package org.odk.collect.android.preferences
+
+import org.odk.collect.android.BuildConfig
+import org.odk.collect.android.version.VersionInformation
+import org.odk.collect.shared.settings.Settings
+
+object SettingsExt {
+    fun Settings.getExperimentalOptIn(key: String): Boolean {
+        val versionInformation = VersionInformation { BuildConfig.VERSION_NAME }
+
+        return if (versionInformation.isRelease) {
+            this.getBoolean(key)
+        } else {
+            false
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/SettingsExt.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/SettingsExt.kt
@@ -8,7 +8,7 @@ object SettingsExt {
     fun Settings.getExperimentalOptIn(key: String): Boolean {
         val versionInformation = VersionInformation { BuildConfig.VERSION_NAME }
 
-        return if (versionInformation.isRelease) {
+        return if (!versionInformation.isRelease) {
             this.getBoolean(key)
         } else {
             false

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/AdminPasswordDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/AdminPasswordDialogFragment.kt
@@ -10,7 +10,6 @@ import android.widget.CompoundButton
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import org.odk.collect.android.R
 import org.odk.collect.android.databinding.AdminPasswordDialogLayoutBinding
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.preferences.ProjectPreferencesViewModel
@@ -62,7 +61,6 @@ class AdminPasswordDialogFragment : DialogFragment() {
                     projectPreferencesViewModel.setStateUnlocked()
                 } else {
                     ToastUtils.showShortToast(
-                        requireContext(),
                         org.odk.collect.strings.R.string.admin_password_incorrect
                     )
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ChangeAdminPasswordDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ChangeAdminPasswordDialog.kt
@@ -10,7 +10,6 @@ import android.widget.CompoundButton
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import org.odk.collect.android.R
 import org.odk.collect.android.databinding.PasswordDialogLayoutBinding
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.preferences.ProjectPreferencesViewModel
@@ -66,13 +65,11 @@ class ChangeAdminPasswordDialog : DialogFragment() {
                 if (password.isEmpty()) {
                     projectPreferencesViewModel.setStateNotProtected()
                     ToastUtils.showShortToast(
-                        requireContext(),
                         org.odk.collect.strings.R.string.admin_password_disabled
                     )
                 } else {
                     projectPreferencesViewModel.setStateUnlocked()
                     ToastUtils.showShortToast(
-                        requireContext(),
                         org.odk.collect.strings.R.string.admin_password_changed
                     )
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ExperimentalPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ExperimentalPreferencesFragment.java
@@ -36,7 +36,7 @@ public class ExperimentalPreferencesFragment extends BaseProjectPreferencesFragm
         super.onViewCreated(view, savedInstanceState);
 
         if (getPreferenceScreen().getPreferenceCount() == 0) {
-            ToastUtils.showLongToast(requireContext(), "No experimental settings at the moment!");
+            ToastUtils.showLongToast("No experimental settings at the moment!");
             getParentFragmentManager().popBackStack();
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
@@ -59,7 +59,7 @@ public class FormMetadataPreferencesFragment extends BaseProjectPreferencesFragm
         emailPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             String newValueString = newValue.toString();
             if (!newValueString.isEmpty() && !Validator.isEmailAddressValid(newValueString)) {
-                ToastUtils.showLongToast(requireContext(), org.odk.collect.strings.R.string.invalid_email_address);
+                ToastUtils.showLongToast(org.odk.collect.strings.R.string.invalid_email_address);
                 return false;
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
@@ -104,7 +104,6 @@ class ProjectManagementPreferencesFragment :
                     MainMenuActivity::class.java
                 )
                 ToastUtils.showLongToast(
-                    requireContext(),
                     getString(
                         org.odk.collect.strings.R.string.switched_project,
                         newCurrentProject.name

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
@@ -89,7 +89,7 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment {
                     if (Validator.isUrlValid(url)) {
                         preference.setSummary(newValue.toString());
                     } else {
-                        ToastUtils.showShortToast(requireContext(), org.odk.collect.strings.R.string.url_error);
+                        ToastUtils.showShortToast(org.odk.collect.strings.R.string.url_error);
                         return false;
                     }
                     break;
@@ -99,7 +99,7 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment {
 
                     // do not allow leading and trailing whitespace
                     if (!username.equals(username.trim())) {
-                        ToastUtils.showShortToast(requireContext(), org.odk.collect.strings.R.string.username_error_whitespace);
+                        ToastUtils.showShortToast(org.odk.collect.strings.R.string.username_error_whitespace);
                         return false;
                     }
 
@@ -111,7 +111,7 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment {
 
                     // do not allow leading and trailing whitespace
                     if (!pw.equals(pw.trim())) {
-                        ToastUtils.showShortToast(requireContext(), org.odk.collect.strings.R.string.password_error_whitespace);
+                        ToastUtils.showShortToast(org.odk.collect.strings.R.string.password_error_whitespace);
                         return false;
                     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -104,7 +104,7 @@ class ManualProjectCreatorDialog :
 
     private fun handleAddingNewProject() {
         if (!Validator.isUrlValid(binding.urlInputText.text?.trim().toString())) {
-            ToastUtils.showShortToast(requireContext(), org.odk.collect.strings.R.string.url_error)
+            ToastUtils.showShortToast(org.odk.collect.strings.R.string.url_error)
         } else {
             val settingsJson = appConfigurationGenerator.getAppConfigurationAsJsonWithServerDetails(
                 binding.urlInputText.text?.trim().toString(),
@@ -132,7 +132,6 @@ class ManualProjectCreatorDialog :
         projectCreator.createNewProject(settingsJson)
         ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
         ToastUtils.showLongToast(
-            requireContext(),
             getString(org.odk.collect.strings.R.string.switched_project, projectsDataService.requireCurrentProject().name)
         )
     }
@@ -141,7 +140,6 @@ class ManualProjectCreatorDialog :
         projectsDataService.setCurrentProject(uuid)
         ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
         ToastUtils.showLongToast(
-            requireContext(),
             getString(
                 org.odk.collect.strings.R.string.switched_project,
                 projectsDataService.requireCurrentProject().name

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
@@ -118,7 +118,6 @@ class ProjectSettingsDialog(private val viewModelFactory: ViewModelProvider.Fact
             MainMenuActivity::class.java
         )
         ToastUtils.showLongToast(
-            requireContext(),
             getString(org.odk.collect.strings.R.string.switched_project, project.name)
         )
         dismiss()

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -100,13 +100,11 @@ class QrCodeProjectCreatorDialog :
                                         qrCodeDecoder.decode(it)
                                     } catch (e: QRCodeDecoder.QRCodeInvalidException) {
                                         showShortToast(
-                                            requireContext(),
                                             org.odk.collect.strings.R.string.invalid_qrcode
                                         )
                                         ""
                                     } catch (e: QRCodeDecoder.QRCodeNotFoundException) {
                                         showShortToast(
-                                            requireContext(),
                                             org.odk.collect.strings.R.string.qr_code_not_found
                                         )
                                         ""
@@ -188,7 +186,6 @@ class QrCodeProjectCreatorDialog :
                         photoPickerIntent
                     ) {
                         showShortToast(
-                            requireContext(),
                             getString(
                                 org.odk.collect.strings.R.string.activity_not_found,
                                 getString(org.odk.collect.strings.R.string.choose_image)
@@ -261,7 +258,6 @@ class QrCodeProjectCreatorDialog :
                 CompressionUtils.decompress(barcodeResult.text)
             } catch (e: Exception) {
                 showShortToast(
-                    requireContext(),
                     getString(org.odk.collect.strings.R.string.invalid_qrcode)
                 )
                 ""
@@ -295,7 +291,6 @@ class QrCodeProjectCreatorDialog :
 
                 ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
                 ToastUtils.showLongToast(
-                    requireContext(),
                     getString(
                         org.odk.collect.strings.R.string.switched_project,
                         projectsDataService.requireCurrentProject().name
@@ -304,14 +299,12 @@ class QrCodeProjectCreatorDialog :
             }
 
             SettingsImportingResult.INVALID_SETTINGS -> ToastUtils.showLongToast(
-                requireContext(),
                 getString(
                     org.odk.collect.strings.R.string.invalid_qrcode
                 )
             )
 
             SettingsImportingResult.GD_PROJECT -> ToastUtils.showLongToast(
-                requireContext(),
                 getString(
                     org.odk.collect.strings.R.string.settings_with_gd_protocol
                 )
@@ -323,7 +316,6 @@ class QrCodeProjectCreatorDialog :
         projectsDataService.setCurrentProject(uuid)
         ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
         ToastUtils.showLongToast(
-            requireContext(),
             getString(
                 org.odk.collect.strings.R.string.switched_project,
                 projectsDataService.requireCurrentProject().name

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.kt
@@ -17,7 +17,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import org.odk.collect.android.BuildConfig
-import org.odk.collect.android.R
 import org.odk.collect.androidshared.system.IntentLauncher
 import org.odk.collect.androidshared.ui.ToastUtils
 import timber.log.Timber
@@ -44,7 +43,7 @@ class MediaUtils(private val intentLauncher: IntentLauncher, private val content
         if (!file.exists()) {
             val errorMsg: String = context.getString(org.odk.collect.strings.R.string.file_missing, file)
             Timber.d("File %s is missing", file)
-            ToastUtils.showLongToast(context, errorMsg)
+            ToastUtils.showLongToast(errorMsg)
             return
         }
 
@@ -55,7 +54,7 @@ class MediaUtils(private val intentLauncher: IntentLauncher, private val content
         )
 
         if (contentUri == null) {
-            ToastUtils.showLongToast(context, "Can't open file. If you are on a Huawei device, this is expected and will not be fixed.")
+            ToastUtils.showLongToast("Can't open file. If you are on a Huawei device, this is expected and will not be fixed.")
             return
         }
 
@@ -70,7 +69,7 @@ class MediaUtils(private val intentLauncher: IntentLauncher, private val content
                 org.odk.collect.strings.R.string.activity_not_found,
                 context.getString(org.odk.collect.strings.R.string.open_file)
             )
-            ToastUtils.showLongToast(context, message)
+            ToastUtils.showLongToast(message)
             Timber.w(message)
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -136,7 +136,7 @@ public class AnnotateWidget extends BaseImageWidget {
         if (newImageObj instanceof File) {
             String mimeType = FileUtils.getMimeType((File) newImageObj);
             if ("image/gif".equals(mimeType)) {
-                ToastUtils.showLongToast(getContext(), org.odk.collect.strings.R.string.gif_not_supported);
+                ToastUtils.showLongToast(org.odk.collect.strings.R.string.gif_not_supported);
             } else {
                 super.setData(newImageObj);
                 binding.annotateButton.setEnabled(binaryName != null);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -147,7 +147,7 @@ public class BarcodeWidget extends QuestionWidget implements WidgetDataReceiver 
             if (cameraUtils.isFrontCameraAvailable(getContext())) {
                 intent.addExtra(FRONT, true);
             } else {
-                ToastUtils.showLongToast(getContext(), org.odk.collect.strings.R.string.error_front_camera_unavailable);
+                ToastUtils.showLongToast(org.odk.collect.strings.R.string.error_front_camera_unavailable);
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -121,7 +121,7 @@ public class BearingWidget extends QuestionWidget implements WidgetDataReceiver 
 
             waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         } else {
-            ToastUtils.showLongToast(getContext(), org.odk.collect.strings.R.string.bearing_lack_of_sensors);
+            ToastUtils.showLongToast(org.odk.collect.strings.R.string.bearing_lack_of_sensors);
 
             binding.bearingButton.setEnabled(false);
             binding.widgetAnswerText.updateState(false);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -102,7 +102,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
             }
         } else if (object != null) {
             if (object instanceof File) {
-                ToastUtils.showLongToast(getContext(), org.odk.collect.strings.R.string.invalid_file_type);
+                ToastUtils.showLongToast(org.odk.collect.strings.R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
                 Timber.e(new Error("ExAudioWidget's setBinaryData must receive a audio file but received: " + FileUtils.getMimeType((File) object)));
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
@@ -98,7 +98,7 @@ public class ExImageWidget extends QuestionWidget implements FileWidget, WidgetD
             }
         } else if (object != null) {
             if (object instanceof File) {
-                ToastUtils.showLongToast(getContext(), org.odk.collect.strings.R.string.invalid_file_type);
+                ToastUtils.showLongToast(org.odk.collect.strings.R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
                 Timber.e(new Error("ExImageWidget's setBinaryData must receive an image file but received: " + FileUtils.getMimeType((File) object)));
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
@@ -93,7 +93,7 @@ public class ExVideoWidget extends QuestionWidget implements FileWidget, WidgetD
             }
         } else if (object != null) {
             if (object instanceof File) {
-                ToastUtils.showLongToast(getContext(), org.odk.collect.strings.R.string.invalid_file_type);
+                ToastUtils.showLongToast(org.odk.collect.strings.R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
                 Timber.e(new Error("ExVideoWidget's setBinaryData must receive a video file but received: " + FileUtils.getMimeType((File) object)));
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
@@ -51,7 +51,7 @@ public class UrlWidget extends QuestionWidget {
 
     @Override
     public void clearAnswer() {
-        ToastUtils.showShortToast(getContext(), "URL is readonly");
+        ToastUtils.showShortToast("URL is readonly");
     }
 
     @Override
@@ -85,7 +85,7 @@ public class UrlWidget extends QuestionWidget {
             externalWebPageHelper.bindCustomTabsService(getContext(), null);
             externalWebPageHelper.openWebPageInCustomTab((Activity) getContext(), Uri.parse(getFormEntryPrompt().getAnswerText()));
         } else {
-            ToastUtils.showShortToast(getContext(), "No URL set");
+            ToastUtils.showShortToast("No URL set");
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/FileRequester.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/FileRequester.kt
@@ -2,7 +2,6 @@ package org.odk.collect.android.widgets.utilities
 
 import android.app.Activity
 import org.javarosa.form.api.FormEntryPrompt
-import org.odk.collect.android.R
 import org.odk.collect.android.javarosawrapper.FormController
 import org.odk.collect.android.utilities.ExternalAppIntentProvider
 import org.odk.collect.androidshared.system.IntentLauncher
@@ -40,13 +39,13 @@ class FileRequesterImpl(
                     intentWithoutDefaultCategory,
                     requestCode
                 ) {
-                    showLongToast(activity, getErrorMessage(formEntryPrompt, activity))
+                    showLongToast(getErrorMessage(formEntryPrompt, activity))
                 }
             }
         } catch (e: Exception) {
-            showLongToast(activity, e.message!!)
+            showLongToast(e.message!!)
         } catch (e: Error) {
-            showLongToast(activity, e.message!!)
+            showLongToast(e.message!!)
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
@@ -221,7 +221,7 @@ public class RangeWidgetUtils {
         boolean result = true;
         if (rangeStep.compareTo(BigDecimal.ZERO) == 0
                 || rangeEnd.subtract(rangeStart).remainder(rangeStep).compareTo(BigDecimal.ZERO) != 0) {
-            ToastUtils.showLongToast(context, org.odk.collect.strings.R.string.invalid_range_widget);
+            ToastUtils.showLongToast(org.odk.collect.strings.R.string.invalid_range_widget);
             result = false;
         }
         return result;

--- a/collect_app/src/main/res/xml/dev_tools_preferences.xml
+++ b/collect_app/src/main/res/xml/dev_tools_preferences.xml
@@ -12,7 +12,7 @@
     <SwitchPreferenceCompat
         android:key="experimental_debug_filters"
         android:title="@string/debug_filters"
-        android:summary="@string/show_debug_information_for_filter_expression_executions_during_form_entry"
+        android:summary="@string/debug_filters_summary"
         app:iconSpaceReserved="false" />
 
 </PreferenceScreen>

--- a/collect_app/src/main/res/xml/dev_tools_preferences.xml
+++ b/collect_app/src/main/res/xml/dev_tools_preferences.xml
@@ -11,8 +11,8 @@
 
     <SwitchPreferenceCompat
         android:key="experimental_debug_filters"
-        android:title="Debug filters"
-        android:summary="Show debug information for filter expression executions during form entry"
+        android:title="@string/debug_filters"
+        android:summary="@string/show_debug_information_for_filter_expression_executions_during_form_entry"
         app:iconSpaceReserved="false" />
 
 </PreferenceScreen>

--- a/collect_app/src/main/res/xml/dev_tools_preferences.xml
+++ b/collect_app/src/main/res/xml/dev_tools_preferences.xml
@@ -9,4 +9,10 @@
         android:key="crash_app"
         app:persistent="false"/>
 
+    <SwitchPreferenceCompat
+        android:key="experimental_debug_filters"
+        android:title="Debug filters"
+        android:summary="Show debug information for filter expression executions during form entry"
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>

--- a/geo/src/main/java/org/odk/collect/geo/GeoActivityUtils.kt
+++ b/geo/src/main/java/org/odk/collect/geo/GeoActivityUtils.kt
@@ -15,7 +15,7 @@ internal object GeoActivityUtils {
         )
 
         if (!permissionGranted) {
-            ToastUtils.showLongToast(activity, org.odk.collect.strings.R.string.not_granted_permission)
+            ToastUtils.showLongToast(org.odk.collect.strings.R.string.not_granted_permission)
             activity.finish()
         }
     }

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapActivity.java
@@ -154,7 +154,7 @@ public class GeoPointMapActivity extends LocalizedActivity {
             setContentView(R.layout.geopoint_layout);
         } catch (NoClassDefFoundError e) {
             Timber.e(e, "Google maps not accessible due to: %s ", e.getMessage());
-            ToastUtils.showShortToast(this, org.odk.collect.strings.R.string.google_play_services_error_occured);
+            ToastUtils.showShortToast(org.odk.collect.strings.R.string.google_play_services_error_occured);
             finish();
             return;
         }

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -117,7 +117,7 @@ class SelectionMapFragment(
                 Manifest.permission.ACCESS_COARSE_LOCATION
             )
         ) {
-            ToastUtils.showLongToast(requireContext(), org.odk.collect.strings.R.string.not_granted_permission)
+            ToastUtils.showLongToast(org.odk.collect.strings.R.string.not_granted_permission)
             requireActivity().finish()
         }
 

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapConfigurator.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapConfigurator.java
@@ -64,7 +64,7 @@ public class GoogleMapConfigurator implements MapConfigurator {
 
     @Override public void showUnavailableMessage(Context context) {
         if (!isGoogleMapsSdkAvailable(context)) {
-            ToastUtils.showLongToast(context, context.getString(
+            ToastUtils.showLongToast(context.getString(
                 org.odk.collect.strings.R.string.basemap_source_unavailable, context.getString(sourceLabelId)));
         }
 

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -152,7 +152,7 @@ public class GoogleMapFragment extends Fragment implements
         SupportMapFragment mapFragment = (SupportMapFragment) getChildFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync((GoogleMap googleMap) -> {
             if (googleMap == null) {
-                ToastUtils.showShortToast(requireContext(), org.odk.collect.strings.R.string.google_play_services_error_occured);
+                ToastUtils.showShortToast(org.odk.collect.strings.R.string.google_play_services_error_occured);
                 if (errorListener != null) {
                     errorListener.onError();
                 }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapConfigurator.java
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapConfigurator.java
@@ -51,8 +51,7 @@ public class MapboxMapConfigurator implements MapConfigurator {
     }
 
     @Override public void showUnavailableMessage(Context context) {
-        ToastUtils.showLongToast(context, context.getString(
-            org.odk.collect.strings.R.string.basemap_source_unavailable, context.getString(sourceLabelId)));
+        ToastUtils.showLongToast(context.getString(org.odk.collect.strings.R.string.basemap_source_unavailable, context.getString(sourceLabelId)));
     }
 
     @Override public List<Preference> createPrefs(Context context, Settings settings) {

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CaptureSelfieActivity.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CaptureSelfieActivity.kt
@@ -58,7 +58,7 @@ class CaptureSelfieActivity : LocalizedActivity() {
                 Camera.State.UNINITIALIZED -> {}
                 Camera.State.INITIALIZED -> setupCamera(camera)
                 Camera.State.FAILED_TO_INITIALIZE -> {
-                    showLongToast(this, org.odk.collect.strings.R.string.camera_failed_to_initialize)
+                    showLongToast(org.odk.collect.strings.R.string.camera_failed_to_initialize)
                 }
             }
         }
@@ -72,11 +72,11 @@ class CaptureSelfieActivity : LocalizedActivity() {
             camera.takePicture(
                 imagePath,
                 { ExternalAppUtils.returnSingleValue(this, imagePath) },
-                { showLongToast(this, org.odk.collect.strings.R.string.camera_error) }
+                { showLongToast(org.odk.collect.strings.R.string.camera_error) }
             )
         }
 
-        showLongToast(this, org.odk.collect.strings.R.string.take_picture_instruction)
+        showLongToast(org.odk.collect.strings.R.string.take_picture_instruction)
     }
 
     private fun permissionsGranted(): Boolean {

--- a/selfie-camera/src/test/java/org/odk/collect/selfiecamera/CaptureSelfieActivityTest.kt
+++ b/selfie-camera/src/test/java/org/odk/collect/selfiecamera/CaptureSelfieActivityTest.kt
@@ -104,7 +104,7 @@ class CaptureSelfieActivityTest {
         launcher.launch<CaptureSelfieActivity>(intent)
         onView(withId(R.id.preview)).perform(click())
 
-        val latestToast = ToastUtils.popRecordedToasts()[1]
+        val latestToast = ToastUtils.popRecordedToasts().last()
         assertThat(latestToast, equalTo(application.getString(org.odk.collect.strings.R.string.camera_error)))
     }
 
@@ -118,7 +118,7 @@ class CaptureSelfieActivityTest {
         }
 
         launcher.launch<CaptureSelfieActivity>(intent)
-        val latestToast = ToastUtils.popRecordedToasts()[0]
+        val latestToast = ToastUtils.popRecordedToasts().first()
         assertThat(latestToast, equalTo(application.getString(org.odk.collect.strings.R.string.camera_failed_to_initialize)))
     }
 }

--- a/selfie-camera/src/test/java/org/odk/collect/selfiecamera/CaptureSelfieActivityTest.kt
+++ b/selfie-camera/src/test/java/org/odk/collect/selfiecamera/CaptureSelfieActivityTest.kt
@@ -19,11 +19,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidshared.livedata.NonNullLiveData
+import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.externalapp.ExternalAppUtils
 import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.selfiecamera.support.RobolectricApplication
-import org.robolectric.shadows.ShadowToast
 
 @RunWith(AndroidJUnit4::class)
 class CaptureSelfieActivityTest {
@@ -94,6 +94,7 @@ class CaptureSelfieActivityTest {
 
     @Test
     fun clickingPreview_whenThereIsAnErrorSavingImage_showsToast() {
+        ToastUtils.recordToasts = true
         camera.failToSave = true
 
         val intent = Intent(application, CaptureSelfieActivity::class.java).also {
@@ -103,12 +104,13 @@ class CaptureSelfieActivityTest {
         launcher.launch<CaptureSelfieActivity>(intent)
         onView(withId(R.id.preview)).perform(click())
 
-        val latestToast = ShadowToast.getTextOfLatestToast()
+        val latestToast = ToastUtils.popRecordedToasts()[1]
         assertThat(latestToast, equalTo(application.getString(org.odk.collect.strings.R.string.camera_error)))
     }
 
     @Test
     fun whenCameraFailsToInitialize_showsToast() {
+        ToastUtils.recordToasts = true
         camera.failToInitialize = true
 
         val intent = Intent(application, CaptureSelfieActivity::class.java).also {
@@ -116,7 +118,7 @@ class CaptureSelfieActivityTest {
         }
 
         launcher.launch<CaptureSelfieActivity>(intent)
-        val latestToast = ShadowToast.getTextOfLatestToast()
+        val latestToast = ToastUtils.popRecordedToasts()[0]
         assertThat(latestToast, equalTo(application.getString(org.odk.collect.strings.R.string.camera_failed_to_initialize)))
     }
 }

--- a/selfie-camera/src/test/java/org/odk/collect/selfiecamera/support/RobolectricApplication.kt
+++ b/selfie-camera/src/test/java/org/odk/collect/selfiecamera/support/RobolectricApplication.kt
@@ -1,10 +1,16 @@
 package org.odk.collect.selfiecamera.support
 
 import android.app.Application
+import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.selfiecamera.SelfieCameraDependencyComponent
 import org.odk.collect.selfiecamera.SelfieCameraDependencyComponentProvider
 
 class RobolectricApplication : Application(), SelfieCameraDependencyComponentProvider {
 
     override lateinit var selfieCameraDependencyComponent: SelfieCameraDependencyComponent
+
+    override fun onCreate() {
+        super.onCreate()
+        ToastUtils.setApplication(this)
+    }
 }

--- a/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
@@ -50,6 +50,9 @@ object ProjectKeys {
     const val KEY_BACKGROUND_LOCATION = "background_location"
     const val KEY_BACKGROUND_RECORDING = "background_recording"
 
+    // experimental_preferences.xml
+    const val KEY_DEBUG_FILTERS = "experimental_debug_filters"
+
     // values
     const val PROTOCOL_SERVER = "odk_default"
     const val PROTOCOL_GOOGLE_SHEETS = "google_sheets"

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1226,6 +1226,8 @@
     <string name="crash_app">Crash app</string>
     <!-- An uncaught exception is an exception that is not handled by ODK Collect and so will force the application to close -->
     <string name="crash_app_summary">Force an uncaught exception causing the app to crash</string>
+    <string name="debug_filters">Debug filters</string>
+    <string name="show_debug_information_for_filter_expression_executions_during_form_entry">Show debug information for filter expression executions during form entry</string>
 
     <string name="permission_dialog_title">About permissions</string>
     <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1226,8 +1226,10 @@
     <string name="crash_app">Crash app</string>
     <!-- An uncaught exception is an exception that is not handled by ODK Collect and so will force the application to close -->
     <string name="crash_app_summary">Force an uncaught exception causing the app to crash</string>
+
+    <!-- Option provided in the Developer tools settings tool allow debugging filters during form entry -->
     <string name="debug_filters">Debug filters</string>
-    <string name="show_debug_information_for_filter_expression_executions_during_form_entry">Show debug information for filter expression executions during form entry</string>
+    <string name="debug_filters_summary">Show debug information for filter expression executions during form entry</string>
 
     <string name="permission_dialog_title">About permissions</string>
     <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1227,7 +1227,7 @@
     <!-- An uncaught exception is an exception that is not handled by ODK Collect and so will force the application to close -->
     <string name="crash_app_summary">Force an uncaught exception causing the app to crash</string>
 
-    <!-- Option provided in the Developer tools settings tool allow debugging filters during form entry -->
+    <!-- Option provided in the Developer tools settings to allow debugging filters during form entry -->
     <string name="debug_filters">Debug filters</string>
     <string name="debug_filters_summary">Show debug information for filter expression executions during form entry</string>
 


### PR DESCRIPTION
This adds a toast that shows the execution time for filters during form entry. The goal here is to allow developers and QA to quickly debug optimizations/changes to filter code without needing to reach for timers.

#### Why is this the best possible solution? Were any other approaches considered?

The biggest thing to discuss here is the change that removes `Application` as an arg from the `ToastUtils` helpers. My goal here was to make `ToastUtils` more like Timber or Analytics, but I'm happy to discuss if that doesn't feel write!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Not a lot to check here other than playing around with the new "Debug filters" setting in "Experimental". It should be enabled by default in the builds available from CI.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
