### PR TITLE
Don't create/update entities with non-relevant `save_to`

### DIFF
--- a/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.java
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.java
@@ -11,12 +11,12 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.form.api.FormEntryFinalizationProcessor;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.model.xform.XPathReference;
+import org.odk.collect.entities.javarosa.parse.EntityFormExtra;
 import org.odk.collect.entities.javarosa.spec.EntityAction;
 import org.odk.collect.entities.javarosa.spec.EntityFormParser;
-import org.odk.collect.entities.javarosa.parse.EntityFormExtra;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import kotlin.Pair;
 
@@ -47,16 +47,20 @@ public class EntityFormFinalizationProcessor implements FormEntryFinalizationPro
     }
 
     private FormEntity createEntity(TreeElement entityElement, String dataset, List<Pair<XPathReference, String>> saveTos, FormInstance mainInstance, EntityAction action) {
-        List<Pair<String, String>> fields = saveTos.stream().map(saveTo -> {
+        ArrayList<Pair<String, String>> fields = new ArrayList<>();
+        for (Pair<XPathReference, String> saveTo : saveTos) {
             IDataReference reference = saveTo.getFirst();
-            IAnswerData answerData = mainInstance.resolveReference(reference).getValue();
+            TreeElement element = mainInstance.resolveReference(reference);
 
-            if (answerData != null) {
-                return new Pair<>(saveTo.getSecond(), answerData.uncast().getString());
-            } else {
-                return new Pair<>(saveTo.getSecond(), "");
+            if (element.isRelevant()) {
+                IAnswerData answerData = element.getValue();
+                if (answerData != null) {
+                    fields.add(new Pair<>(saveTo.getSecond(), answerData.uncast().getString()));
+                } else {
+                    fields.add(new Pair<>(saveTo.getSecond(), ""));
+                }
             }
-        }).collect(Collectors.toList());
+        }
 
         String id = EntityFormParser.parseId(entityElement);
         String label = EntityFormParser.parseLabel(entityElement);


### PR DESCRIPTION
Closes #6634

#### Why is this the best possible solution? Were any other approaches considered?

This just adds a check for relevance to the code that generates the properties for the entity create/update.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Aside from the case in the issue, check for other times when relevance would affect `save_to` questions (like group relevance for instance) would be good. As far as I can tell, the opposite problem (data not being included when a `save_to` becomes relevant) is not present, but that's probably also worth playing with.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
