### PR TITLE
Fix `./` expressions in entity filters

### DIFF
--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -91,7 +91,12 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
         val candidate = CompareToNodeExpression.parse(predicate)
 
         return if (candidate != null) {
-            val child = candidate.nodeSide.steps[0].name.name
+            val child = if (candidate.nodeSide.steps.size == 1) {
+                candidate.nodeSide.steps[0].name.name
+            } else {
+                candidate.nodeSide.steps[1].name.name
+            }
+
             val value = candidate.evalContextSide(sourceInstance, evaluationContext)
 
             if (predicate.isEqual) {

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategy.kt
@@ -7,7 +7,7 @@ import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.xpath.expr.XPathExpression
 import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceAdapter
 import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceProvider
-import org.odk.collect.entities.javarosa.parse.XPathExpressionExt.parseToQuery
+import org.odk.collect.entities.javarosa.parse.XPathExpressionExt.toQuery
 import org.odk.collect.entities.storage.EntitiesRepository
 import org.odk.collect.entities.storage.QueryException
 import org.odk.collect.shared.Query
@@ -37,7 +37,7 @@ class LocalEntitiesFilterStrategy(entitiesRepository: EntitiesRepository) :
             return next.get()
         }
 
-        val query = predicate.parseToQuery(sourceInstance, evaluationContext)
+        val query = predicate.toQuery(sourceInstance, evaluationContext)
         return if (query != null) {
             try {
                 queryToTreeReferences(query, sourceInstance)

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
@@ -1,0 +1,86 @@
+package org.odk.collect.entities.javarosa.parse
+
+import org.javarosa.core.model.CompareToNodeExpression
+import org.javarosa.core.model.condition.EvaluationContext
+import org.javarosa.core.model.instance.DataInstance
+import org.javarosa.xpath.expr.XPathBoolExpr
+import org.javarosa.xpath.expr.XPathEqExpr
+import org.javarosa.xpath.expr.XPathExpression
+import org.odk.collect.shared.Query
+
+object XPathExpressionExt {
+
+    /**
+     * Converts an XPath expression to a [Query]. For example:
+     * - `label = 'blah'` will be converted to `Query.StringEq("label", "foo")`
+     * - `label` = /some/string/ref will be converted to `Query.StringEq("label", "blah")`
+     * (where `/some/string/ref` evaluates to `"blah"` within the context of the passed
+     * `DataInstance` and `EvaluationContext`)
+     *
+     * `and`, `or`, `=` and `!=` are all supported. If an expression cannot be converted to a
+     * `Query`, `null` will be returned.
+     */
+    fun XPathExpression.parseToQuery(
+        sourceInstance: DataInstance<*>,
+        evaluationContext: EvaluationContext
+    ): Query? {
+        return when (this) {
+            is XPathBoolExpr -> xPathBoolExprToQuery(this, sourceInstance, evaluationContext)
+            is XPathEqExpr -> xPathEqExprToQuery(this, sourceInstance, evaluationContext)
+            else -> null
+        }
+    }
+
+    private fun xPathBoolExprToQuery(
+        predicate: XPathBoolExpr,
+        sourceInstance: DataInstance<*>,
+        evaluationContext: EvaluationContext
+    ): Query? {
+        val queryA = predicate.a.parseToQuery(sourceInstance, evaluationContext)
+        val queryB = predicate.b.parseToQuery(sourceInstance, evaluationContext)
+
+        return if (queryA != null && queryB != null) {
+            if (predicate.op == XPathBoolExpr.AND) {
+                Query.And(queryA, queryB)
+            } else {
+                Query.Or(queryA, queryB)
+            }
+        } else {
+            null
+        }
+    }
+
+    private fun xPathEqExprToQuery(
+        predicate: XPathEqExpr,
+        sourceInstance: DataInstance<*>,
+        evaluationContext: EvaluationContext
+    ): Query? {
+        val candidate = CompareToNodeExpression.parse(predicate)
+
+        return if (candidate != null) {
+            val child = if (candidate.nodeSide.steps.size == 1) {
+                candidate.nodeSide.steps[0].name.name
+            } else {
+                candidate.nodeSide.steps[1].name.name
+            }
+
+            val value = candidate.evalContextSide(sourceInstance, evaluationContext)
+
+            if (predicate.isEqual) {
+                if (value is Double) {
+                    Query.NumericEq(child, value)
+                } else {
+                    Query.StringEq(child, value.toString())
+                }
+            } else {
+                if (value is Double) {
+                    Query.NumericNotEq(child, value)
+                } else {
+                    Query.StringNotEq(child, value.toString())
+                }
+            }
+        } else {
+            null
+        }
+    }
+}

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
@@ -6,6 +6,7 @@ import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.xpath.expr.XPathBoolExpr
 import org.javarosa.xpath.expr.XPathEqExpr
 import org.javarosa.xpath.expr.XPathExpression
+import org.javarosa.xpath.expr.XPathStep
 import org.odk.collect.shared.Query
 
 object XPathExpressionExt {
@@ -20,7 +21,7 @@ object XPathExpressionExt {
      * `and`, `or`, `=` and `!=` are all supported. If an expression cannot be converted to a
      * `Query`, `null` will be returned.
      */
-    fun XPathExpression.parseToQuery(
+    fun XPathExpression.toQuery(
         sourceInstance: DataInstance<*>,
         evaluationContext: EvaluationContext
     ): Query? {
@@ -36,8 +37,8 @@ object XPathExpressionExt {
         sourceInstance: DataInstance<*>,
         evaluationContext: EvaluationContext
     ): Query? {
-        val queryA = predicate.a.parseToQuery(sourceInstance, evaluationContext)
-        val queryB = predicate.b.parseToQuery(sourceInstance, evaluationContext)
+        val queryA = predicate.a.toQuery(sourceInstance, evaluationContext)
+        val queryB = predicate.b.toQuery(sourceInstance, evaluationContext)
 
         return if (queryA != null && queryB != null) {
             if (predicate.op == XPathBoolExpr.AND) {
@@ -60,8 +61,10 @@ object XPathExpressionExt {
         return if (candidate != null) {
             val child = if (candidate.nodeSide.steps.size == 1) {
                 candidate.nodeSide.steps[0].name.name
-            } else {
+            } else if (candidate.nodeSide.steps.size == 2 && candidate.nodeSide.steps[0] == XPathStep.ABBR_SELF()) {
                 candidate.nodeSide.steps[1].name.name
+            } else {
+                return null
             }
 
             val value = candidate.evalContextSide(sourceInstance, evaluationContext)

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
@@ -16,7 +16,7 @@ object XPathExpressionExt {
 
     /**
      * Converts an XPath expression to a [Query]. For example:
-     * - `label = 'blah'` will be converted to `Query.StringEq("label", "foo")`
+     * - `label = 'blah'` will be converted to `Query.StringEq("label", "blah")`
      * - `label` = /some/string/ref will be converted to `Query.StringEq("label", "blah")`
      * (where `/some/string/ref` evaluates to `"blah"` within the context of the passed
      * `DataInstance` and `EvaluationContext`)

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
@@ -92,8 +92,10 @@ object XPathExpressionExt {
     }
 
     private fun isNodeRelativeExpression(steps: Array<XPathStep>): Boolean {
-        val dotSlash = XPathStep(AXIS_SELF, TEST_TYPE_NODE)
-        val nodeFunc = XPathStep(AXIS_CHILD, TEST_TYPE_NODE)
-        return steps.size == 2 && steps[0] == dotSlash || steps[0] == nodeFunc
+        return if (steps.size == 2 && steps[0].test == TEST_TYPE_NODE) {
+            return steps[0].axis == AXIS_SELF || steps[0].axis == AXIS_CHILD
+        } else {
+            false
+        }
     }
 }

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExt.kt
@@ -7,6 +7,9 @@ import org.javarosa.xpath.expr.XPathBoolExpr
 import org.javarosa.xpath.expr.XPathEqExpr
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.expr.XPathStep
+import org.javarosa.xpath.expr.XPathStep.AXIS_CHILD
+import org.javarosa.xpath.expr.XPathStep.AXIS_SELF
+import org.javarosa.xpath.expr.XPathStep.TEST_TYPE_NODE
 import org.odk.collect.shared.Query
 
 object XPathExpressionExt {
@@ -59,10 +62,11 @@ object XPathExpressionExt {
         val candidate = CompareToNodeExpression.parse(predicate)
 
         return if (candidate != null) {
-            val child = if (candidate.nodeSide.steps.size == 1) {
-                candidate.nodeSide.steps[0].name.name
-            } else if (candidate.nodeSide.steps.size == 2 && candidate.nodeSide.steps[0] == XPathStep.ABBR_SELF()) {
-                candidate.nodeSide.steps[1].name.name
+            val steps = candidate.nodeSide.steps
+            val child = if (steps.size == 1) {
+                steps[0].name.name
+            } else if (isNodeRelativeExpression(steps)) {
+                steps[1].name.name
             } else {
                 return null
             }
@@ -85,5 +89,11 @@ object XPathExpressionExt {
         } else {
             null
         }
+    }
+
+    private fun isNodeRelativeExpression(steps: Array<XPathStep>): Boolean {
+        val dotSlash = XPathStep(AXIS_SELF, TEST_TYPE_NODE)
+        val nodeFunc = XPathStep(AXIS_CHILD, TEST_TYPE_NODE)
+        return steps.size == 2 && steps[0] == dotSlash || steps[0] == nodeFunc
     }
 }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -501,6 +501,43 @@ class LocalEntitiesFilterStrategyTest {
     }
 
     @Test
+    fun `works correctly in the optimized way with node()`() {
+        entitiesRepository.save("things", Entity.New("thing1", "Thing1"))
+
+        val scenario = Scenario.init(
+            "Secondary instance form",
+            html(
+                head(
+                    title("Secondary instance form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("question"),
+                            )
+                        ),
+                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
+                        bind("/data/question").type("string")
+                    )
+                ),
+                body(
+                    select1Dynamic(
+                        "/data/question",
+                        "instance('things')/root/item[./label='Thing1']",
+                        "name",
+                        "label"
+                    )
+                )
+            ),
+            controllerSupplier
+        )
+
+        val choices = scenario.choicesOf("/data/question").map { it.value }
+        assertThat(choices, containsInAnyOrder("thing1"))
+        assertThat(fallthroughFilterStrategy.fellThrough, equalTo(false))
+    }
+
+    @Test
     fun `works correctly in the optimized way with version = expressions`() {
         entitiesRepository.save("things", Entity.New("thing1", "Thing1", version = 2))
 

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/LocalEntitiesFilterStrategyTest.kt
@@ -501,43 +501,6 @@ class LocalEntitiesFilterStrategyTest {
     }
 
     @Test
-    fun `works correctly in the optimized way with node()`() {
-        entitiesRepository.save("things", Entity.New("thing1", "Thing1"))
-
-        val scenario = Scenario.init(
-            "Secondary instance form",
-            html(
-                head(
-                    title("Secondary instance form"),
-                    model(
-                        mainInstance(
-                            t(
-                                "data id=\"create-entity-form\"",
-                                t("question"),
-                            )
-                        ),
-                        t("instance id=\"things\" src=\"jr://file-csv/things.csv\""),
-                        bind("/data/question").type("string")
-                    )
-                ),
-                body(
-                    select1Dynamic(
-                        "/data/question",
-                        "instance('things')/root/item[./label='Thing1']",
-                        "name",
-                        "label"
-                    )
-                )
-            ),
-            controllerSupplier
-        )
-
-        val choices = scenario.choicesOf("/data/question").map { it.value }
-        assertThat(choices, containsInAnyOrder("thing1"))
-        assertThat(fallthroughFilterStrategy.fellThrough, equalTo(false))
-    }
-
-    @Test
     fun `works correctly in the optimized way with version = expressions`() {
         entitiesRepository.save("things", Entity.New("thing1", "Thing1", version = 2))
 

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExtTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExtTest.kt
@@ -7,8 +7,33 @@ import org.javarosa.core.model.instance.ExternalDataInstance
 import org.javarosa.xpath.XPathParseTool
 import org.junit.Test
 import org.odk.collect.entities.javarosa.parse.XPathExpressionExt.toQuery
+import org.odk.collect.shared.Query
 
 class XPathExpressionExtTest {
+
+    @Test
+    fun `#toQuery returns Query when node side is qualified relative expression`() {
+        val sourceInstance = ExternalDataInstance()
+        val evaluationContext = EvaluationContext(sourceInstance)
+
+        val expression = XPathParseTool.parseXPath("./label = 'blah'")
+        assertThat(
+            expression.toQuery(sourceInstance, evaluationContext),
+            equalTo(Query.StringEq("label", "blah"))
+        )
+    }
+
+    @Test
+    fun `#toQuery returns Query when node side is node() expression`() {
+        val sourceInstance = ExternalDataInstance()
+        val evaluationContext = EvaluationContext(sourceInstance)
+
+        val expression = XPathParseTool.parseXPath("node()/label = 'blah'")
+        assertThat(
+            expression.toQuery(sourceInstance, evaluationContext),
+            equalTo(Query.StringEq("label", "blah"))
+        )
+    }
 
     @Test
     fun `#toQuery returns null when node side is multiple levels`() {

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExtTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/parse/XPathExpressionExtTest.kt
@@ -1,0 +1,36 @@
+package org.odk.collect.entities.javarosa.parse
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.javarosa.core.model.condition.EvaluationContext
+import org.javarosa.core.model.instance.ExternalDataInstance
+import org.javarosa.xpath.XPathParseTool
+import org.junit.Test
+import org.odk.collect.entities.javarosa.parse.XPathExpressionExt.toQuery
+
+class XPathExpressionExtTest {
+
+    @Test
+    fun `#toQuery returns null when node side is multiple levels`() {
+        val sourceInstance = ExternalDataInstance()
+        val evaluationContext = EvaluationContext(sourceInstance)
+
+        val expression = XPathParseTool.parseXPath("one/two = 'blah'")
+        assertThat(
+            expression.toQuery(sourceInstance, evaluationContext),
+            equalTo(null)
+        )
+    }
+
+    @Test
+    fun `#toQuery returns null when node side is multiple levels and contains level called node`() {
+        val sourceInstance = ExternalDataInstance()
+        val evaluationContext = EvaluationContext(sourceInstance)
+
+        val expression = XPathParseTool.parseXPath("node/two = 'blah'")
+        assertThat(
+            expression.toQuery(sourceInstance, evaluationContext),
+            equalTo(null)
+        )
+    }
+}

--- a/shared/src/main/java/org/odk/collect/shared/Query.kt
+++ b/shared/src/main/java/org/odk/collect/shared/Query.kt
@@ -8,12 +8,12 @@ import org.odk.collect.shared.Query.StringEq
 import org.odk.collect.shared.Query.StringNotEq
 
 sealed class Query {
-    class StringEq(val column: String, val value: String) : Query()
-    class StringNotEq(val column: String, val value: String) : Query()
-    class NumericEq(val column: String, val value: Double) : Query()
-    class NumericNotEq(val column: String, val value: Double) : Query()
-    class And(val queryA: Query, val queryB: Query) : Query()
-    class Or(val queryA: Query, val queryB: Query) : Query()
+    data class StringEq(val column: String, val value: String) : Query()
+    data class StringNotEq(val column: String, val value: String) : Query()
+    data class NumericEq(val column: String, val value: Double) : Query()
+    data class NumericNotEq(val column: String, val value: Double) : Query()
+    data class And(val queryA: Query, val queryB: Query) : Query()
+    data class Or(val queryA: Query, val queryB: Query) : Query()
 }
 
 fun Query.mapColumns(columnMapper: (String) -> String): Query {


### PR DESCRIPTION
Closes #6788

#### Why is this the best possible solution? Were any other approaches considered?

I've just made sure that `./` and `node()` expressions work correctly (and are optimized) when used with entity lists. We could have alternatively skipped optimization, but this seemed like it would have been an equivalent amount of effort.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue! Verifying should be fairly simple: any entity update or follow-up form that uses an expression like `<property> = <something>` can be changed to `./<property> = <something>` or `node()/<property> = <something>` as all of these should behave the same.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
