### PR TITLE
Fixed setting zoom level for Zoom.Box

### DIFF
--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -212,7 +212,7 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
                     if (count == 1) {
                         zoomToPoint(lastPoint, zoom.getAnimate());
                     } else if (count > 1) {
-                        final LatLngBounds bounds = expandBounds(builder.build(), 1 / zoom.getLevel());
+                        final LatLngBounds bounds = expandBounds(builder.build(), 1 / zoom.getScaleFactor());
                         new Handler().postDelayed(() -> {
                             try {
                                 moveOrAnimateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), zoom.getAnimate());

--- a/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
@@ -30,8 +30,8 @@ class MapViewModel(
         }
     }
 
-    fun zoomTo(boundingBox: List<MapPoint>, level: Double, animate: Boolean) {
-        _zoom.value = Zoom.Box(boundingBox, level, animate)
+    fun zoomTo(boundingBox: List<MapPoint>, scaleFactor: Double, animate: Boolean) {
+        _zoom.value = Zoom.Box(boundingBox, scaleFactor, _zoom.value?.level ?: DEFAULT_ZOOM, animate)
     }
 
     fun zoomToCurrentLocation(location: MapPoint?) {
@@ -107,6 +107,7 @@ sealed class Zoom {
 
     data class Box(
         val box: List<MapPoint>,
+        val scaleFactor: Double,
         override val level: Double,
         override val animate: Boolean
     ) : Zoom() {

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -251,7 +251,7 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
             public void onZoomToBox(@NonNull Zoom.Box zoom) {
                 List<MapPoint> points = zoom.getBox();
                 boolean animate = zoom.getAnimate();
-                Double scaleFactor = zoom.getLevel();
+                Double scaleFactor = zoom.getScaleFactor();
 
                 int count = 0;
                 List<GeoPoint> geoPoints = new ArrayList<>();


### PR DESCRIPTION
Closes #6759

#### Why is this the best possible solution? Were any other approaches considered?
`scaleFactor` is not the same as `zoomLevel`, but it was passed to `Zoom.Box` class as the zoom level. We need to keep both values to be able to use them separately.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As we know, handling zoom levels can be tricky, and there are many edge cases where things can break. Please take some time not only to ensure this issue is fully resolved but also to check for any related bugs that might have been missed. I don't have anything particular in mind, just everything zoom-related.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
