### PR TITLE
Fixed clearing errors

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredQuestionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredQuestionTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.odk.collect.android.support.StorageUtils.getAuditLogForFirstInstance
+import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 import org.odk.collect.strings.R
@@ -42,6 +43,17 @@ class RequiredQuestionTest {
             .copyForm("required_question_with_custom_error_message.xml")
             .startBlankForm("required_question_with_custom_error_message")
             .swipeToNextQuestionWithConstraintViolation("Custom message")
+    }
+
+    @Test
+    fun errorMessageDisappearsAfterActivityRecreation() {
+        rule.startAtMainMenu()
+            .copyForm("required_question_with_custom_error_message.xml")
+            .startBlankForm("required_question_with_custom_error_message")
+            .swipeToNextQuestionWithConstraintViolation("Custom message")
+            .rotateToLandscape(FormEntryPage("required_question_with_custom_error_message"))
+            .rotateToPortrait(FormEntryPage("required_question_with_custom_error_message"))
+            .assertTextDoesNotExist("Custom message")
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredQuestionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredQuestionTest.kt
@@ -52,7 +52,6 @@ class RequiredQuestionTest {
             .startBlankForm("required_question_with_custom_error_message")
             .swipeToNextQuestionWithConstraintViolation("Custom message")
             .rotateToLandscape(FormEntryPage("required_question_with_custom_error_message"))
-            .rotateToPortrait(FormEntryPage("required_question_with_custom_error_message"))
             .assertTextDoesNotExist("Custom message")
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/WidgetAnswerText.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/views/WidgetAnswerText.kt
@@ -63,6 +63,7 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
             binding.editText.transformationMethod = PasswordTransformationMethod.getInstance()
             binding.textView.transformationMethod = PasswordTransformationMethod.getInstance()
         }
+        setError(null)
     }
 
     fun updateState(readOnly: Boolean) {
@@ -166,7 +167,9 @@ class WidgetAnswerText(context: Context, attrs: AttributeSet?) : FrameLayout(con
     }
 
     fun setError(error: String?) {
-        binding.textInputLayout.error = error
+        binding.textInputLayout.post {
+            binding.textInputLayout.error = error
+        }
     }
 
     fun setFocus(focus: Boolean) {


### PR DESCRIPTION
Closes #6508 

#### Why is this the best possible solution? Were any other approaches considered?
It seems that Android might be retaining the error, possibly through the text field ID, and keeps it displayed after the view is recreated. To resolve this, we need to programmatically clear the error during the view creation process.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue but please make sure errors are displayed and cleared correctly in text questions.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form from the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
