### PR TITLE
Fixed parsing the doc with deleted entities

### DIFF
--- a/open-rosa/src/main/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParser.kt
+++ b/open-rosa/src/main/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParser.kt
@@ -240,11 +240,15 @@ object Kxml2OpenRosaResponseParser :
 
         try {
             val entities = data.getElement(null, "entities")
-            return 0.until(entities.childCount).map {
-                val entity = entities.getElement(null, "entity")
-                val deleted = entity.getElement(null, "deleted").getChild(0) as String
-                EntityIntegrity(entity.getAttributeValue(null, "id"), deleted.toBooleanStrict())
-            }
+            val entitiesList = 0.until(entities.childCount)
+                .map { entities.getElement(it) }
+                .filter { it.name == "entity" }
+                .map {
+                    val deleted = it.getElement(null, "deleted").getChild(0) as String
+                    EntityIntegrity(it.getAttributeValue(null, "id"), deleted.toBooleanStrict())
+                }
+
+            return entitiesList.takeIf { it.isNotEmpty() }
         } catch (e: RuntimeException) {
             return null
         }

--- a/open-rosa/src/test/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParserTest.kt
+++ b/open-rosa/src/test/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParserTest.kt
@@ -248,4 +248,30 @@ class Kxml2OpenRosaResponseParserTest {
             assertThat("The following should not be parsed:\n$it\n\n", response, equalTo(null))
         }
     }
+
+    @Test
+    fun `#parseIntegrityResponse returns list of deleted entities when the response contains multiple entities`() {
+        val integrityDoc = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <data>
+                <entities>
+                    <entity id="1">
+                        <deleted>true</deleted>
+                    </entity>
+                    <entity id="2">
+                        <deleted>true</deleted>
+                    </entity>
+                </entities>
+            </data>
+        """.trimIndent()
+
+        val doc = XFormParser.getXMLDocument(integrityDoc.reader())
+        val response = Kxml2OpenRosaResponseParser.parseIntegrityResponse(doc)!!
+
+        assertThat(response.size, equalTo(2))
+        assertThat(response[0].id, equalTo("1"))
+        assertThat(response[0].deleted, equalTo(true))
+        assertThat(response[1].id, equalTo("2"))
+        assertThat(response[1].deleted, equalTo(true))
+    }
 }


### PR DESCRIPTION
Closes #6667 

#### Why is this the best possible solution? Were any other approaches considered?
The implementation of parsing the document was incorrect. If the document contained multiple `<entity>` children, an exception was thrown due to the way we tried to retrieve those children one by one.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The issue occurred when there was more than one deleted entity. Please test such scenarios. I don't think there is any big risk here.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
