### PR TITLE
Display marker with cutout if symbol is not defined or blank

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -165,8 +165,8 @@ internal class SelectChoicesMapData(
                                     properties,
                                     selectChoice.index == selectedIndex,
                                     point = points[0],
-                                    smallIcon = if (markerSymbol == null) org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small else org.odk.collect.icons.R.drawable.ic_map_marker_small,
-                                    largeIcon = if (markerSymbol == null) org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big else org.odk.collect.icons.R.drawable.ic_map_marker_big,
+                                    smallIcon = if (markerSymbol.isNullOrBlank()) org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small else org.odk.collect.icons.R.drawable.ic_map_marker_small,
+                                    largeIcon = if (markerSymbol.isNullOrBlank()) org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big else org.odk.collect.icons.R.drawable.ic_map_marker_big,
                                     color = markerColor,
                                     symbol = markerSymbol,
                                     action = IconifiedText(

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -304,7 +304,7 @@ class SelectChoicesMapDataTest {
     }
 
     @Test
-    fun `uses different icon if marker-symbol is defined`() {
+    fun `uses marker with cutout if marker-symbol is defined`() {
         val choices = listOf(
             selectChoice(
                 value = "a",
@@ -327,6 +327,44 @@ class SelectChoicesMapDataTest {
         val item = data.getMappableItems().getOrAwaitValue()!![0] as MappableSelectItem.MappableSelectPoint
         assertThat(item.smallIcon, equalTo(org.odk.collect.icons.R.drawable.ic_map_marker_small))
         assertThat(item.largeIcon, equalTo(org.odk.collect.icons.R.drawable.ic_map_marker_big))
+    }
+
+    @Test
+    fun `uses marker without cutout if marker-symbol is not defined or blank`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 305 0")
+                    )
+                )
+            ),
+            selectChoice(
+                value = "b",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(SelectChoicesMapData.GEOMETRY, "0 170.00 0 0"),
+                        treeElement(SelectChoicesMapData.MARKER_SYMBOL, " ")
+                    )
+                )
+            )
+        )
+
+        val prompt = MockFormEntryPromptBuilder()
+            .withLongText("Which is your favourite place?")
+            .withSelectChoices(choices)
+            .build()
+
+        val data = loadDataForPrompt(prompt)
+
+        val firstItem = data.getMappableItems().getOrAwaitValue()!![0] as MappableSelectItem.MappableSelectPoint
+        assertThat(firstItem.smallIcon, equalTo(org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small))
+        assertThat(firstItem.largeIcon, equalTo(org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big))
+
+        val secondItem = data.getMappableItems().getOrAwaitValue()!![1] as MappableSelectItem.MappableSelectPoint
+        assertThat(secondItem.smallIcon, equalTo(org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_small))
+        assertThat(secondItem.largeIcon, equalTo(org.odk.collect.icons.R.drawable.ic_map_marker_with_hole_big))
     }
 
     private fun loadDataForPrompt(prompt: FormEntryPrompt): SelectChoicesMapData {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -304,7 +304,7 @@ class SelectChoicesMapDataTest {
     }
 
     @Test
-    fun `uses marker with cutout if marker-symbol is defined`() {
+    fun `uses marker without cutout if marker-symbol is defined`() {
         val choices = listOf(
             selectChoice(
                 value = "a",
@@ -330,7 +330,7 @@ class SelectChoicesMapDataTest {
     }
 
     @Test
-    fun `uses marker without cutout if marker-symbol is not defined or blank`() {
+    fun `uses marker with cutout if marker-symbol is not defined or blank`() {
         val choices = listOf(
             selectChoice(
                 value = "a",


### PR DESCRIPTION
Closes #6779

#### Why is this the best possible solution? Were any other approaches considered?
It simply makes more sense to always display markers with a cutout whenever a symbol is not defined properly.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It simply fixes the bug, with minimal risk of affecting other functionality.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used this one:
[form.zip](https://github.com/user-attachments/files/21026214/form.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
