### PR TITLE
Added benchmark test for comparing media files

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -66,6 +66,7 @@ def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxAccessToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
 def entitiesFilterTestProjectUrl = secrets.getProperty('ENTITIES_FILTER_TEST_PROJECT_URL', '')
 def entitiesFilterSearchTestProjectUrl = secrets.getProperty('ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL', '')
+def collectBenchmarksTestProjectUrl = secrets.getProperty('COLLECT_BENCHMARKS_TEST_PROJECT_URL', '')
 
 android {
     compileSdk libs.versions.compileSdk.get().toInteger()
@@ -147,6 +148,7 @@ android {
             resValue("string", "mapbox_access_token", mapboxAccessToken)
             buildConfigField("String", "ENTITIES_FILTER_TEST_PROJECT_URL", "\"$entitiesFilterTestProjectUrl\"")
             buildConfigField("String", "ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL", "\"$entitiesFilterSearchTestProjectUrl\"")
+            buildConfigField("String", "COLLECT_BENCHMARKS_TEST_PROJECT_URL", "\"$collectBenchmarksTestProjectUrl\"")
         }
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -1,0 +1,72 @@
+package org.odk.collect.android.benchmark
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.blankOrNullString
+import org.hamcrest.Matchers.not
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.odk.collect.android.benchmark.support.Benchmarker
+import org.odk.collect.android.benchmark.support.benchmark
+import org.odk.collect.android.support.TestDependencies
+import org.odk.collect.android.support.pages.MainMenuPage
+import org.odk.collect.android.support.rules.CollectTestRule
+import org.odk.collect.android.support.rules.TestRuleChain.chain
+import org.odk.collect.android.test.BuildConfig.COLLECT_BENCHMARKS_TEST_PROJECT_URL
+
+/**
+ * Benchmarks the performance of updating forms. [COLLECT_BENCHMARKS_TEST_PROJECT_URL] should
+ * be set to a project that contains a form with 1k media files.
+ *
+ * Devices that currently pass:
+ * - Pixel 3
+ */
+@RunWith(AndroidJUnit4::class)
+class FormsUpdateBenchmarkTest {
+    private val rule = CollectTestRule(useDemoProject = false)
+
+    @get:Rule
+    val chain: RuleChain = chain(TestDependencies(true)).around(rule)
+
+    @Test
+    fun run() {
+        assertThat(
+            "Need to set COLLECT_BENCHMARKS_TEST_PROJECT_URL before running!",
+            COLLECT_BENCHMARKS_TEST_PROJECT_URL,
+            not(blankOrNullString())
+        )
+
+        val benchmarker = Benchmarker()
+
+        rule.startAtFirstLaunch()
+            .clickManuallyEnterProjectDetails()
+            .inputUrl(COLLECT_BENCHMARKS_TEST_PROJECT_URL)
+            .addProject()
+
+            .clickGetBlankForm()
+            .clickGetSelected()
+            .clickOKOnDialog(MainMenuPage())
+            .benchmark(
+                "Fetching form list with 1k media files when there are no updates",
+                5,
+                benchmarker
+            ) {
+                it
+                    .clickGetBlankForm()
+                    .clickSelectAll()
+            }
+            .benchmark(
+                "Redownloading a form with 1k media files when there are no updates",
+                20,
+                benchmarker
+            ) {
+                it
+                    .clickGetSelected()
+                    .clickOKOnDialog(MainMenuPage())
+            }
+
+        benchmarker.assertResults()
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -21,6 +21,7 @@ import org.odk.collect.android.test.BuildConfig.COLLECT_BENCHMARKS_TEST_PROJECT_
  * be set to a project that contains a form with 1k media files.
  *
  * Devices that currently pass:
+ * - Fairphone 3
  * - Pixel 3
  */
 @RunWith(AndroidJUnit4::class)
@@ -50,7 +51,7 @@ class FormsUpdateBenchmarkTest {
             .clickOKOnDialog(MainMenuPage())
             .benchmark(
                 "Fetching form list with 1k media files when there are no updates",
-                5,
+                7,
                 benchmarker
             ) {
                 it
@@ -59,7 +60,7 @@ class FormsUpdateBenchmarkTest {
             }
             .benchmark(
                 "Redownloading a form with 1k media files when there are no updates",
-                20,
+                25,
                 benchmarker
             ) {
                 it

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -46,9 +46,11 @@ class FormsUpdateBenchmarkTest {
             .inputUrl(COLLECT_BENCHMARKS_TEST_PROJECT_URL)
             .addProject()
 
+            // Download all forms
             .clickGetBlankForm()
             .clickGetSelected()
             .clickOKOnDialog(MainMenuPage())
+
             .benchmark(
                 "Fetching form list with 1k media files when there are no updates",
                 7,
@@ -58,6 +60,7 @@ class FormsUpdateBenchmarkTest {
                     .clickGetBlankForm()
                     .clickSelectAll()
             }
+
             .benchmark(
                 "Redownloading a form with 1k media files when there are no updates",
                 25,


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?
This pr adds tests for fetching the media files (to determine if there are updates available) and redownloading a form when there are no changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
