### PR TITLE
Use nav graph in form hierarchy

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -340,6 +340,7 @@ dependencies {
     }
 
     implementation libs.splashscreen
+    implementation libs.androidxNavigationFragmentKtx
 
     testImplementation project(':forms-test')
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.kotlinParcelize)
     alias(libs.plugins.ossLicenses)
+    alias(libs.plugins.safeargs)
 }
 apply from: '../config/quality.gradle'
 

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragment.java
@@ -175,8 +175,6 @@ public class FormHierarchyFragment extends Fragment {
         });
     }
 
-
-
     private void handleInstanceEditResult(InstanceEditResult result) {
         Instance instance = result.getInstance();
 

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragment.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.formhierarchy;
 import static android.app.Activity.RESULT_OK;
 import static org.odk.collect.android.formentry.repeats.DeleteRepeatDialogFragment.REQUEST_DELETE_REPEAT;
 import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getPreviousLevel;
+import static org.odk.collect.androidshared.ui.SnackbarUtils.showLongSnackbar;
 
 import android.content.Context;
 import android.content.DialogInterface;
@@ -174,6 +175,8 @@ public class FormHierarchyFragment extends Fragment {
         });
     }
 
+
+
     private void handleInstanceEditResult(InstanceEditResult result) {
         Instance instance = result.getInstance();
 
@@ -294,6 +297,17 @@ public class FormHierarchyFragment extends Fragment {
         }
 
         getChildFragmentManager().setFragmentResultListener(REQUEST_DELETE_REPEAT, getViewLifecycleOwner(), (requestKey, result) -> onRepeatDeleted());
+
+        boolean newEdit = FormHierarchyFragmentArgs.fromBundle(getArguments()).getNewEdit();
+        if (newEdit) {
+            showLongSnackbar(
+                    view,
+                    getString(org.odk.collect.strings.R.string.finalized_form_edit_started),
+                    null,
+                    null,
+                    true
+            );
+        }
     }
 
     public void refreshView() {

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragmentHostActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragmentHostActivity.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.android.formhierarchy
 
 import android.os.Bundle
+import androidx.navigation.fragment.NavHostFragment
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.FormEntryViewModelFactory
@@ -137,13 +138,19 @@ class FormHierarchyFragmentHostActivity : LocalizedActivity() {
         } else {
             super.onCreate(savedInstanceState)
             setContentView(R.layout.hierarchy_host_layout)
+
+            val navHostFragment =
+                supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+            val navController = navHostFragment.navController
+            navController.setGraph(R.navigation.form_entry)
+
             setSupportActionBar(findViewById(org.odk.collect.androidshared.R.id.toolbar))
         }
 
         val shouldShowNewEditMessage = intent.getBooleanExtra(SHOW_NEW_EDIT_MESSAGE, false)
         if (shouldShowNewEditMessage) {
             showLongSnackbar(
-                findViewById(R.id.fragment_container),
+                findViewById(R.id.nav_host_fragment),
                 getString(org.odk.collect.strings.R.string.finalized_form_edit_started),
                 null,
                 null,

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragmentHostActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragmentHostActivity.kt
@@ -19,7 +19,6 @@ import org.odk.collect.android.utilities.InstancesRepositoryProvider
 import org.odk.collect.android.utilities.MediaUtils
 import org.odk.collect.android.utilities.SavepointsRepositoryProvider
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
-import org.odk.collect.androidshared.ui.SnackbarUtils.showLongSnackbar
 import org.odk.collect.async.Scheduler
 import org.odk.collect.audiorecorder.recording.AudioRecorder
 import org.odk.collect.location.LocationClient
@@ -142,20 +141,16 @@ class FormHierarchyFragmentHostActivity : LocalizedActivity() {
             val navHostFragment =
                 supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
             val navController = navHostFragment.navController
-            navController.setGraph(R.navigation.form_entry)
+
+            val shouldShowNewEditMessage = intent.getBooleanExtra(SHOW_NEW_EDIT_MESSAGE, false)
+            navController.setGraph(
+                R.navigation.form_entry,
+                FormHierarchyFragmentArgs.Builder(shouldShowNewEditMessage)
+                    .build()
+                    .toBundle()
+            )
 
             setSupportActionBar(findViewById(org.odk.collect.androidshared.R.id.toolbar))
-        }
-
-        val shouldShowNewEditMessage = intent.getBooleanExtra(SHOW_NEW_EDIT_MESSAGE, false)
-        if (shouldShowNewEditMessage) {
-            showLongSnackbar(
-                findViewById(R.id.nav_host_fragment),
-                getString(org.odk.collect.strings.R.string.finalized_form_edit_started),
-                null,
-                null,
-                true
-            )
         }
     }
 

--- a/collect_app/src/main/res/layout/hierarchy_host_layout.xml
+++ b/collect_app/src/main/res/layout/hierarchy_host_layout.xml
@@ -7,10 +7,10 @@
     <include layout="@layout/app_bar_layout" />
 
     <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragment_container"
-        android:name="org.odk.collect.android.formhierarchy.FormHierarchyFragment"
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/collect_app/src/main/res/navigation/form_entry.xml
+++ b/collect_app/src/main/res/navigation/form_entry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/form_entry.xml"
+    app:startDestination="@id/hierarchy">
+
+    <fragment
+        android:id="@+id/hierarchy"
+        android:name="org.odk.collect.android.formhierarchy.FormHierarchyFragment">
+    </fragment>
+
+</navigation>

--- a/collect_app/src/main/res/navigation/form_entry.xml
+++ b/collect_app/src/main/res/navigation/form_entry.xml
@@ -7,6 +7,9 @@
     <fragment
         android:id="@+id/hierarchy"
         android:name="org.odk.collect.android.formhierarchy.FormHierarchyFragment">
+        <argument
+            android:name="new_edit"
+            app:argType="boolean" />
     </fragment>
 
 </navigation>

--- a/collect_app/src/main/res/navigation/form_entry.xml
+++ b/collect_app/src/main/res/navigation/form_entry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/form_entry.xml"
+    android:id="@+id/form_entry"
     app:startDestination="@id/hierarchy">
 
     <fragment

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -114,4 +114,5 @@ kotlinAndroid = { id = "kotlin-android" }
 kotlinKapt = { id = "kotlin-kapt" }
 kotlinParcelize = { id = "kotlin-parcelize" }
 safeargsKotlin = { id = "androidx.navigation.safeargs.kotlin" }
+safeargs = { id = "androidx.navigation.safeargs" }
 ossLicenses = { id = "com.google.android.gms.oss-licenses-plugin" }


### PR DESCRIPTION
Work towards https://github.com/getodk/collect/issues/5420

As much as possible, this prepares `FormHierarchyFragment` to be used in a single activity with a (not yet ready) `FormEntryFragment` in a nav graph.

#### Why is this the best possible solution? Were any other approaches considered?

I thought I'd already done this as part of an earlier refactor, but just realized it was missing. The next step here is to convert `FormFillingActivity` into a host activity a single destination nav graph (`FormEntryFragment`) and then we'll be able to integrate `FormHierarchyFragment`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Navigating to and from the hierarchy is the area most affected here.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
