### PR TITLE
Add analytics for edit from finalized/sent

### DIFF
--- a/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
@@ -42,6 +42,11 @@ interface Analytics {
             params[key] = value
         }
 
+        @JvmStatic
+        fun getParamValue(key: String): String? {
+            return params[key]
+        }
+
         fun setUserProperty(name: String, value: String) {
             instance.setUserProperty(name, value)
         }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -75,10 +75,6 @@ object AnalyticsEvents {
 
     const val FORMS_PROVIDER_QUERY = "FormsProviderQuery"
 
-    const val FORMS_PROVIDER_INSERT = "FormsProviderInsert"
-
-    const val FORMS_PROVIDER_UPDATE = "FormsProviderUpdate"
-
     const val FORMS_PROVIDER_DELETE = "FormsProviderDelete"
 
     const val INSTANCE_PROVIDER_QUERY = "InstanceProviderQuery"

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -112,7 +112,7 @@ object AnalyticsEvents {
     const val EDIT_FINALIZED_FORM = "EditFinalizedForm"
 
     /**
-     * Tracks how often sent forms are edited
+     * Tracks how often finalized or sent forms are edited
      */
-    const val EDIT_SENT_FORM = "EditSentForm"
+    const val EDIT_FINALIZED_OR_SENT_FORM = "EditFinalizedOrSentForm"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -107,11 +107,6 @@ object AnalyticsEvents {
     const val RESET_PROJECT = "ResetProject"
 
     /**
-     * Tracks how often finalized forms are edited
-     */
-    const val EDIT_FINALIZED_FORM = "EditFinalizedForm"
-
-    /**
      * Tracks how often finalized or sent forms are edited
      */
     const val EDIT_FINALIZED_OR_SENT_FORM = "EditFinalizedOrSentForm"

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -105,4 +105,14 @@ object AnalyticsEvents {
      * Tracks how often projects are reset
      */
     const val RESET_PROJECT = "ResetProject"
+
+    /**
+     * Tracks how often finalized forms are edited
+     */
+    const val EDIT_FINALIZED_FORM = "EditFinalizedForm"
+
+    /**
+     * Tracks how often sent forms are edited
+     */
+    const val EDIT_SENT_FORM = "EditSentForm"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/LocalInstancesUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/LocalInstancesUseCases.kt
@@ -53,10 +53,9 @@ object LocalInstancesUseCases {
             return InstanceEditResult.EditBlockedByNewerExistingEdit(latestEditInstance)
         }
 
+        Analytics.log(AnalyticsEvents.EDIT_FINALIZED_OR_SENT_FORM)
         if (sourceInstance.status == Instance.STATUS_COMPLETE) {
             Analytics.log(AnalyticsEvents.EDIT_FINALIZED_FORM)
-        } else {
-            Analytics.log(AnalyticsEvents.EDIT_SENT_FORM)
         }
 
         val targetInstance = cloneInstance(sourceInstance, instanceFilePath, instancesDir, instancesRepository, formsRepository, clock)

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/LocalInstancesUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/LocalInstancesUseCases.kt
@@ -1,5 +1,7 @@
 package org.odk.collect.android.instancemanagement
 
+import org.odk.collect.analytics.Analytics
+import org.odk.collect.android.analytics.AnalyticsEvents
 import org.odk.collect.android.utilities.FileUtils
 import org.odk.collect.android.utilities.FormNameUtils
 import org.odk.collect.forms.FormsRepository
@@ -49,6 +51,12 @@ object LocalInstancesUseCases {
         val latestEditInstance = findLatestEditIfExists(sourceInstance, instancesRepository)
         if (latestEditInstance != null) {
             return InstanceEditResult.EditBlockedByNewerExistingEdit(latestEditInstance)
+        }
+
+        if (sourceInstance.status == Instance.STATUS_COMPLETE) {
+            Analytics.log(AnalyticsEvents.EDIT_FINALIZED_FORM)
+        } else {
+            Analytics.log(AnalyticsEvents.EDIT_SENT_FORM)
         }
 
         val targetInstance = cloneInstance(sourceInstance, instanceFilePath, instancesDir, instancesRepository, formsRepository, clock)

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/LocalInstancesUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/LocalInstancesUseCases.kt
@@ -53,10 +53,13 @@ object LocalInstancesUseCases {
             return InstanceEditResult.EditBlockedByNewerExistingEdit(latestEditInstance)
         }
 
-        Analytics.log(AnalyticsEvents.EDIT_FINALIZED_OR_SENT_FORM)
-        if (sourceInstance.status == Instance.STATUS_COMPLETE) {
-            Analytics.log(AnalyticsEvents.EDIT_FINALIZED_FORM)
+        val formHash = Analytics.getParamValue("form")
+        val actionValue = if (sourceInstance.status == Instance.STATUS_COMPLETE) {
+            "finalized $formHash"
+        } else {
+            "sent $formHash"
         }
+        Analytics.log(AnalyticsEvents.EDIT_FINALIZED_OR_SENT_FORM, "action", actionValue)
 
         val targetInstance = cloneInstance(sourceInstance, instanceFilePath, instancesDir, instancesRepository, formsRepository, clock)
 


### PR DESCRIPTION
Closes #6815 

#### Why is this the best possible solution? Were any other approaches considered?
@lognaturel, I’m not sure if I understood correctly, but did you want to have a single event for editing forms regardless of whether they’re finalized or sent, and another event just for sent forms to track the total number of events while still being able to calculate them separately? If so, I implemented it a bit differently: I’m logging separate events for finalized and sent forms, which makes it clearer and also allows the sum to be easily calculated. So it is quite different, but the result is the same, so I guess it's ok.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
