### PR TITLE
Carry form language selection over to new form version

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormsRepository.java
@@ -46,6 +46,7 @@ import org.odk.collect.shared.strings.Md5;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -170,6 +171,12 @@ public class DatabaseFormsRepository implements FormsRepository {
 
         if (form.getDbId() == null) {
             values.put(DATE, clock.get());
+
+            List<Form> existingFormsWithSameFormId = getAllByFormId(form.getFormId());
+            if (!existingFormsWithSameFormId.isEmpty()) {
+                Form latestFormWithSameFormId = Collections.max(existingFormsWithSameFormId, Comparator.comparing(Form::getDate));
+                values.put(LANGUAGE, latestFormWithSameFormId.getLanguage());
+            }
 
             Long idFromUri = insertForm(values);
             if (idFromUri == -1) {

--- a/forms-test/src/main/java/org/odk/collect/formstest/FormsRepositoryTest.java
+++ b/forms-test/src/main/java/org/odk/collect/formstest/FormsRepositoryTest.java
@@ -252,6 +252,25 @@ public abstract class FormsRepositoryTest {
     }
 
     @Test
+    public void save_withNewFormVersion_copiesLanguageFromLatestFormVersion() {
+        FormsRepository formsRepository = buildSubject();
+
+        Form formV1 = formsRepository.save(FormUtils.buildForm("id", "1", getFormFilesPath()).build());
+        formsRepository.save(new Form.Builder(formV1)
+                .language("Spanish")
+                .build());
+
+        Form formV2 = formsRepository.save(FormUtils.buildForm(formV1.getFormId(), "2", getFormFilesPath()).build());
+        formsRepository.save(new Form.Builder(formV2)
+                .language("Polish")
+                .build());
+
+        Form formV3 = formsRepository.save(FormUtils.buildForm(formV1.getFormId(), "3", getFormFilesPath()).build());
+
+        assertThat(formsRepository.get(formV3.getDbId()).getLanguage(), is("Polish"));
+    }
+
+    @Test
     public void delete_deletesFiles() throws Exception {
         FormsRepository formsRepository = buildSubject();
         Form form = formsRepository.save(FormUtils.buildForm("id", "version", getFormFilesPath()).build());

--- a/forms-test/src/main/java/org/odk/collect/formstest/InMemFormsRepository.java
+++ b/forms-test/src/main/java/org/odk/collect/formstest/InMemFormsRepository.java
@@ -11,6 +11,7 @@ import org.odk.collect.shared.TempFiles;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -139,6 +140,12 @@ public class InMemFormsRepository implements FormsRepository {
 
             if (form.getJrCacheFilePath() == null) {
                 builder.jrCacheFilePath(TempFiles.getPathInTempDir(hash, ".formdef"));
+            }
+
+            List<Form> existingFormsWithSameFormId = getAllByFormId(form.getFormId());
+            if (!existingFormsWithSameFormId.isEmpty()) {
+                Form latestFormWithSameFormId = Collections.max(existingFormsWithSameFormId, Comparator.comparing(Form::getDate));
+                builder.language(latestFormWithSameFormId.getLanguage());
             }
 
             Form formToSave = builder.build();


### PR DESCRIPTION
Closes #6579

#### Why is this the best possible solution? Were any other approaches considered?
I don’t think there’s anything significant to discuss here. We just need to check if the form we’re saving in our database is a new version of an existing one, and if so, copy the language.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only change is copying the selected language when saving an updated version of an existing form. Please test cases with multiple forms to ensure the language copied to the new form comes from the latest version. For example:  
- Form v1: selected language – Spanish  
- Form v2: selected language – Polish  

After downloading Form v3, the language should be Polish, not Spanish.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with more than 1 language I've used: 
[languageTest.xlsx](https://github.com/user-attachments/files/18932148/languageTest.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
