### PR TITLE
Improve the logic for determining whether a form update should be scheduled after importing settings

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.kt
@@ -31,9 +31,13 @@ class CollectSettingsChangeHandler(
         }
     }
 
-    override fun onSettingsChanged(projectId: String, formUpdateSettingsChanged: Boolean) {
+    override fun onSettingsChanged(
+        projectId: String,
+        changedUnprotectedKeys: List<String>,
+        changedProtectedKeys: List<String>
+    ) {
         propertyManager.reload()
-        if (formUpdateSettingsChanged) {
+        if (changedUnprotectedKeys.contains(ProjectKeys.KEY_FORM_UPDATE_MODE) || changedUnprotectedKeys.contains(ProjectKeys.KEY_PERIODIC_FORM_UPDATES_CHECK)) {
             formUpdateScheduler.scheduleUpdates(projectId)
         }
     }

--- a/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
@@ -78,7 +78,7 @@ class ODKAppSettingsImporterTest {
 
     @Test
     fun `rejects JSON when exception is thrown during importing`() {
-        whenever(settingsChangeHandler.onSettingsChanged(any(), any())).thenThrow(RuntimeException::class.java)
+        whenever(settingsChangeHandler.onSettingsChanged(any(), any(), any())).thenThrow(RuntimeException::class.java)
 
         val result = settingsImporter.fromJSON(
             "{\n" +

--- a/settings/src/test/java/org/odk/collect/settings/importing/SettingsImporterTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/importing/SettingsImporterTest.kt
@@ -9,7 +9,6 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
@@ -259,24 +258,7 @@ class SettingsImporterTest {
     }
 
     @Test
-    fun afterSettingsImportedAndMigrated_runsSettingsChangeHandler() {
-        importer = SettingsImporter(
-            settingsProvider,
-            { _: Settings?, _: Settings? -> },
-            settingsValidator,
-            generalDefaults,
-            adminDefaults,
-            settingsChangeHandler,
-            projectsRepository,
-            projectDetailsCreator
-        )
-        assertThat(importer.fromJSON(emptySettings(), currentProject, JSONObject()), `is`(ProjectConfigurationResult.SUCCESS))
-        verify(settingsChangeHandler).onSettingsChanged("1", false)
-        verifyNoMoreInteractions(settingsChangeHandler)
-    }
-
-    @Test
-    fun afterSettingsImportedAndMigrated_runsSettingsChangeIfFormUpdateSettingsChanged() {
+    fun afterSettingsImportedAndMigrated_runsSettingsChangeHandlerWithUpdatedKeys() {
         importer = SettingsImporter(
             settingsProvider,
             { _: Settings?, _: Settings? -> },
@@ -288,43 +270,29 @@ class SettingsImporterTest {
             projectDetailsCreator
         )
 
-        // First import
         var generalJson = JSONObject()
-            .put(ProjectKeys.KEY_FORM_UPDATE_MODE, "foo")
-            .put(ProjectKeys.KEY_PERIODIC_FORM_UPDATES_CHECK, "bar")
+            .put("key1", "default")
+            .put("key2", true)
+        var adminJson = JSONObject()
+            .put("key2", 5)
         var settings = JSONObject()
             .put(AppConfigurationKeys.GENERAL, generalJson)
-            .put(AppConfigurationKeys.ADMIN, JSONObject())
+            .put(AppConfigurationKeys.ADMIN, adminJson)
 
         assertThat(importer.fromJSON(settings.toString(), currentProject, JSONObject()), `is`(ProjectConfigurationResult.SUCCESS))
-        verify(settingsChangeHandler).onSettingsChanged("1", true)
+        verify(settingsChangeHandler).onSettingsChanged("1", emptyList(), emptyList())
 
-        // Second import - the same settings
-        assertThat(importer.fromJSON(settings.toString(), currentProject, JSONObject()), `is`(ProjectConfigurationResult.SUCCESS))
-        verify(settingsChangeHandler).onSettingsChanged("1", false)
-
-        // Third import - ProjectKeys.KEY_PERIODIC_FORM_UPDATES_CHECK updated
         generalJson = JSONObject()
-            .put(ProjectKeys.KEY_FORM_UPDATE_MODE, "bar")
-            .put(ProjectKeys.KEY_PERIODIC_FORM_UPDATES_CHECK, "bar")
+            .put("key1", "foo")
+            .put("key2", true)
+        adminJson = JSONObject()
+            .put("key2", 10)
         settings = JSONObject()
             .put(AppConfigurationKeys.GENERAL, generalJson)
-            .put(AppConfigurationKeys.ADMIN, JSONObject())
+            .put(AppConfigurationKeys.ADMIN, adminJson)
 
         assertThat(importer.fromJSON(settings.toString(), currentProject, JSONObject()), `is`(ProjectConfigurationResult.SUCCESS))
-        verify(settingsChangeHandler, times(2)).onSettingsChanged("1", true)
-
-        // Fourth import - ProjectKeys.KEY_FORM_UPDATE_MODE updated
-        generalJson = JSONObject()
-            .put(ProjectKeys.KEY_FORM_UPDATE_MODE, "bar")
-            .put(ProjectKeys.KEY_PERIODIC_FORM_UPDATES_CHECK, "foo")
-        settings = JSONObject()
-            .put(AppConfigurationKeys.GENERAL, generalJson)
-            .put(AppConfigurationKeys.ADMIN, JSONObject())
-
-        assertThat(importer.fromJSON(settings.toString(), currentProject, JSONObject()), `is`(ProjectConfigurationResult.SUCCESS))
-        verify(settingsChangeHandler, times(3)).onSettingsChanged("1", true)
-
+        verify(settingsChangeHandler).onSettingsChanged("1", listOf("key1"), listOf("key2"))
         verifyNoMoreInteractions(settingsChangeHandler)
     }
 


### PR DESCRIPTION
Closes https://github.com/getodk/collect/pull/6814#pullrequestreview-3029176111

#### Why is this the best possible solution? Were any other approaches considered?
As discussed in https://github.com/getodk/collect/pull/6814#pullrequestreview-3029176111, passing the list of updated keys (when updating multiple settings) is a better and more consistent approach, aligning with how we handle single-setting updates.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no visible change. It's just refactoring, but it would be good to verify that there is no regression in https://github.com/getodk/collect/pull/6814

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
