### PR TITLE
Optimize form updates with entities and media files

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - run `./gradlew releaseCheck`. If successful, a signed release will be at `collect_app/build/outputs/apk` (with an old version name)
 - verify a basic "happy path": scan a QR code to configure a new project, get a blank form, fill it, open the form map (confirms that the Google Maps key is correct), send form
 - run `./benchmark.sh` with a real device connected to verify performance
+  - To run benchmarks a project will need to be setup in Central with the benchmark forms and app users. The forms and entities needed for that are available [here](https://drive.google.com/drive/folders/1dPLvDY0LhVX-5qTUEs6EDoraDnLpUS0g?usp=drive_link).
 - verify new APK can be installed as update to previous version and that above "happy path" works in that case also
 - create and publish scheduled forum post with release description
 - write Play Store release notes, include link to forum post

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - run `./gradlew releaseCheck`. If successful, a signed release will be at `collect_app/build/outputs/apk` (with an old version name)
 - verify a basic "happy path": scan a QR code to configure a new project, get a blank form, fill it, open the form map (confirms that the Google Maps key is correct), send form
 - run `./benchmark.sh` with a real device connected to verify performance
-  - To run benchmarks a project will need to be setup in Central with the benchmark forms and app users. The forms and entities needed for that are available [here](https://drive.google.com/drive/folders/1dPLvDY0LhVX-5qTUEs6EDoraDnLpUS0g?usp=drive_link).
+  - To run benchmarks a project will need to be set up in Central with the benchmark forms and app users. The forms and entities needed for that are available [here](https://drive.google.com/drive/folders/1dPLvDY0LhVX-5qTUEs6EDoraDnLpUS0g?usp=drive_link).
 - verify new APK can be installed as update to previous version and that above "happy path" works in that case also
 - create and publish scheduled forum post with release description
 - write Play Store release notes, include link to forum post

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -64,8 +64,8 @@ def getVersionName = { ->
 def secrets = getSecrets()
 def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxAccessToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
-def entitiesFilterTestProjectUrl = secrets.getProperty('ENTITIES_FILTER_TEST_PROJECT_URL', '')
-def entitiesFilterSearchTestProjectUrl = secrets.getProperty('ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL', '')
+def entitiesFilterProjectUrl = secrets.getProperty('ENTITIES_FILTER_TEST_PROJECT_URL', '')
+def entitiesFilterSearchProjectUrl = secrets.getProperty('ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL', '')
 def thousandMediaFileProjectUrl = secrets.getProperty('THOUSAND_MEDIA_FILE_PROJECT_URL', '')
 def thousandMediaFileEntityListProjectUrl = secrets.getProperty('THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL', '')
 
@@ -147,8 +147,8 @@ android {
             debuggable(true)
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             resValue("string", "mapbox_access_token", mapboxAccessToken)
-            buildConfigField("String", "ENTITIES_FILTER_TEST_PROJECT_URL", "\"$entitiesFilterTestProjectUrl\"")
-            buildConfigField("String", "ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL", "\"$entitiesFilterSearchTestProjectUrl\"")
+            buildConfigField("String", "ENTITIES_FILTER_PROJECT_URL", "\"$entitiesFilterProjectUrl\"")
+            buildConfigField("String", "ENTITIES_FILTER_SEARCH_PROJECT_URL", "\"$entitiesFilterSearchProjectUrl\"")
             buildConfigField("String", "THOUSAND_MEDIA_FILE_PROJECT_URL", "\"$thousandMediaFileProjectUrl\"")
             buildConfigField("String", "THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL", "\"$thousandMediaFileEntityListProjectUrl\"")
         }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -66,7 +66,8 @@ def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxAccessToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
 def entitiesFilterTestProjectUrl = secrets.getProperty('ENTITIES_FILTER_TEST_PROJECT_URL', '')
 def entitiesFilterSearchTestProjectUrl = secrets.getProperty('ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL', '')
-def collectBenchmarksTestProjectUrl = secrets.getProperty('COLLECT_BENCHMARKS_TEST_PROJECT_URL', '')
+def thousandMediaFileProjectUrl = secrets.getProperty('THOUSAND_MEDIA_FILE_PROJECT_URL', '')
+def thousandMediaFileEntityListProjectUrl = secrets.getProperty('THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL', '')
 
 android {
     compileSdk libs.versions.compileSdk.get().toInteger()
@@ -148,7 +149,8 @@ android {
             resValue("string", "mapbox_access_token", mapboxAccessToken)
             buildConfigField("String", "ENTITIES_FILTER_TEST_PROJECT_URL", "\"$entitiesFilterTestProjectUrl\"")
             buildConfigField("String", "ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL", "\"$entitiesFilterSearchTestProjectUrl\"")
-            buildConfigField("String", "COLLECT_BENCHMARKS_TEST_PROJECT_URL", "\"$collectBenchmarksTestProjectUrl\"")
+            buildConfigField("String", "THOUSAND_MEDIA_FILE_PROJECT_URL", "\"$thousandMediaFileProjectUrl\"")
+            buildConfigField("String", "THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL", "\"$thousandMediaFileEntityListProjectUrl\"")
         }
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -17,12 +17,13 @@ import org.odk.collect.android.support.pages.FirstLaunchPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
-import org.odk.collect.android.test.BuildConfig.ENTITIES_FILTER_TEST_PROJECT_URL
+import org.odk.collect.android.test.BuildConfig.ENTITIES_FILTER_PROJECT_URL
 import org.odk.collect.strings.R
 
 /**
- * Benchmarks the performance of entity follow up forms. [ENTITIES_FILTER_TEST_PROJECT_URL] should
- * be set to a project that contains the "100k Entities Filter" form.
+ * Benchmarks the performance of entity follow up forms. [ENTITIES_FILTER_PROJECT_URL] should
+ * be set to a project that contains the "100k Entities Filter" benchmark form and the
+ * "entities_100k" entity list.
  *
  * Devices that currently pass:
  * - Fairphone 3
@@ -41,8 +42,8 @@ class EntitiesBenchmarkTest {
     @Test
     fun run() {
         assertThat(
-            "Need to set ENTITIES_FILTER_TEST_PROJECT_URL before running!",
-            ENTITIES_FILTER_TEST_PROJECT_URL,
+            "Need to set ENTITIES_FILTER_PROJECT_URL before running!",
+            ENTITIES_FILTER_PROJECT_URL,
             not(blankOrNullString())
         )
         clearAndroidCache()
@@ -51,7 +52,7 @@ class EntitiesBenchmarkTest {
 
         rule.startAtFirstLaunch()
             .clickManuallyEnterProjectDetails()
-            .inputUrl(ENTITIES_FILTER_TEST_PROJECT_URL)
+            .inputUrl(ENTITIES_FILTER_PROJECT_URL)
             .addProject()
 
             // Populate http cache and recreate project
@@ -64,7 +65,7 @@ class EntitiesBenchmarkTest {
             .clickOnDeleteProject()
             .clickOnTextInDialog(R.string.yes, FirstLaunchPage())
             .clickManuallyEnterProjectDetails()
-            .inputUrl(ENTITIES_FILTER_TEST_PROJECT_URL)
+            .inputUrl(ENTITIES_FILTER_PROJECT_URL)
             .addProject()
 
             .clickGetBlankForm()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -104,7 +104,7 @@ class FormsUpdateBenchmarkTest {
             .clickGetBlankForm()
             .benchmark(
                 "Redownloading a form with 1k media files and entity list when there are no updates",
-                15,
+                5,
                 benchmarker
             ) {
                 it

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -63,7 +63,7 @@ class FormsUpdateBenchmarkTest {
 
             .benchmark(
                 "Redownloading a form with 1k media files when there are no updates",
-                25,
+                5,
                 benchmarker
             ) {
                 it

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -27,7 +27,7 @@ class FormsUpdateBenchmarkTest {
 
     /**
      * Benchmarks the performance of updating forms. [THOUSAND_MEDIA_FILE_PROJECT_URL] should
-     * be set to a project that contains a form with 1k media files.
+     * be set to a project that contains the "1000-media-files" benchmark form.
      *
      * Devices that currently pass:
      * - Fairphone 3
@@ -77,7 +77,7 @@ class FormsUpdateBenchmarkTest {
 
     /**
      * Benchmarks the performance of updating forms. [THOUSAND_MEDIA_FILE_PROJECT_URL] should
-     * be set to a project that contains a form with 1k media files.
+     * be set to a project that contains the "1000-media-files-entity-list" form.
      *
      * Devices that currently pass:
      * - Fairphone 3

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -76,7 +76,7 @@ class FormsUpdateBenchmarkTest {
     }
 
     /**
-     * Benchmarks the performance of updating forms. [THOUSAND_MEDIA_FILE_PROJECT_URL] should
+     * Benchmarks the performance of updating forms. [THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL] should
      * be set to a project that contains the "1000-media-files-entity-list" form.
      *
      * Devices that currently pass:

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -14,16 +14,9 @@ import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
-import org.odk.collect.android.test.BuildConfig.COLLECT_BENCHMARKS_TEST_PROJECT_URL
+import org.odk.collect.android.test.BuildConfig.THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL
+import org.odk.collect.android.test.BuildConfig.THOUSAND_MEDIA_FILE_PROJECT_URL
 
-/**
- * Benchmarks the performance of updating forms. [COLLECT_BENCHMARKS_TEST_PROJECT_URL] should
- * be set to a project that contains a form with 1k media files.
- *
- * Devices that currently pass:
- * - Fairphone 3
- * - Pixel 3
- */
 @RunWith(AndroidJUnit4::class)
 class FormsUpdateBenchmarkTest {
     private val rule = CollectTestRule(useDemoProject = false)
@@ -31,11 +24,19 @@ class FormsUpdateBenchmarkTest {
     @get:Rule
     val chain: RuleChain = chain(TestDependencies(true)).around(rule)
 
+    /**
+     * Benchmarks the performance of updating forms. [THOUSAND_MEDIA_FILE_PROJECT_URL] should
+     * be set to a project that contains a form with 1k media files.
+     *
+     * Devices that currently pass:
+     * - Fairphone 3
+     * - Pixel 3
+     */
     @Test
-    fun run() {
+    fun oneThousandMediaFiles() {
         assertThat(
-            "Need to set COLLECT_BENCHMARKS_TEST_PROJECT_URL before running!",
-            COLLECT_BENCHMARKS_TEST_PROJECT_URL,
+            "Need to set THOUSAND_MEDIA_FILE_PROJECT_URL before running!",
+            THOUSAND_MEDIA_FILE_PROJECT_URL,
             not(blankOrNullString())
         )
 
@@ -43,7 +44,7 @@ class FormsUpdateBenchmarkTest {
 
         rule.startAtFirstLaunch()
             .clickManuallyEnterProjectDetails()
-            .inputUrl(COLLECT_BENCHMARKS_TEST_PROJECT_URL)
+            .inputUrl(THOUSAND_MEDIA_FILE_PROJECT_URL)
             .addProject()
 
             // Download all forms
@@ -67,6 +68,58 @@ class FormsUpdateBenchmarkTest {
                 benchmarker
             ) {
                 it
+                    .clickGetSelected()
+                    .clickOKOnDialog(MainMenuPage())
+            }
+
+        benchmarker.assertResults()
+    }
+
+    /**
+     * Benchmarks the performance of updating forms. [THOUSAND_MEDIA_FILE_PROJECT_URL] should
+     * be set to a project that contains a form with 1k media files.
+     *
+     * Devices that currently pass:
+     * - Fairphone 3
+     */
+    @Test
+    fun oneThousandMediaFilesWithEntityList() {
+        assertThat(
+            "Need to set THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL before running!",
+            THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL,
+            not(blankOrNullString())
+        )
+
+        val benchmarker = Benchmarker()
+
+        rule.startAtFirstLaunch()
+            .clickManuallyEnterProjectDetails()
+            .inputUrl(THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL)
+            .addProject()
+
+            // Download all forms
+            .clickGetBlankForm()
+            .clickGetSelected()
+            .clickOKOnDialog(MainMenuPage())
+
+            .benchmark(
+                "Fetching form list with 1k media files and entity list when there are no updates",
+                7,
+                benchmarker
+            ) {
+                it
+                    .clickGetBlankForm()
+                    .clickGetSelected()
+                    .clickOKOnDialog(MainMenuPage())
+            }
+
+            .benchmark(
+                "Redownloading a form with 1k media files and entity list when there are no updates",
+                5,
+                benchmarker
+            ) {
+                it
+                    .clickGetBlankForm()
                     .clickGetSelected()
                     .clickOKOnDialog(MainMenuPage())
             }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -30,7 +30,6 @@ class FormsUpdateBenchmarkTest {
      *
      * Devices that currently pass:
      * - Fairphone 3
-     * - Pixel 3
      */
     @Test
     fun oneThousandMediaFiles() {
@@ -64,7 +63,7 @@ class FormsUpdateBenchmarkTest {
 
             .benchmark(
                 "Redownloading a form with 1k media files when there are no updates",
-                5,
+                12,
                 benchmarker
             ) {
                 it
@@ -102,24 +101,13 @@ class FormsUpdateBenchmarkTest {
             .clickGetSelected()
             .clickOKOnDialog(MainMenuPage())
 
-            .benchmark(
-                "Fetching form list with 1k media files and entity list when there are no updates",
-                7,
-                benchmarker
-            ) {
-                it
-                    .clickGetBlankForm()
-                    .clickGetSelected()
-                    .clickOKOnDialog(MainMenuPage())
-            }
-
+            .clickGetBlankForm()
             .benchmark(
                 "Redownloading a form with 1k media files and entity list when there are no updates",
-                5,
+                15,
                 benchmarker
             ) {
                 it
-                    .clickGetBlankForm()
                     .clickGetSelected()
                     .clickOKOnDialog(MainMenuPage())
             }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -8,6 +8,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import org.odk.collect.android.application.FeatureFlags
 import org.odk.collect.android.benchmark.support.Benchmarker
 import org.odk.collect.android.benchmark.support.benchmark
 import org.odk.collect.android.support.TestDependencies
@@ -104,7 +105,7 @@ class FormsUpdateBenchmarkTest {
             .clickGetBlankForm()
             .benchmark(
                 "Redownloading a form with 1k media files and entity list when there are no updates",
-                5,
+                if (FeatureFlags.FASTER_FORM_UPDATES) 5 else 15,
                 benchmarker
             ) {
                 it

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/SearchBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/SearchBenchmarkTest.kt
@@ -15,7 +15,6 @@ import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 import org.odk.collect.android.test.BuildConfig.ENTITIES_FILTER_SEARCH_PROJECT_URL
-import org.odk.collect.android.test.BuildConfig.ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL
 
 /**
  * Benchmarks the performance of search() forms. [ENTITIES_FILTER_SEARCH_PROJECT_URL] should be
@@ -38,7 +37,7 @@ class SearchBenchmarkTest {
     @Test
     fun run() {
         assertThat(
-            "Need to set ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL before running!",
+            "Need to set ENTITIES_FILTER_SEARCH_PROJECT_URL before running!",
             ENTITIES_FILTER_SEARCH_PROJECT_URL,
             not(blankOrNullString())
         )

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/SearchBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/SearchBenchmarkTest.kt
@@ -14,11 +14,13 @@ import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
+import org.odk.collect.android.test.BuildConfig.ENTITIES_FILTER_SEARCH_PROJECT_URL
 import org.odk.collect.android.test.BuildConfig.ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL
 
 /**
- * Benchmarks the performance of search() forms. [ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL] should be
- * set to a project that contains the "100k Entities Filter search()" form.
+ * Benchmarks the performance of search() forms. [ENTITIES_FILTER_SEARCH_PROJECT_URL] should be
+ * set to a project that contains the "100k Entities Filter search()" benchmark form and the
+ * "entities_100k" entity list.
  *
  * Devices that currently pass:
  * - Fairphone 3
@@ -37,7 +39,7 @@ class SearchBenchmarkTest {
     fun run() {
         assertThat(
             "Need to set ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL before running!",
-            ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL,
+            ENTITIES_FILTER_SEARCH_PROJECT_URL,
             not(blankOrNullString())
         )
 
@@ -45,7 +47,7 @@ class SearchBenchmarkTest {
 
         rule.startAtFirstLaunch()
             .clickManuallyEnterProjectDetails()
-            .inputUrl(ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL)
+            .inputUrl(ENTITIES_FILTER_SEARCH_PROJECT_URL)
             .addProject()
 
             .clickGetBlankForm()

--- a/collect_app/src/main/java/org/odk/collect/android/application/FeatureFlags.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/FeatureFlags.kt
@@ -3,5 +3,5 @@ package org.odk.collect.android.application
 object FeatureFlags {
 
     const val NO_THEME_SETTING = true
-    const val FASTER_FORM_UPDATES = true
+    const val FASTER_FORM_UPDATES = false
 }

--- a/collect_app/src/main/java/org/odk/collect/android/application/FeatureFlags.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/FeatureFlags.kt
@@ -3,4 +3,5 @@ package org.odk.collect.android.application
 object FeatureFlags {
 
     const val NO_THEME_SETTING = true
+    const val FASTER_FORM_UPDATES = false
 }

--- a/collect_app/src/main/java/org/odk/collect/android/application/FeatureFlags.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/FeatureFlags.kt
@@ -3,5 +3,5 @@ package org.odk.collect.android.application
 object FeatureFlags {
 
     const val NO_THEME_SETTING = true
-    const val FASTER_FORM_UPDATES = false
+    const val FASTER_FORM_UPDATES = true
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDetails.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDetails.kt
@@ -16,7 +16,7 @@ package org.odk.collect.android.formmanagement
 import org.odk.collect.forms.ManifestFile
 import java.io.Serializable
 
-data class ServerFormDetails(
+data class ServerFormDetails @JvmOverloads constructor(
     val formName: String?,
     val downloadUrl: String?,
     val formId: String?,
@@ -24,10 +24,11 @@ data class ServerFormDetails(
     val hash: String?,
     val isNotOnDevice: Boolean,
     val isUpdated: Boolean,
-    val manifest: ManifestFile?
+    val manifest: ManifestFile?,
+    val mediaOnlyUpdate: Boolean = false
 ) : Serializable {
 
     companion object {
-        private const val serialVersionUID = 1L
+        private const val serialVersionUID = 2L
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -88,7 +88,10 @@ object ServerFormUseCases {
 
         val tempMediaDir = File(tempMediaPath).also { it.mkdir() }
 
+        val existingForm = formsRepository.getAllByFormIdAndVersion(formToDownload.formId, formToDownload.formVersion).firstOrNull()
         val allFormVersionsSorted = formsRepository.getAllByFormId(formToDownload.formId).sortedByDescending { it.date }
+        val currentOrLastFormVersion = existingForm ?: allFormVersionsSorted.firstOrNull()
+
         formToDownload.manifest!!.mediaFiles.forEachIndexed { i, mediaFile ->
             stateListener.progressUpdate(i + 1)
 
@@ -135,7 +138,7 @@ object ServerFormUseCases {
                     }
                 }
             } else {
-                val existingFile = searchForExistingMediaFile(allFormVersionsSorted, mediaFile)
+                val existingFile = searchForExistingMediaFile(currentOrLastFormVersion, mediaFile)
                 if (existingFile != null) {
                     val existingFileHash = existingFile.getMd5Hash()
 
@@ -203,13 +206,18 @@ object ServerFormUseCases {
         mediaFile.filename.substringBefore(".csv")
 
     private fun searchForExistingMediaFile(
-        allFormVersionsSorted: List<Form>,
+        currentOrLastFormVersion: Form?,
         mediaFile: MediaFile
     ): File? {
-        return allFormVersionsSorted.map { form: Form ->
-            File(form.formMediaPath, mediaFile.filename)
-        }.firstOrNull { file: File ->
-            file.exists()
+        if (currentOrLastFormVersion != null) {
+            val candidate = File(currentOrLastFormVersion.formMediaPath, mediaFile.filename)
+            return if (candidate.exists()) {
+                candidate
+            } else {
+                null
+            }
+        } else {
+            return null
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -212,15 +212,15 @@ object ServerFormUseCases {
         currentOrLastFormVersion: Form?,
         mediaFile: MediaFile
     ): File? {
-        if (currentOrLastFormVersion != null) {
+        return if (currentOrLastFormVersion != null) {
             val candidate = File(currentOrLastFormVersion.formMediaPath, mediaFile.filename)
-            return if (candidate.exists()) {
+            if (candidate.exists()) {
                 candidate
             } else {
                 null
             }
         } else {
-            return null
+            null
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.android.formmanagement
 
+import org.apache.commons.io.FileUtils.copyFileToDirectory
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.formmanagement.download.FormDownloadException
 import org.odk.collect.android.formmanagement.download.FormDownloader
@@ -143,7 +144,7 @@ object ServerFormUseCases {
                     val existingFileHash = existingFile.getMd5Hash()
 
                     if (existingFileHash.contentEquals(mediaFile.hash)) {
-                        FileUtils.copyFile(existingFile, tempMediaFile)
+                        copyFileToDirectory(existingFile, tempMediaDir)
                     } else {
                         downloadMediaFile(
                             formSource,

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -144,7 +144,9 @@ object ServerFormUseCases {
                     val existingFileHash = existingFile.getMd5Hash()
 
                     if (existingFileHash.contentEquals(mediaFile.hash)) {
-                        copyFileToDirectory(existingFile, tempMediaDir)
+                        if (!formToDownload.mediaOnlyUpdate) {
+                            copyFileToDirectory(existingFile, tempMediaDir)
+                        }
                     } else {
                         downloadMediaFile(
                             formSource,

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
@@ -15,6 +15,7 @@
  */
 package org.odk.collect.android.formmanagement
 
+import org.odk.collect.android.application.FeatureFlags
 import org.odk.collect.android.utilities.FormUtils
 import org.odk.collect.android.utilities.WebCredentialsUtils
 import org.odk.collect.forms.Form
@@ -85,7 +86,7 @@ open class ServerFormsDetailsFetcher(
                 !thisFormAlreadyDownloaded,
                 isNewerFormVersionAvailable || areNewerMediaFilesAvailable,
                 manifestFile,
-                !isNewerFormVersionAvailable && areNewerMediaFilesAvailable
+                FeatureFlags.FASTER_FORM_UPDATES && (!isNewerFormVersionAvailable && areNewerMediaFilesAvailable)
             )
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
@@ -52,21 +52,28 @@ open class ServerFormsDetailsFetcher(
 
             val forms = formsRepository.getAllNotDeletedByFormId(listItem.formID)
             val thisFormAlreadyDownloaded = forms.isNotEmpty()
+
+            val formHash = listItem.hash
+            val existingForm = if (formHash != null) {
+                getFormByHash(formHash)
+            } else {
+                null
+            }
+
             val isNewerFormVersionAvailable = listItem.hash.let {
                 if (it == null) {
                     false
                 } else if (thisFormAlreadyDownloaded) {
-                    val existingForm = getFormByHash(it)
-                    if (existingForm == null || existingForm.isDeleted) {
-                        true
-                    } else if (manifestFile != null) {
-                        areNewerMediaFilesAvailable(existingForm, manifestFile.mediaFiles)
-                    } else {
-                        false
-                    }
+                    existingForm == null || existingForm.isDeleted
                 } else {
                     false
                 }
+            }
+
+            val areNewerMediaFilesAvailable = if (existingForm != null && manifestFile != null) {
+                areNewerMediaFilesAvailable(existingForm, manifestFile.mediaFiles)
+            } else {
+                false
             }
 
             ServerFormDetails(
@@ -76,8 +83,9 @@ open class ServerFormsDetailsFetcher(
                 listItem.version,
                 listItem.hash,
                 !thisFormAlreadyDownloaded,
-                isNewerFormVersionAvailable,
-                manifestFile
+                isNewerFormVersionAvailable || areNewerMediaFilesAvailable,
+                manifestFile,
+                !isNewerFormVersionAvailable && areNewerMediaFilesAvailable
             )
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
@@ -79,23 +79,14 @@ public class ServerFormDownloader implements FormDownloader {
 
         OngoingWorkListener stateListener = new ProgressReporterAndSupplierStateListener(progressReporter, isCancelled);
 
-        if (formOnDevice != null && form.getMediaOnlyUpdate()) {
-            try {
-                MediaFilesDownloadResult mediaFilesDownloadResult = ServerFormUseCases.downloadMediaFiles(form, formSource, formsRepository, tempMediaPath, tempDir, entitiesRepository, entitySource, stateListener);
-                installEverything(tempMediaPath, new FileResult(new File(formOnDevice.getFormFilePath()), false), null, formsDirPath, mediaFilesDownloadResult);
-            } catch (FormSourceException | IOException | InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            try {
-                processOneForm(form, stateListener, tempDir, formsDirPath, formMetadataParser, tempMediaPath);
-            } catch (FormSourceException e) {
-                throw new FormDownloadException.FormSourceError(e);
-            } finally {
-                FileExt.deleteDirectory(tempDir);
-                for (Form formToDelete : preExistingFormsWithSameIdAndVersion) {
-                    formsRepository.delete(formToDelete.getDbId());
-                }
+        try {
+            processOneForm(form, stateListener, tempDir, formsDirPath, formMetadataParser, tempMediaPath);
+        } catch (FormSourceException e) {
+            throw new FormDownloadException.FormSourceError(e);
+        } finally {
+            FileExt.deleteDirectory(tempDir);
+            for (Form formToDelete : preExistingFormsWithSameIdAndVersion) {
+                formsRepository.delete(formToDelete.getDbId());
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
@@ -75,12 +75,10 @@ public class ServerFormDownloader implements FormDownloader {
 
         File tempDir = new File(cacheDir, "download-" + UUID.randomUUID().toString());
         tempDir.mkdirs();
-        String tempMediaPath = new File(tempDir, "media").getAbsolutePath();
-
-        OngoingWorkListener stateListener = new ProgressReporterAndSupplierStateListener(progressReporter, isCancelled);
 
         try {
-            processOneForm(form, stateListener, tempDir, formsDirPath, formMetadataParser, tempMediaPath);
+            OngoingWorkListener stateListener = new ProgressReporterAndSupplierStateListener(progressReporter, isCancelled);
+            processOneForm(form, stateListener, tempDir, formsDirPath, formMetadataParser);
         } catch (FormSourceException e) {
             throw new FormDownloadException.FormSourceError(e);
         } finally {
@@ -91,8 +89,9 @@ public class ServerFormDownloader implements FormDownloader {
         }
     }
 
-    private void processOneForm(ServerFormDetails fd, OngoingWorkListener stateListener, File tempDir, String formsDirPath, FormMetadataParser formMetadataParser, String tempMediaPath) throws FormDownloadException, FormSourceException {
+    private void processOneForm(ServerFormDetails fd, OngoingWorkListener stateListener, File tempDir, String formsDirPath, FormMetadataParser formMetadataParser) throws FormDownloadException, FormSourceException {
         // use a temporary media path until everything is ok.
+        String tempMediaPath = new File(tempDir, "media").getAbsolutePath();
         FileResult fileResult = null;
         MediaFilesDownloadResult mediaFilesDownloadResult;
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/download/ServerFormDownloader.java
@@ -75,23 +75,33 @@ public class ServerFormDownloader implements FormDownloader {
 
         File tempDir = new File(cacheDir, "download-" + UUID.randomUUID().toString());
         tempDir.mkdirs();
+        String tempMediaPath = new File(tempDir, "media").getAbsolutePath();
 
-        try {
-            OngoingWorkListener stateListener = new ProgressReporterAndSupplierStateListener(progressReporter, isCancelled);
-            processOneForm(form, stateListener, tempDir, formsDirPath, formMetadataParser);
-        } catch (FormSourceException e) {
-            throw new FormDownloadException.FormSourceError(e);
-        } finally {
-            FileExt.deleteDirectory(tempDir);
-            for (Form formToDelete : preExistingFormsWithSameIdAndVersion) {
-                formsRepository.delete(formToDelete.getDbId());
+        OngoingWorkListener stateListener = new ProgressReporterAndSupplierStateListener(progressReporter, isCancelled);
+
+        if (formOnDevice != null && form.getMediaOnlyUpdate()) {
+            try {
+                MediaFilesDownloadResult mediaFilesDownloadResult = ServerFormUseCases.downloadMediaFiles(form, formSource, formsRepository, tempMediaPath, tempDir, entitiesRepository, entitySource, stateListener);
+                installEverything(tempMediaPath, new FileResult(new File(formOnDevice.getFormFilePath()), false), null, formsDirPath, mediaFilesDownloadResult);
+            } catch (FormSourceException | IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            try {
+                processOneForm(form, stateListener, tempDir, formsDirPath, formMetadataParser, tempMediaPath);
+            } catch (FormSourceException e) {
+                throw new FormDownloadException.FormSourceError(e);
+            } finally {
+                FileExt.deleteDirectory(tempDir);
+                for (Form formToDelete : preExistingFormsWithSameIdAndVersion) {
+                    formsRepository.delete(formToDelete.getDbId());
+                }
             }
         }
     }
 
-    private void processOneForm(ServerFormDetails fd, OngoingWorkListener stateListener, File tempDir, String formsDirPath, FormMetadataParser formMetadataParser) throws FormDownloadException, FormSourceException {
+    private void processOneForm(ServerFormDetails fd, OngoingWorkListener stateListener, File tempDir, String formsDirPath, FormMetadataParser formMetadataParser, String tempMediaPath) throws FormDownloadException, FormSourceException {
         // use a temporary media path until everything is ok.
-        String tempMediaPath = new File(tempDir, "media").getAbsolutePath();
         FileResult fileResult = null;
         MediaFilesDownloadResult mediaFilesDownloadResult;
 


### PR DESCRIPTION
Closes #6807

#### Why is this the best possible solution? Were any other approaches considered?

There's absolutely a better route here, but this should allow a fork to set `FeatureFlags.FASTER_FORM_UPDATES` to `true` to enable faster form updates with many media files and entity lists. 

The core change here is to detect the case where the form hasn't changed, but media files have and then skip downloading/copying media files. We can do that when using Central because we can make the assumption that if media files have changed and the OpenRosa form hash hasn't, then we'll just be downloading new media files and copying them to an existing form directory rather than creating a new one. This might also work for other servers, but we'll need to do additional manual and automated testing to verify. I also think we'd want to try and simplify our download logic more to handle these kinds of cases more explicitly: right now downloading a form (`ServerFormDownloader`) involves a series of steps that are pretty unrelated - we should break them into parts and have explicit branching for different scenarios (downloading a new form, updating a form, updating just media files etc).

I also changed our optimization around copying media files from previous form versions: it now only checks the last version or the "current" one in the case of just updating media files. This will probably be faster in most cases (as we're not scanning every previous version), but the main goal was to reduce the number of possible situations I had to consider.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It should provide faster refreshes for forms with entity lists and many media files in both cases where the entity list is the same and when it changes (but not when the form version is updated or for initial download). There are definitely a bunch of risks here so checking form download and updates in general is a must, although we only need to check against Central initially (we'll see how broken this is with other servers later).

Another thing to point out is that we don't currently have an automated benchmark for actual form version updates for forms with many media files. These should remain as fast as they are in the current store version (v2025.2.0).

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
