### PR TITLE
Add view finder to MLKit scanner

### DIFF
--- a/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
@@ -1,0 +1,43 @@
+package org.odk.collect.qrcode
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.View
+import kotlin.math.roundToInt
+
+class ScannerOverlay(context: Context, attrs: AttributeSet?) :
+    View(context, attrs) {
+
+    private val laserPaint = Paint().also {
+        it.color = Color.RED
+    }
+
+    private val laserAnim = ValueAnimator.ofFloat(0f, 100f).also { animator ->
+        animator.setDuration(1000)
+        animator.repeatCount = ValueAnimator.INFINITE
+        animator.repeatMode = ValueAnimator.REVERSE
+        animator.addUpdateListener {
+            laserPaint.alpha = (it.animatedValue as Float).roundToInt()
+            invalidate()
+        }
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val verticalMid = height / 2
+        canvas.drawRect(
+            0f + 2,
+            verticalMid.toFloat() - 2,
+            width.toFloat() - 2,
+            verticalMid.toFloat() + 2,
+            laserPaint
+        )
+
+        if (!laserAnim.isStarted) {
+            laserAnim.start()
+        }
+    }
+}

--- a/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
@@ -22,8 +22,8 @@ class ScannerOverlay(context: Context, attrs: AttributeSet?) :
         it.alpha = 75
     }
 
-    private val laserAnim = ValueAnimator.ofFloat(0f, 100f).also { animator ->
-        animator.setDuration(1000)
+    private val laserAnim = ValueAnimator.ofFloat(0f, 255f).also { animator ->
+        animator.setDuration(320)
         animator.repeatCount = ValueAnimator.INFINITE
         animator.repeatMode = ValueAnimator.REVERSE
     }

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -11,6 +11,7 @@ import androidx.camera.core.TorchState
 import androidx.camera.mlkit.vision.MlKitAnalyzer
 import androidx.camera.view.LifecycleCameraController
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.google.android.gms.common.moduleinstall.ModuleInstall
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
@@ -70,6 +71,16 @@ private class MlKitBarcodeScannerView(
 
     init {
         binding.prompt.text = prompt
+
+        lifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onResume(owner: LifecycleOwner) {
+                binding.scannerOverlay.startAnimations()
+            }
+
+            override fun onPause(owner: LifecycleOwner) {
+                binding.scannerOverlay.stopAnimations()
+            }
+        })
     }
 
     override fun scan(callback: (String) -> Unit) {

--- a/qr-code/src/main/res/layout/mlkit_barcode_scanner_layout.xml
+++ b/qr-code/src/main/res/layout/mlkit_barcode_scanner_layout.xml
@@ -10,6 +10,11 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <org.odk.collect.qrcode.ScannerOverlay
+        android:id="@+id/scanner_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/prompt"
         android:layout_width="wrap_content"


### PR DESCRIPTION
Closes #6777 

#### Why is this the best possible solution? Were any other approaches considered?

I'd initially looked at just using the `ViewFinderView` that Zxing uses, but it's highly coupled to that library's `BarcodeView`, and really only intended to be used together with it as a part of `DecoratedBarcodeView`. Instead, I just ended up creating a simple overlay view that uses `onDraw` to draw out the borders and "laser" line.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The main risk here is that the view finder borders will look wonky somewhere. Trying out different places it appears in different rotations is probably the thing to be looking at here.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
