### PR TITLE
Make the recovery dialog non-cancelable

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -119,6 +119,7 @@ class FormUriActivity : LocalizedActivity() {
         MaterialAlertDialogBuilder(this)
             .setTitle(string.savepoint_recovery_dialog_title)
             .setMessage(SimpleDateFormat(getString(string.savepoint_recovery_dialog_message), Locale.getDefault()).format(File(savepoint.savepointFilePath).lastModified()))
+            .setCancelable(false)
             .setPositiveButton(string.recover) { _, _ ->
                 val uri = intent.data!!
                 val uriMimeType = contentResolver.getType(uri)!!
@@ -131,7 +132,6 @@ class FormUriActivity : LocalizedActivity() {
             .setNegativeButton(string.do_not_recover) { _, _ ->
                 formUriViewModel.deleteSavepoint(savepoint)
             }
-            .setOnCancelListener { finish() }
             .create()
             .show()
     }

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -866,7 +866,7 @@ class FormUriActivityTest {
         launcherRule.launch<FormUriActivity>(getBlankFormIntent(project.uuid, form.dbId))
         fakeScheduler.flush()
 
-        assertSavepointRecoveryDialog(savepointFile)
+        assertNonCancelableSavepointRecoveryDialog(savepointFile)
     }
 
     @Test
@@ -898,7 +898,7 @@ class FormUriActivityTest {
         launcherRule.launch<FormUriActivity>(getSavedIntent(project.uuid, instance.dbId))
         fakeScheduler.flush()
 
-        assertSavepointRecoveryDialog(savepointFile)
+        assertNonCancelableSavepointRecoveryDialog(savepointFile)
     }
 
     @Test
@@ -930,7 +930,7 @@ class FormUriActivityTest {
         launcherRule.launch<FormUriActivity>(getBlankFormIntent(project.uuid, formV2.dbId))
         fakeScheduler.flush()
 
-        assertSavepointRecoveryDialog(savepointFile)
+        assertNonCancelableSavepointRecoveryDialog(savepointFile)
         onView(withText(org.odk.collect.strings.R.string.recover)).perform(click())
         assertStartBlankFormIntent(project.uuid, formV1.dbId)
     }
@@ -964,7 +964,7 @@ class FormUriActivityTest {
         launcherRule.launch<FormUriActivity>(getBlankFormIntent(project.uuid, formV2.dbId))
         fakeScheduler.flush()
 
-        assertSavepointRecoveryDialog(savepointFile)
+        assertNonCancelableSavepointRecoveryDialog(savepointFile)
         onView(withText(org.odk.collect.strings.R.string.do_not_recover)).perform(click())
         fakeScheduler.flush()
         assertStartBlankFormIntent(project.uuid, formV2.dbId)
@@ -992,7 +992,7 @@ class FormUriActivityTest {
         launcherRule.launch<FormUriActivity>(getBlankFormIntent(project.uuid, form.dbId))
         fakeScheduler.flush()
 
-        assertSavepointRecoveryDialog(savepointFile)
+        assertNonCancelableSavepointRecoveryDialog(savepointFile)
         onView(withText(org.odk.collect.strings.R.string.do_not_recover)).perform(click())
         fakeScheduler.flush()
         assertThat(savepointsRepository.getAll().isEmpty(), equalTo(true))
@@ -1031,7 +1031,7 @@ class FormUriActivityTest {
         launcherRule.launch<FormUriActivity>(getSavedIntent(project.uuid, instance.dbId))
         fakeScheduler.flush()
 
-        assertSavepointRecoveryDialog(savepointFile)
+        assertNonCancelableSavepointRecoveryDialog(savepointFile)
         onView(withText(org.odk.collect.strings.R.string.do_not_recover)).perform(click())
         fakeScheduler.flush()
         assertThat(savepointsRepository.getAll().isEmpty(), equalTo(true))
@@ -1263,7 +1263,8 @@ class FormUriActivityTest {
         }
     }
 
-    private fun assertSavepointRecoveryDialog(savepointFile: File) {
+    private fun assertNonCancelableSavepointRecoveryDialog(savepointFile: File) {
+        onView(isRoot()).perform(pressBack())
         onView(withText(org.odk.collect.strings.R.string.savepoint_recovery_dialog_title)).inRoot(isDialog()).check(matches(isDisplayed()))
         onView(withText(SimpleDateFormat(context.getString(org.odk.collect.strings.R.string.savepoint_recovery_dialog_message), Locale.getDefault()).format(savepointFile.lastModified()))).inRoot(isDialog()).check(matches(isDisplayed()))
         onView(withText(org.odk.collect.strings.R.string.recover)).inRoot(isDialog()).check(matches(isDisplayed()))


### PR DESCRIPTION
Closes #6616 

#### Why is this the best possible solution? Were any other approaches considered?
When we start opening a form with entities, we place a lock on the forms database to prevent downloading updates during form filling. This lock is removed when the form is closed. However, if a savepoint existed, we displayed a dialog after locking the database but before actually opening the form. As a result, if the user dismissed the dialog by clicking outside its area, the lock was never removed.

The simplest solution is to make the dialog non-cancelable, preventing this issue altogether. Another approach would be to remove the lock when the dialog is canceled, but is there any reason to keep it cancelable? I don't think so, which makes the first solution simpler.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think we can simply verify that the described issue no longer exists. Also, please check if making the recovery dialog non-cancelable causes any problems (I hope not but let's double-check). That should be sufficient.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with entities.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
