### PR TITLE
Optimize downloading media files

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -136,25 +136,11 @@ object ServerFormUseCases {
                 }
             } else {
                 val existingFile = searchForExistingMediaFile(allFormVersionsSorted, mediaFile)
-                existingFile.also {
-                    if (it != null) {
-                        if (it.getMd5Hash().contentEquals(mediaFile.hash)) {
-                            FileUtils.copyFile(it, tempMediaFile)
-                        } else {
-                            val existingFileHash = it.getMd5Hash()
-                            downloadMediaFile(
-                                formSource,
-                                mediaFile,
-                                tempMediaFile,
-                                tempDir,
-                                stateListener
-                            )
-
-                            if (!tempMediaFile.getMd5Hash().contentEquals(existingFileHash)) {
-                                newAttachmentsDownloaded = true
-                            }
-                        }
+                if (existingFile != null) {
+                    if (existingFile.getMd5Hash().contentEquals(mediaFile.hash)) {
+                        FileUtils.copyFile(existingFile, tempMediaFile)
                     } else {
+                        val existingFileHash = existingFile.getMd5Hash()
                         downloadMediaFile(
                             formSource,
                             mediaFile,
@@ -162,8 +148,20 @@ object ServerFormUseCases {
                             tempDir,
                             stateListener
                         )
-                        newAttachmentsDownloaded = true
+
+                        if (!tempMediaFile.getMd5Hash().contentEquals(existingFileHash)) {
+                            newAttachmentsDownloaded = true
+                        }
                     }
+                } else {
+                    downloadMediaFile(
+                        formSource,
+                        mediaFile,
+                        tempMediaFile,
+                        tempDir,
+                        stateListener
+                    )
+                    newAttachmentsDownloaded = true
                 }
 
                 logEntityListClashes(mediaFile, entitiesRepository)

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -137,10 +137,11 @@ object ServerFormUseCases {
             } else {
                 val existingFile = searchForExistingMediaFile(allFormVersionsSorted, mediaFile)
                 if (existingFile != null) {
-                    if (existingFile.getMd5Hash().contentEquals(mediaFile.hash)) {
+                    val existingFileHash = existingFile.getMd5Hash()
+
+                    if (existingFileHash.contentEquals(mediaFile.hash)) {
                         FileUtils.copyFile(existingFile, tempMediaFile)
                     } else {
-                        val existingFileHash = existingFile.getMd5Hash()
                         downloadMediaFile(
                             formSource,
                             mediaFile,


### PR DESCRIPTION
Work towards https://github.com/getodk/collect/issues/6807.

#### Why is this the best possible solution? Were any other approaches considered?

This pull request includes two optimizations related to downloading media files:

1. **Reading the list of forms only once**  [[Commit link](https://github.com/getodk/collect/pull/6808/commits/046da79d63a9c924541cf1fa7f6a3e98cb6d7277)]
2. **Avoiding duplicate MD5 hash calculation for new media files**  [[Commit link](https://github.com/getodk/collect/pull/6808/commits/5f7d65a8b1eb4173113cab7acec81f70e85e605c)]

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should make downloading (not just comparing, like in the case of https://github.com/getodk/collect/pull/6803) media files faster. It would be good to have a form with hundreds of media files to test that.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with many media files (hundreds).

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
