### PR TITLE
Add `AsyncPage` for generically handling intermediary states

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AsyncPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AsyncPage.kt
@@ -1,0 +1,11 @@
+package org.odk.collect.android.support.pages
+
+import org.odk.collect.testshared.WaitFor
+
+class AsyncPage<T : Page<T>>(private val destination: T) : Page<T>() {
+    override fun assertOnPage(): T {
+        return WaitFor.waitFor {
+            destination.assertOnPage()
+        }
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/BulkFinalizationConfirmationDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/BulkFinalizationConfirmationDialogPage.kt
@@ -21,7 +21,7 @@ class BulkFinalizationConfirmationDialogPage(private val count: Int) : Page<Bulk
     }
 
     fun clickFinalize(): EditSavedFormPage {
-        return this.clickOnTextInDialog(R.string.finalize, EditSavedFormPage())
+        return this.clickOnTextInDialog(R.string.finalize, AsyncPage(EditSavedFormPage()))
     }
 
     fun clickCancel(): EditSavedFormPage {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -295,11 +295,11 @@ abstract class Page<T : Page<T>> {
         return clickOnTextInDialog(getTranslatedString(text))
     }
 
-    fun <D : Page<D>> clickOnTextInDialog(text: Int, destination: D): D {
+    fun <D : Page<D>> clickOnTextInDialog(text: Int, destination: Page<D>): D {
         return clickOnTextInDialog(getTranslatedString(text), destination)
     }
 
-    fun <D : Page<D>> clickOnTextInDialog(text: String, destination: D): D {
+    fun <D : Page<D>> clickOnTextInDialog(text: String, destination: Page<D>): D {
         clickOnTextInDialog(text)
         return destination.assertOnPage()
     }
@@ -582,6 +582,10 @@ abstract class Page<T : Page<T>> {
     fun assertNoId(id: Int): T {
         onView(withId(id)).check(doesNotExist())
         return this as T
+    }
+
+    fun async(): AsyncPage<T> {
+        return AsyncPage(this as T)
     }
 
     companion object {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/CollectTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/CollectTestRule.kt
@@ -85,7 +85,7 @@ class CollectTestRule @JvmOverloads constructor(
         actions: Consumer<T>
     ): Instrumentation.ActivityResult {
         val scenario = launchForResult<Activity>(intent)
-        destination.assertOnPage()
+        destination.async().assertOnPage()
         actions.accept(destination)
         return scenario.result
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
@@ -68,7 +68,7 @@ open class FormEntryActivityTestRule :
     fun editForm(formFilename: String, instanceName: String): FormHierarchyPage {
         intent = createEditFormIntent(formFilename)
         scenario = ActivityScenario.launch(intent)
-        return FormHierarchyPage(instanceName).assertOnPage()
+        return FormHierarchyPage(instanceName).async().assertOnPage()
     }
 
     fun editFormWithSavepoint(formFilename: String): SavepointRecoveryDialogPage {


### PR DESCRIPTION
We've seen some flakes on CI's `nightly` build over the last week that all look like they are related to assertions running too early. 

In theory, Espresso's [Idling Resource](https://developer.android.com/training/testing/espresso/idling-resource) system should prevent this, but in practice it seems to not cover all cases. We've done our best to make sure async work within our control uses `IdlingResource` to provide synchronization for tests, but I suspect that there are parts of the Android SDK that are incompatible as it doesn't seem like the Idling Resource concept is something Google will continue to embrace (https://medium.com/androiddevelopers/alternatives-to-idling-resources-in-compose-tests-8ae71f9fc473).

Here I've added a generic way for to make a `Page` use a "wait" pattern using its `assertOnPage` and used it in the places we've seen tests fail due to early asserting. Long term, we might want to embrace this more widely and start to remove Idling Resource entirely (although they still add helpful hints to prevent waits needing to be used).