### PR TITLE
Fix support for servers that have already introduced type to manifest

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
@@ -235,6 +235,7 @@ class EntityFormTest {
 
     @Test
     fun aLocallyCreatedEntity_thatIsDeletedOnTheServer_isNotAvailableToFollowUpForms() {
+        testDependencies.server.includeIntegrityUrl()
         testDependencies.server.addForm("one-question-entity-registration-id.xml")
         testDependencies.server.addForm(
             "one-question-entity-update.xml",

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
@@ -54,6 +54,7 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
      */
     private final List<File> submittedForms = new ArrayList<>();
     private List<String> deletedEntities = new ArrayList<>();
+    private boolean includeIntegrityUrl;
 
     @NonNull
     @Override
@@ -180,6 +181,10 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
         randomHash = true;
     }
 
+    public void includeIntegrityUrl() {
+        includeIntegrityUrl = true;
+    }
+
     public String getURL() {
         return "https://" + HOST;
     }
@@ -298,7 +303,7 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
                 stringBuilder
                         .append("<downloadUrl>" + getURL() + "/mediaFile/" + formID + "/" + mediaFile.getId() + "</downloadUrl>\n");
 
-                if (mediaFile instanceof EntityListItem) {
+                if (mediaFile instanceof EntityListItem && includeIntegrityUrl) {
                     stringBuilder.append("<integrityUrl>" + getURL() + "/integrityUrl</integrityUrl>\n");
                 }
 

--- a/open-rosa/src/main/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParser.kt
+++ b/open-rosa/src/main/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParser.kt
@@ -226,10 +226,6 @@ object Kxml2OpenRosaResponseParser :
                 }
 
                 val isEntityList = type == "entityList"
-                if (isEntityList && integrityUrl == null) {
-                    return null
-                }
-
                 files.add(MediaFile(filename, hash, downloadUrl, isEntityList, integrityUrl))
             }
         }

--- a/open-rosa/src/test/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParserTest.kt
+++ b/open-rosa/src/test/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParserTest.kt
@@ -3,6 +3,7 @@ package org.odk.collect.openrosa.parse
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.javarosa.xform.parse.XFormParser
+import org.junit.Ignore
 import org.junit.Test
 import org.kxml2.kdom.Document
 
@@ -156,6 +157,7 @@ class Kxml2OpenRosaResponseParserTest {
     }
 
     @Test
+    @Ignore("This would break servers that had implemented type before integrityUrl was added to the spec. https://forum.getodk.org/t/openrosa-spec-proposal-support-offline-entities/48052/2")
     fun `#parseManifest returns null if a media file with type entityList is missing integrityUrl`() {
         val response = """
             <?xml version='1.0' encoding='UTF-8' ?>


### PR DESCRIPTION
Closes #6652

#### Why is this the best possible solution? Were any other approaches considered?

This just removes the strict check for `integrityUrl` that was added in the original implementation. I've left the test there (but with an `@Ignore`) while we discuss if that check should be added back in some way.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix entities on older versions of Central (and any other servers that have implemented entities).

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
