### PR TITLE
Improved handling zoom level in maps

### DIFF
--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -195,7 +195,7 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
                 public void onZoomToPoint(@NonNull Zoom.Point zoom) {
                     MapPoint point = zoom.getPoint();
                     moveOrAnimateCamera(
-                            CameraUpdateFactory.newLatLngZoom(toLatLng(point), (float) zoom.getLevel().doubleValue()), zoom.getAnimate());
+                            CameraUpdateFactory.newLatLngZoom(toLatLng(point), (float) zoom.getLevel()), zoom.getAnimate());
                 }
 
                 @Override

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -219,7 +219,7 @@ class MapboxMapFragment :
 
         getMapViewModel().zoom.observe(viewLifecycleOwner, object : ZoomObserver() {
             override fun onZoomToPoint(zoom: Zoom.Point) {
-                moveOrAnimateCamera(zoom.point, zoom.animate, zoom.level ?: getZoom())
+                moveOrAnimateCamera(zoom.point, zoom.animate, zoom.level)
             }
 
             override fun onZoomToBox(zoom: Zoom.Box) {

--- a/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
@@ -39,7 +39,9 @@ class MapViewModel(
             return
         }
 
-        val level = if (metaSettings.contains(LAST_KNOWN_ZOOM_LEVEL)) {
+        val level = if (userZoomLevel != null) {
+            userZoomLevel
+        } else if (metaSettings.contains(LAST_KNOWN_ZOOM_LEVEL)) {
             metaSettings.getFloat(LAST_KNOWN_ZOOM_LEVEL).toDouble()
         } else {
             DEFAULT_ZOOM

--- a/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
@@ -50,7 +50,7 @@ class MapViewModel(
 
     fun moveTo(location: MapPoint?, animate: Boolean) {
         if (location != null) {
-            _zoom.value = Zoom.Point(location, _zoom.value?.level, animate, false)
+            _zoom.value = Zoom.Point(location, _zoom.value?.level ?: DEFAULT_ZOOM, animate, false)
         }
     }
 
@@ -92,20 +92,20 @@ class MapViewModel(
 
 sealed class Zoom {
 
-    abstract val level: Double?
+    abstract val level: Double
     abstract val animate: Boolean
     abstract val user: Boolean
 
     data class Point(
         val point: MapPoint,
-        override val level: Double?,
+        override val level: Double,
         override val animate: Boolean,
         override val user: Boolean
     ) : Zoom()
 
     data class Box(
         val box: List<MapPoint>,
-        override val level: Double?,
+        override val level: Double,
         override val animate: Boolean
     ) : Zoom() {
         override val user = false

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -259,7 +259,7 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
                     count++;
                 }
                 if (count == 1) {
-                    systemZoom(lastPoint, null);
+                    systemZoom(lastPoint, zoom.getLevel());
                 } else if (count > 1) {
                     // TODO(ping): Find a better solution.
                     // zoomToBoundingBox sometimes fails to zoom correctly, either

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -241,7 +241,10 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
         mapViewModel.getZoom().observe(getViewLifecycleOwner(), new ZoomObserver() {
             @Override
             public void onZoomToPoint(@NonNull Zoom.Point zoom) {
-                systemZoom(zoom.getPoint(), zoom.getLevel());
+                isSystemZooming = true;
+                map.getController().setZoom((int) Math.round(zoom.getLevel()));
+                map.getController().setCenter(toGeoPoint(zoom.getPoint()));
+                isSystemZooming = false;
             }
 
             @Override
@@ -259,7 +262,7 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
                     count++;
                 }
                 if (count == 1) {
-                    systemZoom(lastPoint, zoom.getLevel());
+                    zoomToPoint(lastPoint, zoom.getAnimate());
                 } else if (count > 1) {
                     // TODO(ping): Find a better solution.
                     // zoomToBoundingBox sometimes fails to zoom correctly, either
@@ -280,13 +283,6 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
         });
 
         return view;
-    }
-
-    private void systemZoom(MapPoint point, Double level) {
-        isSystemZooming = true;
-        map.getController().setZoom((int) Math.round(level));
-        map.getController().setCenter(toGeoPoint(point));
-        isSystemZooming = false;
     }
 
     @Override


### PR DESCRIPTION
Closes #6714 
Closes #6731 
Closes #6749

#### Why is this the best possible solution? Were any other approaches considered?
The main change I made was disallowing null values for zoom levels to make their handling safer (default values should be used instead). There isn’t much to discuss in that regard.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It might be a good idea to spend some extra time testing how the zoom level is remembered, as recent refactorings could have caused other regressions.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
