### PR TITLE
Fixed touch tracking in the range slider

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/TrackingTouchSlider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/views/TrackingTouchSlider.kt
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
 import android.util.AttributeSet
-import android.view.MotionEvent
-import android.view.View
 import com.google.android.material.R
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.slider.Slider
@@ -27,24 +25,16 @@ class TrackingTouchSlider(
     init {
         addOnSliderTouchListener(this)
         setLabelFormatter(null)
-        setOnTouchListener { v: View, event: MotionEvent ->
-            val action = event.action
-            when (action) {
-                MotionEvent.ACTION_DOWN -> v.parent.requestDisallowInterceptTouchEvent(
-                    true
-                )
+        addOnSliderTouchListener(object : OnSliderTouchListener {
+            override fun onStartTrackingTouch(slider: Slider) {}
 
-                MotionEvent.ACTION_UP -> {
-                    v.parent.requestDisallowInterceptTouchEvent(false)
-                    setTickActiveTintList(defaultTickActiveTintList)
-                    setThumbWidth(defaultThumbWidth)
-                    setThumbTrackGapSize(defaultThumbTrackGapSize)
-                    listener?.onValueChange(this, value, true)
-                }
+            override fun onStopTrackingTouch(slider: Slider) {
+                setTickActiveTintList(defaultTickActiveTintList)
+                setThumbWidth(defaultThumbWidth)
+                setThumbTrackGapSize(defaultThumbTrackGapSize)
+                listener?.onValueChange(this@TrackingTouchSlider, value, true)
             }
-            v.onTouchEvent(event)
-            true
-        }
+        })
     }
 
     @SuppressLint("RestrictedApi")


### PR DESCRIPTION
Closes #6607

#### Why is this the best possible solution? Were any other approaches considered?
The way we tracked touch events was incorrect. We set a listener and in that listener tried to call `v.onTouchEvent(event)` where v refers to the view that received the touch event. So it was like overriding the listener but also trying to call the default implementation and the order of those calls caused the problems with setting/reading values.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test setting values in the range widgets (only those that use sliders, there is no need to test the picker one). Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
