### PR TITLE
Only use MLKit for barcode scanning in form entry in non-release builds

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.kt
@@ -16,6 +16,7 @@ import org.odk.collect.async.Scheduler
 import org.odk.collect.async.network.NetworkStateProvider
 import org.odk.collect.openrosa.http.OpenRosaHttpInterface
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
+import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.testshared.FakeBarcodeScannerViewFactory
 import org.odk.collect.testshared.FakeBroadcastReceiverRegister
 import org.odk.collect.utilities.UserAgentProvider
@@ -57,7 +58,7 @@ open class TestDependencies @JvmOverloads constructor(
         return scheduler
     }
 
-    override fun providesBarcodeScannerViewFactory(): BarcodeScannerViewContainer.Factory {
+    override fun providesBarcodeScannerViewFactory(settingsProvider: SettingsProvider): BarcodeScannerViewContainer.Factory {
         return fakeBarcodeScannerViewFactory
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/SettingsBarcodeScannerViewFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/SettingsBarcodeScannerViewFactory.kt
@@ -1,0 +1,34 @@
+package org.odk.collect.android.configure.qr
+
+import android.app.Activity
+import androidx.lifecycle.LifecycleOwner
+import org.odk.collect.android.preferences.SettingsExt.getExperimentalOptIn
+import org.odk.collect.qrcode.BarcodeScannerView
+import org.odk.collect.qrcode.BarcodeScannerViewContainer
+import org.odk.collect.qrcode.mlkit.PlayServicesFallbackBarcodeScannerViewFactory
+import org.odk.collect.qrcode.zxing.ZxingBarcodeScannerViewFactory
+import org.odk.collect.settings.keys.ProjectKeys
+import org.odk.collect.shared.settings.Settings
+
+class SettingsBarcodeScannerViewFactory(
+    private val settings: Settings
+) : BarcodeScannerViewContainer.Factory {
+    private val playServicesFallbackFactory = PlayServicesFallbackBarcodeScannerViewFactory()
+    private val zxingFactory = ZxingBarcodeScannerViewFactory()
+
+    override fun create(
+        activity: Activity,
+        lifecycleOwner: LifecycleOwner,
+        qrOnly: Boolean,
+        prompt: String,
+        useFrontCamera: Boolean
+    ): BarcodeScannerView {
+        val factory = if (qrOnly || settings.getExperimentalOptIn(ProjectKeys.KEY_MLKIT_SCANNING)) {
+            playServicesFallbackFactory
+        } else {
+            zxingFactory
+        }
+
+        return factory.create(activity, lifecycleOwner, qrOnly, prompt, useFrontCamera)
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -41,6 +41,7 @@ import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler;
 import org.odk.collect.android.configure.qr.AppConfigurationGenerator;
 import org.odk.collect.android.configure.qr.CachingQRCodeGenerator;
 import org.odk.collect.android.configure.qr.QRCodeGenerator;
+import org.odk.collect.android.configure.qr.SettingsBarcodeScannerViewFactory;
 import org.odk.collect.android.database.itemsets.DatabaseFastExternalItemsetsRepository;
 import org.odk.collect.android.entities.EntitiesRepositoryProvider;
 import org.odk.collect.android.external.InstancesContract;
@@ -51,8 +52,6 @@ import org.odk.collect.android.formmanagement.CollectFormEntryControllerFactory;
 import org.odk.collect.android.formmanagement.FormsDataService;
 import org.odk.collect.android.formmanagement.OpenRosaClientProvider;
 import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
-import org.odk.collect.qrcode.BarcodeScannerViewContainer;
-import org.odk.collect.qrcode.mlkit.PlayServicesFallbackBarcodeScannerViewFactory;
 import org.odk.collect.android.geo.MapConfiguratorProvider;
 import org.odk.collect.android.geo.MapFragmentFactoryImpl;
 import org.odk.collect.android.instancemanagement.InstancesDataService;
@@ -127,6 +126,7 @@ import org.odk.collect.projects.ProjectCreator;
 import org.odk.collect.projects.ProjectsRepository;
 import org.odk.collect.projects.SettingsConnectionMatcher;
 import org.odk.collect.projects.SharedPreferencesProjectsRepository;
+import org.odk.collect.qrcode.BarcodeScannerViewContainer;
 import org.odk.collect.qrcode.zxing.QRCodeCreatorImpl;
 import org.odk.collect.qrcode.zxing.QRCodeDecoder;
 import org.odk.collect.qrcode.zxing.QRCodeDecoderImpl;
@@ -650,7 +650,7 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public BarcodeScannerViewContainer.Factory providesBarcodeScannerViewFactory() {
-        return new PlayServicesFallbackBarcodeScannerViewFactory();
+    public BarcodeScannerViewContainer.Factory providesBarcodeScannerViewFactory(SettingsProvider settingsProvider) {
+        return new SettingsBarcodeScannerViewFactory(settingsProvider.getUnprotectedSettings());
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
@@ -53,6 +53,7 @@ object Defaults {
             hashMap[ProjectKeys.KEY_MAPBOX_MAP_STYLE] = "mapbox://styles/mapbox/streets-v11"
             // experimental_preferences.xml
             hashMap[ProjectKeys.KEY_DEBUG_FILTERS] = BuildConfig.BUILD_TYPE == "selfSignedRelease"
+            hashMap[ProjectKeys.KEY_MLKIT_SCANNING] = true
             return hashMap
         }
 

--- a/collect_app/src/main/res/xml/experimental_preferences.xml
+++ b/collect_app/src/main/res/xml/experimental_preferences.xml
@@ -8,6 +8,12 @@
         android:title="@string/dev_tools"
         app:persistent="false" />
 
+    <SwitchPreference
+        android:key="mlkit_scanning"
+        android:title="Use MLKit for barcode scanning"
+        android:summary="MLKit is always used for scanning project QR codes"
+        app:iconSpaceReserved="false" />
+
     <PreferenceCategory
         android:title="@string/entities_title"
         app:allowDividerAbove="false"

--- a/collect_app/src/main/res/xml/experimental_preferences.xml
+++ b/collect_app/src/main/res/xml/experimental_preferences.xml
@@ -10,8 +10,8 @@
 
     <SwitchPreference
         android:key="mlkit_scanning"
-        android:title="Use MLKit for barcode scanning"
-        android:summary="MLKit is always used for scanning project QR codes"
+        android:title="@string/use_mlkit_for_barcode_scanning"
+        android:summary="@string/mlkit_is_always_used_for_scanning_project_qr_codes"
         app:iconSpaceReserved="false" />
 
     <PreferenceCategory

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FirstLaunchActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FirstLaunchActivityTest.kt
@@ -32,6 +32,7 @@ import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.androidtest.RecordedIntentsRule
 import org.odk.collect.material.MaterialProgressDialogFragment
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
+import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.strings.localization.getLocalizedString
 import org.odk.collect.testshared.FakeBarcodeScannerViewFactory
 import org.odk.collect.testshared.RobolectricHelpers
@@ -48,7 +49,7 @@ class FirstLaunchActivityTest {
     @Before
     fun setup() {
         CollectHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
-            override fun providesBarcodeScannerViewFactory(): BarcodeScannerViewContainer.Factory {
+            override fun providesBarcodeScannerViewFactory(settingsProvider: SettingsProvider): BarcodeScannerViewContainer.Factory {
                 return FakeBarcodeScannerViewFactory()
             }
         })

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectSettingsDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectSettingsDialogTest.kt
@@ -78,7 +78,7 @@ class ProjectSettingsDialogTest {
                 return projectsRepository
             }
 
-            override fun providesBarcodeScannerViewFactory(): BarcodeScannerViewContainer.Factory {
+            override fun providesBarcodeScannerViewFactory(settingsProvider: SettingsProvider): BarcodeScannerViewContainer.Factory {
                 return FakeBarcodeScannerViewFactory()
             }
         })

--- a/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
@@ -37,6 +37,7 @@ import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.permissions.PermissionsProvider
 import org.odk.collect.projects.ProjectCreator
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
+import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.testshared.FakeBarcodeScannerViewFactory
 import org.odk.collect.testshared.FakeScheduler
 import org.robolectric.shadows.ShadowToast
@@ -56,7 +57,7 @@ class QrCodeProjectCreatorDialogTest {
         permissionsProvider.setPermissionGranted(true)
 
         CollectHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
-            override fun providesBarcodeScannerViewFactory(): BarcodeScannerViewContainer.Factory {
+            override fun providesBarcodeScannerViewFactory(settingsProvider: SettingsProvider): BarcodeScannerViewContainer.Factory {
                 return barcodeScannerViewFactory
             }
 

--- a/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
@@ -52,6 +52,7 @@ object ProjectKeys {
 
     // experimental_preferences.xml
     const val KEY_DEBUG_FILTERS = "experimental_debug_filters"
+    const val KEY_MLKIT_SCANNING = "mlkit_scanning"
 
     // values
     const val PROTOCOL_SERVER = "odk_default"

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1245,6 +1245,10 @@
     <string name="debug_filters">Debug filters</string>
     <string name="debug_filters_summary">Show debug information for filter expression executions during form entry</string>
 
+    <!-- Option provided in the Experimental settings to opt in/out of the newer MLKit based barcode scanner -->
+    <string name="use_mlkit_for_barcode_scanning">Use MLKit for barcode scanning</string>
+    <string name="mlkit_is_always_used_for_scanning_project_qr_codes">MLKit is always used for scanning project QR codes</string>
+
     <string name="permission_dialog_title">About permissions</string>
     <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>
     <string name="notifications">Notifications</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1245,9 +1245,9 @@
     <string name="debug_filters">Debug filters</string>
     <string name="debug_filters_summary">Show debug information for filter expression executions during form entry</string>
 
-    <!-- Option provided in the Experimental settings to opt in/out of the newer MLKit based barcode scanner -->
-    <string name="use_mlkit_for_barcode_scanning">Use MLKit for barcode scanning</string>
-    <string name="mlkit_is_always_used_for_scanning_project_qr_codes">MLKit is always used for scanning project QR codes</string>
+    <!-- Option provided in the Experimental settings to opt in/out of the newer ML Kit based barcode scanner -->
+    <string name="use_mlkit_for_barcode_scanning">Use ML Kit for barcode scanning</string>
+    <string name="mlkit_is_always_used_for_scanning_project_qr_codes">ML Kit is always used for scanning project QR codes</string>
 
     <string name="permission_dialog_title">About permissions</string>
     <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>


### PR DESCRIPTION
This disables MLKit for barcode questions in release builds. It will still be available in beta and other builds, and can be opted in/out from an experimental setting. Project QR codes will continue to use MLKit regardless of the setting.

When reviewing, it's important to double-check me on the logic around hiding/using the setting here.