### PR TITLE
Correct support for using select questions with search and the last-saved feature

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
@@ -71,9 +71,10 @@ class ExternalSelectsTest {
 
             // Start a new form to verify that answers from the previous form are retained
             .startBlankForm("Search with last-saved")
+            .swipeToNextQuestion("Select fruit 2")
             .clickGoToArrow()
             .assertHierarchyItem(0, "Select fruit 1", "Mango")
-            .assertHierarchyItem(1, "Select fruit 2", "oranges")
+            .assertHierarchyItem(1, "Select fruit 2", "Oranges")
 
             // Change an answer in a field-list and verify no errors occur
             .clickOnQuestion("Select fruit 2")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
@@ -56,4 +56,30 @@ class ExternalSelectsTest {
             .assertText("File: $formsDirPath/search_and_select-media/nombre.csv is missing.")
             .assertText("File: $formsDirPath/search_and_select-media/nombre2.csv is missing.")
     }
+
+    @Test // https://github.com/getodk/collect/issues/6801
+    fun searchFunctionWorksWellWithLastSaved() {
+        rule.startAtMainMenu()
+            // Fill out and finalize the first form
+            .copyForm("search-with-last-saved.xml", listOf("fruits.csv"))
+            .startBlankForm("Search with last-saved")
+            .clickOnText("Mango")
+            .swipeToNextQuestion("Select fruit 2")
+            .clickOnText("Oranges")
+            .swipeToEndScreen()
+            .clickFinalize()
+
+            // Start a new form to verify that answers from the previous form are retained
+            .startBlankForm("Search with last-saved")
+            .clickGoToArrow()
+            .assertHierarchyItem(0, "Select fruit 1", "Mango")
+            .assertHierarchyItem(1, "Select fruit 2", "oranges")
+
+            // Change an answer in a field-list and verify no errors occur
+            .clickOnQuestion("Select fruit 2")
+            .clickOnText("Strawberries")
+            .clickGoToArrow()
+            .assertHierarchyItem(0, "Select fruit 1", "Mango")
+            .assertHierarchyItem(1, "Select fruit 2", "Strawberries")
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUtil.java
@@ -22,6 +22,8 @@ import android.widget.Toast;
 
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -210,6 +212,7 @@ public final class ExternalDataUtil {
                     }
                 }
             }
+            updateQuestionAnswer(formEntryPrompt, returnedChoices);
             return returnedChoices;
         } catch (Exception e) {
             String fileName = String.valueOf(xpathfuncexpr.args[0].eval(null, null));
@@ -226,6 +229,23 @@ public final class ExternalDataUtil {
 
             throw new ExternalDataException(e.getMessage(), e);
         }
+    }
+
+    private static void updateQuestionAnswer(FormEntryPrompt formEntryPrompt, List<SelectChoice> returnedChoices) {
+        IAnswerData value = formEntryPrompt.getAnswerValue();
+        if (value == null) {
+            return;
+        }
+
+        Selection selection = (Selection) value.getValue();
+        if (selection.index != -1) {
+            return;
+        }
+
+        returnedChoices.stream()
+                .filter(choice -> selection.getValue().equals(choice.getValue()))
+                .findFirst()
+                .ifPresent(selection::attachChoice);
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -161,7 +161,6 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
             LifecycleOwner viewLifecycle
     ) {
         super(context);
-        updateQuestions(questionPrompts);
 
         this.viewLifecycle = viewLifecycle;
         this.audioPlayer = audioPlayer;
@@ -209,6 +208,7 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
 
         setupAudioErrors();
         autoplayIfNeeded(advancingPage);
+        updateQuestions(questionPrompts);
     }
 
     private void setupAudioErrors() {

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/QuestionAnswerProcessor.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/QuestionAnswerProcessor.kt
@@ -25,12 +25,7 @@ object QuestionAnswerProcessor {
             return ""
         }
 
-        val answerText = try {
-            fep.answerText
-        } catch (e: Exception) {
-            fep.answerValue?.displayText
-        }
-        if (!answerText.isNullOrBlank() &&
+        if (!fep.answerText.isNullOrBlank() &&
             Appearances.isMasked(fep) &&
             fep.controlType == Constants.CONTROL_INPUT &&
             fep.dataType == Constants.DATATYPE_TEXT
@@ -77,7 +72,7 @@ object QuestionAnswerProcessor {
 
         if (data != null && appearance != null && appearance.contains(Appearances.THOUSANDS_SEP)) {
             return try {
-                val answerAsDecimal = BigDecimal(answerText)
+                val answerAsDecimal = BigDecimal(fep.answerText)
 
                 val df = DecimalFormat()
                 df.groupingSize = 3
@@ -106,6 +101,6 @@ object QuestionAnswerProcessor {
             }
             return ItemsetDao(ItemsetDbAdapter()).getItemLabel(fep.answerValue!!.displayText, formController.getMediaFolder()!!.absolutePath, language)
         }
-        return answerText ?: ""
+        return fep.answerText ?: ""
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/QuestionAnswerProcessor.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/QuestionAnswerProcessor.kt
@@ -25,7 +25,12 @@ object QuestionAnswerProcessor {
             return ""
         }
 
-        if (!fep.answerText.isNullOrBlank() &&
+        val answerText = try {
+            fep.answerText
+        } catch (e: Exception) {
+            fep.answerValue?.displayText
+        }
+        if (!answerText.isNullOrBlank() &&
             Appearances.isMasked(fep) &&
             fep.controlType == Constants.CONTROL_INPUT &&
             fep.dataType == Constants.DATATYPE_TEXT
@@ -72,7 +77,7 @@ object QuestionAnswerProcessor {
 
         if (data != null && appearance != null && appearance.contains(Appearances.THOUSANDS_SEP)) {
             return try {
-                val answerAsDecimal = BigDecimal(fep.answerText)
+                val answerAsDecimal = BigDecimal(answerText)
 
                 val df = DecimalFormat()
                 df.groupingSize = 3
@@ -101,6 +106,6 @@ object QuestionAnswerProcessor {
             }
             return ItemsetDao(ItemsetDbAdapter()).getItemLabel(fep.answerValue!!.displayText, formController.getMediaFolder()!!.absolutePath, language)
         }
-        return fep.answerText ?: ""
+        return answerText ?: ""
     }
 }

--- a/test-forms/src/main/resources/forms/search-with-last-saved.xml
+++ b/test-forms/src/main/resources/forms/search-with-last-saved.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<h:html
+    xmlns="http://www.w3.org/2002/xforms"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:odk="http://www.opendatakit.org/xforms">
+    <h:head>
+        <h:title>Search with last-saved</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="search-with-last-saved">
+                    <fruit/>
+                    <group>
+                        <fruit2/>
+                        <details/>
+                    </group>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <instance id="__last-saved" src="jr://instance/last-saved"/>
+            <bind nodeset="/data/fruit" type="string"/>
+            <setvalue ref="/data/fruit" value=" instance('__last-saved')/data/fruit " event="odk-instance-first-load"/>
+            <bind nodeset="/data/group/fruit2" type="string"/>
+            <setvalue ref="/data/group/fruit2" value=" instance('__last-saved')/data/group/fruit2 " event="odk-instance-first-load"/>
+            <bind nodeset="/data/group/details" type="string"/>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/data/fruit" appearance="search('fruits')">
+            <label>Select fruit 1</label>
+            <item>
+                <label>name</label>
+                <value>name_key</value>
+            </item>
+        </select1>
+        <group appearance="field-list" ref="/data/group">
+            <select1 ref="/data/group/fruit2" appearance="search('fruits')">
+                <label>Select fruit 2</label>
+                <item>
+                    <label>name</label>
+                    <value>name_key</value>
+                </item>
+            </select1>
+            <input ref="/data/group/details">
+                <label>Fruit details</label>
+            </input>
+        </group>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #6801 

#### Why is this the best possible solution? Were any other approaches considered?
As I mentioned in the issue, this wasn’t a new bug, but due to recent changes, it became much more noticeable and started breaking some workflows, as we've seen on the forum. It’s something that needs to be addressed. I've included some comments below explaining the rationale behind my changes.
All the problems stem from the way external choices are handled by the `search()` function. Unlike internal choices or those from `select_one_from_file`, they are not immediately available in JavaRosa. Instead, they are loaded later, when the question is actually displayed. Because of this, if there is a default answer coming from the `last-saved` feature, we might not be able to immediately determine the user-visible label for that answer.
As far as I understand, this is not a priority for us, and `select_one_from_file` is the recommended way to load choices from external files. So we don’t plan to completely rework how `search()` handles external choices. Instead, I’ve made some fixes to improve its behavior in certain cases.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test the cases I described in the issue, as well as anything else you know that uses the `search()` function.

#### Do we need any specific form for testing your changes? If so, please attach one.
I've attached some forms in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
