### PR TITLE
Filter detected barcodes

### DIFF
--- a/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
@@ -9,7 +9,7 @@ class BarcodeFilter(private val bounds: Rect, private val threshold: Int = 1) {
 
     fun filter(barcodeCandidates: List<BarcodeCandidate>): DetectedBarcode? {
         val candidate = barcodeCandidates.firstOrNull()
-        return if (candidate != null && candidate.boundingBox != null && bounds.contains(candidate.boundingBox)) {
+        return if (candidate?.boundingBox != null && bounds.contains(candidate.boundingBox)) {
             if (!candidate.bytes.contentEquals(potential?.bytes)) {
                 potential = candidate
                 potentialOccurrences = 0

--- a/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
@@ -50,6 +50,9 @@ sealed class DetectedBarcode {
         override val format: Int,
         override val bytes: ByteArray
     ) : DetectedBarcode() {
+        /**
+         * Requires custom [equals] due to [ByteArray] field
+         */
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
@@ -75,6 +78,9 @@ sealed class DetectedBarcode {
         override val format: Int,
         override val bytes: ByteArray
     ) : DetectedBarcode() {
+        /**
+         * Requires custom [equals] due to [ByteArray] field
+         */
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false

--- a/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
@@ -37,17 +37,17 @@ class BarcodeCandidate(
     val bytes: ByteArray?,
     val utfContents: String?,
     val boundingBox: Rect?,
-    val format: Int
+    val format: BarcodeFormat
 )
 
 sealed class DetectedBarcode {
 
     abstract val bytes: ByteArray
-    abstract val format: Int
+    abstract val format: BarcodeFormat
 
     data class Utf8(
         val contents: String,
-        override val format: Int,
+        override val format: BarcodeFormat,
         override val bytes: ByteArray
     ) : DetectedBarcode() {
         /**
@@ -59,23 +59,23 @@ sealed class DetectedBarcode {
 
             other as Utf8
 
-            if (format != other.format) return false
             if (contents != other.contents) return false
+            if (format != other.format) return false
             if (!bytes.contentEquals(other.bytes)) return false
 
             return true
         }
 
         override fun hashCode(): Int {
-            var result = format
-            result = 31 * result + contents.hashCode()
+            var result = contents.hashCode()
+            result = 31 * result + format.hashCode()
             result = 31 * result + bytes.contentHashCode()
             return result
         }
     }
 
     data class Bytes(
-        override val format: Int,
+        override val format: BarcodeFormat,
         override val bytes: ByteArray
     ) : DetectedBarcode() {
         /**
@@ -94,9 +94,14 @@ sealed class DetectedBarcode {
         }
 
         override fun hashCode(): Int {
-            var result = format
+            var result = format.hashCode()
             result = 31 * result + bytes.contentHashCode()
             return result
         }
     }
+}
+
+enum class BarcodeFormat {
+    PDF417,
+    OTHER
 }

--- a/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
@@ -2,12 +2,25 @@ package org.odk.collect.qrcode
 
 import android.graphics.Rect
 
-class BarcodeFilter(private val bounds: Rect) {
+class BarcodeFilter(private val bounds: Rect, private val threshold: Int) {
+
+    private var potential: BarcodeCandidate? = null
+    private var potentialOccurrences = 0
 
     fun filter(barcodeCandidates: List<BarcodeCandidate>): BarcodeCandidate? {
         val candidate = barcodeCandidates.firstOrNull()
         return if (candidate != null && candidate.boundingBox != null && bounds.contains(candidate.boundingBox)) {
-            candidate
+            if (!candidate.bytes.contentEquals(potential?.bytes)) {
+                potential = candidate
+                potentialOccurrences = 0
+            }
+
+            potentialOccurrences++
+            if (potentialOccurrences == threshold) {
+                potential
+            } else {
+                null
+            }
         } else {
             null
         }

--- a/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/BarcodeFilter.kt
@@ -1,0 +1,22 @@
+package org.odk.collect.qrcode
+
+import android.graphics.Rect
+
+class BarcodeFilter(private val bounds: Rect) {
+
+    fun filter(barcodeCandidates: List<BarcodeCandidate>): BarcodeCandidate? {
+        val candidate = barcodeCandidates.firstOrNull()
+        return if (candidate != null && candidate.boundingBox != null && bounds.contains(candidate.boundingBox)) {
+            candidate
+        } else {
+            null
+        }
+    }
+}
+
+class BarcodeCandidate(
+    val bytes: ByteArray?,
+    val utfContents: String?,
+    val boundingBox: Rect?,
+    val format: Int
+)

--- a/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
 import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.View
@@ -22,7 +24,16 @@ internal class ScannerOverlay(context: Context, attrs: AttributeSet?) :
         it.alpha = 75
     }
 
+    private val viewFinderPaint = Paint().apply {
+        xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
+    }
+
     var viewFinderRect = Rect()
+
+    init {
+        // Provides better performance for using `PorterDuff.Mode.CLEAR`
+        setLayerType(LAYER_TYPE_HARDWARE, null)
+    }
 
     private val laserAnim = ValueAnimator.ofFloat(0f, 255f).also { animator ->
         animator.duration = 320
@@ -36,40 +47,16 @@ internal class ScannerOverlay(context: Context, attrs: AttributeSet?) :
     }
 
     private fun drawBorder(canvas: Canvas) {
-        // Top
-        canvas.drawRect(
-            0f,
-            0f,
-            width.toFloat(),
-            viewFinderRect.top.toFloat(),
-            borderPaint
-        )
+        // Draw full screen semi-transparent overlay
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), borderPaint)
 
-        // Left
+        // Clear the center
         canvas.drawRect(
-            0f,
-            viewFinderRect.top.toFloat(),
             viewFinderRect.left.toFloat(),
-            viewFinderRect.bottom.toFloat(),
-            borderPaint
-        )
-
-        // Right
-        canvas.drawRect(
-            viewFinderRect.right.toFloat(),
             viewFinderRect.top.toFloat(),
-            width.toFloat(),
+            viewFinderRect.right.toFloat(),
             viewFinderRect.bottom.toFloat(),
-            borderPaint
-        )
-
-        // Bottom
-        canvas.drawRect(
-            0f,
-            viewFinderRect.bottom.toFloat(),
-            width.toFloat(),
-            height.toFloat(),
-            borderPaint
+            viewFinderPaint
         )
     }
 

--- a/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
@@ -10,7 +10,7 @@ import android.util.AttributeSet
 import android.view.View
 import kotlin.math.roundToInt
 
-class ScannerOverlay(context: Context, attrs: AttributeSet?) :
+internal class ScannerOverlay(context: Context, attrs: AttributeSet?) :
     View(context, attrs) {
 
     private val laserPaint = Paint().also {
@@ -98,10 +98,5 @@ class ScannerOverlay(context: Context, attrs: AttributeSet?) :
     fun stopAnimations() {
         laserAnim.cancel()
         laserAnim.removeAllUpdateListeners()
-    }
-
-    companion object {
-        const val SQUARE_SIZE = 820f
-        const val MIN_BORDER_SIZE = 80f
     }
 }

--- a/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
@@ -37,37 +37,43 @@ class ScannerOverlay(context: Context, attrs: AttributeSet?) :
     }
 
     private fun drawBorder(canvas: Canvas, horizontalSize: Float, verticalSize: Float) {
+        // Calculate view finder rect based border sizes
+        val leftEdge = horizontalSize
+        val topEdge = verticalSize
+        val rightEdge = width.toFloat() - horizontalSize
+        val bottomEdge = height.toFloat() - verticalSize
+
         // Top
         canvas.drawRect(
             0f,
             0f,
             width.toFloat(),
-            verticalSize,
+            topEdge,
             borderPaint
         )
 
         // Left
         canvas.drawRect(
             0f,
-            verticalSize,
-            horizontalSize,
-            height.toFloat() - verticalSize,
+            topEdge,
+            leftEdge,
+            bottomEdge,
             borderPaint
         )
 
         // Right
         canvas.drawRect(
-            width.toFloat() - horizontalSize,
-            verticalSize,
+            rightEdge,
+            topEdge,
             width.toFloat(),
-            height.toFloat() - verticalSize,
+            bottomEdge,
             borderPaint
         )
 
         // Bottom
         canvas.drawRect(
             0f,
-            height.toFloat() - verticalSize,
+            bottomEdge,
             width.toFloat(),
             height.toFloat(),
             borderPaint

--- a/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
@@ -10,6 +10,7 @@ import android.graphics.PorterDuffXfermode
 import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.View
+import kotlin.math.max
 import kotlin.math.roundToInt
 
 internal class ScannerOverlay(context: Context, attrs: AttributeSet?) :
@@ -29,6 +30,7 @@ internal class ScannerOverlay(context: Context, attrs: AttributeSet?) :
     }
 
     var viewFinderRect = Rect()
+        private set
 
     init {
         // Provides better performance for using `PorterDuff.Mode.CLEAR`
@@ -47,6 +49,15 @@ internal class ScannerOverlay(context: Context, attrs: AttributeSet?) :
     }
 
     private fun drawBorder(canvas: Canvas) {
+        val verticalBorder = max((height - VIEW_FINDER_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
+        val horizontalBorder = max((width - VIEW_FINDER_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
+        viewFinderRect.set(
+            horizontalBorder,
+            verticalBorder,
+            this.width - horizontalBorder,
+            this.height - verticalBorder
+        )
+
         // Draw full screen semi-transparent overlay
         canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), borderPaint)
 
@@ -85,5 +96,10 @@ internal class ScannerOverlay(context: Context, attrs: AttributeSet?) :
     fun stopAnimations() {
         laserAnim.cancel()
         laserAnim.removeAllUpdateListeners()
+    }
+
+    companion object {
+        const val VIEW_FINDER_SIZE = 820f
+        const val MIN_BORDER_SIZE = 80f
     }
 }

--- a/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
@@ -8,7 +8,6 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.View
-import kotlin.math.max
 import kotlin.math.roundToInt
 
 class ScannerOverlay(context: Context, attrs: AttributeSet?) :
@@ -23,7 +22,7 @@ class ScannerOverlay(context: Context, attrs: AttributeSet?) :
         it.alpha = 75
     }
 
-    private val viewFinderRect = Rect()
+    var viewFinderRect = Rect()
 
     private val laserAnim = ValueAnimator.ofFloat(0f, 255f).also { animator ->
         animator.duration = 320
@@ -32,15 +31,6 @@ class ScannerOverlay(context: Context, attrs: AttributeSet?) :
     }
 
     override fun onDraw(canvas: Canvas) {
-        val verticalBorder = max((height - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
-        val horizontalBorder = max((width - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
-        viewFinderRect.set(
-            verticalBorder,
-            horizontalBorder,
-            this.width - horizontalBorder,
-            this.height - verticalBorder
-        )
-
         drawBorder(canvas)
         drawLaser(canvas)
     }

--- a/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/ScannerOverlay.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.View
 import kotlin.math.max
@@ -22,67 +23,69 @@ class ScannerOverlay(context: Context, attrs: AttributeSet?) :
         it.alpha = 75
     }
 
+    private val viewFinderRect = Rect()
+
     private val laserAnim = ValueAnimator.ofFloat(0f, 255f).also { animator ->
-        animator.setDuration(320)
+        animator.duration = 320
         animator.repeatCount = ValueAnimator.INFINITE
         animator.repeatMode = ValueAnimator.REVERSE
     }
 
     override fun onDraw(canvas: Canvas) {
-        val verticalBorder = max((height - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE)
-        val horizontalBorder = max((width - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE)
+        val verticalBorder = max((height - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
+        val horizontalBorder = max((width - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
+        viewFinderRect.set(
+            verticalBorder,
+            horizontalBorder,
+            this.width - horizontalBorder,
+            this.height - verticalBorder
+        )
 
-        drawBorder(canvas, horizontalBorder, verticalBorder)
-        drawLaser(canvas, horizontalBorder)
+        drawBorder(canvas)
+        drawLaser(canvas)
     }
 
-    private fun drawBorder(canvas: Canvas, horizontalSize: Float, verticalSize: Float) {
-        // Calculate view finder rect based border sizes
-        val leftEdge = horizontalSize
-        val topEdge = verticalSize
-        val rightEdge = width.toFloat() - horizontalSize
-        val bottomEdge = height.toFloat() - verticalSize
-
+    private fun drawBorder(canvas: Canvas) {
         // Top
         canvas.drawRect(
             0f,
             0f,
             width.toFloat(),
-            topEdge,
+            viewFinderRect.top.toFloat(),
             borderPaint
         )
 
         // Left
         canvas.drawRect(
             0f,
-            topEdge,
-            leftEdge,
-            bottomEdge,
+            viewFinderRect.top.toFloat(),
+            viewFinderRect.left.toFloat(),
+            viewFinderRect.bottom.toFloat(),
             borderPaint
         )
 
         // Right
         canvas.drawRect(
-            rightEdge,
-            topEdge,
+            viewFinderRect.right.toFloat(),
+            viewFinderRect.top.toFloat(),
             width.toFloat(),
-            bottomEdge,
+            viewFinderRect.bottom.toFloat(),
             borderPaint
         )
 
         // Bottom
         canvas.drawRect(
             0f,
-            bottomEdge,
+            viewFinderRect.bottom.toFloat(),
             width.toFloat(),
             height.toFloat(),
             borderPaint
         )
     }
 
-    private fun drawLaser(canvas: Canvas, horizontalBorder: Float) {
+    private fun drawLaser(canvas: Canvas) {
         val verticalMid = height / 2
-        val horizontalMargin = horizontalBorder + 8f
+        val horizontalMargin = viewFinderRect.left + 8f
 
         canvas.drawRect(
             0f + horizontalMargin,

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -20,6 +20,7 @@ import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
 import org.odk.collect.qrcode.BarcodeCandidate
 import org.odk.collect.qrcode.BarcodeFilter
+import org.odk.collect.qrcode.BarcodeFormat
 import org.odk.collect.qrcode.BarcodeScannerView
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
 import org.odk.collect.qrcode.DetectedBarcode
@@ -173,7 +174,7 @@ private class MlKitBarcodeScannerView(
             }
 
             is DetectedBarcode.Bytes -> {
-                if (barcode.format == Barcode.FORMAT_PDF417) {
+                if (barcode.format == BarcodeFormat.PDF417) {
                     /**
                      * Allow falling back to Latin encoding for PDF417 barcodes. This provides parity
                      * with the Zxing implementation.
@@ -191,7 +192,12 @@ private class MlKitBarcodeScannerView(
         const val MIN_BORDER_SIZE = 80f
 
         private fun Barcode.toCandidate(): BarcodeCandidate {
-            return BarcodeCandidate(this.rawBytes, this.rawValue, this.boundingBox, this.format)
+            val format = when (this.format) {
+                Barcode.FORMAT_PDF417 -> BarcodeFormat.PDF417
+                else -> BarcodeFormat.OTHER
+            }
+
+            return BarcodeCandidate(this.rawBytes, this.rawValue, this.boundingBox, format)
         }
     }
 }

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.graphics.Rect
 import android.view.LayoutInflater
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis.COORDINATE_SYSTEM_VIEW_REFERENCED
@@ -19,7 +20,10 @@ import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
 import org.odk.collect.qrcode.BarcodeScannerView
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
+import org.odk.collect.qrcode.ScannerOverlay.Companion.MIN_BORDER_SIZE
+import org.odk.collect.qrcode.ScannerOverlay.Companion.SQUARE_SIZE
 import org.odk.collect.qrcode.databinding.MlkitBarcodeScannerLayoutBinding
+import kotlin.math.max
 
 class MlKitBarcodeScannerViewFactory : BarcodeScannerViewContainer.Factory {
     override fun create(
@@ -68,6 +72,8 @@ private class MlKitBarcodeScannerView(
     private val binding =
         MlkitBarcodeScannerLayoutBinding.inflate(LayoutInflater.from(context), this, true)
     private val cameraController = LifecycleCameraController(context)
+
+    private val viewFinderRect = Rect()
 
     init {
         binding.prompt.text = prompt
@@ -136,6 +142,26 @@ private class MlKitBarcodeScannerView(
                 torchListener.onTorchOff()
             }
         }
+    }
+
+    override fun onLayout(
+        changed: Boolean,
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int
+    ) {
+        val verticalBorder = max((height - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
+        val horizontalBorder = max((width - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
+        viewFinderRect.set(
+            horizontalBorder,
+            verticalBorder,
+            this.width - horizontalBorder,
+            this.height - verticalBorder
+        )
+
+        binding.scannerOverlay.viewFinderRect = viewFinderRect
+        super.onLayout(changed, left, top, right, bottom)
     }
 
     private fun processBarcode(barcode: Barcode): String? {

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -22,6 +22,7 @@ import org.odk.collect.qrcode.BarcodeCandidate
 import org.odk.collect.qrcode.BarcodeFilter
 import org.odk.collect.qrcode.BarcodeScannerView
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
+import org.odk.collect.qrcode.DetectedBarcode
 import org.odk.collect.qrcode.databinding.MlkitBarcodeScannerLayoutBinding
 import kotlin.math.max
 
@@ -165,20 +166,23 @@ private class MlKitBarcodeScannerView(
         super.onLayout(changed, left, top, right, bottom)
     }
 
-    private fun processBarcode(barcode: BarcodeCandidate): String? {
-        val bytes = barcode.bytes
-        val utf8Contents = barcode.utfContents
+    private fun processBarcode(barcode: DetectedBarcode): String? {
+        return when (barcode) {
+            is DetectedBarcode.Utf8 -> {
+                barcode.contents
+            }
 
-        return if (!utf8Contents.isNullOrEmpty()) {
-            utf8Contents
-        } else if (bytes != null && barcode.format == Barcode.FORMAT_PDF417) {
-            /**
-             * Allow falling back to Latin encoding for PDF417 barcodes. This provides parity
-             * with the Zxing implementation.
-             */
-            String(bytes, Charsets.ISO_8859_1)
-        } else {
-            null
+            is DetectedBarcode.Bytes -> {
+                if (barcode.format == Barcode.FORMAT_PDF417) {
+                    /**
+                     * Allow falling back to Latin encoding for PDF417 barcodes. This provides parity
+                     * with the Zxing implementation.
+                     */
+                    String(barcode.bytes, Charsets.ISO_8859_1)
+                } else {
+                    null
+                }
+            }
         }
     }
 

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -119,7 +119,7 @@ private class MlKitBarcodeScannerView(
                 val value = result.getValue(barcodeScanner)
                 val barcode = value?.firstOrNull()
 
-                if (barcode != null) {
+                if (barcode != null && viewFinderRect.contains(barcode.boundingBox!!)) {
                     val contents = processBarcode(barcode)
                     if (!contents.isNullOrEmpty()) {
                         cameraController.unbind()

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Application
 import android.content.Context
-import android.graphics.Rect
 import android.view.LayoutInflater
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis.COORDINATE_SYSTEM_VIEW_REFERENCED
@@ -25,7 +24,6 @@ import org.odk.collect.qrcode.BarcodeScannerView
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
 import org.odk.collect.qrcode.DetectedBarcode
 import org.odk.collect.qrcode.databinding.MlkitBarcodeScannerLayoutBinding
-import kotlin.math.max
 
 class MlKitBarcodeScannerViewFactory : BarcodeScannerViewContainer.Factory {
     override fun create(
@@ -75,8 +73,6 @@ private class MlKitBarcodeScannerView(
         MlkitBarcodeScannerLayoutBinding.inflate(LayoutInflater.from(context), this, true)
     private val cameraController = LifecycleCameraController(context)
 
-    private val viewFinderRect = Rect()
-
     init {
         binding.prompt.text = prompt
 
@@ -111,7 +107,7 @@ private class MlKitBarcodeScannerView(
         val barcodeScanner = BarcodeScanning.getClient(options)
 
         val executor = ContextCompat.getMainExecutor(context)
-        val barcodeFilter = BarcodeFilter(viewFinderRect, 10)
+        val barcodeFilter = BarcodeFilter(binding.scannerOverlay.viewFinderRect, 10)
         cameraController.setImageAnalysisAnalyzer(
             executor,
             MlKitAnalyzer(
@@ -147,26 +143,6 @@ private class MlKitBarcodeScannerView(
         }
     }
 
-    override fun onLayout(
-        changed: Boolean,
-        left: Int,
-        top: Int,
-        right: Int,
-        bottom: Int
-    ) {
-        val verticalBorder = max((height - VIEW_FINDER_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
-        val horizontalBorder = max((width - VIEW_FINDER_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
-        viewFinderRect.set(
-            horizontalBorder,
-            verticalBorder,
-            this.width - horizontalBorder,
-            this.height - verticalBorder
-        )
-
-        binding.scannerOverlay.viewFinderRect = viewFinderRect
-        super.onLayout(changed, left, top, right, bottom)
-    }
-
     private fun processBarcode(barcode: DetectedBarcode): String? {
         return when (barcode) {
             is DetectedBarcode.Utf8 -> {
@@ -188,8 +164,6 @@ private class MlKitBarcodeScannerView(
     }
 
     companion object {
-        const val VIEW_FINDER_SIZE = 820f
-        const val MIN_BORDER_SIZE = 80f
 
         private fun Barcode.toCandidate(): BarcodeCandidate {
             val format = when (this.format) {

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -109,7 +109,7 @@ private class MlKitBarcodeScannerView(
         val barcodeScanner = BarcodeScanning.getClient(options)
 
         val executor = ContextCompat.getMainExecutor(context)
-        val barcodeFilter = BarcodeFilter(viewFinderRect)
+        val barcodeFilter = BarcodeFilter(viewFinderRect, 10)
         cameraController.setImageAnalysisAnalyzer(
             executor,
             MlKitAnalyzer(

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -20,8 +20,6 @@ import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
 import org.odk.collect.qrcode.BarcodeScannerView
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
-import org.odk.collect.qrcode.ScannerOverlay.Companion.MIN_BORDER_SIZE
-import org.odk.collect.qrcode.ScannerOverlay.Companion.SQUARE_SIZE
 import org.odk.collect.qrcode.databinding.MlkitBarcodeScannerLayoutBinding
 import kotlin.math.max
 
@@ -151,8 +149,8 @@ private class MlKitBarcodeScannerView(
         right: Int,
         bottom: Int
     ) {
-        val verticalBorder = max((height - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
-        val horizontalBorder = max((width - SQUARE_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
+        val verticalBorder = max((height - VIEW_FINDER_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
+        val horizontalBorder = max((width - VIEW_FINDER_SIZE) / 2f, MIN_BORDER_SIZE).toInt()
         viewFinderRect.set(
             horizontalBorder,
             verticalBorder,
@@ -179,5 +177,10 @@ private class MlKitBarcodeScannerView(
         } else {
             null
         }
+    }
+
+    companion object {
+        const val VIEW_FINDER_SIZE = 820f
+        const val MIN_BORDER_SIZE = 80f
     }
 }

--- a/qr-code/src/test/java/org/odk/collect/qrcode/BarcodeFilterTest.kt
+++ b/qr-code/src/test/java/org/odk/collect/qrcode/BarcodeFilterTest.kt
@@ -37,4 +37,41 @@ class BarcodeFilterTest {
             equalTo(true)
         )
     }
+
+    @Test
+    fun `returns UTF8 barcode when candidate has UTF8 contents`() {
+        val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100))
+        val candidate = BarcodeCandidate(byteArrayOf(0), "blah", Rect(50, 50, 50, 50), 0)
+        assertThat(
+            barcodeFilter.filter(listOf(candidate)),
+            equalTo(DetectedBarcode.Utf8("blah", 0, byteArrayOf(0)))
+        )
+    }
+
+    @Test
+    fun `returns Bytes barcode when candidate has no UTF8 contents`() {
+        val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100))
+        val candidate = BarcodeCandidate(byteArrayOf(0), null, Rect(50, 50, 50, 50), 0)
+        assertThat(
+            barcodeFilter.filter(listOf(candidate)),
+            equalTo(DetectedBarcode.Bytes(0, byteArrayOf(0)))
+        )
+    }
+
+    @Test
+    fun `returns Bytes barcode when candidate has empty UTF8 contents`() {
+        val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100))
+        val candidate = BarcodeCandidate(byteArrayOf(0), "", Rect(50, 50, 50, 50), 0)
+        assertThat(
+            barcodeFilter.filter(listOf(candidate)),
+            equalTo(DetectedBarcode.Bytes(0, byteArrayOf(0)))
+        )
+    }
+
+    @Test
+    fun `returns null when candidate has no bytes`() {
+        val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100))
+        val candidate = BarcodeCandidate(null, null, Rect(50, 50, 50, 50), 0)
+        assertThat(barcodeFilter.filter(listOf(candidate)), equalTo(null))
+    }
 }

--- a/qr-code/src/test/java/org/odk/collect/qrcode/BarcodeFilterTest.kt
+++ b/qr-code/src/test/java/org/odk/collect/qrcode/BarcodeFilterTest.kt
@@ -16,7 +16,8 @@ class BarcodeFilterTest {
     fun `only returns barcode after threshold met`() {
         val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100), 2)
 
-        val candidate = BarcodeCandidate(byteArrayOf(0), "blah", Rect(50, 50, 50, 50), 0)
+        val candidate =
+            BarcodeCandidate(byteArrayOf(0), "blah", Rect(50, 50, 50, 50), BarcodeFormat.OTHER)
         assertThat(barcodeFilter.filter(listOf(candidate)), equalTo(null))
         assertThat(barcodeFilter.filter(listOf(candidate)), not(nullValue()))
     }
@@ -25,10 +26,12 @@ class BarcodeFilterTest {
     fun `requires threshold to be met in sequence`() {
         val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100), 2)
 
-        val candidate = BarcodeCandidate(byteArrayOf(0), "blah", Rect(50, 50, 50, 50), 0)
+        val candidate =
+            BarcodeCandidate(byteArrayOf(0), "blah", Rect(50, 50, 50, 50), BarcodeFormat.OTHER)
         assertThat(barcodeFilter.filter(listOf(candidate)), equalTo(null))
 
-        val other = BarcodeCandidate(byteArrayOf(1), "blah", Rect(50, 50, 50, 50), 0)
+        val other =
+            BarcodeCandidate(byteArrayOf(1), "blah", Rect(50, 50, 50, 50), BarcodeFormat.OTHER)
         assertThat(barcodeFilter.filter(listOf(other)), equalTo(null))
 
         assertThat(barcodeFilter.filter(listOf(candidate)), equalTo(null))
@@ -41,37 +44,40 @@ class BarcodeFilterTest {
     @Test
     fun `returns UTF8 barcode when candidate has UTF8 contents`() {
         val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100))
-        val candidate = BarcodeCandidate(byteArrayOf(0), "blah", Rect(50, 50, 50, 50), 0)
+        val candidate =
+            BarcodeCandidate(byteArrayOf(0), "blah", Rect(50, 50, 50, 50), BarcodeFormat.OTHER)
         assertThat(
             barcodeFilter.filter(listOf(candidate)),
-            equalTo(DetectedBarcode.Utf8("blah", 0, byteArrayOf(0)))
+            equalTo(DetectedBarcode.Utf8("blah", BarcodeFormat.OTHER, byteArrayOf(0)))
         )
     }
 
     @Test
     fun `returns Bytes barcode when candidate has no UTF8 contents`() {
         val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100))
-        val candidate = BarcodeCandidate(byteArrayOf(0), null, Rect(50, 50, 50, 50), 0)
+        val candidate =
+            BarcodeCandidate(byteArrayOf(0), null, Rect(50, 50, 50, 50), BarcodeFormat.OTHER)
         assertThat(
             barcodeFilter.filter(listOf(candidate)),
-            equalTo(DetectedBarcode.Bytes(0, byteArrayOf(0)))
+            equalTo(DetectedBarcode.Bytes(BarcodeFormat.OTHER, byteArrayOf(0)))
         )
     }
 
     @Test
     fun `returns Bytes barcode when candidate has empty UTF8 contents`() {
         val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100))
-        val candidate = BarcodeCandidate(byteArrayOf(0), "", Rect(50, 50, 50, 50), 0)
+        val candidate =
+            BarcodeCandidate(byteArrayOf(0), "", Rect(50, 50, 50, 50), BarcodeFormat.OTHER)
         assertThat(
             barcodeFilter.filter(listOf(candidate)),
-            equalTo(DetectedBarcode.Bytes(0, byteArrayOf(0)))
+            equalTo(DetectedBarcode.Bytes(BarcodeFormat.OTHER, byteArrayOf(0)))
         )
     }
 
     @Test
     fun `returns null when candidate has no bytes`() {
         val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100))
-        val candidate = BarcodeCandidate(null, null, Rect(50, 50, 50, 50), 0)
+        val candidate = BarcodeCandidate(null, null, Rect(50, 50, 50, 50), BarcodeFormat.OTHER)
         assertThat(barcodeFilter.filter(listOf(candidate)), equalTo(null))
     }
 }

--- a/qr-code/src/test/java/org/odk/collect/qrcode/BarcodeFilterTest.kt
+++ b/qr-code/src/test/java/org/odk/collect/qrcode/BarcodeFilterTest.kt
@@ -1,0 +1,40 @@
+package org.odk.collect.qrcode
+
+import android.graphics.Rect
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.nullValue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BarcodeFilterTest {
+
+    @Test
+    fun `only returns barcode after threshold met`() {
+        val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100), 2)
+
+        val candidate = BarcodeCandidate(byteArrayOf(0), "blah", Rect(50, 50, 50, 50), 0)
+        assertThat(barcodeFilter.filter(listOf(candidate)), equalTo(null))
+        assertThat(barcodeFilter.filter(listOf(candidate)), not(nullValue()))
+    }
+
+    @Test
+    fun `requires threshold to be met in sequence`() {
+        val barcodeFilter = BarcodeFilter(Rect(0, 0, 100, 100), 2)
+
+        val candidate = BarcodeCandidate(byteArrayOf(0), "blah", Rect(50, 50, 50, 50), 0)
+        assertThat(barcodeFilter.filter(listOf(candidate)), equalTo(null))
+
+        val other = BarcodeCandidate(byteArrayOf(1), "blah", Rect(50, 50, 50, 50), 0)
+        assertThat(barcodeFilter.filter(listOf(other)), equalTo(null))
+
+        assertThat(barcodeFilter.filter(listOf(candidate)), equalTo(null))
+        assertThat(
+            barcodeFilter.filter(listOf(candidate))!!.bytes.contentEquals(candidate.bytes),
+            equalTo(true)
+        )
+    }
+}


### PR DESCRIPTION
Work towards #6784

This makes the two non user-visible changes discussed in #6784:

- Barcodes are ignored when they are not in the "view finder"
- Barcodes are ignored until they have been scanned multiple times

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I've actually found that this removes partial scans for me on my Pixel 4a with issue's example Code 39 barcode. The main risk would be that this makes scanning legitimate barcodes harder (or just take longer). I currently have the "threshold" number of scans before a barcode is accepted set to 10, but we can definitely tweak this if it feels like too much/not enough.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
