### PR TITLE
Prevent crashes after problems saving entities

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith
 import org.odk.collect.android.benchmark.support.Benchmarker
 import org.odk.collect.android.benchmark.support.benchmark
 import org.odk.collect.android.support.TestDependencies
+import org.odk.collect.android.support.pages.FirstLaunchPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
@@ -53,18 +54,18 @@ class EntitiesBenchmarkTest {
             .inputUrl(ENTITIES_FILTER_TEST_PROJECT_URL)
             .addProject()
 
-            // Populate http cache and clear out form/entities
+            // Populate http cache and recreate project
             .clickGetBlankForm()
             .clickGetSelected()
             .clickOK(MainMenuPage())
             .openProjectSettingsDialog()
             .clickSettings()
             .clickProjectManagement()
-            .clickOnResetProject()
-            .clickOnString(R.string.reset_blank_forms)
-            .clickOnString(R.string.reset_saved_forms)
-            .clickOnString(R.string.reset_settings_button_reset)
-            .clickOKOnDialog(MainMenuPage())
+            .clickOnDeleteProject()
+            .clickOnTextInDialog(R.string.yes, FirstLaunchPage())
+            .clickManuallyEnterProjectDetails()
+            .inputUrl(ENTITIES_FILTER_TEST_PROJECT_URL)
+            .addProject()
 
             .clickGetBlankForm()
             .benchmark("Downloading form with http cache", 40, benchmarker) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/support/Benchmarker.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/support/Benchmarker.kt
@@ -1,7 +1,7 @@
 package org.odk.collect.android.benchmark.support
 
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.lessThan
+import org.hamcrest.Matchers.lessThanOrEqualTo
 import org.odk.collect.android.support.pages.Page
 import org.odk.collect.shared.TimeInMs
 
@@ -21,7 +21,7 @@ class Benchmarker {
 
         targets.entries.forEach {
             val time = stopwatch.getTime(it.key)
-            assertThat("\"${it.key}\" took ${time}s!", time, lessThan(it.value))
+            assertThat("\"${it.key}\" took ${time}s!", time, lessThanOrEqualTo(it.value))
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -13,7 +13,9 @@ import org.odk.collect.db.sqlite.CursorExt.getString
 import org.odk.collect.db.sqlite.CursorExt.getStringOrNull
 import org.odk.collect.db.sqlite.CursorExt.rowToMap
 import org.odk.collect.db.sqlite.DatabaseMigrator
-import org.odk.collect.db.sqlite.SQLiteColumns.ROW_ID
+import org.odk.collect.db.sqlite.RowNumbers.invalidateRowNumbers
+import org.odk.collect.db.sqlite.RowNumbers.rawQueryWithRowNumber
+import org.odk.collect.db.sqlite.SQLiteColumns.ROW_NUMBER
 import org.odk.collect.db.sqlite.SQLiteDatabaseExt.delete
 import org.odk.collect.db.sqlite.SQLiteDatabaseExt.doesColumnExist
 import org.odk.collect.db.sqlite.SQLiteDatabaseExt.getColumnNames
@@ -124,7 +126,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             }
         }
 
-        invalidateRowIdTables()
+        invalidateRowNumbers()
     }
 
     override fun getLists(): Set<String> {
@@ -161,7 +163,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             return emptyList()
         }
 
-        return queryWithAttachedRowId(list, null)
+        return queryWithAttachedRowNumber(list, null)
     }
 
     override fun getCount(list: String): Int {
@@ -185,7 +187,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
     override fun addList(list: String) {
         if (!listExists(list)) {
             createList(list)
-            invalidateRowIdTables()
+            invalidateRowNumbers()
         }
     }
 
@@ -200,7 +202,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             }
         }
 
-        invalidateRowIdTables()
+        invalidateRowNumbers()
     }
 
     override fun query(list: String, query: Query): List<Entity.Saved> {
@@ -208,7 +210,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             return emptyList()
         }
 
-        return queryWithAttachedRowId(list, query.mapColumns { columnName ->
+        return queryWithAttachedRowNumber(list, query.mapColumns { columnName ->
             when (columnName) {
                 EntitySchema.ID -> EntitiesTable.COLUMN_ID
                 EntitySchema.LABEL -> EntitiesTable.COLUMN_LABEL
@@ -223,7 +225,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             return null
         }
 
-        return queryWithAttachedRowId(list, Query.Eq(EntitiesTable.COLUMN_ID, id)).firstOrNull()
+        return queryWithAttachedRowNumber(list, Query.Eq(EntitiesTable.COLUMN_ID, id)).firstOrNull()
     }
 
     override fun getAllByProperty(
@@ -240,12 +242,12 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         }
 
         return if (propertyExists) {
-            queryWithAttachedRowId(
+            queryWithAttachedRowNumber(
                 list,
                 Query.Eq(EntitiesTable.getPropertyColumn(property), value)
             )
         } else if (value == "") {
-            queryWithAttachedRowId(list, null)
+            queryWithAttachedRowNumber(list, null)
         } else {
             emptyList()
         }
@@ -256,82 +258,30 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             return null
         }
 
-        return queryWithAttachedRowId(list, Query.Eq("i.$ROW_ID", (index + 1).toString())).firstOrNull()
+        val query = Query.Eq(ROW_NUMBER, (index + 1).toString())
+        return queryWithAttachedRowNumber(list, query).firstOrNull()
     }
 
-    private fun queryWithAttachedRowId(list: String, query: Query?): List<Entity.Saved> {
-        ensureRowIdTable(list)
-
+    private fun queryWithAttachedRowNumber(list: String, query: Query?): List<Entity.Saved> {
         try {
             return if (query == null) {
-                databaseConnection.withConnection {
-                    readableDatabase
-                        .rawQuery(
-                            """
-                            SELECT *, i.$ROW_ID
-                            FROM "$list" e, "${getRowIdTableName(list)}" i
-                            WHERE e._id = i._id
-                            ORDER BY i.$ROW_ID
-                            """.trimIndent(),
-                            null
-                        )
-                }
+                databaseConnection.rawQueryWithRowNumber(list)
             } else {
-                databaseConnection.withConnection {
-                    val sqlQuery = query.toSql()
-                    readableDatabase
-                        .rawQuery(
-                            """
-                            SELECT *, i.$ROW_ID
-                            FROM "$list" e, "${getRowIdTableName(list)}" i
-                            WHERE e._id = i._id AND ${sqlQuery.selection}
-                            ORDER BY i.$ROW_ID
-                            """.trimIndent(),
-                            sqlQuery.selectionArgs
-                        )
-                }
+                val sqlQuery = query.toSql()
+                databaseConnection.rawQueryWithRowNumber(list, sqlQuery.selection, sqlQuery.selectionArgs)
             }.foldAndClose {
-                mapCursorRowToEntity(it, it.getInt(ROW_ID))
+                mapCursorRowToEntity(it, it.getInt(ROW_NUMBER))
             }
         } catch (e: SQLiteException) {
             throw QueryException(e.message)
         }
     }
 
-
-    private fun invalidateRowIdTables() {
-        databaseConnection.resetTransaction {
-            getLists().forEach {
-                execSQL(
-                    """
-                    DROP TABLE IF EXISTS "${getRowIdTableName(it)}";
-                    """.trimIndent()
-                )
-            }
+    private fun invalidateRowNumbers() {
+        getLists().forEach {
+            databaseConnection.invalidateRowNumbers(it)
         }
     }
-
-    /**
-     * This table allows to maintain a sequential "positions" for each entity that can be used as
-     * [Entity.Saved.index]. This method appears to be faster than using a nested query to generate
-     * these at query time (calculating how many _ids are higher than each entity _id). This might
-     * be replaceable with SQLite's `row_number()` function, but that's not available in all the
-     * supported versions of Android.
-     *
-     * For this to work [invalidateRowIdTables] must be called whenever there is a change to a
-     * list table.
-     */
-    private fun ensureRowIdTable(list: String) {
-        databaseConnection.resetTransaction {
-            execSQL(
-                """
-                CREATE TABLE IF NOT EXISTS "${getRowIdTableName(list)}" AS SELECT _id FROM "$list" ORDER BY _id;
-                """.trimIndent()
-            )
-        }
-    }
-
-    private fun getRowIdTableName(it: String) = "${it}_row_numbers"
 
     private fun listExists(list: String): Boolean {
         return databaseConnection.withConnection {

--- a/db/src/main/java/org/odk/collect/db/sqlite/RowNumbers.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/RowNumbers.kt
@@ -1,0 +1,63 @@
+package org.odk.collect.db.sqlite
+
+import android.database.Cursor
+import org.odk.collect.db.sqlite.SQLiteColumns.ROW_ID
+import org.odk.collect.db.sqlite.SQLiteColumns.ROW_NUMBER
+
+object RowNumbers {
+    fun SynchronizedDatabaseConnection.rawQueryWithRowNumber(table: String, selection: String? = null, selectionArgs: Array<String>? = null): Cursor {
+        ensureRowIdTable(this, table)
+
+        val cursor = if (selection != null) {
+            this.withConnection {
+                readableDatabase
+                    .rawQuery(
+                        """
+                        SELECT *, i.$ROW_ID as $ROW_NUMBER
+                        FROM "$table" e, "${getRowIdTableName(table)}" i
+                        WHERE e._id = i._id AND $selection
+                        ORDER BY i.$ROW_ID
+                        """.trimIndent(),
+                        selectionArgs
+                    )
+            }
+        } else {
+            this.withConnection {
+                readableDatabase
+                    .rawQuery(
+                        """
+                        SELECT *, i.$ROW_ID as $ROW_NUMBER
+                        FROM "$table" e, "${getRowIdTableName(table)}" i
+                        WHERE e._id = i._id
+                        ORDER BY i.$ROW_ID
+                        """.trimIndent(),
+                        null
+                    )
+            }
+        }
+
+        return cursor
+    }
+
+    fun SynchronizedDatabaseConnection.invalidateRowNumbers(table: String) {
+        this.resetTransaction {
+            execSQL(
+                """
+                DROP TABLE IF EXISTS "${getRowIdTableName(table)}";
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun ensureRowIdTable(databaseConnection: SynchronizedDatabaseConnection, table: String) {
+        databaseConnection.resetTransaction {
+            execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS "${getRowIdTableName(table)}" AS SELECT _id FROM "$table" ORDER BY _id;
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun getRowIdTableName(it: String) = "${it}_row_numbers"
+}

--- a/db/src/main/java/org/odk/collect/db/sqlite/RowNumbers.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/RowNumbers.kt
@@ -6,7 +6,7 @@ import org.odk.collect.db.sqlite.SQLiteColumns.ROW_NUMBER
 
 object RowNumbers {
     fun SynchronizedDatabaseConnection.rawQueryWithRowNumber(table: String, selection: String? = null, selectionArgs: Array<String>? = null): Cursor {
-        ensureRowIdTable(this, table)
+        this.ensureRowIdTable(table)
 
         val cursor = if (selection != null) {
             this.withConnection {
@@ -49,8 +49,8 @@ object RowNumbers {
         }
     }
 
-    private fun ensureRowIdTable(databaseConnection: SynchronizedDatabaseConnection, table: String) {
-        databaseConnection.resetTransaction {
+    private fun SynchronizedDatabaseConnection.ensureRowIdTable(table: String) {
+        resetTransaction {
             execSQL(
                 """
                 CREATE TABLE IF NOT EXISTS "${getRowIdTableName(table)}" AS SELECT _id FROM "$table" ORDER BY _id;

--- a/db/src/main/java/org/odk/collect/db/sqlite/SQLiteColumns.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SQLiteColumns.kt
@@ -2,4 +2,5 @@ package org.odk.collect.db.sqlite
 
 object SQLiteColumns {
     const val ROW_ID = "rowid"
+    const val ROW_NUMBER = "row_number"
 }

--- a/db/src/test/java/org/odk/collect/db/sqlite/RowNumbersTest.kt
+++ b/db/src/test/java/org/odk/collect/db/sqlite/RowNumbersTest.kt
@@ -1,0 +1,100 @@
+package org.odk.collect.db.sqlite
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.provider.BaseColumns._ID
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.db.sqlite.CursorExt.foldAndClose
+import org.odk.collect.db.sqlite.CursorExt.rowToMap
+import org.odk.collect.db.sqlite.RowNumbers.invalidateRowNumbers
+import org.odk.collect.db.sqlite.RowNumbers.rawQueryWithRowNumber
+import org.odk.collect.db.sqlite.SQLiteColumns.ROW_NUMBER
+import org.odk.collect.shared.TempFiles
+
+@RunWith(AndroidJUnit4::class)
+class RowNumbersTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `#rawQueryWithRowNumber returns results ordered by row_number column`() {
+        val dbConnection = SynchronizedDatabaseConnection(
+            context,
+            TempFiles.createTempDir().absolutePath,
+            "temp.db",
+            NoopMigrator(),
+            1
+        )
+
+        dbConnection.resetTransaction {
+            execSQL("CREATE TABLE test_table ($_ID integer PRIMARY KEY, position text)")
+        }
+
+        dbConnection.transaction {
+            insertOrThrow("test_table", null, ContentValues().also { it.put("position", "first") })
+            insertOrThrow("test_table", null, ContentValues().also { it.put("position", "second") })
+        }
+
+        val rows =
+            dbConnection.rawQueryWithRowNumber("test_table").foldAndClose { it.rowToMap() }
+        assertThat(rows.size, equalTo(2))
+
+        assertThat(rows[0]["position"], equalTo("first"))
+        assertThat(rows[0][ROW_NUMBER], equalTo("1"))
+
+        assertThat(rows[1]["position"], equalTo("second"))
+        assertThat(rows[1][ROW_NUMBER], equalTo("2"))
+    }
+
+    @Test
+    fun `#rawQueryWithRowNumber returns results ordered by updated row_number column after row deleted and invalidate`() {
+        val dbConnection = SynchronizedDatabaseConnection(
+            context,
+            TempFiles.createTempDir().absolutePath,
+            "temp.db",
+            NoopMigrator(),
+            1
+        )
+
+        dbConnection.resetTransaction {
+            execSQL("CREATE TABLE test_table ($_ID integer PRIMARY KEY, position text)")
+        }
+
+        dbConnection.transaction {
+            insertOrThrow("test_table", null, ContentValues().also { it.put("position", "first") })
+            insertOrThrow("test_table", null, ContentValues().also { it.put("position", "second") })
+            insertOrThrow("test_table", null, ContentValues().also { it.put("position", "third") })
+        }
+
+        val beforeRows =
+            dbConnection.rawQueryWithRowNumber("test_table").foldAndClose { it.rowToMap() }
+        assertThat(beforeRows.size, equalTo(3))
+
+        dbConnection.transaction {
+            delete("test_table", "position = ?", arrayOf("second"))
+        }
+
+        dbConnection.invalidateRowNumbers("test_table")
+
+        val afterRows =
+            dbConnection.rawQueryWithRowNumber("test_table").foldAndClose { it.rowToMap() }
+        assertThat(afterRows.size, equalTo(2))
+
+        assertThat(afterRows[0]["position"], equalTo("first"))
+        assertThat(afterRows[0][ROW_NUMBER], equalTo("1"))
+
+        assertThat(afterRows[1]["position"], equalTo("third"))
+        assertThat(afterRows[1][ROW_NUMBER], equalTo("2"))
+    }
+}
+
+class NoopMigrator : DatabaseMigrator {
+    override fun onCreate(db: SQLiteDatabase?) {}
+    override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int) {}
+}

--- a/db/src/test/java/org/odk/collect/db/sqlite/RowNumbersTest.kt
+++ b/db/src/test/java/org/odk/collect/db/sqlite/RowNumbersTest.kt
@@ -94,7 +94,7 @@ class RowNumbersTest {
     }
 }
 
-class NoopMigrator : DatabaseMigrator {
+private class NoopMigrator : DatabaseMigrator {
     override fun onCreate(db: SQLiteDatabase?) {}
     override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int) {}
 }


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/d46581040275a32208280880bb06961c?time=last-ninety-days&sessionEventKey=67B7470500570001633BFCB53B04A02E_2051966355542245025)

#### Why is this the best possible solution? Were any other approaches considered?

The approach here is to move away from creating our "row numbers" table eagerly whenever there's a change to the data and replace it with a "lazy" approach. The row numbers table is now created if it doesn't currently exist when performing queries that need it, and then "invalidated" (dropped) when data changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We still don't have a predictable way to recreate the crash so just generally checking for regressions in entity forms is all we can do here. I've already checked that this new approach still passes our benchmarks, but checking entity forms with a large amount of entities would be good here. I'd also encourage checking upgrading the with an existing entity project(s).  

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
