### PR TITLE
Fix Audio widget crash

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioControllerView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioControllerView.java
@@ -65,7 +65,11 @@ public class AudioControllerView extends FrameLayout {
         seekBar.setOnSeekBarChangeListener(swipeListener);
 
         binding.play.setOnClickListener(view -> playClicked());
-        binding.remove.setOnClickListener(view -> listener.onRemoveClicked());
+        binding.remove.setOnClickListener(view -> {
+            if (listener != null) {
+                listener.onRemoveClicked();
+            }
+        });
     }
 
     private void playClicked() {

--- a/collect_app/src/test/java/org/odk/collect/android/audio/AudioControllerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/AudioControllerViewTest.java
@@ -117,4 +117,9 @@ public class AudioControllerViewTest {
         shadowOf(seekBar).getOnSeekBarChangeListener().onStopTrackingTouch(seekBar);
         assertThat(activity.isSwipingAllowed(), equalTo(true));
     }
+
+    @Test
+    public void whenNoListenerSet_clickingRemove_doesNotExplode() {
+        view.binding.remove.performClick();
+    }
 }


### PR DESCRIPTION
Should fix [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/52ed09febc0bb7433254da550ec02197?time=last-ninety-days&sessionEventKey=682A185703050001759678A97299924C_2084302675448915896). 

This crash scared me a little as if the user somehow clicks remove before the `AudioControllerView` has been set up correctly, they could end up in a state where they can recover work, but without the screen of the form they were on (including the audio file). Given that they were hitting "Remove" that's arguably not a problem, but I think it makes more sense to prevent the crash than allow it. I'd also generally expect a view to protect against nullable listeners, so the fix isn't unusual.