### PR TITLE
Catch QueryException in PullDataFunctionHandler

### DIFF
--- a/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandler.kt
@@ -5,6 +5,7 @@ import org.javarosa.core.model.condition.IFunctionHandler
 import org.javarosa.xpath.expr.XPathFuncExpr
 import org.odk.collect.entities.javarosa.intance.LocalEntitiesInstanceAdapter
 import org.odk.collect.entities.storage.EntitiesRepository
+import org.odk.collect.entities.storage.QueryException
 import org.odk.collect.shared.Query
 
 class PullDataFunctionHandler(
@@ -38,8 +39,12 @@ class PullDataFunctionHandler(
             val filterChild = XPathFuncExpr.toString(args[2])
             val filterValue = XPathFuncExpr.toString(args[3])
 
-            instanceAdapter.query(instanceId, Query.StringEq(filterChild, filterValue)).firstOrNull()
-                ?.getFirstChild(child)?.value?.value ?: ""
+            try {
+                instanceAdapter.query(instanceId, Query.StringEq(filterChild, filterValue)).firstOrNull()
+                    ?.getFirstChild(child)?.value?.value ?: ""
+            } catch (e: QueryException) {
+                ""
+            }
         } else {
             fallback?.eval(args, ec) ?: ""
         }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandlerTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandlerTest.kt
@@ -141,4 +141,44 @@ class PullDataFunctionHandlerTest {
 
         assertThat(scenario.answerOf<StringData>("/data/calculate"), equalTo(null))
     }
+
+    @Test
+    fun `returns empty string when uses not existing property with no value`() {
+        val entitiesRepository = InMemEntitiesRepository()
+        entitiesRepository.save(
+            "things",
+            Entity.New("one", "One")
+        )
+
+        val scenario = Scenario.init(
+            "Pull data form",
+            html(
+                head(
+                    title("Pull data form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"pull-data-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("pulldata('things', 'label', 'property', '')")
+                    )
+                ),
+                body(
+                    input("/data/question"),
+                    input("/data/calculate")
+                )
+            )
+        ) { formDef ->
+            FormEntryController(FormEntryModel(formDef)).also {
+                it.addFunctionHandler(PullDataFunctionHandler(entitiesRepository))
+            }
+        }
+
+        assertThat(scenario.answerOf<StringData>("/data/calculate"), equalTo(null))
+    }
 }

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandlerTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/filter/PullDataFunctionHandlerTest.kt
@@ -101,4 +101,44 @@ class PullDataFunctionHandlerTest {
 
         assertThat(scenario.answerOf<StringData>("/data/calculate").value, equalTo("One"))
     }
+
+    @Test
+    fun `returns empty string when uses not existing property`() {
+        val entitiesRepository = InMemEntitiesRepository()
+        entitiesRepository.save(
+            "things",
+            Entity.New("one", "One")
+        )
+
+        val scenario = Scenario.init(
+            "Pull data form",
+            html(
+                head(
+                    title("Pull data form"),
+                    model(
+                        mainInstance(
+                            t(
+                                "data id=\"pull-data-form\"",
+                                t("question"),
+                                t("calculate")
+                            )
+                        ),
+                        bind("/data/question").type("string"),
+                        bind("/data/calculate").type("string")
+                            .calculate("pulldata('things', 'label', 'property', 'value')")
+                    )
+                ),
+                body(
+                    input("/data/question"),
+                    input("/data/calculate")
+                )
+            )
+        ) { formDef ->
+            FormEntryController(FormEntryModel(formDef)).also {
+                it.addFunctionHandler(PullDataFunctionHandler(entitiesRepository))
+            }
+        }
+
+        assertThat(scenario.answerOf<StringData>("/data/calculate"), equalTo(null))
+    }
 }


### PR DESCRIPTION
Closes #6796 

#### Why is this the best possible solution? Were any other approaches considered?
If we try to use a non-existent property, an error is thrown, which we should catch similarly to how it works for a non-entities dataset:
https://github.com/getodk/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/handler/ExternalDataHandlerPull.java#L108

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change is safe, so we can focus on testing the scenario described in the issue. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
The one from the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
