### PR TITLE
Handle case 'process killed by system case' for form entry

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragmentHostActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragmentHostActivity.kt
@@ -1,12 +1,10 @@
 package org.odk.collect.android.formhierarchy
 
 import android.os.Bundle
-import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.FormEntryViewModelFactory
 import org.odk.collect.android.entities.EntitiesRepositoryProvider
-import org.odk.collect.android.formentry.FormEntryViewModel
 import org.odk.collect.android.formentry.FormSessionRepository
 import org.odk.collect.android.formentry.repeats.DeleteRepeatDialogFragment
 import org.odk.collect.android.injection.DaggerUtils
@@ -124,17 +122,15 @@ class FormHierarchyFragmentHostActivity : LocalizedActivity() {
             }
             .build()
 
-        super.onCreate(savedInstanceState)
-
-        val formEntryViewModel =
-            ViewModelProvider(this, viewModelFactory)[FormEntryViewModel::class.java]
-        if (formEntryViewModel.formController == null) {
+        if (formSessionRepository.get(sessionId).value == null) {
+            super.onCreate(null)
             finish()
             return
+        } else {
+            super.onCreate(savedInstanceState)
+            setContentView(R.layout.hierarchy_host_layout)
+            setSupportActionBar(findViewById(org.odk.collect.androidshared.R.id.toolbar))
         }
-
-        setContentView(R.layout.hierarchy_host_layout)
-        setSupportActionBar(findViewById(org.odk.collect.androidshared.R.id.toolbar))
     }
 
     companion object {


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/3c507e40bc21d0019184c20ca4e6b9f8?time=last-ninety-days&types=crash&versions=v2025.1.0-beta.1%20(5034);v2025.1.0-beta.0%20(5030)&sessionEventKey=679B8272005200015661824558E8CA27_2044149839258744411).

#### Why is this the best possible solution? Were any other approaches considered?

I've just updated the code to behave similarly to how it did before a `Fragment` was pulled out for the hierarchy. I didn't want to do any further rework before we've got form entry and the hierarchy in one Activity.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the crash!

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
