### PR TITLE
Add hidden-answer appearance for string with external app

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.widgets;
 
+import static org.odk.collect.android.utilities.Appearances.hasAppearance;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
 import android.annotation.SuppressLint;
@@ -124,6 +125,9 @@ public class ExStringWidget extends QuestionWidget implements WidgetDataReceiver
                 this::widgetValueChanged
         );
         binding.widgetAnswerText.setAnswer(getFormEntryPrompt().getAnswerText());
+        if (hasAppearance(getFormEntryPrompt(), Appearances.HIDDEN_ANSWER)) {
+            binding.widgetAnswerText.setVisibility(GONE);
+        }
 
         return binding.getRoot();
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
@@ -7,19 +7,28 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAppearance;
 
 import android.text.InputType;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.support.MockFormEntryPromptBuilder;
+import org.odk.collect.android.support.WidgetTestActivity;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
+import org.odk.collect.android.widgets.support.QuestionWidgetHelpers;
 import org.odk.collect.android.widgets.utilities.StringRequester;
 
 import java.text.NumberFormat;
@@ -100,5 +109,26 @@ public class ExDecimalWidgetTest extends GeneralExStringWidgetTest<ExDecimalWidg
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED | InputType.TYPE_NUMBER_FLAG_DECIMAL));
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), equalTo(null));
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
+    }
+
+    @Override
+    @Test
+    public void whenPromptHasHiddenAnswerAppearance_answerIsNotDisplayed() {
+        FormEntryPrompt prompt = new MockFormEntryPromptBuilder(promptWithAppearance(Appearances.HIDDEN_ANSWER))
+                .withAnswer(new DecimalData(10.5))
+                .build();
+
+        WidgetTestActivity widgetTestActivity = QuestionWidgetHelpers.widgetTestActivity();
+        ExDecimalWidget widget = new ExDecimalWidget(widgetTestActivity, new QuestionDetails(prompt),
+                new FakeWaitingForDataRegistry(), stringRequester);
+
+        // Check initial value is not shown
+        assertThat(widget.binding.widgetAnswerText.getVisibility(), Matchers.equalTo(View.GONE));
+        assertThat(widget.getAnswer(), CoreMatchers.equalTo(new DecimalData(10.5)));
+
+        // Check updates aren't shown
+        widget.setData(15.5);
+        assertThat(widget.binding.widgetAnswerText.getVisibility(), Matchers.equalTo(View.GONE));
+        assertThat(widget.getAnswer(), CoreMatchers.equalTo(new DecimalData(15.5)));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
@@ -5,18 +5,26 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.THOUSANDS_SEP;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAppearance;
 
 import android.text.InputType;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 
+import org.hamcrest.Matchers;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.IntegerData;
+import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.support.MockFormEntryPromptBuilder;
+import org.odk.collect.android.support.WidgetTestActivity;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
+import org.odk.collect.android.widgets.support.QuestionWidgetHelpers;
 import org.odk.collect.android.widgets.utilities.StringRequester;
 
 /**
@@ -74,5 +82,26 @@ public class ExIntegerWidgetTest extends GeneralExStringWidgetTest<ExIntegerWidg
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getInputType(), equalTo(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED));
         assertThat(widget.binding.widgetAnswerText.getBinding().editText.getTransformationMethod(), equalTo(null));
         assertThat(widget.binding.widgetAnswerText.getBinding().textView.getTransformationMethod(), equalTo(null));
+    }
+
+    @Override
+    @Test
+    public void whenPromptHasHiddenAnswerAppearance_answerIsNotDisplayed() {
+        FormEntryPrompt prompt = new MockFormEntryPromptBuilder(promptWithAppearance(Appearances.HIDDEN_ANSWER))
+                .withAnswer(new IntegerData(10))
+                .build();
+
+        WidgetTestActivity widgetTestActivity = QuestionWidgetHelpers.widgetTestActivity();
+        ExIntegerWidget widget = new ExIntegerWidget(widgetTestActivity, new QuestionDetails(prompt),
+                new FakeWaitingForDataRegistry(), stringRequester);
+
+        // Check initial value is not shown
+        assertThat(widget.binding.widgetAnswerText.getVisibility(), Matchers.equalTo(View.GONE));
+        assertThat(widget.getAnswer(), equalTo(new IntegerData(10)));
+
+        // Check updates aren't shown
+        widget.setData(15);
+        assertThat(widget.binding.widgetAnswerText.getVisibility(), Matchers.equalTo(View.GONE));
+        assertThat(widget.getAnswer(), equalTo(new IntegerData(15)));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExStringWidgetTest.java
@@ -6,12 +6,16 @@ import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.StringData;
+import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.support.MockFormEntryPromptBuilder;
+import org.odk.collect.android.support.WidgetTestActivity;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.base.GeneralExStringWidgetTest;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
+import org.odk.collect.android.widgets.support.QuestionWidgetHelpers;
 import org.odk.collect.android.widgets.utilities.StringRequester;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,9 +25,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.Appearances.MASKED;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAppearance;
 
 import android.text.InputType;
 import android.text.method.PasswordTransformationMethod;
+import android.view.View;
 
 /**
  * @author James Knight
@@ -89,5 +95,26 @@ public class ExStringWidgetTest extends GeneralExStringWidgetTest<ExStringWidget
     public void whenNumberOfRowsSpecifiedEditTextShouldHaveProperNumberOfMinLines() {
         when(questionDef.getAdditionalAttribute(null, "rows")).thenReturn("5");
         assertThat(getWidget().binding.widgetAnswerText.getBinding().editText.getMinLines(), equalTo(5));
+    }
+
+    @Override
+    @Test
+    public void whenPromptHasHiddenAnswerAppearance_answerIsNotDisplayed() {
+        FormEntryPrompt prompt = new MockFormEntryPromptBuilder(promptWithAppearance(Appearances.HIDDEN_ANSWER))
+                .withAnswer(new StringData("original contents"))
+                .build();
+
+        WidgetTestActivity widgetTestActivity = QuestionWidgetHelpers.widgetTestActivity();
+        ExStringWidget widget = new ExStringWidget(widgetTestActivity, new QuestionDetails(prompt),
+                new FakeWaitingForDataRegistry(), stringRequester);
+
+        // Check initial value is not shown
+        assertThat(widget.binding.widgetAnswerText.getVisibility(), equalTo(View.GONE));
+        assertThat(widget.getAnswer(), equalTo(new StringData("original contents")));
+
+        // Check updates aren't shown
+        widget.setData("updated contents");
+        assertThat(widget.binding.widgetAnswerText.getVisibility(), equalTo(View.GONE));
+        assertThat(widget.getAnswer(), equalTo(new StringData("updated contents")));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
@@ -88,4 +88,7 @@ public abstract class GeneralExStringWidgetTest<W extends ExStringWidget, A exte
 
     @Test
     public abstract void verifyInputType();
+
+    @Test
+    public abstract void whenPromptHasHiddenAnswerAppearance_answerIsNotDisplayed();
 }


### PR DESCRIPTION
Closes #6572 

#### Why is this the best possible solution? Were any other approaches considered?
There’s not much to discuss here. We hide the answer when the new appearance is used, similar to how it works with the barcode widget.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It simply adds a new appearance, allowing us to focus primarily on testing it to ensure answers are hidden.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with external widgets (string/integer/decimal) and the new appearance. I've used:
[external_widgets_hidden.xlsx](https://github.com/user-attachments/files/18950210/external_widgets_hidden.xlsx)
[external_widgets.xlsx](https://github.com/user-attachments/files/18950211/external_widgets.xlsx)
which work with [CollectAnswersProvider](https://github.com/grzesiek2010/CollectAnswersProvider)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
https://github.com/getodk/docs/issues/1922

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
