### PR TITLE
Add support for scanning Latin encoded PDF417 barcodes

### DIFF
--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -134,6 +134,10 @@ private class MlKitBarcodeScannerView(
         return if (!utf8Contents.isNullOrEmpty()) {
             utf8Contents
         } else if (bytes != null && barcode.format == Barcode.FORMAT_PDF417) {
+            /**
+             * Allow falling back to Latin encoding for PDF417 barcodes. This provides parity
+             * with the Zxing implementation.
+             */
             String(bytes, Charsets.ISO_8859_1)
         } else {
             null

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -100,11 +100,18 @@ private class MlKitBarcodeScannerView(
                 executor
             ) { result: MlKitAnalyzer.Result ->
                 val value = result.getValue(barcodeScanner)
-                val rawValue = value?.firstOrNull()?.rawValue
+                val barcode = value?.firstOrNull()
 
-                if (!rawValue.isNullOrEmpty()) {
-                    cameraController.unbind()
-                    callback(rawValue)
+                if (barcode != null) {
+                    val bytes = barcode.rawBytes
+                    val utf8Contents = barcode.rawValue
+                    if (!utf8Contents.isNullOrEmpty()) {
+                        cameraController.unbind()
+                        callback(utf8Contents)
+                    } else if (bytes != null && barcode.format == Barcode.FORMAT_PDF417) {
+                        cameraController.unbind()
+                        callback(String(bytes, Charsets.ISO_8859_1))
+                    }
                 }
             }
         )

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -103,14 +103,10 @@ private class MlKitBarcodeScannerView(
                 val barcode = value?.firstOrNull()
 
                 if (barcode != null) {
-                    val bytes = barcode.rawBytes
-                    val utf8Contents = barcode.rawValue
-                    if (!utf8Contents.isNullOrEmpty()) {
+                    val contents = processBarcode(barcode)
+                    if (!contents.isNullOrEmpty()) {
                         cameraController.unbind()
-                        callback(utf8Contents)
-                    } else if (bytes != null && barcode.format == Barcode.FORMAT_PDF417) {
-                        cameraController.unbind()
-                        callback(String(bytes, Charsets.ISO_8859_1))
+                        callback(contents)
                     }
                 }
             }
@@ -128,6 +124,19 @@ private class MlKitBarcodeScannerView(
             } else if (it == TorchState.OFF) {
                 torchListener.onTorchOff()
             }
+        }
+    }
+
+    private fun processBarcode(barcode: Barcode): String? {
+        val bytes = barcode.rawBytes
+        val utf8Contents = barcode.rawValue
+
+        return if (!utf8Contents.isNullOrEmpty()) {
+            utf8Contents
+        } else if (bytes != null && barcode.format == Barcode.FORMAT_PDF417) {
+            String(bytes, Charsets.ISO_8859_1)
+        } else {
+            null
         }
     }
 }


### PR DESCRIPTION
Closes #6762

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There are only minor changes to the MLKit scanner code here to allow for Latin encoded contents of specifically PDF417 barcodes (other barcodes will still need to be UTF8 encoded), but that code is untested, so it'd be good to check both project QR scanning and barcode scanning in form entry.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
