### PR TITLE
Optimize JVM for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,11 @@ jobs:
 
       - run:
           name: Run code quality checks
-          command: ./gradlew pmd ktlintCheck checkstyle lintDebug
+          command: ./gradlew pmd ktlintCheck checkstyle
+
+      - run:
+          name: Run Android lint
+          command: ./gradlew lintDebug
 
   test_modules:
     <<: *android_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - run:
           name: Generate combined build.gradle file for cache key
-          command: cat build.gradle */build.gradle */build.gradle.kts .circleci/gradle-compile.properties .circleci/config.yml gradle/libs.versions.toml > deps.txt
+          command: cat build.gradle */build.gradle */build.gradle.kts .circleci/config.yml gradle/libs.versions.toml > deps.txt
       - restore_cache:
           keys:
             - compile-deps-{{ checksum "deps.txt" }}
@@ -93,7 +93,7 @@ jobs:
 
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-large.properties ~/.gradle/gradle.properties
 
       - run:
           name: Run code quality checks
@@ -203,7 +203,7 @@ jobs:
 
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-large.properties ~/.gradle/gradle.properties
 
       - run:
           name: Assemble connected test build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - run:
           name: Generate combined build.gradle file for cache key
-          command: cat build.gradle */build.gradle */build.gradle.kts .circleci/gradle.properties .circleci/config.yml gradle/libs.versions.toml > deps.txt
+          command: cat build.gradle */build.gradle */build.gradle.kts .circleci/gradle-compile.properties .circleci/config.yml gradle/libs.versions.toml > deps.txt
       - restore_cache:
           keys:
             - compile-deps-{{ checksum "deps.txt" }}
@@ -33,7 +33,7 @@ jobs:
             - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-compile.properties ~/.gradle/gradle.properties
 
       - run:
           name: Download Robolectric deps

--- a/.circleci/gradle-compile.properties
+++ b/.circleci/gradle-compile.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=1g
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.workers.max=3
+kotlin.compiler.execution.strategy=in-process

--- a/.circleci/gradle-large.properties
+++ b/.circleci/gradle-large.properties
@@ -1,0 +1,6 @@
+org.gradle.jvmargs=-Xmx2560m -XX:MaxMetaspaceSize=1g
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.workers.max=4
+test.heap.max=1g
+kotlin.compiler.execution.strategy=in-process


### PR DESCRIPTION
This makes a few tweaks to our jobs based on how much RAM they use to try and improve run times.