### PR TITLE
Make sure min zoom level is used by default when scanning barcodes

### DIFF
--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -111,6 +111,7 @@ private class MlKitBarcodeScannerView(
                 }
             }
         )
+        cameraController.setLinearZoom(0f)
     }
 
     override fun setTorchOn(on: Boolean) {


### PR DESCRIPTION
Closes #6774

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/docs/CONTRIBUTING.md
-->

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
