### PR TITLE
Correct dependency backup tar name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           command: ./gradlew cacheToMavenLocal
       - run:
           name: Compress Maven repo
-          command: tar -cvzf $(git describe --tags).tar .local-m2
+          command: tar -cvzf maven.tar .local-m2
       - store_artifacts:
           path: maven.tar
 


### PR DESCRIPTION
The `tar` command used the most recent tag, but the artifact upload was just using `maven.tar`. Circle CI doesn't support globs/wildcards as part of artifact upload paths so using the static name makes sense.