### PR TITLE
Don't show unexpected decimals for range slider value

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeBaseWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeBaseWidget.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.widgets.range;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.material.slider.Slider;
+
+import org.javarosa.core.model.data.DecimalData;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.IntegerData;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.views.TrackingTouchSlider;
+import org.odk.collect.android.widgets.QuestionWidget;
+import org.odk.collect.android.widgets.utilities.RangeWidgetUtils;
+
+import java.math.BigDecimal;
+
+@SuppressLint("ViewConstructor")
+public class RangeBaseWidget extends QuestionWidget implements Slider.OnChangeListener {
+    private final boolean isIntegerType;
+    TrackingTouchSlider slider;
+    TextView currentValue;
+
+    protected RangeBaseWidget(Context context,
+                              QuestionDetails prompt,
+                              Dependencies dependencies,
+                              boolean isIntegerType) {
+        super(context, dependencies, prompt);
+        this.isIntegerType = isIntegerType;
+        render();
+    }
+
+    @Override
+    protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
+        RangeWidgetUtils.RangeWidgetLayoutElements layoutElements = RangeWidgetUtils.setUpLayoutElements(context, prompt);
+        slider = layoutElements.getSlider();
+        currentValue = layoutElements.getCurrentValue();
+
+        setUpActualValueLabel(RangeWidgetUtils.setUpSlider(prompt, slider, true));
+
+        if (slider.isEnabled()) {
+            slider.setListener(this);
+        }
+        return layoutElements.getAnswerView();
+    }
+
+    @Override
+    public IAnswerData getAnswer() {
+        String stringAnswer = currentValue.getText().toString();
+        return stringAnswer.isEmpty() ? null
+                : isIntegerType ? new IntegerData(Integer.parseInt(stringAnswer))
+                : new DecimalData(Double.parseDouble(stringAnswer));
+    }
+
+    @Override
+    public void setOnLongClickListener(OnLongClickListener l) {
+    }
+
+    @Override
+    public boolean shouldSuppressFlingGesture() {
+        return slider.isTrackingTouch();
+    }
+
+    @Override
+    public void clearAnswer() {
+        setUpActualValueLabel(null);
+        widgetValueChanged();
+    }
+
+    @SuppressLint("RestrictedApi")
+    @Override
+    public void onValueChange(@NonNull Slider slider, float value, boolean fromUser) {
+        if (fromUser) {
+            setUpActualValueLabel(RangeWidgetUtils.getActualValue(getFormEntryPrompt(), value));
+            widgetValueChanged();
+        }
+    }
+
+    private void setUpActualValueLabel(BigDecimal actualValue) {
+        if (actualValue != null) {
+            currentValue.setText(
+                    isIntegerType ? String.valueOf(actualValue.intValue())
+                            : String.valueOf(actualValue)
+            );
+        } else {
+            currentValue.setText("");
+            slider.reset();
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeBaseWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeBaseWidget.java
@@ -57,7 +57,8 @@ public class RangeBaseWidget extends QuestionWidget implements Slider.OnChangeLi
         slider = layoutElements.getSlider();
         currentValue = layoutElements.getCurrentValue();
 
-        setUpActualValueLabel(RangeWidgetUtils.setUpSlider(prompt, slider, true));
+        BigDecimal set = RangeWidgetUtils.setUpSlider(prompt, slider, isIntegerType);
+        setUpActualValueLabel(set == null ? null : set.floatValue());
 
         if (slider.isEnabled()) {
             slider.setListener(this);
@@ -97,7 +98,7 @@ public class RangeBaseWidget extends QuestionWidget implements Slider.OnChangeLi
         }
     }
 
-    private void setUpActualValueLabel(BigDecimal actualValue) {
+    private void setUpActualValueLabel(Float actualValue) {
         if (actualValue != null) {
             currentValue.setText(
                     isIntegerType ? String.valueOf(actualValue.intValue())

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeDecimalWidget.java
@@ -18,91 +18,14 @@ package org.odk.collect.android.widgets.range;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.view.View;
-import android.widget.TextView;
 
-import androidx.annotation.NonNull;
-
-import com.google.android.material.slider.Slider;
-
-import org.javarosa.core.model.data.DecimalData;
-import org.javarosa.core.model.data.IAnswerData;
-import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.views.TrackingTouchSlider;
-import org.odk.collect.android.widgets.QuestionWidget;
-import org.odk.collect.android.widgets.utilities.RangeWidgetUtils;
-
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 @SuppressLint("ViewConstructor")
-public class RangeDecimalWidget extends QuestionWidget implements Slider.OnChangeListener {
-    TrackingTouchSlider slider;
-    TextView currentValue;
-
-    public RangeDecimalWidget(Context context, QuestionDetails prompt, Dependencies dependencies) {
-        super(context, dependencies, prompt);
-        render();
-    }
-
-    @Override
-    protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
-        RangeWidgetUtils.RangeWidgetLayoutElements layoutElements = RangeWidgetUtils.setUpLayoutElements(context, prompt);
-        slider = layoutElements.getSlider();
-        currentValue = layoutElements.getCurrentValue();
-
-        setUpActualValueLabel(RangeWidgetUtils.setUpSlider(prompt, slider, false));
-
-        if (slider.isEnabled()) {
-            slider.setListener(this);
-        }
-        return layoutElements.getAnswerView();
-    }
-
-    @Override
-    public IAnswerData getAnswer() {
-        String stringAnswer = currentValue.getText().toString();
-        return stringAnswer.isEmpty() ? null : new DecimalData(Double.parseDouble(stringAnswer));
-    }
-
-    @Override
-    public void setOnLongClickListener(OnLongClickListener l) {
-    }
-
-    @Override
-    public boolean shouldSuppressFlingGesture() {
-        return slider.isTrackingTouch();
-    }
-
-    @Override
-    public void clearAnswer() {
-        setUpActualValueLabel(null);
-        widgetValueChanged();
-    }
-
-    @SuppressLint("RestrictedApi")
-    @Override
-    public void onValueChange(@NonNull Slider slider, float value, boolean fromUser) {
-        if (fromUser) {
-            BigDecimal actualValue = RangeWidgetUtils.getActualValue(getFormEntryPrompt(), value);
-            setUpActualValueLabel(actualValue);
-            widgetValueChanged();
-        }
-    }
-
-    private void setUpActualValueLabel(BigDecimal actualValue) {
-        if (actualValue != null) {
-            double doubleValue;
-            if (slider.getStepSize() < 1) {
-                doubleValue = actualValue.setScale(3, RoundingMode.HALF_UP).doubleValue();
-            } else {
-                doubleValue = actualValue.doubleValue();
-            }
-            currentValue.setText(String.valueOf(doubleValue));
-        } else {
-            currentValue.setText("");
-            slider.reset();
-        }
+public class RangeDecimalWidget extends RangeBaseWidget {
+    public RangeDecimalWidget(Context context,
+                              QuestionDetails prompt,
+                              Dependencies dependencies) {
+        super(context, prompt, dependencies, false);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeDecimalWidget.java
@@ -34,6 +34,7 @@ import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.utilities.RangeWidgetUtils;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @SuppressLint("ViewConstructor")
 public class RangeDecimalWidget extends QuestionWidget implements Slider.OnChangeListener {
@@ -92,7 +93,13 @@ public class RangeDecimalWidget extends QuestionWidget implements Slider.OnChang
 
     private void setUpActualValueLabel(BigDecimal actualValue) {
         if (actualValue != null) {
-            currentValue.setText(String.valueOf(actualValue.doubleValue()));
+            double doubleValue;
+            if (slider.getStepSize() < 1) {
+                doubleValue = actualValue.setScale(3, RoundingMode.HALF_UP).doubleValue();
+            } else {
+                doubleValue = actualValue.doubleValue();
+            }
+            currentValue.setText(String.valueOf(doubleValue));
         } else {
             currentValue.setText("");
             slider.reset();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeIntegerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeIntegerWidget.java
@@ -18,84 +18,14 @@ package org.odk.collect.android.widgets.range;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.view.View;
-import android.widget.TextView;
 
-import androidx.annotation.NonNull;
-
-import com.google.android.material.slider.Slider;
-
-import org.javarosa.core.model.data.IAnswerData;
-import org.javarosa.core.model.data.IntegerData;
-import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.views.TrackingTouchSlider;
-import org.odk.collect.android.widgets.QuestionWidget;
-import org.odk.collect.android.widgets.utilities.RangeWidgetUtils;
-
-import java.math.BigDecimal;
 
 @SuppressLint("ViewConstructor")
-public class RangeIntegerWidget extends QuestionWidget implements Slider.OnChangeListener {
-    TrackingTouchSlider slider;
-    TextView currentValue;
-
-    public RangeIntegerWidget(Context context, QuestionDetails prompt, Dependencies dependencies) {
-        super(context, dependencies, prompt);
-        render();
-    }
-
-    @Override
-    protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
-        RangeWidgetUtils.RangeWidgetLayoutElements layoutElements = RangeWidgetUtils.setUpLayoutElements(context, prompt);
-        slider = layoutElements.getSlider();
-        currentValue = layoutElements.getCurrentValue();
-
-        setUpActualValueLabel(RangeWidgetUtils.setUpSlider(prompt, slider, true));
-
-        if (slider.isEnabled()) {
-            slider.setListener(this);
-        }
-        return layoutElements.getAnswerView();
-    }
-
-    @Override
-    public IAnswerData getAnswer() {
-        String stringAnswer = currentValue.getText().toString();
-        return stringAnswer.isEmpty() ? null : new IntegerData(Integer.parseInt(stringAnswer));
-    }
-
-    @Override
-    public void setOnLongClickListener(OnLongClickListener l) {
-    }
-
-    @Override
-    public boolean shouldSuppressFlingGesture() {
-        return slider.isTrackingTouch();
-    }
-
-    @Override
-    public void clearAnswer() {
-        setUpActualValueLabel(null);
-        widgetValueChanged();
-    }
-
-    @SuppressLint("RestrictedApi")
-    @Override
-    public void onValueChange(@NonNull Slider slider, float value, boolean fromUser) {
-        if (fromUser) {
-            BigDecimal actualValue = RangeWidgetUtils.getActualValue(getFormEntryPrompt(), value);
-            setUpActualValueLabel(actualValue);
-            widgetValueChanged();
-        }
-    }
-
-    private void setUpActualValueLabel(BigDecimal actualValue) {
-        if (actualValue != null) {
-            currentValue.setText(String.valueOf(actualValue.intValue()));
-        } else {
-            currentValue.setText("");
-            slider.reset();
-        }
+public class RangeIntegerWidget extends RangeBaseWidget {
+    public RangeIntegerWidget(Context context,
+                              QuestionDetails prompt,
+                              Dependencies dependencies) {
+        super(context, prompt, dependencies, true);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
@@ -15,8 +15,8 @@ import org.odk.collect.android.databinding.RangePickerWidgetAnswerBinding;
 import org.odk.collect.android.databinding.RangeWidgetHorizontalBinding;
 import org.odk.collect.android.databinding.RangeWidgetVerticalBinding;
 import org.odk.collect.android.fragments.dialogs.NumberPickerDialog;
-import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.android.views.TrackingTouchSlider;
+import org.odk.collect.androidshared.ui.ToastUtils;
 
 import java.math.BigDecimal;
 
@@ -167,17 +167,16 @@ public class RangeWidgetUtils {
         }
     }
 
-    public static BigDecimal getActualValue(FormEntryPrompt prompt, float value) {
+    public static Float getActualValue(FormEntryPrompt prompt, float value) {
         RangeQuestion rangeQuestion = (RangeQuestion) prompt.getQuestion();
-        BigDecimal rangeStart = rangeQuestion.getRangeStart();
-        BigDecimal rangeEnd = rangeQuestion.getRangeEnd();
-        BigDecimal actualValue = BigDecimal.valueOf(value);
+        Float rangeStart = rangeQuestion.getRangeStart().floatValue();
+        Float rangeEnd = rangeQuestion.getRangeEnd().floatValue();
 
         if (rangeEnd.compareTo(rangeStart) < 0) {
-            actualValue = rangeEnd.add(rangeStart).subtract(actualValue);
+            value = rangeEnd + rangeStart - value;
         }
 
-        return actualValue;
+        return value;
     }
 
     public static void showNumberPickerDialog(FragmentActivity activity, String[] displayedValuesForNumberPicker, int id, int progress) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeDecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeDecimalWidgetTest.java
@@ -1,5 +1,19 @@
 package org.odk.collect.android.widgets.range;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.mockValueChangedListener;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithQuestionDefAndAnswer;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithReadOnlyAndQuestionDef;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.widgetDependencies;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.widgetTestActivity;
+
 import android.view.View;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -17,20 +31,6 @@ import org.odk.collect.testshared.SliderExtKt;
 
 import java.math.BigDecimal;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.mockValueChangedListener;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithQuestionDefAndAnswer;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithReadOnlyAndQuestionDef;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.widgetDependencies;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.widgetTestActivity;
-
 @RunWith(AndroidJUnit4.class)
 public class RangeDecimalWidgetTest {
     private static final String NO_TICKS_APPEARANCE = "no-ticks";
@@ -42,7 +42,7 @@ public class RangeDecimalWidgetTest {
         rangeQuestion = mock(RangeQuestion.class);
         when(rangeQuestion.getRangeStart()).thenReturn(BigDecimal.valueOf(1.5));
         when(rangeQuestion.getRangeEnd()).thenReturn(BigDecimal.valueOf(5.5));
-        when(rangeQuestion.getRangeStep()).thenReturn(BigDecimal.valueOf(0.5));
+        when(rangeQuestion.getRangeStep()).thenReturn(BigDecimal.valueOf(0.1));
     }
 
     @Test
@@ -213,6 +213,14 @@ public class RangeDecimalWidgetTest {
         SliderExtKt.clickOnMaxValue(widget.slider);
 
         assertThat(widget.currentValue.getText(), equalTo("5.5"));
+    }
+
+    @Test
+    public void changingSliderValueToAnIntermediate_setsTheValueCorrectly() {
+        RangeDecimalWidget widget = createWidget(promptWithQuestionDefAndAnswer(rangeQuestion, null));
+
+        SliderExtKt.clickOnFractionalValue(widget.slider, 0.3f);
+        assertThat(widget.currentValue.getText(), equalTo("2.3"));
     }
 
     private RangeDecimalWidget createWidget(FormEntryPrompt prompt) {

--- a/test-shared/src/main/java/org/odk/collect/testshared/SliderExt.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/SliderExt.kt
@@ -11,6 +11,10 @@ fun Slider.clickOnMaxValue() {
     clickOnPosition(width.toFloat())
 }
 
+fun Slider.clickOnFractionalValue(fraction: Float) {
+    clickOnPosition(width.toFloat() * fraction)
+}
+
 fun Slider.clickOnPosition(xPosition: Float) {
     val currentTime = System.currentTimeMillis()
 


### PR DESCRIPTION
Fixes #6424

#### Why is this the best possible solution? Were any other approaches considered?
Code improvement seems to fix issue; see _Design detail_ below. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Issue behaviour has disappeared; passes new and all existing tests. 

#### Do we need any specific form for testing your changes? If so, please attach one.
[6424.xml.txt](https://github.com/user-attachments/files/19870439/6424.xml.txt) demonstrates issue and fix.  

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)

## Design detail
In `RangeDecimalWidget`, `setUpActualValueLabel` checks the slider `stepSize` and if less than 1 applies `BigDecimal`.`setScale` to `actualValue`; parameter `newScale` is set to 3 to allow a one-eighth step ie 0.125.

In `RangeDecimalWidgetTest`, `setup` enables trapping the issue by setting `getRangeStep` to return 0.1, which doesn't affect any of the existing tests. 

New `changingSliderValueToAnIntermediate_setsTheValueCorrectly` is modelled on `changingSliderValueToAnyOtherThanTheMinOne_setsTheValueCorrectly`. By calling new `clickOnFractionalValue` in `SliderExt` it sets a value that traps the issue.
