### PR TITLE
Handle integrity responses that contain an empty list of entities

### DIFF
--- a/open-rosa/src/main/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParser.kt
+++ b/open-rosa/src/main/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParser.kt
@@ -248,7 +248,7 @@ object Kxml2OpenRosaResponseParser :
                     EntityIntegrity(it.getAttributeValue(null, "id"), deleted.toBooleanStrict())
                 }
 
-            return entitiesList.takeIf { it.isNotEmpty() }
+            return entitiesList
         } catch (e: RuntimeException) {
             return null
         }

--- a/open-rosa/src/test/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParserTest.kt
+++ b/open-rosa/src/test/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParserTest.kt
@@ -198,17 +198,6 @@ class Kxml2OpenRosaResponseParserTest {
             </data>
         """.trimIndent()
 
-        val noEntity = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <data>
-                <entities>
-                    <thing id="958e00b2-43f5-4d21-8adb-3d27aaa045f5">
-                        <deleted>true</deleted>
-                    </thing>
-                </entities>
-            </data>
-        """.trimIndent()
-
         val noDeleted = """
             <?xml version="1.0" encoding="UTF-8"?>
             <data>
@@ -242,7 +231,7 @@ class Kxml2OpenRosaResponseParserTest {
             </data>
         """.trimIndent()
 
-        listOf(noData, noEntities, noEntity, noDeleted, emptyDeleted, invalidDeleted).forEach {
+        listOf(noData, noEntities, noDeleted, emptyDeleted, invalidDeleted).forEach {
             val doc = XFormParser.getXMLDocument(it.reader())
             val response = Kxml2OpenRosaResponseParser.parseIntegrityResponse(doc)
             assertThat("The following should not be parsed:\n$it\n\n", response, equalTo(null))
@@ -273,5 +262,22 @@ class Kxml2OpenRosaResponseParserTest {
         assertThat(response[0].deleted, equalTo(true))
         assertThat(response[1].id, equalTo("2"))
         assertThat(response[1].deleted, equalTo(true))
+    }
+
+    @Test
+    fun `#parseIntegrityResponse returns an empty list if the response has no entities`() {
+        val integrityDoc = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <data>
+                <entities>
+
+                </entities>
+            </data>
+        """.trimIndent()
+
+        val doc = XFormParser.getXMLDocument(integrityDoc.reader())
+        val response = Kxml2OpenRosaResponseParser.parseIntegrityResponse(doc)!!
+
+        assertThat(response.isEmpty(), equalTo(true))
     }
 }


### PR DESCRIPTION
Closes #6679

#### Why is this the best possible solution? Were any other approaches considered?
It turns out that Central can send a document without any deleted entities. I'm not sure if that's the intended behavior, but we should handle it in Collect.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should simply fix the issue. I can't think of any specific cases that might be affected, but you already know there could be similar scenarios, so proceed with caution.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
