### PR TITLE
Log deserialization problems as errors

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalizableFormDefCache.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalizableFormDefCache.java
@@ -91,7 +91,7 @@ public final class ExternalizableFormDefCache implements FormDefCache {
             } catch (Exception e) {
                 // New .formdef will be created from XML
                 Timber.w("Deserialization FAILED! Deleting cache file: %s", cachedForm.getAbsolutePath());
-                Timber.w(e);
+                Timber.e(e, "Deserialization FAILED!");
                 cachedForm.delete();
             }
         }


### PR DESCRIPTION
Work towards #6658

#### Why is this the best possible solution? Were any other approaches considered?
I've been trying to reproduce the issue described in #6658, but without success. This is the third issue we've identified that's related to problems reading forms from the cache (see #6658), though I suspect there are more. The challenge is that these issues are grouped together with OOM errors in reports, which makes it hard to isolate them and determine how common they actually are. To improve visibility and help us better understand their severity, I've changed the logging level for these issues from warnings to errors.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
