### PR TITLE
Schedule form updates only if relevant settings have changed after import

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.kt
@@ -31,8 +31,10 @@ class CollectSettingsChangeHandler(
         }
     }
 
-    override fun onSettingsChanged(projectId: String) {
+    override fun onSettingsChanged(projectId: String, formUpdateSettingsChanged: Boolean) {
         propertyManager.reload()
-        formUpdateScheduler.scheduleUpdates(projectId)
+        if (formUpdateSettingsChanged) {
+            formUpdateScheduler.scheduleUpdates(projectId)
+        }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/application/CollectSettingsChangeHandlerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/CollectSettingsChangeHandlerTest.kt
@@ -58,13 +58,19 @@ class CollectSettingsChangeHandlerTest {
 
     @Test
     fun `updates PropertyManager when multiple settings are changed`() {
-        handler.onSettingsChanged("projectId")
+        handler.onSettingsChanged("projectId", false)
         verify(propertyManager).reload()
     }
 
     @Test
-    fun `schedule updates when multiple settings are changes`() {
-        handler.onSettingsChanged("projectId")
+    fun `schedules updates when multiple settings change and include form update-related ones`() {
+        handler.onSettingsChanged("projectId", true)
         verify(formUpdateScheduler).scheduleUpdates("projectId")
+    }
+
+    @Test
+    fun `does not schedule updates when multiple settings change but none relate to form updates`() {
+        handler.onSettingsChanged("projectId", false)
+        verifyNoInteractions(formUpdateScheduler)
     }
 }

--- a/settings/src/main/java/org/odk/collect/settings/importing/SettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/importing/SettingsImporter.kt
@@ -27,6 +27,9 @@ internal class SettingsImporter(
         }
 
         val generalSettings = settingsProvider.getUnprotectedSettings(project.uuid)
+        val oldFormUpdateMode = generalSettings.getString(ProjectKeys.KEY_FORM_UPDATE_MODE)
+        val oldPeriodicFormUpdatesCheck = generalSettings.getString(ProjectKeys.KEY_PERIODIC_FORM_UPDATES_CHECK)
+
         val adminSettings = settingsProvider.getProtectedSettings(project.uuid)
 
         generalSettings.clear()
@@ -40,6 +43,8 @@ internal class SettingsImporter(
 
         // Import unprotected settings
         importToPrefs(jsonObject, AppConfigurationKeys.GENERAL, generalSettings, deviceUnsupportedSettings)
+        val newFormUpdateMode = generalSettings.getString(ProjectKeys.KEY_FORM_UPDATE_MODE)
+        val newPeriodicFormUpdatesCheck = generalSettings.getString(ProjectKeys.KEY_PERIODIC_FORM_UPDATES_CHECK)
 
         // Import protected settings
         importToPrefs(jsonObject, AppConfigurationKeys.ADMIN, adminSettings, deviceUnsupportedSettings)
@@ -64,7 +69,8 @@ internal class SettingsImporter(
         loadDefaults(generalSettings, generalDefaults)
         loadDefaults(adminSettings, adminDefaults)
 
-        settingsChangedHandler.onSettingsChanged(project.uuid)
+        val formUpdateSettingsChanged = oldFormUpdateMode != newFormUpdateMode || oldPeriodicFormUpdatesCheck != newPeriodicFormUpdatesCheck
+        settingsChangedHandler.onSettingsChanged(project.uuid, formUpdateSettingsChanged)
 
         return ProjectConfigurationResult.SUCCESS
     }
@@ -144,7 +150,7 @@ internal interface SettingsValidator {
 interface SettingsChangeHandler {
     fun onSettingChanged(projectId: String, newValue: Any?, changedKey: String)
 
-    fun onSettingsChanged(projectId: String)
+    fun onSettingsChanged(projectId: String, formUpdateSettingsChanged: Boolean)
 }
 
 internal fun interface SettingsMigrator {

--- a/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
@@ -78,7 +78,7 @@ class ODKAppSettingsImporterTest {
 
     @Test
     fun `rejects JSON when exception is thrown during importing`() {
-        whenever(settingsChangeHandler.onSettingsChanged(any())).thenThrow(RuntimeException::class.java)
+        whenever(settingsChangeHandler.onSettingsChanged(any(), any())).thenThrow(RuntimeException::class.java)
 
         val result = settingsImporter.fromJSON(
             "{\n" +


### PR DESCRIPTION
Closes #6810

#### Why is this the best possible solution? Were any other approaches considered?
To summarize all the discussions we've had across different channels:

The issue was that when MDM applied settings to Collect, those settings were re-applied every time the Main Menu was opened. After saving the settings, the form update process was triggered, which meant it ran every time a user returned to the Main Menu to start a new blank form. If the form that needed to be updated (or even just checked for updates) included a large number of media attachments, the process became time-consuming. Additionally, if such a form contained entities, opening it was blocked until the update process completed.

I didn't change the approach of continuously saving settings. Instead, I updated the code responsible for triggering form updates so that the update is now triggered only when relevant settings have actually changed. The relevant settings are:
- [Blank form update mode](https://docs.getodk.org/collect-settings/#blank-form-update-mode)
- [Automatic update frequency](https://docs.getodk.org/collect-settings/#automatic-update-frequency)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should prevent redundant form update scheduling when new settings are applied - whether they come from MDM and are re-applied every time the Main Menu is opened, or when a user reconfigures the app using a QR code that doesn't change anything related to form updates (i.e., the two settings mentioned above).

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with entities + thousands of media files.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
