### PR TITLE
Do not limit the maximum zoom level to 22

### DIFF
--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -199,7 +199,6 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         map.setMultiTouchControls(true);
         map.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.NEVER);
         map.setMinZoomLevel(2.0);
-        map.setMaxZoomLevel(22.0);
         map.getController().setCenter(toGeoPoint(MapFragment.Companion.getINITIAL_CENTER()));
         map.getController().setZoom((int) INITIAL_ZOOM);
         map.setTilesScaledToDpi(true);

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -208,12 +208,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
             @Override
             public boolean onZoom(ZoomEvent event) {
                 if (!isSystemZooming) {
-                    float zoomLevel = (float) event.getZoomLevel();
-                    if (zoomLevel < 2) {
-                        mapFragmentDelegate.onZoomLevelChangedByUserListener(2f);
-                    } else {
-                        mapFragmentDelegate.onZoomLevelChangedByUserListener(zoomLevel);
-                    }
+                    mapFragmentDelegate.onZoomLevelChangedByUserListener((float) event.getZoomLevel());
                 }
                 return false;
             }


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?
We agreed that we should not limit the max OSM zoom level. It might be useful for users that have offline layers. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The thing that needs testing is switching between map providers with boundary zoom levels. So for example switching from OSM with zoom 29 to Google/Mapbox to verify that there is no crash and the max zoom available in Google/Mapbox is used. The same should be tested for the min-supported zoom.

New zoom levels for different providers are:
**Google**: 2 - 22
**Mapbox**: 0 - 22
**OSM**: 2-29

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
