### PR TITLE
Always reset DB connections after modifying entity DB

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -307,15 +307,15 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
      * function, but that's not available in all the supported versions of Android.
      */
     private fun updateRowIdTables() {
-        databaseConnection.withConnection {
+        databaseConnection.resetTransaction {
             getLists().forEach {
-                writableDatabase.execSQL(
+                execSQL(
                     """
                     DROP TABLE IF EXISTS "${getRowIdTableName(it)}";
                     """.trimIndent()
                 )
 
-                writableDatabase.execSQL(
+                execSQL(
                     """
                     CREATE TABLE "${getRowIdTableName(it)}" AS SELECT _id FROM "$it" ORDER BY _id;
                     """.trimIndent()
@@ -338,7 +338,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
     }
 
     private fun createList(list: String) {
-        databaseConnection.transaction {
+        databaseConnection.resetTransaction {
             val contentValues = ContentValues()
             contentValues.put(ListsTable.COLUMN_NAME, list)
             insertOrThrow(


### PR DESCRIPTION
Hopefully fixes [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/d46581040275a32208280880bb06961c?time=last-seven-days&sessionEventKey=67A3A1490147000147DBDF386236902D_2046435611287331940).

#### Why is this the best possible solution? Were any other approaches considered?

Fixing the crash this way is a guess based on how we fixed [a similar issue](https://github.com/getodk/collect/issues/6396). Like with that one, I wasn't able to find a good way to replicate the problem with a test (or manually).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There's no way to reproduce the crash as far as we know so verifying the fix isn't possible. The changes here are mostly around form/entity list so generally checking that using forms with entity lists works as expected is all we can do here really!

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
