### PR TITLE
Fixed sorting saved forms

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModel.kt
@@ -43,21 +43,10 @@ class SavedFormListViewModel(
         .map { instances -> instances.filter { instance -> instance.deletedDate == null } }
         .combine(_sortOrder) { instances, order ->
             when (order) {
-                SortOrder.NAME_DESC -> {
-                    instances.sortedByDescending { it.displayName }
-                }
-
-                SortOrder.DATE_DESC -> {
-                    instances.sortedByDescending { it.lastStatusChangeDate }
-                }
-
-                SortOrder.NAME_ASC -> {
-                    instances.sortedBy { it.displayName }
-                }
-
-                SortOrder.DATE_ASC -> {
-                    instances.sortedBy { it.lastStatusChangeDate }
-                }
+                SortOrder.NAME_DESC -> instances.sortedByDescending { it.displayName.lowercase() }
+                SortOrder.DATE_DESC -> instances.sortedByDescending { it.lastStatusChangeDate }
+                SortOrder.NAME_ASC -> instances.sortedBy { it.displayName.lowercase() }
+                SortOrder.DATE_ASC -> instances.sortedBy { it.lastStatusChangeDate }
             }
         }.combine(_filterText) { instances, filter ->
             instances.filter { it.displayName.contains(filter, ignoreCase = true) }

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/savedformlist/SavedFormListViewModelTest.kt
@@ -110,9 +110,10 @@ class SavedFormListViewModelTest {
 
     @Test
     fun `can sort forms by ascending name`() {
-        val a = InstanceFixtures.instance(displayName = "A")
+        val aa = InstanceFixtures.instance(displayName = "Aa")
+        val ab = InstanceFixtures.instance(displayName = "ab")
         val b = InstanceFixtures.instance(displayName = "B")
-        saveForms("projectId", listOf(b, a),)
+        saveForms("projectId", listOf(b, aa, ab),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -120,15 +121,16 @@ class SavedFormListViewModelTest {
         viewModel.sortOrder = SortOrder.NAME_ASC
         assertThat(
             viewModel.formsToDisplay.getOrAwaitValue(scheduler),
-            contains(a, b)
+            contains(aa, ab, b)
         )
     }
 
     @Test
     fun `can sort forms by descending name`() {
-        val a = InstanceFixtures.instance(displayName = "A")
+        val aa = InstanceFixtures.instance(displayName = "Aa")
+        val ab = InstanceFixtures.instance(displayName = "ab")
         val b = InstanceFixtures.instance(displayName = "B")
-        saveForms("projectId", listOf(a, b),)
+        saveForms("projectId", listOf(b, aa, ab),)
 
         val viewModel =
             SavedFormListViewModel(scheduler, settings, instancesDataService, "projectId")
@@ -136,7 +138,7 @@ class SavedFormListViewModelTest {
         viewModel.sortOrder = SortOrder.NAME_DESC
         assertThat(
             viewModel.formsToDisplay.getOrAwaitValue(scheduler),
-            contains(b, a)
+            contains(b, ab, aa)
         )
     }
 


### PR DESCRIPTION
Closes #6603 

#### Why is this the best possible solution? Were any other approaches considered?
The fix uses the same approach we already use for blank forms - we call `lowercase() `to make sorting case-insensitive.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
All we need here is to test the sorting of saved forms. We can focus on testing name sorting (A–Z and Z–A), nothing else has changed.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
