### PR TITLE
Enhanced efficiency of detecting new media files

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
@@ -60,7 +60,7 @@ open class ServerFormsDetailsFetcher(
                     if (existingForm == null || existingForm.isDeleted) {
                         true
                     } else if (manifestFile != null) {
-                        hasUpdatedMediaFiles(manifestFile, existingForm)
+                        areNewerMediaFilesAvailable(existingForm, manifestFile.mediaFiles)
                     } else {
                         false
                     }
@@ -82,18 +82,6 @@ open class ServerFormsDetailsFetcher(
         }
     }
 
-    private fun hasUpdatedMediaFiles(
-        manifestFile: ManifestFile,
-        existingForm: Form
-    ): Boolean {
-        val newMediaFiles = manifestFile.mediaFiles
-        return if (newMediaFiles.isNotEmpty()) {
-            areNewerMediaFilesAvailable(existingForm, newMediaFiles)
-        } else {
-            false
-        }
-    }
-
     private fun getManifestFile(formSource: FormSource, manifestUrl: String): ManifestFile? {
         return try {
             formSource.fetchManifest(manifestUrl)
@@ -107,6 +95,10 @@ open class ServerFormsDetailsFetcher(
         existingForm: Form,
         newMediaFiles: List<MediaFile>
     ): Boolean {
+        if (newMediaFiles.isEmpty()) {
+            return false
+        }
+
         val localMediaHashes = FormUtils.getMediaFiles(existingForm)
             .map { it.getMd5Hash() }
             .toSet()


### PR DESCRIPTION
Work towards https://github.com/getodk/collect/issues/6807.

#### Why is this the best possible solution? Were any other approaches considered?
This change optimizes the process of comparing available media files with those already downloaded.
Previously, the implementation checked for new media files by iterating over each new file and, for each one, looping through all existing files to compare their hashes. Additionally, the hash of each local file was recalculated during every comparison.
This resulted in an inefficient O(n × m) operation with redundant hash computations, especially costly when handling a large number of media files.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
If we have a form with many media files, it would be good to compare performance; otherwise, please just make sure there is no regression with comparing media files.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
