### PR TITLE
Fix shortcuts on Android 16

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.feature.external
 import android.content.Intent
 import android.content.Intent.EXTRA_SHORTCUT_INTENT
 import android.content.Intent.EXTRA_SHORTCUT_NAME
+import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -62,5 +63,13 @@ class AndroidShortcutsTest {
         val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
         assertThat(shortcutTargetIntent.action, equalTo(Intent.ACTION_EDIT))
         assertThat(shortcutTargetIntent.data, equalTo(FormsContract.getUri("DEMO", formId)))
+
+        // Check we're using ShortcutManager.createShortcutResultIntent on Android 16+
+        if (Build.VERSION.SDK_INT >= 36) {
+            assertThat(
+                shortcutIntent.hasExtra("android.content.pm.extra.PIN_ITEM_REQUEST"),
+                equalTo(true)
+            )
+        }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
@@ -14,20 +14,25 @@ class PrepDeviceForTestsRule : TestRule {
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
-                disableAnimations()
-                increaseLongPressTimeout()
+                setAnimationScale(0)
+                setLongPressTimeout(3000)
 
-                base.evaluate()
+                try {
+                    base.evaluate()
+                } finally {
+                    setAnimationScale(1)
+                    setLongPressTimeout(500)
+                }
             }
         }
     }
 
-    private fun increaseLongPressTimeout() {
-        executeShellCommand("settings put secure long_press_timeout 3000")
+    private fun setLongPressTimeout(timeout: Int) {
+        executeShellCommand("settings put secure long_press_timeout $timeout")
     }
 
-    private fun disableAnimations() {
-        ANIMATIONS.forEach { executeShellCommand("settings put global $it 0") }
+    private fun setAnimationScale(scale: Int) {
+        ANIMATIONS.forEach { executeShellCommand("settings put global $it $scale") }
     }
 
     private fun executeShellCommand(command: String) {

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -110,4 +110,9 @@ object AnalyticsEvents {
      * Tracks how often finalized or sent forms are edited
      */
     const val EDIT_FINALIZED_OR_SENT_FORM = "EditFinalizedOrSentForm"
+
+    /**
+     * Tracks how often shortcuts for forms are added
+     */
+    const val ADD_SHORTCUT = "AddShortcut"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.kt
@@ -25,7 +25,9 @@ import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
+import org.odk.collect.android.analytics.AnalyticsEvents
 import org.odk.collect.android.formlists.blankformlist.BlankFormListItem
 import org.odk.collect.android.formlists.blankformlist.BlankFormListViewModel
 import org.odk.collect.android.injection.DaggerUtils
@@ -65,6 +67,8 @@ class AndroidShortcutsActivity : AppCompatActivity() {
                     .map { it.formName }
                     .toTypedArray()
             ) { _: DialogInterface?, item: Int ->
+                Analytics.log(AnalyticsEvents.ADD_SHORTCUT)
+
                 val intent = getShortcutIntent(blankFormListItems, item)
                 setResult(RESULT_OK, intent)
                 finish()

--- a/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.kt
@@ -15,17 +15,22 @@ package org.odk.collect.android.external
 
 import android.content.DialogInterface
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.android.R
 import org.odk.collect.android.formlists.blankformlist.BlankFormListItem
 import org.odk.collect.android.formlists.blankformlist.BlankFormListViewModel
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.settings.SettingsProvider
+import java.util.UUID
 import javax.inject.Inject
 
 /**
@@ -79,12 +84,26 @@ class AndroidShortcutsActivity : AppCompatActivity() {
             data = forms[item].contentUri
         }
 
-        return Intent().apply {
-            putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent)
-            putExtra(Intent.EXTRA_SHORTCUT_NAME, forms[item].formName)
-            val iconResource: Parcelable =
-                Intent.ShortcutIconResource.fromContext(this@AndroidShortcutsActivity, R.drawable.notes)
-            putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, iconResource)
+        return if (Build.VERSION.SDK_INT >= 36) {
+            ShortcutManagerCompat.createShortcutResultIntent(
+                this,
+                ShortcutInfoCompat.Builder(this, UUID.randomUUID().toString())
+                    .setIntent(shortcutIntent)
+                    .setShortLabel(forms[item].formName)
+                    .setIcon(IconCompat.createWithResource(this, R.drawable.notes))
+                    .build()
+            )
+        } else {
+            Intent().apply {
+                putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent)
+                putExtra(Intent.EXTRA_SHORTCUT_NAME, forms[item].formName)
+                val iconResource: Parcelable =
+                    Intent.ShortcutIconResource.fromContext(
+                        this@AndroidShortcutsActivity,
+                        R.drawable.notes
+                    )
+                putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, iconResource)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/getodk/collect/issues/6833

#### Why is this the best possible solution? Were any other approaches considered?

I've switched to using a helper in just Android 16+ to lower the risk of this change. 

Our approach to shortcuts seems to very out of date looking at the most [up-to-date docs](https://developer.android.com/develop/ui/views/launch/shortcuts) - using the widgets menu isn't even mentioned. Anecdotally, I've also never seen another app work like this. We should look at reworking things so that we support "dynamic" or "pinned" shortcuts in the future, and I've added analytics to allow ourselves to make a decision about how that should be prioritized.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just allow shortcuts to work again on Android 16. Other OS versions should be unaffected.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
