### PR TITLE
Fix JVM config for cgroupsv2 Circle CI upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,12 @@ references:
       - image: cimg/android:2025.02
     resource_class: medium+
 
+  android_config_large: &android_config_large
+    working_directory: ~/work
+    docker:
+      - image: cimg/android:2025.02
+    resource_class: large
+
 jobs:
   compile:
     <<: *android_config
@@ -73,7 +79,7 @@ jobs:
           path: maven.tar
 
   check_quality:
-    <<: *android_config
+    <<: *android_config_large
     steps:
       - attach_workspace:
           at: ~/work
@@ -182,7 +188,7 @@ jobs:
           key: test-app-deps-{{ checksum "deps.txt" }}
 
   build_instrumented:
-    <<: *android_config
+    <<: *android_config_large
     steps:
       - attach_workspace:
           at: ~/work

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,5 +1,6 @@
-org.gradle.jvmargs=-Xmx2560m -Dkotlin.compiler.execution.strategy="in-process"
+org.gradle.jvmargs=-Xmx2560m -XX:MaxMetaspaceSize=1g
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=2
 test.heap.max=1g
+kotlin.compiler.execution.strategy=in-process


### PR DESCRIPTION
This fixes our config so that everything works in the new Circle CI executor.