### PR TITLE
Log errors if IOException is thrown when accessing canonicalPath

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/PathUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/PathUtils.kt
@@ -1,0 +1,18 @@
+package org.odk.collect.androidshared.utils
+
+import org.odk.collect.shared.files.FileExt.sanitizedCanonicalPath
+import java.io.File
+
+object PathUtils {
+    @JvmStatic
+    fun getAbsoluteFilePath(dirPath: String, filePath: String): String {
+        val absoluteFilePath =
+            if (filePath.startsWith(dirPath)) filePath else dirPath + File.separator + filePath
+
+        if (File(absoluteFilePath).sanitizedCanonicalPath().startsWith(File(dirPath).sanitizedCanonicalPath())) {
+            return absoluteFilePath
+        } else {
+            throw SecurityException("Contact support@getodk.org. Attempt to access file outside of Collect directory: $absoluteFilePath")
+        }
+    }
+}

--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/PathUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/PathUtils.kt
@@ -1,7 +1,9 @@
 package org.odk.collect.androidshared.utils
 
 import org.odk.collect.shared.files.FileExt.sanitizedCanonicalPath
+import timber.log.Timber
 import java.io.File
+import java.io.IOException
 
 object PathUtils {
     @JvmStatic
@@ -9,10 +11,22 @@ object PathUtils {
         val absoluteFilePath =
             if (filePath.startsWith(dirPath)) filePath else dirPath + File.separator + filePath
 
-        if (File(absoluteFilePath).sanitizedCanonicalPath().startsWith(File(dirPath).sanitizedCanonicalPath())) {
-            return absoluteFilePath
-        } else {
-            throw SecurityException("Contact support@getodk.org. Attempt to access file outside of Collect directory: $absoluteFilePath")
+        val absoluteFile = File(absoluteFilePath)
+        return try {
+            if (absoluteFile.sanitizedCanonicalPath().startsWith(File(dirPath).sanitizedCanonicalPath())) {
+                absoluteFilePath
+            } else {
+                throw SecurityException("Contact support@getodk.org. Attempt to access file outside of Collect directory: $absoluteFilePath")
+            }
+        } catch (e: IOException) {
+            Timber.e(
+                "Failed attempt to access canonicalPath:\n" +
+                    "dirPath: $dirPath\n" +
+                    "filePath: $filePath\n" +
+                    "absoluteFilePath: $absoluteFilePath\n" +
+                    "absoluteFilePath exists: ${absoluteFile.exists()}\n"
+            )
+            absoluteFilePath
         }
     }
 }

--- a/androidshared/src/test/java/org/odk/collect/androidshared/utils/PathUtilsTest.kt
+++ b/androidshared/src/test/java/org/odk/collect/androidshared/utils/PathUtilsTest.kt
@@ -3,7 +3,6 @@ package org.odk.collect.androidshared.utils
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
-import org.odk.collect.shared.PathUtils
 import org.odk.collect.shared.TempFiles
 import java.io.File
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseObjectMapper.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseObjectMapper.kt
@@ -5,9 +5,9 @@ import android.database.Cursor
 import android.provider.BaseColumns
 import org.odk.collect.android.database.forms.DatabaseFormColumns
 import org.odk.collect.android.database.instances.DatabaseInstanceColumns
+import org.odk.collect.androidshared.utils.PathUtils.getAbsoluteFilePath
 import org.odk.collect.forms.Form
 import org.odk.collect.forms.instances.Instance
-import org.odk.collect.shared.PathUtils.getAbsoluteFilePath
 import org.odk.collect.shared.PathUtils.getRelativeFilePath
 import java.lang.Boolean
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/savepoints/DatabaseSavepointsRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/savepoints/DatabaseSavepointsRepository.kt
@@ -8,6 +8,7 @@ import org.odk.collect.android.database.DatabaseConstants.SAVEPOINTS_DATABASE_VE
 import org.odk.collect.android.database.DatabaseConstants.SAVEPOINTS_TABLE_NAME
 import org.odk.collect.android.database.savepoints.DatabaseSavepointsColumns.FORM_DB_ID
 import org.odk.collect.android.database.savepoints.DatabaseSavepointsColumns.INSTANCE_DB_ID
+import org.odk.collect.androidshared.utils.PathUtils.getAbsoluteFilePath
 import org.odk.collect.db.sqlite.CursorExt.foldAndClose
 import org.odk.collect.db.sqlite.DatabaseConnection
 import org.odk.collect.db.sqlite.SQLiteDatabaseExt.delete
@@ -15,7 +16,6 @@ import org.odk.collect.db.sqlite.SQLiteDatabaseExt.query
 import org.odk.collect.forms.savepoints.Savepoint
 import org.odk.collect.forms.savepoints.SavepointsRepository
 import org.odk.collect.shared.PathUtils
-import org.odk.collect.shared.PathUtils.getAbsoluteFilePath
 import java.io.File
 
 class DatabaseSavepointsRepository(

--- a/collect_app/src/main/java/org/odk/collect/android/fastexternalitemset/ItemsetDbAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fastexternalitemset/ItemsetDbAdapter.java
@@ -1,6 +1,6 @@
 package org.odk.collect.android.fastexternalitemset;
 
-import static org.odk.collect.shared.PathUtils.getAbsoluteFilePath;
+import static org.odk.collect.androidshared.utils.PathUtils.getAbsoluteFilePath;
 
 import android.content.ContentValues;
 import android.database.Cursor;

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/ServerFormDownloaderTest.java
@@ -11,9 +11,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.FileUtils.read;
+import static org.odk.collect.androidshared.utils.PathUtils.getAbsoluteFilePath;
 import static org.odk.collect.formstest.FormUtils.buildForm;
 import static org.odk.collect.formstest.FormUtils.createXFormBody;
-import static org.odk.collect.shared.PathUtils.getAbsoluteFilePath;
 import static java.util.Arrays.asList;
 
 import com.google.common.io.Files;

--- a/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
+++ b/shared/src/main/java/org/odk/collect/shared/PathUtils.kt
@@ -1,8 +1,5 @@
 package org.odk.collect.shared
 
-import org.odk.collect.shared.files.FileExt.sanitizedCanonicalPath
-import java.io.File
-
 object PathUtils {
 
     @JvmStatic
@@ -13,16 +10,4 @@ object PathUtils {
     // https://stackoverflow.com/questions/2679699/what-characters-allowed-in-file-names-on-android
     @JvmStatic
     fun getPathSafeFileName(fileName: String) = fileName.replace("[\"*/:<>?\\\\|]".toRegex(), "_")
-
-    @JvmStatic
-    fun getAbsoluteFilePath(dirPath: String, filePath: String): String {
-        val absoluteFilePath =
-            if (filePath.startsWith(dirPath)) filePath else dirPath + File.separator + filePath
-
-        if (File(absoluteFilePath).sanitizedCanonicalPath().startsWith(File(dirPath).sanitizedCanonicalPath())) {
-            return absoluteFilePath
-        } else {
-            throw SecurityException("Contact support@getodk.org. Attempt to access file outside of Collect directory: $absoluteFilePath")
-        }
-    }
 }


### PR DESCRIPTION
Closes #6576 

#### Why is this the best possible solution? Were any other approaches considered?
I don't know if there is anything we can do to fix the issue. Let's first add logs to see if there is anything suspicious.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
