### PR TITLE
Log project resets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -104,4 +104,9 @@ object AnalyticsEvents {
      * Tracks how often the INSTANCE_UPLOAD action is used with a custom server URL
      */
     const val INSTANCE_UPLOAD_CUSTOM_SERVER = "InstanceUploadCustomServer"
+
+    /**
+     * Tracks how often projects are reset
+     */
+    const val RESET_PROJECT = "ResetProject"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ResetDialogPreferenceFragmentCompat.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ResetDialogPreferenceFragmentCompat.java
@@ -15,7 +15,9 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.AppCompatCheckBox;
 import androidx.preference.PreferenceDialogFragmentCompat;
 
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.fragments.dialogs.ResetSettingsResultDialog;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.screens.ProjectPreferencesActivity;
@@ -101,6 +103,8 @@ public class ResetDialogPreferenceFragmentCompat extends PreferenceDialogFragmen
     }
 
     private void resetSelected() {
+        Analytics.log(AnalyticsEvents.RESET_PROJECT);
+
         final List<Integer> resetActions = new ArrayList<>();
 
         if (preferences.isChecked()) {


### PR DESCRIPTION
This adds an event that tracks how often projects are reset. This should allow us to make more informed decisions about if this feature should be improved or removed in later releases.