### PR TITLE
Fix back button handling in hierarchy view

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormHierarchyTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormHierarchyTest.java
@@ -269,4 +269,17 @@ public class FormHierarchyTest {
                 .clickOnText("what is your age")
                 .assertOnPage(new ViewFormPage("One Question"));
     }
+
+    @Test
+    public void clickingBackButtonAfterNavigatingInTheHierarchyOfGroups_movesToTheQuestionDisplayedBeforeOpeningTheHierarchy() {
+        rule.startAtMainMenu()
+                .copyForm("two-questions-in-group.xml")
+                .startBlankForm("two-questions-in-group")
+                .clickGoToArrow()
+                .clickGoUpIcon()
+                .clickOnGroup("Name")
+                .pressBack(new FormEntryPage("two-questions-in-group"))
+                .assertQuestion("First name")
+                .assertNoQuestion("Last name");
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -252,7 +252,12 @@ abstract class Page<T : Page<T>> {
     }
 
     fun clickOnText(text: String): T {
-        Interactions.clickOn(withText(text))
+        Interactions.clickOn(
+            allOf(
+                withText(text),
+                withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)
+            )
+        )
         return this as T
     }
 

--- a/test-forms/src/main/resources/forms/two-questions-in-group.xml
+++ b/test-forms/src/main/resources/forms/two-questions-in-group.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<h:html
+    xmlns="http://www.w3.org/2002/xforms"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:odk="http://www.opendatakit.org/xforms">
+    <h:head>
+        <h:title>two-questions-in-group</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="two-questions-in-group">
+                    <group>
+                        <first_name/>
+                        <last_name/>
+                    </group>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/group/first_name" type="string"/>
+            <bind nodeset="/data/group/last_name" type="string"/>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/data/group">
+            <label>Name</label>
+            <input ref="/data/group/first_name">
+                <label>First name</label>
+            </input>
+            <input ref="/data/group/last_name">
+                <label>Last name</label>
+            </input>
+        </group>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #6648 

#### Why is this the best possible solution? Were any other approaches considered?
I've restored the code that I believe was accidentally removed in [#6516](https://github.com/getodk/collect/pull/6516/files#diff-ce4484cfdc66208619e30e9d2a79a90f6c63d2537087ca9f0d3032b06f4ffa13L206) and added tests to ensure it doesn't happen again.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue. I can't think of anything that could be at risk due to the changes I made. Please test navigation in complex forms with nested groups using the back button, and that should be sufficient.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with groups, nested groups, repeats etc.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
