### PR TITLE
Use higher memory footprint for build_instrumented

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
 
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-compile.properties ~/.gradle/gradle.properties
 
       - run:
           name: Assemble connected test build

--- a/.circleci/gradle-compile.properties
+++ b/.circleci/gradle-compile.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=-Xmx3g -Dkotlin.compiler.execution.strategy="in-process"
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.workers.max=2
+test.heap.max=512m

--- a/.circleci/gradle-compile.properties
+++ b/.circleci/gradle-compile.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx3g -Dkotlin.compiler.execution.strategy="in-process"
 org.gradle.daemon=false
 org.gradle.parallel=true
-org.gradle.workers.max=2
+org.gradle.workers.max=3
 test.heap.max=512m


### PR DESCRIPTION
Closes #

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/docs/CONTRIBUTING.md
-->

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [ ] added or modified tests for any new or changed behavior
- [ ] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [ ] added a comment above any new strings describing it for translators
- [ ] added any new strings with date formatting to `DateFormatsTest`
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
