### PR TITLE
Consolidate null application component crashes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.dynamicpreload.ExternalDataManager;
@@ -200,6 +201,7 @@ public class Collect extends Application implements
         defaultSysLanguage = newConfig.locale.getLanguage();
     }
 
+    @Nullable
     public AppDependencyComponent getComponent() {
         return applicationComponent;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/DaggerUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/DaggerUtils.java
@@ -24,10 +24,6 @@ public final class DaggerUtils {
 
     private DaggerUtils() {}
 
-    public static AppDependencyComponent getComponent(Activity activity) {
-        return ((Collect) activity.getApplication()).getComponent();
-    }
-
     public static AppDependencyComponent getComponent(Context context) {
         return ((Collect) context.getApplicationContext()).getComponent();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/DaggerUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/DaggerUtils.kt
@@ -21,6 +21,11 @@ object DaggerUtils {
 
     @JvmStatic
     fun getComponent(context: Context): AppDependencyComponent {
-        return (context.applicationContext as Collect).component
+        val component = (context.applicationContext as Collect).component
+        if (component != null) {
+            return component
+        } else {
+            throw IllegalStateException("Collect.applicationComponent is null!")
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/DaggerUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/DaggerUtils.kt
@@ -11,20 +11,16 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+package org.odk.collect.android.injection
 
-package org.odk.collect.android.injection;
+import android.content.Context
+import org.odk.collect.android.application.Collect
+import org.odk.collect.android.injection.config.AppDependencyComponent
 
-import android.app.Activity;
-import android.content.Context;
+object DaggerUtils {
 
-import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.injection.config.AppDependencyComponent;
-
-public final class DaggerUtils {
-
-    private DaggerUtils() {}
-
-    public static AppDependencyComponent getComponent(Context context) {
-        return ((Collect) context.getApplicationContext()).getComponent();
+    @JvmStatic
+    fun getComponent(context: Context): AppDependencyComponent {
+        return (context.applicationContext as Collect).component
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragmentTest.kt
@@ -23,7 +23,7 @@ import org.odk.collect.settings.keys.ProjectKeys
 class FormMetadataPreferencesFragmentTest {
     private val installIDProvider = mock<InstallIDProvider>()
     private val settingsProvider =
-        ApplicationProvider.getApplicationContext<Collect>().component.settingsProvider()
+        ApplicationProvider.getApplicationContext<Collect>().component!!.settingsProvider()
 
     @get:Rule
     var launcherRule = FragmentScenarioLauncherRule()


### PR DESCRIPTION
This is just a small change to make crashes like [this](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/17da39807fcf3fa16c94cf1f648fa5f4?time=last-ninety-days&sessionEventKey=68036D21021500017ECB51B2D2504313_2073399801261791416) all collect in one place so they'll be easier to reason about.