### PR TITLE
Handling deleted forms on form saving

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSaveTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSaveTest.kt
@@ -3,13 +3,12 @@ package org.odk.collect.android.feature.formentry
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
-import org.odk.collect.android.R
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain
 
-class FormSavedSnackbarTest {
+class FormSaveTest {
     private val rule = CollectTestRule()
     private val testDependencies = TestDependencies()
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormSavedSnackbarTest.kt
@@ -4,15 +4,17 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.odk.collect.android.R
+import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain
 
 class FormSavedSnackbarTest {
     private val rule = CollectTestRule()
+    private val testDependencies = TestDependencies()
 
     @get:Rule
-    val copyFormChain: RuleChain = TestRuleChain.chain().around(rule)
+    val copyFormChain: RuleChain = TestRuleChain.chain(testDependencies).around(rule)
 
     @Test
     fun whenBlankFormSavedAsDraft_displaySnackbarWithEditAction() {
@@ -61,5 +63,19 @@ class FormSavedSnackbarTest {
             .assertTextDoesNotExist(org.odk.collect.strings.R.string.form_saved_as_draft)
             .rotateToLandscape(MainMenuPage())
             .assertTextDoesNotExist(org.odk.collect.strings.R.string.form_saved_as_draft)
+    }
+
+    @Test
+    fun whenFormDeletedDuringFilling_displayErrorOnAttemptToSave() {
+        rule.startAtMainMenu()
+            .copyForm("one-question.xml")
+            .setServer(testDependencies.server.url)
+            .enableMatchExactly()
+            .startBlankForm("One Question")
+            .also { testDependencies.scheduler.runDeferredTasks() }
+            .clickSaveWithError("Sorry, form save failed! Form can't be found.")
+            .swipeToEndScreen()
+            .clickSaveAsDraftWithError("Sorry, form save failed! Form can't be found.")
+            .clickFinalizeWithError("Sorry, form save failed! Form can't be found.")
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
@@ -7,6 +7,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+import android.os.Build;
+
 import org.odk.collect.android.R;
 
 public class FormEndPage extends Page<FormEndPage> {
@@ -31,6 +33,12 @@ public class FormEndPage extends Page<FormEndPage> {
         return clickSaveAsDraft(new MainMenuPage());
     }
 
+    public FormEndPage clickSaveAsDraftWithError(String errorMsg) {
+        clickOnString(org.odk.collect.strings.R.string.save_as_draft);
+        checkIsToastWithMessageDisplayed(errorMsg);
+        return this;
+    }
+
     public <D extends Page<D>> D clickFinalize(D destination) {
         return clickOnString(org.odk.collect.strings.R.string.finalize, destination);
     }
@@ -38,6 +46,12 @@ public class FormEndPage extends Page<FormEndPage> {
     public MainMenuPage clickFinalize() {
         clickFinalize(new MainMenuPage());
         return new MainMenuPage();
+    }
+
+    public FormEndPage clickFinalizeWithError(String errorMsg) {
+        clickOnString(org.odk.collect.strings.R.string.finalize);
+        checkIsToastWithMessageDisplayed(errorMsg);
+        return this;
     }
 
     public MainMenuPage clickSend() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
@@ -7,8 +7,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-import android.os.Build;
-
 import org.odk.collect.android.R;
 
 public class FormEndPage extends Page<FormEndPage> {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -24,7 +24,6 @@ import static org.odk.collect.android.support.matchers.CustomMatchers.isQuestion
 import static org.odk.collect.android.support.matchers.CustomMatchers.withIndex;
 
 import android.graphics.Bitmap;
-import android.os.Build;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -251,16 +250,9 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
-    public FormEntryPage clickSaveWithError(int errorMsg) {
+    public FormEntryPage clickSaveWithError(String errorMsg) {
         onView(withId(R.id.menu_save)).perform(click());
-
-        if (Build.VERSION.SDK_INT < 30) {
-            checkIsToastWithMessageDisplayed(errorMsg);
-        } else {
-            assertText(errorMsg);
-            clickOKOnDialog();
-        }
-
+        checkIsToastWithMessageDisplayed(errorMsg);
         return this;
     }
 


### PR DESCRIPTION
Closes #6778 

#### Why is this the best possible solution? Were any other approaches considered?
I considered checking whether the form exists before attempting to save it, to make the logic clearer and handle everything in one place. However, it's not that straightforward - deletion could occur right after the check but before the actual save. Additionally, there are multiple parts of the code responsible for saving forms where a crash could happen. Given that, I believe the current approach of catching the exception remains the most reliable solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I don't see this PR as risky and can't think of any specific functionality that requires extra testing. When testing, just focus on the issue itself and trust your instincts.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
