### PR TITLE
Add script for creating releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ robolectric-deps/
 **/robolectric-deps.properties
 
 .local-m2
+apks

--- a/README.md
+++ b/README.md
@@ -263,11 +263,18 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - verify new APK can be installed as update to previous version and that above "happy path" works in that case also
 - create and publish scheduled forum post with release description
 - write Play Store release notes, include link to forum post
-- create a release with the correct version by tagging the commit and running `./collect_app:assembleOdkCollectRelease`
-  - Tags for full releases must have the format `vX.X.X`. Tags for beta releases must have the format `vX.X.X-beta.X`.
+- when creating a major release:
+  - Tag the commit for the release (`vX.X.0`)
+  - Run `./create-release.sh` <last release version code> <release tag>
+- when creating a hotfix release:
+  - Tag the commit for the release (`vX.X.X`)
+  - Run `./create-release.sh` <last release version code> <release tag> <last beta tag>
+- when creating a beta release:
+  - Tag the commit for the release (`vX.X.X-beta.X`)
+  - Run `./create-release.sh` <last release version code> <release tag>
 - add a release to Github [here](https://github.com/getodk/collect/releases), generate release notes and attach the APK
-- upload APK to Play Store
-- if there was an active beta before release (this can happen with point releases), publish a new beta release to replace the previous one which was disabled by the production release
+- upload APK(s) to Play Store
+  - When creating a hotfix, the beta APK should be uploaded second as it will have a higher version code
 - backup dependencies for the release by downloading the `vX.X.X.tar` artifact from the `create_dependency_backup` job on Circle CI (for the release commit) and then uploading it to [this folder](https://drive.google.com/drive/folders/1_tMKBFLdhzFZF9GKNeob4FbARjdfbtJu?usp=share_link)
 - backup a self signed release APK by downloading the `selfSignedRelease.apk` from the `build_release` job on Circle CI (for the release commit) and then upload to [this folder](https://drive.google.com/drive/folders/1pbbeNaMTziFhtZmedOs0If3BeYu3Ex5x?usp=share_link)
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -79,7 +79,7 @@ android {
         applicationId('org.odk.collect.android')
         minSdk libs.versions.minSdk.get().toInteger()
         targetSdkVersion libs.versions.targetSdk.get().toInteger()
-        versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()
+        versionCode project.hasProperty('versionCode') ? project.getProperties()['versionCode'].toInteger() : 5112
         versionName getVersionName()
         testInstrumentationRunner('androidx.test.runner.AndroidJUnitRunner')
         vectorDrawables.useSupportLibrary = true

--- a/create-release.sh
+++ b/create-release.sh
@@ -1,0 +1,22 @@
+set -e
+
+mkdir -p apks
+rm -f apks/*
+
+last_version_code=$1
+
+git checkout $2
+./gradlew clean
+release_version_code=$((last_version_code + 1))
+./gradlew assembleOdkCollectRelease -PversionCode=$release_version_code
+cp collect_app/build/outputs/apk/odkCollectRelease/*.apk apks
+
+if [[ $# -gt 2 ]]; then
+    git checkout $3
+    ./gradlew clean
+    beta_version_code=$((release_version_code + 1))
+    ./gradlew assembleOdkCollectRelease -PversionCode=$beta_version_code
+    cp collect_app/build/outputs/apk/odkCollectRelease/*.apk apks
+fi
+
+open apks


### PR DESCRIPTION
This adds a new `create-release.sh` script that creates a release and (optionally) a beta APK based on input tag(s) and version codes. This allows us to have reproducible builds and to create hotfix releases with an accompanying beta (with a higher version code) to prevent the existing one from getting clobbered.