### PR TITLE
Catch sqlite exceptions when filter entities

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.odk.collect.android.entities.support.EntitySameAsMatcher.Companion.sameEntityAs
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.Entity
+import org.odk.collect.entities.storage.QueryException
 import org.odk.collect.shared.Query
 
 abstract class EntitiesRepositoryTest {
@@ -871,5 +872,13 @@ abstract class EntitiesRepositoryTest {
 
         val queriedCanet = repository.query("other.favourite.wines", Query.Eq("label", "Pontet-Canet 2014"))
         assertThat(queriedCanet, containsInAnyOrder(sameEntityAs(canet)))
+    }
+
+    @Test(expected = QueryException::class)
+    fun `#query throws an exception when not existing property is used`() {
+        val repository = buildSubject()
+        repository.save("wines", Entity.New("1", "Léoville Barton 2008",))
+
+        repository.query("wines", Query.Eq("score", "92"))
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.entities.javarosa.filter
 
+import android.database.sqlite.SQLiteException
 import org.javarosa.core.model.CompareToNodeExpression
 import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.condition.FilterStrategy
@@ -41,7 +42,11 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
         val query = xPathExpressionToQuery(predicate, sourceInstance, evaluationContext)
 
         return if (query != null) {
-            queryToTreeReferences(query, sourceInstance)
+            try {
+                queryToTreeReferences(query, sourceInstance)
+            } catch (e: SQLiteException) {
+                next.get()
+            }
         } else {
             next.get()
         }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.entities.javarosa.filter
 
-import android.database.sqlite.SQLiteException
 import org.javarosa.core.model.CompareToNodeExpression
 import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.condition.FilterStrategy
@@ -12,6 +11,7 @@ import org.javarosa.xpath.expr.XPathExpression
 import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceAdapter
 import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceProvider
 import org.odk.collect.entities.storage.EntitiesRepository
+import org.odk.collect.entities.storage.QueryException
 import org.odk.collect.shared.Query
 import java.util.function.Supplier
 
@@ -44,7 +44,7 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
         return if (query != null) {
             try {
                 queryToTreeReferences(query, sourceInstance)
-            } catch (e: SQLiteException) {
+            } catch (e: QueryException) {
                 next.get()
             }
         } else {

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.entities.storage
 
-import android.database.sqlite.SQLiteException
 import org.odk.collect.entities.javarosa.parse.EntitySchema
 import org.odk.collect.shared.Query
 
@@ -57,7 +56,7 @@ class InMemEntitiesRepository : EntitiesRepository {
                         EntitySchema.VERSION -> it.version.toString()
                         else -> it.properties.find { propertyName ->
                             propertyName.first == query.column
-                        }?.second ?: throw SQLiteException("No such column: ${query.column}")
+                        }?.second ?: throw QueryException("No such column: ${query.column}")
                     }
                     fieldName == query.value
                 }
@@ -70,7 +69,7 @@ class InMemEntitiesRepository : EntitiesRepository {
                         EntitySchema.VERSION -> it.version.toString()
                         else -> it.properties.find { propertyName ->
                             propertyName.first == query.column
-                        }?.second ?: throw SQLiteException("No such column: ${query.column}")
+                        }?.second ?: throw QueryException("No such column: ${query.column}")
                     }
                     fieldName != query.value
                 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.entities.storage
 
+import android.database.sqlite.SQLiteException
 import org.odk.collect.entities.javarosa.parse.EntitySchema
 import org.odk.collect.shared.Query
 
@@ -56,7 +57,7 @@ class InMemEntitiesRepository : EntitiesRepository {
                         EntitySchema.VERSION -> it.version.toString()
                         else -> it.properties.find { propertyName ->
                             propertyName.first == query.column
-                        }?.second
+                        }?.second ?: throw SQLiteException("No such column: ${query.column}")
                     }
                     fieldName == query.value
                 }
@@ -69,7 +70,7 @@ class InMemEntitiesRepository : EntitiesRepository {
                         EntitySchema.VERSION -> it.version.toString()
                         else -> it.properties.find { propertyName ->
                             propertyName.first == query.column
-                        }?.second
+                        }?.second ?: throw SQLiteException("No such column: ${query.column}")
                     }
                     fieldName != query.value
                 }

--- a/entities/src/main/java/org/odk/collect/entities/storage/QueryException.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/QueryException.kt
@@ -1,0 +1,3 @@
+package org.odk.collect.entities.storage
+
+class QueryException(message: String?) : RuntimeException(message)

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -619,6 +619,43 @@ class LocalEntitiesFilterStrategyTest {
         assertThat(choices, containsInAnyOrder("thing1"))
         assertThat(fallthroughFilterStrategy.fellThrough, equalTo(true))
     }
+
+    @Test
+    fun `works correctly but not in the optimized way with non existing property = expressions`() {
+        entitiesRepository.save("things", Entity.New("thing1", "Thing1"))
+
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("question"),
+                            )
+                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
+                        bind("/data/question").type("string")
+                    )
+                ),
+                body(
+                    select1Dynamic(
+                        "/data/question",
+                        "instance('things')/root/item[not_existing_property='value']",
+                        "name",
+                        "label"
+                    )
+                )
+            ),
+            controllerSupplier
+        )
+
+        val choices = scenario.choicesOf("/data/question").map { it.value }
+        assertThat(choices.isEmpty(), equalTo(true))
+        assertThat(fallthroughFilterStrategy.fellThrough, equalTo(true))
+    }
 }
 
 private class FallthroughFilterStrategy : FilterStrategy {

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -556,57 +556,35 @@ class LocalEntitiesFilterStrategyTest {
                             t(
                                 "data id=\"create-entity-form\"",
                                 t("ref_question"),
-                                t("question"),
+                                t("question1"),
+                                t("question2"),
+                                t("question3"),
                             )
                         ),
                         t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
                         bind("/data/ref_question").type("string"),
-                        bind("/data/question").type("string")
+                        bind("/data/question1").type("string"),
+                        bind("/data/question2").type("string"),
+                        bind("/data/question3").type("string")
                     )
                 ),
                 body(
+                    input("/data/ref_question"),
                     select1Dynamic(
-                        "/data/question",
+                        "/data/question1",
                         "instance('things')/root/item[/data/ref_question='']",
                         "name",
                         "label"
-                    )
-                )
-            ),
-            controllerSupplier
-        )
-
-        val choices = scenario.choicesOf("/data/question").map { it.value }
-        assertThat(choices, containsInAnyOrder("thing1"))
-        assertThat(fallthroughFilterStrategy.fellThrough, equalTo(true))
-    }
-
-    @Test
-    fun `works correctly but not in the optimized way with question = undefined`() {
-        entitiesRepository.save("things", Entity.New("thing1", "Thing1"))
-
-        val scenario = Scenario.init(
-            "Secondary instance form",
-            html(
-                head(
-                    title("Secondary instance form"),
-                    model(
-                        mainInstance(
-                            t(
-                                "data id=\"create-entity-form\"",
-                                t("ref_question"),
-                                t("question"),
-                            )
-                        ),
-                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
-                        bind("/data/ref_question").type("string"),
-                        bind("/data/question").type("string")
-                    )
-                ),
-                body(
+                    ),
                     select1Dynamic(
-                        "/data/question",
+                        "/data/question2",
                         "instance('things')/root/item[/data/ref_question=undefined]",
+                        "name",
+                        "label"
+                    ),
+                    select1Dynamic(
+                        "/data/question3",
+                        "instance('things')/root/item[/data/ref_question=null]",
                         "name",
                         "label"
                     )
@@ -615,8 +593,21 @@ class LocalEntitiesFilterStrategyTest {
             controllerSupplier
         )
 
-        val choices = scenario.choicesOf("/data/question").map { it.value }
+        var choices = scenario.choicesOf("/data/question1").map { it.value }
         assertThat(choices, containsInAnyOrder("thing1"))
+
+        choices = scenario.choicesOf("/data/question2").map { it.value }
+        assertThat(choices, containsInAnyOrder("thing1"))
+
+        choices = scenario.choicesOf("/data/question3").map { it.value }
+        assertThat(choices, containsInAnyOrder("thing1"))
+
+        scenario.next()
+        scenario.answer("blah")
+
+        choices = scenario.choicesOf("/data/question1").map { it.value }
+        assertThat(choices.isEmpty(), equalTo(true))
+
         assertThat(fallthroughFilterStrategy.fellThrough, equalTo(true))
     }
 
@@ -633,16 +624,24 @@ class LocalEntitiesFilterStrategyTest {
                         mainInstance(
                             t(
                                 "data id=\"create-entity-form\"",
-                                t("question"),
+                                t("question1"),
+                                t("question2"),
                             )
                         ),
                         t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
-                        bind("/data/question").type("string")
+                        bind("/data/question1").type("string"),
+                        bind("/data/question2").type("string")
                     )
                 ),
                 body(
                     select1Dynamic(
-                        "/data/question",
+                        "/data/question1",
+                        "instance('things')/root/item[not_existing_property='']",
+                        "name",
+                        "label"
+                    ),
+                    select1Dynamic(
+                        "/data/question2",
                         "instance('things')/root/item[not_existing_property='value']",
                         "name",
                         "label"
@@ -652,8 +651,12 @@ class LocalEntitiesFilterStrategyTest {
             controllerSupplier
         )
 
-        val choices = scenario.choicesOf("/data/question").map { it.value }
+        var choices = scenario.choicesOf("/data/question1").map { it.value }
+        assertThat(choices, containsInAnyOrder("thing1"))
+
+        choices = scenario.choicesOf("/data/question2").map { it.value }
         assertThat(choices.isEmpty(), equalTo(true))
+
         assertThat(fallthroughFilterStrategy.fellThrough, equalTo(true))
     }
 }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -541,6 +541,84 @@ class LocalEntitiesFilterStrategyTest {
         assertThat(fallthroughFilterStrategy.fellThrough, equalTo(false))
         assertThat(instanceProvider.fullParsePerformed, equalTo(false))
     }
+
+    @Test
+    fun `works correctly but not in the optimized way with question = expressions`() {
+        entitiesRepository.save("things", Entity.New("thing1", "Thing1"))
+
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("ref_question"),
+                                t("question"),
+                            )
+                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
+                        bind("/data/ref_question").type("string"),
+                        bind("/data/question").type("string")
+                    )
+                ),
+                body(
+                    select1Dynamic(
+                        "/data/question",
+                        "instance('things')/root/item[/data/ref_question='']",
+                        "name",
+                        "label"
+                    )
+                )
+            ),
+            controllerSupplier
+        )
+
+        val choices = scenario.choicesOf("/data/question").map { it.value }
+        assertThat(choices, containsInAnyOrder("thing1"))
+        assertThat(fallthroughFilterStrategy.fellThrough, equalTo(true))
+    }
+
+    @Test
+    fun `works correctly but not in the optimized way with question = undefined`() {
+        entitiesRepository.save("things", Entity.New("thing1", "Thing1"))
+
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("ref_question"),
+                                t("question"),
+                            )
+                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
+                        bind("/data/ref_question").type("string"),
+                        bind("/data/question").type("string")
+                    )
+                ),
+                body(
+                    select1Dynamic(
+                        "/data/question",
+                        "instance('things')/root/item[/data/ref_question=undefined]",
+                        "name",
+                        "label"
+                    )
+                )
+            ),
+            controllerSupplier
+        )
+
+        val choices = scenario.choicesOf("/data/question").map { it.value }
+        assertThat(choices, containsInAnyOrder("thing1"))
+        assertThat(fallthroughFilterStrategy.fellThrough, equalTo(true))
+    }
 }
 
 private class FallthroughFilterStrategy : FilterStrategy {


### PR DESCRIPTION
Closes #6600 
Closes #6597 

#### Why is this the best possible solution? Were any other approaches considered?
For: #6600 
When a filter applied to entities contains an expression referencing another question, we cannot build an optimized SQLite query. Instead, we need to fall back to Javarosa, which has all the necessary knowledge to evaluate such an expression. The optimized way of filtering can be used only if it uses entity properties available in the entity database.
For: #6597 
At the moment of building an SQLite query to optimize filtering, both **#6600** and **#6597** appear to be the same issue (a missing column). However, when we fall back to Javarosa, **#6600** is evaluated with the referenced question, while **#6597** is still treated as a missing property.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
For: #6600 
We need to test filtering with expressions that reference other questions in a form, not just expressions that use entity properties. The form attached to the issue is an example of it.
For: #6597 
We need to test filtering with expressions that simply use non-existing properties.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached to the issue. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
