### PR TITLE
Fix create-release commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,13 +265,13 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - write Play Store release notes, include link to forum post
 - when creating a major release:
   - Tag the commit for the release (`vX.X.0`)
-  - Run `./create-release.sh` <last release version code> <release tag>
+  - Run `./create-release.sh <last release version code> <release tag>`
 - when creating a hotfix release:
   - Tag the commit for the release (`vX.X.X`)
-  - Run `./create-release.sh` <last release version code> <release tag> <last beta tag>
+  - Run `./create-release.sh <last release version code> <release tag> <last beta tag>`
 - when creating a beta release:
   - Tag the commit for the release (`vX.X.X-beta.X`)
-  - Run `./create-release.sh` <last release version code> <release tag>
+  - Run `./create-release.sh <last release version code> <release tag>`
 - add a release to Github [here](https://github.com/getodk/collect/releases), generate release notes and attach the APK
 - upload APK(s) to Play Store
   - When creating a hotfix, the beta APK should be uploaded second as it will have a higher version code


### PR DESCRIPTION
The arguments are not rendering because they're interpreted as unsupported HTML tags.