### PR TITLE
Add wait to fix flakey test

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.kt
@@ -44,7 +44,7 @@ class AndroidShortcutsTest {
 
         testDependencies.scheduler.runDeferredTasks()
 
-        shortcutsPage.assertText("One Question")
+        shortcutsPage.asyncAssertText("One Question")
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -135,9 +135,9 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public FormEntryPage swipeToNextRepeat(String repeatLabel, int repeatNumber) {
-        waitForText(repeatLabel + " > " + (repeatNumber - 1));
+        asyncAssertText(repeatLabel + " > " + (repeatNumber - 1));
         flingLeft();
-        waitForText(repeatLabel + " > " + repeatNumber);
+        asyncAssertText(repeatLabel + " > " + repeatNumber);
         return this;
     }
 
@@ -358,9 +358,9 @@ public class FormEntryPage extends Page<FormEntryPage> {
 
     public FormEntryPage assertQuestion(String text, boolean isRequired) {
         if (isRequired) {
-            waitForText("* " + text);
+            asyncAssertText("* " + text);
         } else {
-            waitForText(text);
+            asyncAssertText(text);
         }
 
         return this;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/OpenSourceLicensesPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/OpenSourceLicensesPage.java
@@ -4,7 +4,7 @@ class OpenSourceLicensesPage extends Page<OpenSourceLicensesPage> {
 
     @Override
     public OpenSourceLicensesPage assertOnPage() {
-        waitForText("Open Source Licenses");
+        asyncAssertText("Open Source Licenses");
         checkIfWebViewActivityIsDisplayed();
         return this;
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -61,7 +61,6 @@ import org.odk.collect.testshared.Assertions
 import org.odk.collect.testshared.Interactions
 import org.odk.collect.testshared.RecyclerViewMatcher
 import org.odk.collect.testshared.WaitFor.tryAgainOnFail
-import org.odk.collect.testshared.WaitFor.wait250ms
 import org.odk.collect.testshared.WaitFor.waitFor
 import timber.log.Timber
 import java.io.File
@@ -452,8 +451,8 @@ abstract class Page<T : Page<T>> {
         return this as T
     }
 
-    private fun waitForDialogToSettle() {
-        wait250ms() // https://github.com/android/android-test/issues/444
+    protected fun waitForDialogToSettle() {
+        Thread.sleep(250) // https://github.com/android/android-test/issues/444
     }
 
     protected fun waitForText(text: String) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -136,6 +136,12 @@ abstract class Page<T : Page<T>> {
         return this as T
     }
 
+    fun asyncAssertText(text: String): T {
+        return waitFor {
+            assertText(text)
+        }
+    }
+
     @JvmOverloads
     fun assertTextThatContainsExists(text: String, index: Int = 0): T {
         onView(

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -455,10 +455,6 @@ abstract class Page<T : Page<T>> {
         Thread.sleep(250) // https://github.com/android/android-test/issues/444
     }
 
-    protected fun waitForText(text: String) {
-        waitFor { assertText(text) }
-    }
-
     protected fun assertToolbarTitle(title: String?) {
         onView(
             allOf(

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
@@ -10,7 +10,6 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.Matchers.allOf
-import org.odk.collect.testshared.WaitFor
 
 internal class ProjectSettingsDialogPage : Page<ProjectSettingsDialogPage>() {
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
@@ -88,7 +88,7 @@ internal class ProjectSettingsDialogPage : Page<ProjectSettingsDialogPage>() {
     }
 
     fun selectProject(projectName: String): MainMenuPage {
-        WaitFor.wait250ms() // https://github.com/android/android-test/issues/444
+        waitForDialogToSettle()
         onView(
             allOf(
                 hasDescendant(withText(projectName)),

--- a/test-shared/src/main/java/org/odk/collect/testshared/WaitFor.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/WaitFor.kt
@@ -2,7 +2,6 @@ package org.odk.collect.testshared
 
 import junit.framework.AssertionFailedError
 import org.odk.collect.shared.TimeInMs
-import java.sql.Time
 import java.util.concurrent.Callable
 
 object WaitFor {
@@ -28,11 +27,6 @@ object WaitFor {
         }
 
         throw failure!!
-    }
-
-    @JvmStatic
-    fun wait250ms() {
-        Thread.sleep(250)
     }
 
     @JvmStatic

--- a/test-shared/src/main/java/org/odk/collect/testshared/WaitFor.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/WaitFor.kt
@@ -1,17 +1,19 @@
 package org.odk.collect.testshared
 
 import junit.framework.AssertionFailedError
+import org.odk.collect.shared.TimeInMs
+import java.sql.Time
 import java.util.concurrent.Callable
 
 object WaitFor {
 
     @JvmStatic
     fun <T> waitFor(callable: Callable<T>): T {
-        var counter = 0
         var failure: Throwable? = null
+        val startTime = System.currentTimeMillis()
 
-        // Try 20 times/for 5 seconds
-        while (counter < 20) {
+        // Try for 5 seconds
+        while ((System.currentTimeMillis() - startTime) < (5 * TimeInMs.ONE_SECOND)) {
             failure = try {
                 return callable.call()
             } catch (throwable: Exception) {
@@ -22,8 +24,7 @@ object WaitFor {
                 throwable
             }
 
-            wait250ms()
-            counter++
+            Thread.sleep(10)
         }
 
         throw failure!!
@@ -31,11 +32,7 @@ object WaitFor {
 
     @JvmStatic
     fun wait250ms() {
-        try {
-            Thread.sleep(250)
-        } catch (ignored: InterruptedException) {
-            // ignored
-        }
+        Thread.sleep(250)
     }
 
     @JvmStatic
@@ -48,7 +45,7 @@ object WaitFor {
                 return
             } catch (e: Throwable) {
                 failure = e
-                wait250ms()
+                Thread.sleep(250)
             }
         }
 


### PR DESCRIPTION
Closes #6771

This adds a new public method to `Page` to allow for assertions in async situations. We **could** use this as an opportunity to make `waitFor` assertions the default (as we'll want to do down the line due to `IdlingResource` support languishing), but I'd like to hear @grzesiek2010's thoughts on that first.