### PR TITLE
Keep scanning codes when the result is not accepted

### DIFF
--- a/async/src/main/java/org/odk/collect/async/CoroutineScheduler.kt
+++ b/async/src/main/java/org/odk/collect/async/CoroutineScheduler.kt
@@ -20,7 +20,7 @@ open class CoroutineScheduler(private val foregroundContext: CoroutineContext, p
         }
     }
 
-    override fun immediate(foreground: Boolean, runnable: Runnable) {
+    override fun immediate(foreground: Boolean, delay: Long?, runnable: Runnable) {
         val context = if (!foreground) {
             backgroundContext
         } else {
@@ -28,6 +28,10 @@ open class CoroutineScheduler(private val foregroundContext: CoroutineContext, p
         }
 
         CoroutineScope(context).launch {
+            if (delay != null) {
+                delay(delay)
+            }
+
             runnable.run()
         }
     }

--- a/async/src/main/java/org/odk/collect/async/Scheduler.kt
+++ b/async/src/main/java/org/odk/collect/async/Scheduler.kt
@@ -25,7 +25,7 @@ interface Scheduler {
     /**
      * Run work in the foreground or background. Cancelled if application closed.
      */
-    fun immediate(foreground: Boolean = false, runnable: Runnable)
+    fun immediate(foreground: Boolean = false, delay: Long? = null, runnable: Runnable)
 
     /**
      * Schedule a task to run in the background even if the app isn't running. The task

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/TestScheduler.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/TestScheduler.kt
@@ -42,9 +42,9 @@ class TestScheduler(private val networkStateProvider: NetworkStateProvider) : Sc
         }
     }
 
-    override fun immediate(foreground: Boolean, runnable: Runnable) {
+    override fun immediate(foreground: Boolean, delay: Long?, runnable: Runnable) {
         increment()
-        wrappedScheduler.immediate(foreground) {
+        wrappedScheduler.immediate(foreground, delay) {
             runnable.run()
             decrement()
         }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
@@ -71,7 +71,7 @@ public abstract class BarCodeScannerFragment extends Fragment implements Barcode
             switchFlashlightButton.setVisibility(View.GONE);
         }
 
-        barcodeScannerViewContainer.getBarcodeScannerView().latestBarcode().observe(getViewLifecycleOwner(), result -> {
+        barcodeScannerViewContainer.getBarcodeScannerView().getLatestBarcode().observe(getViewLifecycleOwner(), result -> {
             beepManager.playBeepSoundAndVibrate();
 
             try {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
@@ -72,12 +72,13 @@ public abstract class BarCodeScannerFragment extends Fragment implements Barcode
             switchFlashlightButton.setVisibility(View.GONE);
         }
 
-        barcodeScannerViewContainer.getBarcodeScannerView().waitForBarcode(LifecycleOwnerKt.getLifecycleScope(getViewLifecycleOwner())).observe(getViewLifecycleOwner(), result -> {
+        barcodeScannerViewContainer.getBarcodeScannerView().waitForBarcode().observe(getViewLifecycleOwner(), result -> {
             beepManager.playBeepSoundAndVibrate();
 
             try {
                 handleScanningResult(result);
             } catch (IOException | DataFormatException | IllegalArgumentException e) {
+                barcodeScannerViewContainer.getBarcodeScannerView().continueScanning(LifecycleOwnerKt.getLifecycleScope(getViewLifecycleOwner()));
                 ToastUtils.showShortToast(getString(org.odk.collect.strings.R.string.invalid_qrcode));
             }
         });

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
@@ -71,16 +71,17 @@ public abstract class BarCodeScannerFragment extends Fragment implements Barcode
             switchFlashlightButton.setVisibility(View.GONE);
         }
 
-        barcodeScannerViewContainer.getBarcodeScannerView().waitForBarcode().observe(getViewLifecycleOwner(), result -> {
+        barcodeScannerViewContainer.getBarcodeScannerView().latestBarcode().observe(getViewLifecycleOwner(), result -> {
             beepManager.playBeepSoundAndVibrate();
 
             try {
                 handleScanningResult(result);
             } catch (IOException | DataFormatException | IllegalArgumentException e) {
-                barcodeScannerViewContainer.getBarcodeScannerView().continueScanning();
                 ToastUtils.showShortToast(getString(org.odk.collect.strings.R.string.invalid_qrcode));
             }
         });
+
+        barcodeScannerViewContainer.getBarcodeScannerView().start();
 
         return rootView;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
@@ -25,7 +25,6 @@ import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.LifecycleOwnerKt;
 
 import com.google.zxing.client.android.BeepManager;
 
@@ -78,7 +77,7 @@ public abstract class BarCodeScannerFragment extends Fragment implements Barcode
             try {
                 handleScanningResult(result);
             } catch (IOException | DataFormatException | IllegalArgumentException e) {
-                barcodeScannerViewContainer.getBarcodeScannerView().continueScanning(LifecycleOwnerKt.getLifecycleScope(getViewLifecycleOwner()));
+                barcodeScannerViewContainer.getBarcodeScannerView().continueScanning();
                 ToastUtils.showShortToast(getString(org.odk.collect.strings.R.string.invalid_qrcode));
             }
         });

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
@@ -25,6 +25,7 @@ import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.LifecycleOwnerKt;
 
 import com.google.zxing.client.android.BeepManager;
 
@@ -71,7 +72,7 @@ public abstract class BarCodeScannerFragment extends Fragment implements Barcode
             switchFlashlightButton.setVisibility(View.GONE);
         }
 
-        barcodeScannerViewContainer.getBarcodeScannerView().waitForBarcode().observe(getViewLifecycleOwner(), result -> {
+        barcodeScannerViewContainer.getBarcodeScannerView().waitForBarcode(LifecycleOwnerKt.getLifecycleScope(getViewLifecycleOwner())).observe(getViewLifecycleOwner(), result -> {
             beepManager.playBeepSoundAndVibrate();
 
             try {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -153,7 +153,7 @@ class QrCodeProjectCreatorDialog :
             true
         )
 
-        binding.barcodeView.barcodeScannerView.latestBarcode().observe(
+        binding.barcodeView.barcodeScannerView.latestBarcode.observe(
             viewLifecycleOwner
         ) { result: String ->
             try {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -272,11 +272,15 @@ class QrCodeProjectCreatorDialog :
                 )
             }
 
-            ProjectConfigurationResult.INVALID_SETTINGS -> ToastUtils.showLongToast(
-                getString(
-                    org.odk.collect.strings.R.string.invalid_qrcode
+            ProjectConfigurationResult.INVALID_SETTINGS -> {
+                ToastUtils.showLongToast(
+                    getString(
+                        org.odk.collect.strings.R.string.invalid_qrcode
+                    )
                 )
-            )
+
+                restartScanning()
+            }
 
             ProjectConfigurationResult.GD_PROJECT -> {
                 ToastUtils.showLongToast(
@@ -285,10 +289,14 @@ class QrCodeProjectCreatorDialog :
                     )
                 )
 
-                scheduler.immediate(foreground = true, delay = 2000L) {
-                    binding.barcodeView.barcodeScannerView.start()
-                }
+                restartScanning()
             }
+        }
+    }
+
+    private fun restartScanning() {
+        scheduler.immediate(foreground = true, delay = 2000L) {
+            binding.barcodeView.barcodeScannerView.start()
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -274,11 +274,15 @@ class QrCodeProjectCreatorDialog :
                 )
             )
 
-            ProjectConfigurationResult.GD_PROJECT -> ToastUtils.showLongToast(
-                getString(
-                    org.odk.collect.strings.R.string.settings_with_gd_protocol
+            ProjectConfigurationResult.GD_PROJECT -> {
+                ToastUtils.showLongToast(
+                    getString(
+                        org.odk.collect.strings.R.string.settings_with_gd_protocol
+                    )
                 )
-            )
+
+                binding.barcodeView.barcodeScannerView.start()
+            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -24,6 +24,7 @@ import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.androidshared.ui.ToastUtils.showShortToast
 import org.odk.collect.androidshared.ui.enableIconsVisibility
 import org.odk.collect.androidshared.utils.CompressionUtils
+import org.odk.collect.async.Scheduler
 import org.odk.collect.material.MaterialFullScreenDialogFragment
 import org.odk.collect.permissions.PermissionListener
 import org.odk.collect.permissions.PermissionsProvider
@@ -73,6 +74,9 @@ class QrCodeProjectCreatorDialog :
 
     @Inject
     lateinit var barcodeScannerViewFactory: BarcodeScannerViewContainer.Factory
+
+    @Inject
+    lateinit var scheduler: Scheduler
 
     private var savedInstanceState: Bundle? = null
 
@@ -281,7 +285,9 @@ class QrCodeProjectCreatorDialog :
                     )
                 )
 
-                binding.barcodeView.barcodeScannerView.start()
+                scheduler.immediate(foreground = true, delay = 2000L) {
+                    binding.barcodeView.barcodeScannerView.start()
+                }
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.Toolbar
+import androidx.lifecycle.lifecycleScope
 import com.google.zxing.client.android.BeepManager
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
@@ -215,7 +216,7 @@ class QrCodeProjectCreatorDialog :
     }
 
     private fun startScanning() {
-        binding.barcodeView.barcodeScannerView.waitForBarcode().observe(
+        binding.barcodeView.barcodeScannerView.waitForBarcode(lifecycleScope).observe(
             viewLifecycleOwner
         ) { result: String ->
             try {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -216,7 +216,7 @@ class QrCodeProjectCreatorDialog :
     }
 
     private fun startScanning() {
-        binding.barcodeView.barcodeScannerView.waitForBarcode(lifecycleScope).observe(
+        binding.barcodeView.barcodeScannerView.waitForBarcode().observe(
             viewLifecycleOwner
         ) { result: String ->
             try {
@@ -228,6 +228,7 @@ class QrCodeProjectCreatorDialog :
             val settingsJson = try {
                 CompressionUtils.decompress(result)
             } catch (e: Exception) {
+                binding.barcodeView.barcodeScannerView.continueScanning(lifecycleScope)
                 showShortToast(
                     getString(org.odk.collect.strings.R.string.invalid_qrcode)
                 )

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.Toolbar
-import androidx.lifecycle.lifecycleScope
 import com.google.zxing.client.android.BeepManager
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
@@ -228,7 +227,7 @@ class QrCodeProjectCreatorDialog :
             val settingsJson = try {
                 CompressionUtils.decompress(result)
             } catch (e: Exception) {
-                binding.barcodeView.barcodeScannerView.continueScanning(lifecycleScope)
+                binding.barcodeView.barcodeScannerView.continueScanning()
                 showShortToast(
                     getString(org.odk.collect.strings.R.string.invalid_qrcode)
                 )

--- a/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
@@ -195,5 +195,6 @@ class QrCodeProjectCreatorDialogTest {
             )
         )
         verifyNoInteractions(projectCreator)
+        assertThat(barcodeScannerViewFactory.isScanning, equalTo(true))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
@@ -166,7 +166,7 @@ class QrCodeProjectCreatorDialogTest {
     }
 
     @Test
-    fun `When QR code is invalid a toast should be displayed`() {
+    fun `When QR code is invalid a toast should be displayed and scanning continues`() {
         val projectCreator = mock<ProjectCreator>()
         launcherRule.launch(QrCodeProjectCreatorDialog::class.java)
 
@@ -185,7 +185,7 @@ class QrCodeProjectCreatorDialogTest {
     }
 
     @Test
-    fun `When QR code contains GD protocol a toast should be displayed`() {
+    fun `When QR code contains GD protocol a toast should be displayed and scanning continues`() {
         val projectCreator = mock<ProjectCreator>()
         launcherRule.launch(QrCodeProjectCreatorDialog::class.java)
 

--- a/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
@@ -14,6 +14,7 @@ import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.WorkManager
 import com.google.android.material.appbar.MaterialToolbar
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -30,12 +31,14 @@ import org.odk.collect.android.fakes.FakePermissionsProvider
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.support.CollectHelpers
+import org.odk.collect.async.Scheduler
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.permissions.PermissionsProvider
 import org.odk.collect.projects.ProjectCreator
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
 import org.odk.collect.testshared.FakeBarcodeScannerViewFactory
+import org.odk.collect.testshared.FakeScheduler
 import org.robolectric.shadows.ShadowToast
 
 @RunWith(AndroidJUnit4::class)
@@ -43,6 +46,7 @@ class QrCodeProjectCreatorDialogTest {
 
     private val permissionsProvider = FakePermissionsProvider()
     private val barcodeScannerViewFactory = FakeBarcodeScannerViewFactory()
+    private val scheduler = FakeScheduler()
 
     @get:Rule
     val launcherRule = FragmentScenarioLauncherRule()
@@ -58,6 +62,10 @@ class QrCodeProjectCreatorDialogTest {
 
             override fun providesPermissionsProvider(permissionsChecker: PermissionsChecker?): PermissionsProvider {
                 return permissionsProvider
+            }
+
+            override fun providesScheduler(workManager: WorkManager?): Scheduler {
+                return scheduler
             }
         })
     }
@@ -195,6 +203,8 @@ class QrCodeProjectCreatorDialogTest {
             )
         )
         verifyNoInteractions(projectCreator)
+
+        scheduler.runForeground()
         assertThat(barcodeScannerViewFactory.isScanning, equalTo(true))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
@@ -179,6 +179,9 @@ class QrCodeProjectCreatorDialogTest {
             )
         )
         verifyNoInteractions(projectCreator)
+
+        scheduler.runForeground()
+        assertThat(barcodeScannerViewFactory.isScanning, equalTo(true))
     }
 
     @Test

--- a/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeScannerViewContainer.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeScannerViewContainer.kt
@@ -2,15 +2,13 @@ package org.odk.collect.qrcode
 
 import android.app.Activity
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlin.time.Duration.Companion.seconds
 
 class BarcodeScannerViewContainer(context: Context, attrs: AttributeSet?) :
     FrameLayout(context, attrs) {
@@ -62,11 +60,10 @@ abstract class BarcodeScannerView(context: Context) : FrameLayout(context) {
         return liveData
     }
 
-    fun continueScanning(scope: CoroutineScope) {
-        scope.launch {
-            delay(1.seconds)
+    fun continueScanning() {
+        Handler(Looper.getMainLooper()).postDelayed({
             isResultBeingProcessed = false
-        }
+        }, 1000)
     }
 
     interface TorchListener {

--- a/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeScannerViewContainer.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeScannerViewContainer.kt
@@ -7,6 +7,10 @@ import android.widget.FrameLayout
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 class BarcodeScannerViewContainer(context: Context, attrs: AttributeSet?) :
     FrameLayout(context, attrs) {
@@ -43,10 +47,22 @@ abstract class BarcodeScannerView(context: Context) : FrameLayout(context) {
     abstract fun setTorchOn(on: Boolean)
     abstract fun setTorchListener(torchListener: TorchListener)
 
-    fun waitForBarcode(): LiveData<String> {
-        return MutableLiveData<String>().also {
-            this.decodeContinuous { result -> it.value = result }
+    fun waitForBarcode(scope: CoroutineScope): LiveData<String> {
+        val liveData = MutableLiveData<String>()
+        var acceptResult = true
+
+        this.decodeContinuous { result ->
+            if (acceptResult) {
+                acceptResult = false
+                liveData.value = result
+                scope.launch {
+                    delay(1.seconds)
+                    acceptResult = true
+                }
+            }
         }
+
+        return liveData
     }
 
     interface TorchListener {

--- a/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeScannerViewContainer.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeScannerViewContainer.kt
@@ -2,8 +2,6 @@ package org.odk.collect.qrcode
 
 import android.app.Activity
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.lifecycle.LifecycleOwner
@@ -41,29 +39,20 @@ class BarcodeScannerViewContainer(context: Context, attrs: AttributeSet?) :
 }
 
 abstract class BarcodeScannerView(context: Context) : FrameLayout(context) {
-    private var isResultBeingProcessed = false
+    private val latestBarcode = MutableLiveData<String>()
 
-    protected abstract fun decodeContinuous(callback: (String) -> Unit)
+    protected abstract fun scan(callback: (String) -> Unit)
     abstract fun setTorchOn(on: Boolean)
     abstract fun setTorchListener(torchListener: TorchListener)
 
-    fun waitForBarcode(): LiveData<String> {
-        val liveData = MutableLiveData<String>()
-
-        this.decodeContinuous { result ->
-            if (!isResultBeingProcessed) {
-                isResultBeingProcessed = true
-                liveData.value = result
-            }
-        }
-
-        return liveData
+    fun latestBarcode(): LiveData<String> {
+        return latestBarcode
     }
 
-    fun continueScanning() {
-        Handler(Looper.getMainLooper()).postDelayed({
-            isResultBeingProcessed = false
-        }, 1000)
+    fun start() {
+        this.scan { result ->
+            latestBarcode.value = result
+        }
     }
 
     interface TorchListener {

--- a/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeScannerViewContainer.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeScannerViewContainer.kt
@@ -39,19 +39,17 @@ class BarcodeScannerViewContainer(context: Context, attrs: AttributeSet?) :
 }
 
 abstract class BarcodeScannerView(context: Context) : FrameLayout(context) {
-    private val latestBarcode = MutableLiveData<String>()
+
+    private val _latestBarcode = MutableLiveData<String>()
+    val latestBarcode: LiveData<String> = _latestBarcode
 
     protected abstract fun scan(callback: (String) -> Unit)
     abstract fun setTorchOn(on: Boolean)
     abstract fun setTorchListener(torchListener: TorchListener)
 
-    fun latestBarcode(): LiveData<String> {
-        return latestBarcode
-    }
-
     fun start() {
         this.scan { result ->
-            latestBarcode.value = result
+            _latestBarcode.value = result
         }
     }
 

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -103,8 +103,8 @@ private class MlKitBarcodeScannerView(
                 val rawValue = value?.firstOrNull()?.rawValue
 
                 if (!rawValue.isNullOrEmpty()) {
-                    callback(rawValue)
                     cameraController.unbind()
+                    callback(rawValue)
                 }
             }
         )

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -72,7 +72,7 @@ private class MlKitBarcodeScannerView(
         binding.prompt.text = prompt
     }
 
-    override fun decodeContinuous(callback: (String) -> Unit) {
+    override fun scan(callback: (String) -> Unit) {
         if (useFrontCamera) {
             cameraController.cameraSelector = CameraSelector.DEFAULT_FRONT_CAMERA
         }
@@ -104,6 +104,7 @@ private class MlKitBarcodeScannerView(
 
                 if (!rawValue.isNullOrEmpty()) {
                     callback(rawValue)
+                    cameraController.unbind()
                 }
             }
         )

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -99,11 +99,11 @@ private class MlKitBarcodeScannerView(
                 COORDINATE_SYSTEM_VIEW_REFERENCED,
                 executor
             ) { result: MlKitAnalyzer.Result ->
-                val value = result.getValue(barcodeScanner)?.firstOrNull()
-                val content = value?.rawValue ?: value?.displayValue
+                val value = result.getValue(barcodeScanner)
+                val rawValue = value?.firstOrNull()?.rawValue
 
-                if (!content.isNullOrEmpty()) {
-                    callback(content)
+                if (!rawValue.isNullOrEmpty()) {
+                    callback(rawValue)
                 }
             }
         )

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -102,7 +102,6 @@ private class MlKitBarcodeScannerView(
                 val value = result.getValue(barcodeScanner)
                 if (value!!.isNotEmpty()) {
                     callback(value.first().rawValue!!)
-                    cameraController.unbind()
                 }
             }
         )

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -99,11 +99,11 @@ private class MlKitBarcodeScannerView(
                 COORDINATE_SYSTEM_VIEW_REFERENCED,
                 executor
             ) { result: MlKitAnalyzer.Result ->
-                val value = result.getValue(barcodeScanner)
-                val rawValue = value?.firstOrNull()?.rawValue
+                val value = result.getValue(barcodeScanner)?.firstOrNull()
+                val content = value?.rawValue ?: value?.displayValue
 
-                if (!rawValue.isNullOrEmpty()) {
-                    callback(rawValue)
+                if (!content.isNullOrEmpty()) {
+                    callback(content)
                 }
             }
         )

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -100,8 +100,10 @@ private class MlKitBarcodeScannerView(
                 executor
             ) { result: MlKitAnalyzer.Result ->
                 val value = result.getValue(barcodeScanner)
-                if (value!!.isNotEmpty()) {
-                    callback(value.first().rawValue!!)
+                val rawValue = value?.firstOrNull()?.rawValue
+
+                if (!rawValue.isNullOrEmpty()) {
+                    callback(rawValue)
                 }
             }
         )

--- a/qr-code/src/main/java/org/odk/collect/qrcode/zxing/ZxingBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/zxing/ZxingBarcodeScannerViewFactory.kt
@@ -77,8 +77,8 @@ private class ZxingBarcodeScannerView(
         }
 
         binding.barcodeView.decodeSingle {
-            callback(it.text)
             captureManager.onDestroy()
+            callback(it.text)
         }
     }
 

--- a/qr-code/src/main/java/org/odk/collect/qrcode/zxing/ZxingBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/zxing/ZxingBarcodeScannerViewFactory.kt
@@ -40,7 +40,7 @@ private class ZxingBarcodeScannerView(
     private val binding =
         ZxingBarcodeScannerLayoutBinding.inflate(LayoutInflater.from(activity), this, true)
 
-    override fun decodeContinuous(callback: (String) -> Unit) {
+    override fun scan(callback: (String) -> Unit) {
         val supportedFormats = if (qrOnly) {
             listOf(IntentIntegrator.QR_CODE)
         } else {
@@ -76,8 +76,9 @@ private class ZxingBarcodeScannerView(
             binding.barcodeView.barcodeView.cameraSettings = cameraSettings
         }
 
-        binding.barcodeView.decodeContinuous {
+        binding.barcodeView.decodeSingle {
             callback(it.text)
+            captureManager.onDestroy()
         }
     }
 

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeBarcodeScannerView.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeBarcodeScannerView.kt
@@ -25,6 +25,8 @@ class FakeBarcodeScannerView(context: Context) : BarcodeScannerView(context) {
     override fun setTorchListener(torchListener: TorchListener) = Unit
 
     fun scan(result: String) {
+        isScanning = false
+
         if (Looper.myLooper() == Looper.getMainLooper()) {
             callback?.invoke(result)
         } else {
@@ -32,8 +34,6 @@ class FakeBarcodeScannerView(context: Context) : BarcodeScannerView(context) {
                 callback?.invoke(result)
             }
         }
-
-        isScanning = false
     }
 }
 
@@ -41,7 +41,10 @@ class FakeBarcodeScannerViewFactory : BarcodeScannerViewContainer.Factory {
 
     private val views = mutableListOf<FakeBarcodeScannerView>()
 
-    val isScanning = views.any { it.isScanning }
+    val isScanning: Boolean
+        get() {
+            return views.any { it.isScanning }
+        }
 
     override fun create(
         activity: Activity,

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeBarcodeScannerView.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeBarcodeScannerView.kt
@@ -11,9 +11,13 @@ import org.odk.collect.qrcode.BarcodeScannerViewContainer
 
 class FakeBarcodeScannerView(context: Context) : BarcodeScannerView(context) {
 
+    var isScanning = false
+        private set
+
     private var callback: ((String) -> Unit)? = null
 
     override fun scan(callback: (String) -> Unit) {
+        isScanning = true
         this.callback = callback
     }
 
@@ -28,12 +32,16 @@ class FakeBarcodeScannerView(context: Context) : BarcodeScannerView(context) {
                 callback?.invoke(result)
             }
         }
+
+        isScanning = false
     }
 }
 
 class FakeBarcodeScannerViewFactory : BarcodeScannerViewContainer.Factory {
 
     private val views = mutableListOf<FakeBarcodeScannerView>()
+
+    val isScanning = views.any { it.isScanning }
 
     override fun create(
         activity: Activity,
@@ -54,6 +62,10 @@ class FakeBarcodeScannerViewFactory : BarcodeScannerViewContainer.Factory {
 
     fun scan(result: String) {
         val compressedResult = CompressionUtils.compress(result)
-        views.forEach { it.scan(compressedResult) }
+        views.forEach {
+            if (it.isScanning) {
+                it.scan(compressedResult)
+            }
+        }
     }
 }

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeBarcodeScannerView.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeBarcodeScannerView.kt
@@ -42,9 +42,7 @@ class FakeBarcodeScannerViewFactory : BarcodeScannerViewContainer.Factory {
     private val views = mutableListOf<FakeBarcodeScannerView>()
 
     val isScanning: Boolean
-        get() {
-            return views.any { it.isScanning }
-        }
+        get() = views.any { it.isScanning }
 
     override fun create(
         activity: Activity,

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeBarcodeScannerView.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeBarcodeScannerView.kt
@@ -13,7 +13,7 @@ class FakeBarcodeScannerView(context: Context) : BarcodeScannerView(context) {
 
     private var callback: ((String) -> Unit)? = null
 
-    override fun decodeContinuous(callback: (String) -> Unit) {
+    override fun scan(callback: (String) -> Unit) {
         this.callback = callback
     }
 

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeScheduler.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeScheduler.kt
@@ -35,7 +35,7 @@ class FakeScheduler : Scheduler {
         )
     }
 
-    override fun immediate(foreground: Boolean, runnable: Runnable) {
+    override fun immediate(foreground: Boolean, delay: Long?, runnable: Runnable) {
         if (!foreground) {
             backgroundTasks.push(runnable)
         } else {


### PR DESCRIPTION
Closes #6687
Closes #6755 

#### Why is this the best possible solution? Were any other approaches considered?
I updated the shared method used by both MLKit and Zxing to delay scanning new codes by 1s when the previously scanned code cannot be accepted. This change is a result of the discussion we had in: https://github.com/getodk/collect/pull/6737

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change should fix the issue where scanning stops even though the result wasn’t accepted (e.g., due to incorrect settings or when trying to add a Google Drive project). It now allows users to continue scanning in such cases.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
