### PR TITLE
Fix audio playback crashes

### DIFF
--- a/audio-clips/src/main/java/org/odk/collect/audioclips/AudioClipViewModel.kt
+++ b/audio-clips/src/main/java/org/odk/collect/audioclips/AudioClipViewModel.kt
@@ -160,13 +160,10 @@ class AudioClipViewModel(private val mediaPlayerFactory: Supplier<MediaPlayer>, 
         positionUpdatesCancellable = scheduler.repeat(
             {
                 val currentlyPlaying = currentlyPlaying.value
-                if (currentlyPlaying != null) {
+                val currentPosition = mediaPlayer.getPosition()
+                if (currentlyPlaying != null && currentPosition != null) {
                     val position = getPositionForClip(currentlyPlaying.clip.clipID)
-
-                    val currentPosition = mediaPlayer.getPosition()
-                    if (currentPosition != null) {
-                        position.postValue(currentPosition)
-                    }
+                    position.postValue(currentPosition)
                 }
             },
             1000 / 12

--- a/audio-clips/src/main/java/org/odk/collect/audioclips/AudioClipViewModel.kt
+++ b/audio-clips/src/main/java/org/odk/collect/audioclips/AudioClipViewModel.kt
@@ -1,7 +1,6 @@
 package org.odk.collect.audioclips
 
 import android.media.MediaPlayer
-import android.os.StrictMode
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -11,14 +10,13 @@ import org.odk.collect.androidshared.data.Consumable
 import org.odk.collect.async.Cancellable
 import org.odk.collect.async.Scheduler
 import java.io.File
-import java.io.IOException
 import java.util.LinkedList
 import java.util.Queue
 import java.util.function.Supplier
 
 class AudioClipViewModel(private val mediaPlayerFactory: Supplier<MediaPlayer>, private val scheduler: Scheduler) : ViewModel(), MediaPlayer.OnCompletionListener {
 
-    private var _mediaPlayer: MediaPlayer? = null
+    private var mediaPlayer = ThreadSafeMediaPlayerWrapper(mediaPlayerFactory::get, this)
 
     private val currentlyPlaying = MutableLiveData<CurrentlyPlaying?>(null)
     private val error = MutableLiveData<Consumable<Exception>?>()
@@ -39,14 +37,14 @@ class AudioClipViewModel(private val mediaPlayerFactory: Supplier<MediaPlayer>, 
 
     fun stop() {
         if (currentlyPlaying.value != null) {
-            _mediaPlayer?.stop()
+            mediaPlayer.stop()
         }
 
         cleanUpAfterClip()
     }
 
     fun pause() {
-        _mediaPlayer?.pause()
+        mediaPlayer.pause()
         val currentlyPlayingValue = currentlyPlaying.value
         if (currentlyPlayingValue != null) {
             currentlyPlaying.value = currentlyPlayingValue.paused()
@@ -69,14 +67,14 @@ class AudioClipViewModel(private val mediaPlayerFactory: Supplier<MediaPlayer>, 
 
     fun setPosition(clipID: String, newPosition: Int) {
         if (isCurrentPlayingClip(clipID, currentlyPlaying.value)) {
-            _mediaPlayer?.seekTo(newPosition)
+            mediaPlayer.seekTo(newPosition)
         }
         getPositionForClip(clipID).value = newPosition
     }
 
     fun background() {
         cleanUpAfterClip()
-        releaseMediaPlayer()
+        mediaPlayer.release()
     }
 
     public override fun onCleared() {
@@ -109,8 +107,7 @@ class AudioClipViewModel(private val mediaPlayerFactory: Supplier<MediaPlayer>, 
         nextClip: Clip,
         playlist: Queue<Clip>
     ) {
-        _mediaPlayer?.seekTo(getPositionForClip(nextClip.clipID).value!!)
-        _mediaPlayer?.start()
+        mediaPlayer.start(getPositionForClip(nextClip.clipID).value!!)
         currentlyPlaying.value = CurrentlyPlaying(
             Clip(nextClip.clipID, nextClip.uRI),
             false,
@@ -162,11 +159,13 @@ class AudioClipViewModel(private val mediaPlayerFactory: Supplier<MediaPlayer>, 
     private fun schedulePositionUpdates() {
         positionUpdatesCancellable = scheduler.repeat(
             {
-                _mediaPlayer?.let {
-                    val currentlyPlaying = currentlyPlaying.value
-                    if (currentlyPlaying != null) {
-                        val position = getPositionForClip(currentlyPlaying.clip.clipID)
-                        position.postValue(it.currentPosition)
+                val currentlyPlaying = currentlyPlaying.value
+                if (currentlyPlaying != null) {
+                    val position = getPositionForClip(currentlyPlaying.clip.clipID)
+
+                    val currentPosition = mediaPlayer.getPosition()
+                    if (currentPosition != null) {
+                        position.postValue(currentPosition)
                     }
                 }
             },
@@ -178,19 +177,6 @@ class AudioClipViewModel(private val mediaPlayerFactory: Supplier<MediaPlayer>, 
         positionUpdatesCancellable?.cancel()
     }
 
-    private fun releaseMediaPlayer() {
-        _mediaPlayer?.release()
-        _mediaPlayer = null
-    }
-
-    private fun setupNewMediaPlayer(): MediaPlayer {
-        StrictMode.noteSlowCall("MediaPlayer instantiation can be slow")
-
-        val newMediaPlayer: MediaPlayer = mediaPlayerFactory.get()
-        newMediaPlayer.setOnCompletionListener(this)
-        return newMediaPlayer
-    }
-
     private fun isCurrentPlayingClip(clipID: String, currentlyPlayingValue: CurrentlyPlaying?): Boolean {
         return currentlyPlayingValue != null && currentlyPlayingValue.clip.clipID == clipID
     }
@@ -200,20 +186,7 @@ class AudioClipViewModel(private val mediaPlayerFactory: Supplier<MediaPlayer>, 
 
         scheduler.immediate(
             background = {
-                val mediaPlayer = _mediaPlayer ?: run {
-                    val newMediaPlayer = setupNewMediaPlayer()
-                    _mediaPlayer = newMediaPlayer
-                    newMediaPlayer
-                }
-
-                try {
-                    mediaPlayer.reset()
-                    mediaPlayer.setDataSource(uri)
-                    mediaPlayer.prepare()
-                    true
-                } catch (e: IOException) {
-                    false
-                }
+                mediaPlayer.resetWithDataSource(uri)
             },
             foreground = { success ->
                 if (success) {

--- a/audio-clips/src/main/java/org/odk/collect/audioclips/ThreadSafeMediaPlayerWrapper.kt
+++ b/audio-clips/src/main/java/org/odk/collect/audioclips/ThreadSafeMediaPlayerWrapper.kt
@@ -1,0 +1,84 @@
+package org.odk.collect.audioclips
+
+import android.media.MediaPlayer
+import android.os.StrictMode
+import java.io.IOException
+
+/**
+ * Allows a [MediaPlayer] to be interacted with from multiple threads while avoiding illegal states
+ * such as multiple threads attempting to set up data sources at the same time (with interleaved
+ * calls to [MediaPlayer.reset] for example).
+ *
+ * This also handles on-demand creation and allowing the [MediaPlayer] instance to be garbage
+ * collected after calls to [release].
+ */
+internal class ThreadSafeMediaPlayerWrapper(
+    private val mediaPlayerFactory: () -> MediaPlayer,
+    private var onCompletionListener: MediaPlayer.OnCompletionListener
+) {
+
+    private var mediaPlayer: MediaPlayer? = null
+
+    fun resetWithDataSource(uri: String): Boolean {
+        synchronized(this) {
+            val mediaPlayer = mediaPlayer ?: run {
+                val newMediaPlayer = setupNewMediaPlayer()
+                mediaPlayer = newMediaPlayer
+                newMediaPlayer
+            }
+
+            return try {
+                mediaPlayer.reset()
+                mediaPlayer.setDataSource(uri)
+                mediaPlayer.prepare()
+                true
+            } catch (e: IOException) {
+                false
+            }
+        }
+    }
+
+    fun start(position: Int) {
+        synchronized(this) {
+            mediaPlayer?.seekTo(position)
+            mediaPlayer?.start()
+        }
+    }
+
+    fun pause() {
+        synchronized(this) {
+            mediaPlayer?.pause()
+        }
+    }
+
+    fun stop() {
+        synchronized(this) {
+            mediaPlayer?.stop()
+        }
+    }
+
+    fun seekTo(newPosition: Int) {
+        synchronized(this) {
+            mediaPlayer?.seekTo(newPosition)
+        }
+    }
+
+    fun getPosition(): Int? {
+        return mediaPlayer?.currentPosition
+    }
+
+    fun release() {
+        synchronized(this) {
+            mediaPlayer?.release()
+            mediaPlayer = null
+        }
+    }
+
+    private fun setupNewMediaPlayer(): MediaPlayer {
+        StrictMode.noteSlowCall("MediaPlayer instantiation can be slow")
+
+        val newMediaPlayer: MediaPlayer = mediaPlayerFactory()
+        newMediaPlayer.setOnCompletionListener(onCompletionListener)
+        return newMediaPlayer
+    }
+}


### PR DESCRIPTION
Closes #6085 

#### Why is this the best possible solution? Were any other approaches considered?

Our only theory for why the crash happens is that `MediaPlayer` is able to get into weird states because we set it up on a background thread. The fix here is just to wrap `MediaPlayer` in a simplified interfaced that only allows one thread at a time to call methods that mutate the internal state.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We don't have reproduction steps for the crash, so the main focus here is just to check that audio playback in the app still works as expected.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
