### PR TITLE
Don't download already downloaded entity lists

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
@@ -1,8 +1,6 @@
 package org.odk.collect.android.feature.formentry
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -335,21 +333,5 @@ class EntityFormTest {
             .startBlankForm("One Question Entity Update")
             .assertText("Romulus Roy")
             .assertTextDoesNotExist("Roman Roy")
-    }
-
-    @Test
-    fun whenTwoFormsShareTheSameEntityList_itIsOnlyDownloadedOnce() {
-        testDependencies.server.addForm(
-            "one-question-entity-update.xml",
-            listOf(EntityListItem("people.csv"))
-        )
-
-        testDependencies.server.addForm(
-            "one-question-entity-follow-up.xml",
-            listOf(EntityListItem("people.csv"))
-        )
-
-        rule.withMatchExactlyProject(testDependencies.server.url)
-        assertThat(testDependencies.server.accesses, equalTo(6))
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
@@ -1,6 +1,8 @@
 package org.odk.collect.android.feature.formentry
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -333,5 +335,21 @@ class EntityFormTest {
             .startBlankForm("One Question Entity Update")
             .assertText("Romulus Roy")
             .assertTextDoesNotExist("Roman Roy")
+    }
+
+    @Test
+    fun whenTwoFormsShareTheSameEntityList_itIsOnlyDownloadedOnce() {
+        testDependencies.server.addForm(
+            "one-question-entity-update.xml",
+            listOf(EntityListItem("people.csv"))
+        )
+
+        testDependencies.server.addForm(
+            "one-question-entity-follow-up.xml",
+            listOf(EntityListItem("people.csv"))
+        )
+
+        rule.withMatchExactlyProject(testDependencies.server.url)
+        assertThat(testDependencies.server.accesses, equalTo(6))
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.kt
@@ -44,11 +44,16 @@ class StubOpenRosaServer : OpenRosaHttpInterface {
     val submissions: List<File>
         get() = submittedForms
 
+    var accesses = 0
+        private set
+
     override fun executeGetRequest(
         uri: URI,
         contentType: String?,
         credentials: HttpCredentialsInterface
     ): HttpGetResult {
+        accesses += 1
+
         if (alwaysReturnError) {
             return HttpGetResult(null, HashMap(), "", 500)
         }
@@ -91,6 +96,8 @@ class StubOpenRosaServer : OpenRosaHttpInterface {
         uri: URI,
         credentials: HttpCredentialsInterface
     ): HttpHeadResult {
+        accesses += 1
+
         if (alwaysReturnError) {
             return HttpHeadResult(500, CaseInsensitiveEmptyHeaders())
         }
@@ -116,6 +123,8 @@ class StubOpenRosaServer : OpenRosaHttpInterface {
         credentials: HttpCredentialsInterface,
         contentLength: Long
     ): HttpPostResult {
+        accesses += 1
+
         if (alwaysReturnError) {
             return HttpPostResult("", 500, "")
         }

--- a/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/entities/DatabaseEntitiesRepository.kt
@@ -144,17 +144,24 @@ class DatabaseEntitiesRepository(context: Context, dbPath: String) : EntitiesRep
 
     override fun updateList(list: String, hash: String, needsApproval: Boolean) {
         val contentValues = ContentValues().also {
+            it.put(ListsTable.COLUMN_NAME, list)
             it.put(ListsTable.COLUMN_HASH, hash)
             it.put(ListsTable.COLUMN_NEEDS_APPROVAL, if (needsApproval) 1 else 0)
         }
 
-        databaseConnection.withConnection {
-            writableDatabase.update(
-                ListsTable.TABLE_NAME,
-                contentValues,
-                "${ListsTable.COLUMN_NAME} = ?",
-                arrayOf(list)
-            )
+        if (listExists(list)) {
+            databaseConnection.withConnection {
+                writableDatabase.update(
+                    ListsTable.TABLE_NAME,
+                    contentValues,
+                    "${ListsTable.COLUMN_NAME} = ?",
+                    arrayOf(list)
+                )
+            }
+        } else {
+            databaseConnection.withConnection {
+                writableDatabase.insert(ListsTable.TABLE_NAME, null, contentValues)
+            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -88,10 +88,11 @@ object ServerFormUseCases {
 
             val tempMediaFile = File(tempMediaDir, mediaFile.filename)
 
-            if (mediaFile.type != null) {
+            val isEntityList = mediaFile.type != null
+            if (isEntityList) {
                 val entityListName = getEntityListFromFileName(mediaFile)
-                val entityList = entitiesRepository.getList(entityListName)
-                if (entityList == null || mediaFile.hash != entityList.hash) {
+                val localEntityList = entitiesRepository.getList(entityListName)
+                if (localEntityList == null || mediaFile.hash != localEntityList.hash) {
                     downloadMediaFile(formSource, mediaFile, tempMediaFile, tempDir, stateListener)
                     newAttachmentsDownloaded = true
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -168,11 +168,6 @@ object ServerFormUseCases {
      * these CSVs are being used as part of a `select_one_from_file` question, the
      * instance ID will be the file name with the extension removed.
      */
-    /**
-     * Track CSVs that have names that clash with entity lists in the project. If
-     * these CSVs are being used as part of a `select_one_from_file` question, the
-     * instance ID will be the file name with the extension removed.
-     */
     private fun logEntityListClashes(
         mediaFile: MediaFile,
         entitiesRepository: EntitiesRepository

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -91,7 +91,7 @@ object ServerFormUseCases {
             if (mediaFile.type != null) {
                 val entityListName = getEntityListFromFileName(mediaFile)
                 val entityList = entitiesRepository.getList(entityListName)
-                if (entityList == null || mediaFile.hash != entityList.hash?.substringAfter(":")) {
+                if (entityList == null || mediaFile.hash != entityList.hash) {
                     val file = formSource.fetchMediaFile(mediaFile.downloadUrl)
                     FileUtils.interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
                     newAttachmentsDownloaded = true

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -92,8 +92,7 @@ object ServerFormUseCases {
                 val entityListName = getEntityListFromFileName(mediaFile)
                 val entityList = entitiesRepository.getList(entityListName)
                 if (entityList == null || mediaFile.hash != entityList.hash) {
-                    val file = formSource.fetchMediaFile(mediaFile.downloadUrl)
-                    FileUtils.interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
+                    downloadMediaFile(formSource, mediaFile, tempMediaFile, tempDir, stateListener)
                     newAttachmentsDownloaded = true
 
                     /**
@@ -122,16 +121,26 @@ object ServerFormUseCases {
                             FileUtils.copyFile(it, tempMediaFile)
                         } else {
                             val existingFileHash = it.getMd5Hash()
-                            val file = formSource.fetchMediaFile(mediaFile.downloadUrl)
-                            FileUtils.interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
+                            downloadMediaFile(
+                                formSource,
+                                mediaFile,
+                                tempMediaFile,
+                                tempDir,
+                                stateListener
+                            )
 
                             if (!tempMediaFile.getMd5Hash().contentEquals(existingFileHash)) {
                                 newAttachmentsDownloaded = true
                             }
                         }
                     } else {
-                        val file = formSource.fetchMediaFile(mediaFile.downloadUrl)
-                        FileUtils.interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
+                        downloadMediaFile(
+                            formSource,
+                            mediaFile,
+                            tempMediaFile,
+                            tempDir,
+                            stateListener
+                        )
                         newAttachmentsDownloaded = true
                     }
                 }
@@ -141,6 +150,17 @@ object ServerFormUseCases {
         }
 
         return MediaFilesDownloadResult(newAttachmentsDownloaded, entitiesDownloaded)
+    }
+
+    private fun downloadMediaFile(
+        formSource: FormSource,
+        mediaFile: MediaFile,
+        tempMediaFile: File,
+        tempDir: File,
+        stateListener: OngoingWorkListener
+    ) {
+        val file = formSource.fetchMediaFile(mediaFile.downloadUrl)
+        FileUtils.interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/entities/EntitiesRepositoryTest.kt
@@ -818,4 +818,11 @@ abstract class EntitiesRepositoryTest {
         repository.save("wines", leoville)
         assertThat(repository.query("wines", Query.StringEq("score", "92")).size, equalTo(0))
     }
+
+    @Test
+    fun `#updateList creates list if doesn't exist`() {
+        val repository = buildSubject()
+        repository.updateList("blah", "abcd", false)
+        assertThat(repository.getLists().size, equalTo(1))
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormUseCasesTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormUseCasesTest.kt
@@ -27,7 +27,7 @@ import java.io.File
 class ServerFormUseCasesTest {
 
     @Test
-    fun `downloadUpdates returns completed downloads when cancelled`() {
+    fun `#downloadUpdates returns completed downloads when cancelled`() {
         val formDownloader = mock<FormDownloader>()
 
         val serverForms = listOf(
@@ -59,7 +59,7 @@ class ServerFormUseCasesTest {
     }
 
     @Test
-    fun `copySavedFileFromPreviousFormVersionIfExists does not copy any file if there is no matching last-saved file`() {
+    fun `#copySavedFileFromPreviousFormVersionIfExists does not copy any file if there is no matching last-saved file`() {
         val destinationMediaDirPath = TempFiles.createTempDir().absolutePath
         ServerFormUseCases.copySavedFileFromPreviousFormVersionIfExists(InMemFormsRepository(), "1", destinationMediaDirPath)
 
@@ -68,7 +68,7 @@ class ServerFormUseCasesTest {
     }
 
     @Test
-    fun `copySavedFileFromPreviousFormVersionIfExists copies the newest matching last-saved file for given formId`() {
+    fun `#copySavedFileFromPreviousFormVersionIfExists copies the newest matching last-saved file for given formId`() {
         val tempDir1 = TempFiles.createTempDir()
         val file1 = TempFiles.createTempFile(tempDir1, "last-saved", ".xml")
         org.apache.commons.io.FileUtils.writeByteArrayToFile(file1, "file1".toByteArray())
@@ -139,7 +139,7 @@ class ServerFormUseCasesTest {
     }
 
     @Test
-    fun `downloadMediaFiles returns false when there is an existing copy of a media file and an older one`() {
+    fun `#downloadMediaFiles returns false when there is an existing copy of a media file and an older one`() {
         var date: Long = 0
         // Save forms
         val formsRepository = InMemFormsRepository {
@@ -184,7 +184,7 @@ class ServerFormUseCasesTest {
     }
 
     @Test
-    fun `downloadMediaFiles returns false when there is an existing copy of a media file and an older one and media file list hash doesn't match existing copy`() {
+    fun `#downloadMediaFiles returns false when there is an existing copy of a media file and an older one and media file list hash doesn't match existing copy`() {
         // Save forms
         var date: Long = 0
         val formsRepository = InMemFormsRepository {

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -70,9 +70,8 @@ object LocalEntityUseCases {
         entitySource: EntitySource,
         mediaFile: MediaFile
     ) {
-        val newListHash = "server:${mediaFile.hash}"
         val existingListHash = entitiesRepository.getList(list)?.hash
-        if (newListHash == existingListHash) {
+        if (mediaFile.hash == existingListHash) {
             return
         }
 
@@ -128,7 +127,7 @@ object LocalEntityUseCases {
         entitiesRepository.save(list, *newAndUpdated.toTypedArray())
         entitiesRepository.updateList(
             list,
-            newListHash,
+            mediaFile.hash,
             mediaFile.type == MediaFile.Type.APPROVAL_ENTITY_LIST
         )
     }

--- a/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
+++ b/entities/src/main/java/org/odk/collect/entities/storage/InMemEntitiesRepository.kt
@@ -70,6 +70,8 @@ class InMemEntitiesRepository : EntitiesRepository {
             val update = existing.copy(hash = hash, needsApproval = needsApproval)
             lists.remove(existing)
             lists.add(update)
+        } else {
+            lists.add(EntityList(list, hash, needsApproval))
         }
     }
 

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -652,7 +652,7 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `updateLocalEntitiesFromServer updates the list hash with server prefix`() {
+    fun `updateLocalEntitiesFromServer updates the list hash`() {
         val csv = createEntityList(Entity.New("cathedrals", "Cathedrals"))
         LocalEntityUseCases.updateLocalEntitiesFromServer(
             "songs",
@@ -663,7 +663,7 @@ class LocalEntityUseCasesTest {
         )
 
         val hash = entitiesRepository.getList("songs")?.hash
-        assertThat(hash, equalTo("server:hash"))
+        assertThat(hash, equalTo("hash"))
     }
 
     private fun createEntityList(vararg entities: Entity): File {

--- a/open-rosa/src/test/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParserTest.kt
+++ b/open-rosa/src/test/java/org/odk/collect/openrosa/parse/Kxml2OpenRosaResponseParserTest.kt
@@ -80,7 +80,7 @@ class Kxml2OpenRosaResponseParserTest {
     }
 
     @Test
-    fun `#parseManifest when media file has type entityList returns isEntityList as true`() {
+    fun `#parseManifest when media file has type entityList returns it with entity list type`() {
         val response = """
             <?xml version='1.0' encoding='UTF-8' ?>
             <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
@@ -100,7 +100,26 @@ class Kxml2OpenRosaResponseParserTest {
     }
 
     @Test
-    fun `#parseManifest when media file does not have type returns isEntityList as false`() {
+    fun `#parseManifest when media file does not have type returns it with null type`() {
+        val response = """
+            <?xml version='1.0' encoding='UTF-8' ?>
+            <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
+                <mediaFile type="blah">
+                    <filename>badgers.csv</filename>
+                    <hash>blah</hash>
+                    <downloadUrl>http://funk.appspot.com/binaryData?blobKey=%3A477e3</downloadUrl>
+                </mediaFile>
+            </manifest>
+        """.trimIndent()
+
+        val doc = XFormParser.getXMLDocument(response.reader())
+        val mediaFiles = Kxml2OpenRosaResponseParser.parseManifest(doc)!!
+        assertThat(mediaFiles.size, equalTo(1))
+        assertThat(mediaFiles[0].type, equalTo(null))
+    }
+
+    @Test
+    fun `#parseManifest when media file has an unrecognized type returns it with null type`() {
         val response = """
             <?xml version='1.0' encoding='UTF-8' ?>
             <manifest xmlns="http://openrosa.org/xforms/xformsManifest">


### PR DESCRIPTION
Closes #6509

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The big risk here would be that somehow Collect doesn't download updates for entity lists when they are available. 

The best way to check the feature is implemented is probably to use large entity lists and manually download forms sharing them - the second form downloaded should be much faster. Other than that, there are changes to how Collect behaves with empty entity lists so testing around that would be good.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
