### PR TITLE
Fix handling of numbers in SQLite query arguments

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -225,7 +225,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             return null
         }
 
-        return queryWithAttachedRowNumber(list, Query.Eq(EntitiesTable.COLUMN_ID, id)).firstOrNull()
+        return queryWithAttachedRowNumber(list, Query.StringEq(EntitiesTable.COLUMN_ID, id)).firstOrNull()
     }
 
     override fun getAllByProperty(
@@ -244,7 +244,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
         return if (propertyExists) {
             queryWithAttachedRowNumber(
                 list,
-                Query.Eq(EntitiesTable.getPropertyColumn(property), value)
+                Query.StringEq(EntitiesTable.getPropertyColumn(property), value)
             )
         } else if (value == "") {
             queryWithAttachedRowNumber(list, null)
@@ -258,7 +258,7 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
             return null
         }
 
-        val query = Query.Eq(ROW_NUMBER, (index + 1).toString())
+        val query = Query.StringEq(ROW_NUMBER, (index + 1).toString())
         return queryWithAttachedRowNumber(list, query).firstOrNull()
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -881,4 +881,38 @@ abstract class EntitiesRepositoryTest {
 
         repository.query("wines", Query.Eq("score", "92"))
     }
+
+    @Test
+    fun `#query returns matching entities with numeric selection arguments`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New(
+            "1",
+            "Léoville Barton 2008",
+            properties = listOf("score" to "5")
+        )
+
+        val canet = Entity.New(
+            "2",
+            "Pontet-Canet 2014",
+            properties = listOf("score" to "6.0")
+        )
+
+        val dows = Entity.New(
+            "3",
+            "Dow's 1983",
+            properties = listOf("score" to "7.5")
+        )
+
+        repository.save("wines", leoville, canet, dows)
+
+        var wines = repository.query("wines", Query.Eq("score", "5.0"))
+        assertThat(wines, containsInAnyOrder(sameEntityAs(leoville)))
+
+        wines = repository.query("wines", Query.Eq("score", "6"))
+        assertThat(wines, containsInAnyOrder(sameEntityAs(canet)))
+
+        wines = repository.query("wines", Query.Eq("score", "7.5"))
+        assertThat(wines, containsInAnyOrder(sameEntityAs(dows)))
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -883,7 +883,7 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
-    fun `#query returns matching entities with numeric eq selection arguments`() {
+    fun `#query returns matching entities with numeric eq selection arguments for integer values`() {
         val repository = buildSubject()
 
         val leoville = Entity.New(
@@ -895,26 +895,67 @@ abstract class EntitiesRepositoryTest {
         val dows = Entity.New(
             "3",
             "Dow's 1983",
+            properties = listOf("score" to "7")
+        )
+
+        repository.save("wines", leoville, dows)
+
+        val wines = repository.query("wines", Query.NumericEq("score", 5.0))
+        assertThat(wines, containsInAnyOrder(sameEntityAs(leoville)))
+    }
+
+    @Test
+    fun `#query returns matching entities with numeric eq selection arguments for decimal values`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New(
+            "1",
+            "Léoville Barton 2008",
+            properties = listOf("score" to "5.0")
+        )
+
+        val dows = Entity.New(
+            "3",
+            "Dow's 1983",
             properties = listOf("score" to "7.5")
         )
 
         repository.save("wines", leoville, dows)
 
-        var wines = repository.query("wines", Query.NumericEq("score", 5.0))
+        val wines = repository.query("wines", Query.NumericEq("score", 5.0))
         assertThat(wines, containsInAnyOrder(sameEntityAs(leoville)))
+    }
 
-        wines = repository.query("wines", Query.NumericEq("score", 7.5))
+    @Test
+    fun `#query returns matching entities with numeric not eq selection arguments for integer values`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New(
+            "1",
+            "Léoville Barton 2008",
+            properties = listOf("score" to "5")
+        )
+
+        val dows = Entity.New(
+            "3",
+            "Dow's 1983",
+            properties = listOf("score" to "7")
+        )
+
+        repository.save("wines", leoville, dows)
+
+        val wines = repository.query("wines", Query.NumericNotEq("score", 5.0))
         assertThat(wines, containsInAnyOrder(sameEntityAs(dows)))
     }
 
     @Test
-    fun `#query returns matching entities with numeric not eq selection arguments`() {
+    fun `#query returns matching entities with numeric not eq selection arguments for decimal values`() {
         val repository = buildSubject()
 
         val leoville = Entity.New(
             "1",
             "Léoville Barton 2008",
-            properties = listOf("score" to "5")
+            properties = listOf("score" to "5.0")
         )
 
         val dows = Entity.New(
@@ -925,10 +966,7 @@ abstract class EntitiesRepositoryTest {
 
         repository.save("wines", leoville, dows)
 
-        var wines = repository.query("wines", Query.NumericNotEq("score", 5.0))
+        val wines = repository.query("wines", Query.NumericNotEq("score", 5.0))
         assertThat(wines, containsInAnyOrder(sameEntityAs(dows)))
-
-        wines = repository.query("wines", Query.NumericNotEq("score", 7.5))
-        assertThat(wines, containsInAnyOrder(sameEntityAs(leoville)))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -818,7 +818,7 @@ abstract class EntitiesRepositoryTest {
 
         repository.save("wines", leoville, canet)
 
-        val wines = repository.query("wines", Query.Eq("name", "2"))
+        val wines = repository.query("wines", Query.StringEq("name", "2"))
         assertThat(wines, containsInAnyOrder(sameEntityAs(canet)))
     }
 
@@ -835,7 +835,7 @@ abstract class EntitiesRepositoryTest {
 
         repository.save("wines", leoville)
 
-        val wines = repository.query("wines", Query.Eq("name", "3"))
+        val wines = repository.query("wines", Query.StringEq("name", "3"))
         assertThat(wines, equalTo(emptyList()))
     }
 
@@ -849,13 +849,13 @@ abstract class EntitiesRepositoryTest {
         repository.save("wines", leoville)
         repository.save("whisky", ardbeg)
 
-        assertThat(repository.query("wines", Query.Eq("label", "Ardbeg 10")), equalTo(emptyList()))
+        assertThat(repository.query("wines", Query.StringEq("label", "Ardbeg 10")), equalTo(emptyList()))
     }
 
     @Test
     fun `#query returns empty list where there are no entities in the list`() {
         val repository = buildSubject()
-        assertThat(repository.query("wines", Query.Eq("label", "Léoville Barton 2008")), equalTo(emptyList()))
+        assertThat(repository.query("wines", Query.StringEq("label", "Léoville Barton 2008")), equalTo(emptyList()))
     }
 
     @Test
@@ -867,10 +867,10 @@ abstract class EntitiesRepositoryTest {
         repository.save("favourite-wines", leoville)
         repository.save("other.favourite.wines", canet)
 
-        val queriedLeoville = repository.query("favourite-wines", Query.Eq("label", "Léoville Barton 2008"))
+        val queriedLeoville = repository.query("favourite-wines", Query.StringEq("label", "Léoville Barton 2008"))
         assertThat(queriedLeoville, containsInAnyOrder(sameEntityAs(leoville)))
 
-        val queriedCanet = repository.query("other.favourite.wines", Query.Eq("label", "Pontet-Canet 2014"))
+        val queriedCanet = repository.query("other.favourite.wines", Query.StringEq("label", "Pontet-Canet 2014"))
         assertThat(queriedCanet, containsInAnyOrder(sameEntityAs(canet)))
     }
 
@@ -879,7 +879,7 @@ abstract class EntitiesRepositoryTest {
         val repository = buildSubject()
         repository.save("wines", Entity.New("1", "Léoville Barton 2008",))
 
-        repository.query("wines", Query.Eq("score", "92"))
+        repository.query("wines", Query.StringEq("score", "92"))
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -883,7 +883,7 @@ abstract class EntitiesRepositoryTest {
     }
 
     @Test
-    fun `#query returns matching entities with numeric selection arguments`() {
+    fun `#query returns matching entities with numeric eq selection arguments`() {
         val repository = buildSubject()
 
         val leoville = Entity.New(
@@ -892,10 +892,29 @@ abstract class EntitiesRepositoryTest {
             properties = listOf("score" to "5")
         )
 
-        val canet = Entity.New(
-            "2",
-            "Pontet-Canet 2014",
-            properties = listOf("score" to "6.0")
+        val dows = Entity.New(
+            "3",
+            "Dow's 1983",
+            properties = listOf("score" to "7.5")
+        )
+
+        repository.save("wines", leoville, dows)
+
+        var wines = repository.query("wines", Query.NumericEq("score", 5.0))
+        assertThat(wines, containsInAnyOrder(sameEntityAs(leoville)))
+
+        wines = repository.query("wines", Query.NumericEq("score", 7.5))
+        assertThat(wines, containsInAnyOrder(sameEntityAs(dows)))
+    }
+
+    @Test
+    fun `#query returns matching entities with numeric not eq selection arguments`() {
+        val repository = buildSubject()
+
+        val leoville = Entity.New(
+            "1",
+            "Léoville Barton 2008",
+            properties = listOf("score" to "5")
         )
 
         val dows = Entity.New(
@@ -904,15 +923,12 @@ abstract class EntitiesRepositoryTest {
             properties = listOf("score" to "7.5")
         )
 
-        repository.save("wines", leoville, canet, dows)
+        repository.save("wines", leoville, dows)
 
-        var wines = repository.query("wines", Query.Eq("score", "5.0"))
-        assertThat(wines, containsInAnyOrder(sameEntityAs(leoville)))
-
-        wines = repository.query("wines", Query.Eq("score", "6"))
-        assertThat(wines, containsInAnyOrder(sameEntityAs(canet)))
-
-        wines = repository.query("wines", Query.Eq("score", "7.5"))
+        var wines = repository.query("wines", Query.NumericNotEq("score", 5.0))
         assertThat(wines, containsInAnyOrder(sameEntityAs(dows)))
+
+        wines = repository.query("wines", Query.NumericNotEq("score", 7.5))
+        assertThat(wines, containsInAnyOrder(sameEntityAs(leoville)))
     }
 }

--- a/db/src/main/java/org/odk/collect/db/sqlite/SqlQuery.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SqlQuery.kt
@@ -9,8 +9,8 @@ data class SqlQuery(
 
 fun Query.toSql(): SqlQuery {
     return when (this) {
-        is Query.Eq -> SqlQuery("$column = ?", arrayOf(value))
-        is Query.NotEq -> SqlQuery("$column != ?", arrayOf(value))
+        is Query.StringEq -> SqlQuery("$column = ?", arrayOf(value))
+        is Query.StringNotEq -> SqlQuery("$column != ?", arrayOf(value))
         is Query.NumericEq -> SqlQuery("CAST($column AS REAL) = CAST(? AS REAL)", arrayOf(value.toString()))
         is Query.NumericNotEq -> SqlQuery("CAST($column AS REAL) != CAST(? AS REAL)", arrayOf(value.toString()))
         is Query.And -> {

--- a/db/src/main/java/org/odk/collect/db/sqlite/SqlQuery.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SqlQuery.kt
@@ -9,8 +9,20 @@ data class SqlQuery(
 
 fun Query.toSql(): SqlQuery {
     return when (this) {
-        is Query.Eq -> SqlQuery("$column = ?", arrayOf(value))
-        is Query.NotEq -> SqlQuery("$column != ?", arrayOf(value))
+        is Query.Eq -> {
+            if (value.toDoubleOrNull() != null) {
+                SqlQuery("CAST($column AS REAL) = CAST(? AS REAL)", arrayOf(value))
+            } else {
+                SqlQuery("$column = ?", arrayOf(value))
+            }
+        }
+        is Query.NotEq -> {
+            if (value.toDoubleOrNull() != null) {
+                SqlQuery("CAST($column AS REAL) != CAST(? AS REAL)", arrayOf(value))
+            } else {
+                SqlQuery("$column != ?", arrayOf(value))
+            }
+        }
         is Query.And -> {
             val sqlA = queryA.toSql()
             val sqlB = queryB.toSql()

--- a/db/src/main/java/org/odk/collect/db/sqlite/SqlQuery.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SqlQuery.kt
@@ -9,20 +9,10 @@ data class SqlQuery(
 
 fun Query.toSql(): SqlQuery {
     return when (this) {
-        is Query.Eq -> {
-            if (value.toDoubleOrNull() != null) {
-                SqlQuery("CAST($column AS REAL) = CAST(? AS REAL)", arrayOf(value))
-            } else {
-                SqlQuery("$column = ?", arrayOf(value))
-            }
-        }
-        is Query.NotEq -> {
-            if (value.toDoubleOrNull() != null) {
-                SqlQuery("CAST($column AS REAL) != CAST(? AS REAL)", arrayOf(value))
-            } else {
-                SqlQuery("$column != ?", arrayOf(value))
-            }
-        }
+        is Query.Eq -> SqlQuery("$column = ?", arrayOf(value))
+        is Query.NotEq -> SqlQuery("$column != ?", arrayOf(value))
+        is Query.NumericEq -> SqlQuery("CAST($column AS REAL) = CAST(? AS REAL)", arrayOf(value.toString()))
+        is Query.NumericNotEq -> SqlQuery("CAST($column AS REAL) != CAST(? AS REAL)", arrayOf(value.toString()))
         is Query.And -> {
             val sqlA = queryA.toSql()
             val sqlB = queryB.toSql()

--- a/db/src/test/java/org/odk/collect/db/sqlite/SqlQueryTest.kt
+++ b/db/src/test/java/org/odk/collect/db/sqlite/SqlQueryTest.kt
@@ -8,7 +8,7 @@ import org.odk.collect.shared.Query
 class SqlQueryTest {
     @Test
     fun `Eq query generates correct selection and arguments`() {
-        val query = Query.Eq("name", "John").toSql()
+        val query = Query.StringEq("name", "John").toSql()
 
         assertThat(query.selection, equalTo("name = ?"))
         assertThat(query.selectionArgs, equalTo(arrayOf("John")))
@@ -16,7 +16,7 @@ class SqlQueryTest {
 
     @Test
     fun `NotEq query generates correct selection and arguments`() {
-        val query = Query.NotEq("age", "30").toSql()
+        val query = Query.StringNotEq("age", "30").toSql()
 
         assertThat(query.selection, equalTo("age != ?"))
         assertThat(query.selectionArgs, equalTo(arrayOf("30")))
@@ -24,8 +24,8 @@ class SqlQueryTest {
 
     @Test
     fun `And query generates correct selection and arguments`() {
-        val queryA = Query.Eq("name", "John")
-        val queryB = Query.NotEq("age", "30")
+        val queryA = Query.StringEq("name", "John")
+        val queryB = Query.StringNotEq("age", "30")
         val combinedQuery = Query.And(queryA, queryB).toSql()
 
         assertThat(combinedQuery.selection, equalTo("(name = ? AND age != ?)"))
@@ -34,8 +34,8 @@ class SqlQueryTest {
 
     @Test
     fun `Or query generates correct selection and arguments`() {
-        val queryA = Query.Eq("city", "New York")
-        val queryB = Query.NotEq("country", "Canada")
+        val queryA = Query.StringEq("city", "New York")
+        val queryB = Query.StringNotEq("country", "Canada")
         val combinedQuery = Query.Or(queryA, queryB).toSql()
 
         assertThat(combinedQuery.selection, equalTo("(city = ? OR country != ?)"))
@@ -44,9 +44,9 @@ class SqlQueryTest {
 
     @Test
     fun `nested And and Or queries generates correct selection and arguments`() {
-        val queryA = Query.Eq("status", "active")
-        val queryB = Query.NotEq("role", "admin")
-        val queryC = Query.Eq("team", "engineering")
+        val queryA = Query.StringEq("status", "active")
+        val queryB = Query.StringNotEq("role", "admin")
+        val queryC = Query.StringEq("team", "engineering")
 
         val combinedQuery = Query.And(Query.Or(queryA, queryB), queryC).toSql()
 

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -92,7 +92,13 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
 
         return if (candidate != null) {
             val child = candidate.nodeSide.steps[0].name.name
-            val value = candidate.evalContextSide(sourceInstance, evaluationContext) as String
+            var value = candidate.evalContextSide(sourceInstance, evaluationContext)
+
+            value = if (value is Double && value % 1 == 0.0) {
+                value.toInt().toString()
+            } else {
+                value.toString()
+            }
 
             if (predicate.isEqual) {
                 Query.Eq(child, value)

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -92,13 +92,7 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
 
         return if (candidate != null) {
             val child = candidate.nodeSide.steps[0].name.name
-            var value = candidate.evalContextSide(sourceInstance, evaluationContext)
-
-            value = if (value is Double && value % 1 == 0.0) {
-                value.toInt().toString()
-            } else {
-                value.toString()
-            }
+            val value = candidate.evalContextSide(sourceInstance, evaluationContext).toString()
 
             if (predicate.isEqual) {
                 Query.Eq(child, value)

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -92,12 +92,20 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
 
         return if (candidate != null) {
             val child = candidate.nodeSide.steps[0].name.name
-            val value = candidate.evalContextSide(sourceInstance, evaluationContext).toString()
+            val value = candidate.evalContextSide(sourceInstance, evaluationContext)
 
             if (predicate.isEqual) {
-                Query.Eq(child, value)
+                if (value is Double) {
+                    Query.NumericEq(child, value)
+                } else {
+                    Query.Eq(child, value.toString())
+                }
             } else {
-                Query.NotEq(child, value)
+                if (value is Double) {
+                    Query.NumericNotEq(child, value)
+                } else {
+                    Query.NotEq(child, value.toString())
+                }
             }
         } else {
             null

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -98,13 +98,13 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
                 if (value is Double) {
                     Query.NumericEq(child, value)
                 } else {
-                    Query.Eq(child, value.toString())
+                    Query.StringEq(child, value.toString())
                 }
             } else {
                 if (value is Double) {
                     Query.NumericNotEq(child, value)
                 } else {
-                    Query.NotEq(child, value.toString())
+                    Query.StringNotEq(child, value.toString())
                 }
             }
         } else {

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
@@ -38,7 +38,7 @@ class PullDataFunctionHandler(
             val filterChild = XPathFuncExpr.toString(args[2])
             val filterValue = XPathFuncExpr.toString(args[3])
 
-            instanceAdapter.query(instanceId, Query.Eq(filterChild, filterValue)).firstOrNull()
+            instanceAdapter.query(instanceId, Query.StringEq(filterChild, filterValue)).firstOrNull()
                 ?.getFirstChild(child)?.value?.value ?: ""
         } else {
             fallback?.eval(args, ec) ?: ""

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -56,8 +56,8 @@ class InMemEntitiesRepository : EntitiesRepository {
         }
 
         return when (query) {
-            is Query.Eq -> entities.filter { it.getFieldValue(query.column) == query.value }
-            is Query.NotEq -> entities.filter { it.getFieldValue(query.column) != query.value }
+            is Query.StringEq -> entities.filter { it.getFieldValue(query.column) == query.value }
+            is Query.StringNotEq -> entities.filter { it.getFieldValue(query.column) != query.value }
             is Query.NumericEq -> entities.filter { it.getFieldValue(query.column).toDoubleOrNull() == query.value }
             is Query.NumericNotEq -> entities.filter { it.getFieldValue(query.column).toDoubleOrNull() != query.value }
             is Query.And -> query(list, query.queryA).intersect(query(list, query.queryB)).toList()

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -58,7 +58,11 @@ class InMemEntitiesRepository : EntitiesRepository {
                             propertyName.first == query.column
                         }?.second ?: throw QueryException("No such column: ${query.column}")
                     }
-                    fieldName == query.value
+                    if (fieldName?.toDoubleOrNull() != null && query.value.toDoubleOrNull() != null) {
+                        fieldName.toDoubleOrNull() == query.value.toDoubleOrNull()
+                    } else {
+                        fieldName == query.value
+                    }
                 }
             }
             is Query.NotEq -> {
@@ -71,7 +75,11 @@ class InMemEntitiesRepository : EntitiesRepository {
                             propertyName.first == query.column
                         }?.second ?: throw QueryException("No such column: ${query.column}")
                     }
-                    fieldName != query.value
+                    if (fieldName?.toDoubleOrNull() != null && query.value.toDoubleOrNull() != null) {
+                        fieldName.toDoubleOrNull() != query.value.toDoubleOrNull()
+                    } else {
+                        fieldName != query.value
+                    }
                 }
             }
             is Query.And -> {

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -368,6 +368,59 @@ class LocalEntitiesFilterStrategyTest {
     }
 
     @Test
+    fun `works correctly in the optimized way with property = number`() {
+        entitiesRepository.save(
+            "things",
+            Entity.New(
+                "thing1",
+                "Thing1",
+                properties = listOf("age" to "25")
+            )
+        )
+
+        entitiesRepository.save(
+            "things",
+            Entity.New(
+                "thing2",
+                "Thing2",
+                properties = listOf("age" to "30")
+            )
+        )
+
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("question"),
+                            )
+                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
+                        bind("/data/question").type("string")
+                    )
+                ),
+                body(
+                    select1Dynamic(
+                        "/data/question",
+                        "instance('things')/root/item[age=25]",
+                        "name",
+                        "label"
+                    )
+                )
+            ),
+            controllerSupplier
+        )
+
+        val choices = scenario.choicesOf("/data/question").map { it.value }
+        assertThat(choices, containsInAnyOrder("thing1"))
+        assertThat(instanceProvider.fullParsePerformed, equalTo(false))
+    }
+
+    @Test
     fun `replaces partial elements when entity matches property`() {
         entitiesRepository.save(
             "things",

--- a/shared/src/main/java/org/odk/collect/shared/Query.kt
+++ b/shared/src/main/java/org/odk/collect/shared/Query.kt
@@ -1,15 +1,15 @@
 package org.odk.collect.shared
 
 import org.odk.collect.shared.Query.And
-import org.odk.collect.shared.Query.Eq
-import org.odk.collect.shared.Query.NotEq
 import org.odk.collect.shared.Query.NumericEq
 import org.odk.collect.shared.Query.NumericNotEq
 import org.odk.collect.shared.Query.Or
+import org.odk.collect.shared.Query.StringEq
+import org.odk.collect.shared.Query.StringNotEq
 
 sealed class Query {
-    class Eq(val column: String, val value: String) : Query()
-    class NotEq(val column: String, val value: String) : Query()
+    class StringEq(val column: String, val value: String) : Query()
+    class StringNotEq(val column: String, val value: String) : Query()
     class NumericEq(val column: String, val value: Double) : Query()
     class NumericNotEq(val column: String, val value: Double) : Query()
     class And(val queryA: Query, val queryB: Query) : Query()
@@ -18,8 +18,8 @@ sealed class Query {
 
 fun Query.mapColumns(columnMapper: (String) -> String): Query {
     return when (this) {
-        is Eq -> Eq(columnMapper(column), value)
-        is NotEq -> NotEq(columnMapper(column), value)
+        is StringEq -> StringEq(columnMapper(column), value)
+        is StringNotEq -> StringNotEq(columnMapper(column), value)
         is NumericEq -> NumericEq(columnMapper(column), value)
         is NumericNotEq -> NumericNotEq(columnMapper(column), value)
         is And -> And(

--- a/shared/src/main/java/org/odk/collect/shared/Query.kt
+++ b/shared/src/main/java/org/odk/collect/shared/Query.kt
@@ -3,11 +3,15 @@ package org.odk.collect.shared
 import org.odk.collect.shared.Query.And
 import org.odk.collect.shared.Query.Eq
 import org.odk.collect.shared.Query.NotEq
+import org.odk.collect.shared.Query.NumericEq
+import org.odk.collect.shared.Query.NumericNotEq
 import org.odk.collect.shared.Query.Or
 
 sealed class Query {
     class Eq(val column: String, val value: String) : Query()
     class NotEq(val column: String, val value: String) : Query()
+    class NumericEq(val column: String, val value: Double) : Query()
+    class NumericNotEq(val column: String, val value: Double) : Query()
     class And(val queryA: Query, val queryB: Query) : Query()
     class Or(val queryA: Query, val queryB: Query) : Query()
 }
@@ -16,6 +20,8 @@ fun Query.mapColumns(columnMapper: (String) -> String): Query {
     return when (this) {
         is Eq -> Eq(columnMapper(column), value)
         is NotEq -> NotEq(columnMapper(column), value)
+        is NumericEq -> NumericEq(columnMapper(column), value)
+        is NumericNotEq -> NumericNotEq(columnMapper(column), value)
         is And -> And(
             queryA.mapColumns(columnMapper),
             queryB.mapColumns(columnMapper)


### PR DESCRIPTION
Closes #6617 

#### Why is this the best possible solution? Were any other approaches considered?
When filters include numeric values like `age=25`, JavaRosa represents the number as a Double (`25.0`). However, SQLite requires arguments to be strings. To ensure correct comparisons in the database, we need to check if the Double value has a `.0` fractional part. If it does, we should first convert it to an Int and then to a String, resulting in `25` instead of `25.0`. This prevents issues caused by the redundant decimal part during value comparisons.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test filters with numbers like `age=25`. The form that is attached to the issue contains such a filter and that was the cause of the crash.

#### Do we need any specific form for testing your changes? If so, please attach one.
The from that is attached to the issue can be used.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
