### PR TITLE
Fix metadata parsing for main instances with attributes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/FormDownloadException.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/FormDownloadException.kt
@@ -5,7 +5,7 @@ import org.odk.collect.forms.FormSourceException
 sealed class FormDownloadException : Exception() {
     class DownloadingInterrupted : FormDownloadException()
     class FormWithNoHash : FormDownloadException()
-    class FormParsingError : FormDownloadException()
+    class FormParsingError(val original: Exception) : FormDownloadException()
     class DiskError : FormDownloadException()
     class InvalidSubmission : FormDownloadException()
     class FormSourceError(val exception: FormSourceException) : FormDownloadException()

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/FormDownloadExceptionMapper.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/FormDownloadExceptionMapper.kt
@@ -15,11 +15,9 @@ class FormDownloadExceptionMapper(private val context: Context) {
                 )
             }
             is FormDownloadException.FormParsingError -> {
-                context.getLocalizedString(
-                    org.odk.collect.strings.R.string.form_parsing_error
-                ) + ": ${exception.original.message}. " + context.getLocalizedString(
-                    org.odk.collect.strings.R.string.report_to_project_lead
-                )
+                context.getLocalizedString(org.odk.collect.strings.R.string.form_parsing_error) +
+                    "\n\n${exception.original.getStackTraceString(1)}\n\n" +
+                    context.getLocalizedString(org.odk.collect.strings.R.string.report_to_project_lead)
             }
             is FormDownloadException.DiskError -> {
                 context.getLocalizedString(
@@ -42,5 +40,10 @@ class FormDownloadExceptionMapper(private val context: Context) {
                 context.getLocalizedString(org.odk.collect.strings.R.string.report_to_project_lead)
             }
         }
+    }
+
+    private fun Exception.getStackTraceString(lines: Int): String {
+        val stackTrace = this.stackTrace
+        return "${this.message}\n${stackTrace.take(lines).joinToString("\n") { it.toString() }}"
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/FormDownloadExceptionMapper.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/FormDownloadExceptionMapper.kt
@@ -17,7 +17,7 @@ class FormDownloadExceptionMapper(private val context: Context) {
             is FormDownloadException.FormParsingError -> {
                 context.getLocalizedString(
                     org.odk.collect.strings.R.string.form_parsing_error
-                ) + " " + context.getLocalizedString(
+                ) + ": ${exception.original.message}. " + context.getLocalizedString(
                     org.odk.collect.strings.R.string.report_to_project_lead
                 )
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
@@ -128,7 +128,7 @@ public class ServerFormDownloader implements FormDownloader {
 
                 Timber.i("Parse finished in %.3f seconds.", (System.currentTimeMillis() - start) / 1000F);
             } catch (RuntimeException e) {
-                throw new FormDownloadException.FormParsingError();
+                throw new FormDownloadException.FormParsingError(e);
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParser.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParser.kt
@@ -19,21 +19,10 @@ object FormMetadataParser {
         val body = doc.getRootElement().getElement(null, "body")
         val title = head.getElement(null, "title").getChild(0).toString()
 
-        lateinit var mainInstanceRoot: Element
-        var submission: Element? = null
-        for (i in 0 until model.childCount) {
-            val child = model.getElement(i) ?: continue
-
-            if (child.name == "instance" && child.attributeCount == 0) {
-                for (j in 0 until child.childCount) {
-                    val mainInstanceChild = child.getElement(j) ?: continue
-                    mainInstanceRoot = mainInstanceChild
-                    break
-                }
-            } else if (child.name == "submission") {
-                submission = child
-            }
-        }
+        val modelElements = getChildren(model)
+        val mainInstance = modelElements.first { it.name == "instance" }
+        val mainInstanceRoot = getChildren(mainInstance).first()
+        val submission = modelElements.firstOrNull { it.name == "submission" }
 
         val id = mainInstanceRoot.getAttributeValue(null, "id")
         val version = mainInstanceRoot.getAttributeValue(null, "version")
@@ -55,6 +44,17 @@ object FormMetadataParser {
             geometryXPath,
             isEntityForm
         )
+    }
+
+    private fun getChildren(element: Element): List<Element> {
+        return 0.until(element.childCount).fold(emptyList()) { list, i ->
+            val child = element.getElement(i)
+            if (child != null) {
+                list + listOf(child)
+            } else {
+                list
+            }
+        }
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/FormDownloadExceptionMapperTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/FormDownloadExceptionMapperTest.kt
@@ -35,9 +35,9 @@ class FormDownloadExceptionMapperTest {
     fun formParsingError_returnsFormParsingErrorMessage() {
         val expectedString = context.getString(
             org.odk.collect.strings.R.string.form_parsing_error
-        ) + " " + context.getString(org.odk.collect.strings.R.string.report_to_project_lead)
+        ) + ": blah. " + context.getString(org.odk.collect.strings.R.string.report_to_project_lead)
         assertThat(
-            mapper.getMessage(FormDownloadException.FormParsingError()),
+            mapper.getMessage(FormDownloadException.FormParsingError(RuntimeException("blah"))),
             `is`(expectedString)
         )
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/FormDownloadExceptionMapperTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/download/FormDownloadExceptionMapperTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.`is`
 import org.junit.Before
 import org.junit.Test
@@ -33,12 +34,20 @@ class FormDownloadExceptionMapperTest {
 
     @Test
     fun formParsingError_returnsFormParsingErrorMessage() {
-        val expectedString = context.getString(
-            org.odk.collect.strings.R.string.form_parsing_error
-        ) + ": blah. " + context.getString(org.odk.collect.strings.R.string.report_to_project_lead)
+        val original = Exception("original message")
+        original.stackTrace = arrayOf(
+            StackTraceElement("Class", "method", "File", 1),
+            StackTraceElement("Class", "method", "File", 2)
+        )
+
         assertThat(
-            mapper.getMessage(FormDownloadException.FormParsingError(RuntimeException("blah"))),
-            `is`(expectedString)
+            mapper.getMessage(FormDownloadException.FormParsingError(original)),
+            equalTo(
+                context.getString(org.odk.collect.strings.R.string.form_parsing_error) + "\n\n" +
+                    original.message + "\n" +
+                    "Class.method(File:1)" + "\n\n" +
+                    context.getString(org.odk.collect.strings.R.string.report_to_project_lead)
+            )
         )
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParserTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParserTest.kt
@@ -6,6 +6,33 @@ import org.junit.Test
 import org.odk.collect.android.formmanagement.metadata.FormMetadataParser.readMetadata
 
 class FormMetadataParserTest {
+
+    @Test
+    fun readMetadata_canParseWithAttributesOnMainInstance() {
+        val metadata = readMetadata(
+            """
+                <?xml version="1.0"?>
+                <h:html xmlns:h="http://www.w3.org/1999/xhtml"
+                        xmlns="http://www.w3.org/2002/xforms"
+                        xmlns:custom="http://example.com/custom">
+                    <h:head>
+                        <h:title>Form</h:title>
+                        <model>
+                            <instance custom:attribute="blah">
+                                <data id="form">
+                                </data>
+                            </instance>
+                        </model>
+                    </h:head>
+                    <h:body>
+                    </h:body>
+                </h:html>
+            """.trimIndent().byteInputStream()
+        )
+
+        assertThat(metadata.id, equalTo("form"))
+    }
+
     @Test
     fun readMetadata_canParseFormsWithComments() {
         readMetadata(

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParserTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/metadata/FormMetadataParserTest.kt
@@ -34,6 +34,31 @@ class FormMetadataParserTest {
     }
 
     @Test
+    fun readMetadata_canParseWithXformsNamespace() {
+        val metadata = readMetadata(
+            """
+                <?xml version="1.0"?>
+                <h:html xmlns:h="http://www.w3.org/1999/xhtml"
+                        xmlns:custom="http://www.w3.org/2002/xforms">
+                    <h:head>
+                        <h:title>Form</h:title>
+                        <custom:model>
+                            <custom:instance>
+                                <custom:data custom:id="form">
+                                </custom:data>
+                            </custom:instance>
+                        </custom:model>
+                    </h:head>
+                    <h:body>
+                    </h:body>
+                </h:html>
+            """.trimIndent().byteInputStream()
+        )
+
+        assertThat(metadata.id, equalTo("form"))
+    }
+
+    @Test
     fun readMetadata_canParseFormsWithComments() {
         readMetadata(
             """

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FormsDownloadResultInterpreterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FormsDownloadResultInterpreterTest.kt
@@ -25,7 +25,7 @@ class FormsDownloadResultInterpreterTest {
 
     private var resultWithOneError = mapOf<ServerFormDetails, FormDownloadException?>(
         formDetails1 to null,
-        formDetails2 to FormDownloadException.FormParsingError()
+        formDetails2 to FormDownloadException.FormParsingError(RuntimeException())
     )
 
     @Test

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -748,7 +748,7 @@
     <string name="form_with_no_hash_error">The server did not provide a hash for this form.</string>
 
     <!-- Displayed in error dialog for form downloads. Followed by instructions to talk to person who asked to collect data -->
-    <string name="form_parsing_error">This form cannot be processed</string>
+    <string name="form_parsing_error">This form cannot be processed:</string>
 
     <!-- Displayed in error dialog for form downloads. Followed by instructions to talk to person who asked to collect data -->
     <string name="form_save_disk_error">A disk error occurred on device while downloading this form.</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -748,7 +748,7 @@
     <string name="form_with_no_hash_error">The server did not provide a hash for this form.</string>
 
     <!-- Displayed in error dialog for form downloads. Followed by instructions to talk to person who asked to collect data -->
-    <string name="form_parsing_error">This form cannot be processed.</string>
+    <string name="form_parsing_error">This form cannot be processed</string>
 
     <!-- Displayed in error dialog for form downloads. Followed by instructions to talk to person who asked to collect data -->
     <string name="form_save_disk_error">A disk error occurred on device while downloading this form.</string>


### PR DESCRIPTION
Fixes [this forum post issue](https://forum.getodk.org/t/form-with-attachments-broken-since-v2025-1-0-custom-openrosa-backend/54050/15)

#### Why is this the best possible solution? Were any other approaches considered?

This both fixes the issue and improves the error message that users would see for a similar problem.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

To reproduce the issue from the forum, you just need to add an attribute (like `foo="bar"`) to the primary/first `instance` node of any form and then attempt to download it in Collect.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
