### PR TITLE
Catch missing configuration row for external choices

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
@@ -56,4 +56,12 @@ class ExternalSelectsTest {
             .assertText("File: $formsDirPath/search_and_select-media/nombre.csv is missing.")
             .assertText("File: $formsDirPath/search_and_select-media/nombre2.csv is missing.")
     }
+
+    @Test
+    fun dynamicChoicesCanBeMixedWithNumericInternalOnes() {
+        rule.startAtMainMenu()
+            .copyForm("dynamic_and_static_choices.xml", listOf("fruits.csv"))
+            .startBlankForm("dynamic_and_static_choices")
+            .assertTexts("Mango", "Oranges", "Strawberries", "Apples")
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
@@ -64,4 +64,15 @@ class ExternalSelectsTest {
             .startBlankForm("dynamic_and_static_choices")
             .assertTexts("Mango", "Oranges", "Strawberries", "Apples")
     }
+
+    @Test
+    fun missingFileMessage_shouldBeDisplayedIfDynamicChoicesUsedButTheConfigurationRowIsMissing() {
+        val formsDirPath = StoragePathProvider().getOdkDirPath(StorageSubdirectory.FORMS)
+
+        rule.startAtMainMenu()
+            .copyForm("dynamic_and_static_choices.xml", listOf("fruits.csv"))
+            .startBlankForm("dynamic_and_static_choices")
+            .swipeToNextQuestion("Choose a number")
+            .assertText("File: $formsDirPath/dynamic_and_static_choices-media/numbers.csv is missing.")
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
@@ -62,7 +62,7 @@ class ExternalSelectsTest {
         rule.startAtMainMenu()
             .copyForm("dynamic_and_static_choices.xml", listOf("fruits.csv"))
             .startBlankForm("dynamic_and_static_choices")
-            .assertTexts("Mango", "Oranges", "Strawberries", "Apples")
+            .assertTexts("Mango", "Oranges", "Strawberries", "None of the above")
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUtil.java
@@ -167,7 +167,7 @@ public final class ExternalDataUtil {
             XPathFuncExpr xpathfuncexpr, FormController formController) throws FileNotFoundException {
         try {
             List<SelectChoice> selectChoices = formEntryPrompt.getSelectChoices();
-            if (containsConfigurationChoice(selectChoices)) {
+            if (!containsConfigurationChoice(selectChoices)) {
                 String filePath = getFilePath(xpathfuncexpr, formController);
                 throw new FileNotFoundException(filePath);
             }
@@ -351,10 +351,10 @@ public final class ExternalDataUtil {
     private static boolean containsConfigurationChoice(List<SelectChoice> selectChoices) {
         for (SelectChoice choice : selectChoices) {
             if (!isAnInteger(choice.getValue())) {
-                return false;
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
     private static String getFilePath(XPathFuncExpr xpathfuncexpr, FormController formController) {

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUtil.java
@@ -167,6 +167,10 @@ public final class ExternalDataUtil {
             XPathFuncExpr xpathfuncexpr, FormController formController) throws FileNotFoundException {
         try {
             List<SelectChoice> selectChoices = formEntryPrompt.getSelectChoices();
+            if (containsConfigurationChoice(selectChoices)) {
+                String filePath = getFilePath(xpathfuncexpr, formController);
+                throw new FileNotFoundException(filePath);
+            }
             ArrayList<SelectChoice> returnedChoices = new ArrayList<>();
             for (SelectChoice selectChoice : selectChoices) {
                 String value = selectChoice.getValue();
@@ -212,14 +216,7 @@ public final class ExternalDataUtil {
             }
             return returnedChoices;
         } catch (Exception e) {
-            String fileName = String.valueOf(xpathfuncexpr.args[0].eval(null, null));
-            if (!fileName.endsWith(".csv")) {
-                fileName = fileName + ".csv";
-            }
-            String filePath = fileName;
-            if (formController != null) {
-                filePath = formController.getMediaFolder() + File.separator + fileName;
-            }
+            String filePath = getFilePath(xpathfuncexpr, formController);
             if (!new File(filePath).exists()) {
                 throw new FileNotFoundException(filePath);
             }
@@ -344,5 +341,31 @@ public final class ExternalDataUtil {
         } catch (NumberFormatException e) {
             return false;
         }
+    }
+
+    /**
+     * The config row is a special row in the choices worksheet that defines how
+     * choices are mapped from an external .csv file with list_name, name and label,
+     * where these correspond to columns in the .csv file.
+     */
+    private static boolean containsConfigurationChoice(List<SelectChoice> selectChoices) {
+        for (SelectChoice choice : selectChoices) {
+            if (!isAnInteger(choice.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String getFilePath(XPathFuncExpr xpathfuncexpr, FormController formController) {
+        String fileName = String.valueOf(xpathfuncexpr.args[0].eval(null, null));
+        if (!fileName.endsWith(".csv")) {
+            fileName = fileName + ".csv";
+        }
+        String filePath = fileName;
+        if (formController != null) {
+            filePath = formController.getMediaFolder() + File.separator + fileName;
+        }
+        return filePath;
     }
 }

--- a/test-forms/src/main/resources/forms/dynamic_and_static_choices.xml
+++ b/test-forms/src/main/resources/forms/dynamic_and_static_choices.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<h:html
+    xmlns="http://www.w3.org/2002/xforms"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:odk="http://www.opendatakit.org/xforms">
+    <h:head>
+        <h:title>dynamic_and_static_choices</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="dynamic_and_static_choices">
+                    <fruits/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/fruits" type="string"/>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/data/fruits" appearance="search('fruits')">
+            <label>Choose a fruit</label>
+            <item>
+                <label>name</label>
+                <value>name_key</value>
+            </item>
+            <item>
+                <label>Apples</label>
+                <value>0</value>
+            </item>
+        </select1>
+    </h:body>
+</h:html>

--- a/test-forms/src/main/resources/forms/dynamic_and_static_choices.xml
+++ b/test-forms/src/main/resources/forms/dynamic_and_static_choices.xml
@@ -13,12 +13,14 @@
             <instance>
                 <data id="dynamic_and_static_choices">
                     <fruits/>
+                    <numbers/>
                     <meta>
                         <instanceID/>
                     </meta>
                 </data>
             </instance>
             <bind nodeset="/data/fruits" type="string"/>
+            <bind nodeset="/data/numbers" type="string"/>
             <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
         </model>
     </h:head>
@@ -32,6 +34,17 @@
             <item>
                 <label>Apples</label>
                 <value>0</value>
+            </item>
+        </select1>
+        <select1 ref="/data/numbers" appearance="search('numbers')">
+            <label>Choose a number</label>
+            <item>
+                <label>0</label>
+                <value>0</value>
+            </item>
+            <item>
+                <label>1</label>
+                <value>1</value>
             </item>
         </select1>
     </h:body>

--- a/test-forms/src/main/resources/forms/dynamic_and_static_choices.xml
+++ b/test-forms/src/main/resources/forms/dynamic_and_static_choices.xml
@@ -32,7 +32,7 @@
                 <value>name_key</value>
             </item>
             <item>
-                <label>Apples</label>
+                <label>None of the above</label>
                 <value>0</value>
             </item>
         </select1>


### PR DESCRIPTION
Closes #6792 

#### Why is this the best possible solution? Were any other approaches considered?
~~The issue was that the `populateExternalChoices` method, which is responsible for reading from external CSV files, returned internal choices if they existed for values represented as integers: [https://github.com/getodk/collect/pull/6794/commits/08fcc82d76afd42c86a09615e20e35f742b4ec88#diff-5dca0a8d3dc453ec1b67830005c61a9c5a3e4d845c06181cff53506e36c3680dL175](https://github.com/getodk/collect/pull/6794/commits/08fcc82d76afd42c86a09615e20e35f742b4ec88#diff-5dca0a8d3dc453ec1b67830005c61a9c5a3e4d845c06181cff53506e36c3680dL175)
However, this method should always read from the CSV file, as that is its intended purpose.~~

~~I'm not really sure why it was implemented in this way.~~

**It turned out that tearting numeric choices in a different way is a feature - see comments in https://github.com/getodk/collect/issues/6792.**

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Playing with forms that read choices from external files is what we need to test here to make sure there is no regression introduced.

#### Do we need any specific form for testing your changes? If so, please attach one.
I've used: [dynamic_and_static_choices.xlsx](https://github.com/user-attachments/files/22568021/dynamic_and_static_choices.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
