### PR TITLE
Clean up download optimizations

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -65,8 +65,8 @@ def getVersionName = { ->
 def secrets = getSecrets()
 def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxAccessToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
-def entitiesFilterProjectUrl = secrets.getProperty('ENTITIES_FILTER_TEST_PROJECT_URL', '')
-def entitiesFilterSearchProjectUrl = secrets.getProperty('ENTITIES_FILTER_SEARCH_TEST_PROJECT_URL', '')
+def entitiesFilterProjectUrl = secrets.getProperty('ENTITIES_FILTER_PROJECT_URL', '')
+def entitiesFilterSearchProjectUrl = secrets.getProperty('ENTITIES_FILTER_SEARCH_PROJECT_URL', '')
 def thousandMediaFileProjectUrl = secrets.getProperty('THOUSAND_MEDIA_FILE_PROJECT_URL', '')
 def thousandMediaFileEntityListProjectUrl = secrets.getProperty('THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL', '')
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/EntitiesBenchmarkTest.kt
@@ -18,18 +18,8 @@ import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 import org.odk.collect.android.test.BuildConfig.ENTITIES_FILTER_PROJECT_URL
+import org.odk.collect.android.test.BuildConfig.THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL
 import org.odk.collect.strings.R
-
-/**
- * Benchmarks the performance of entity follow up forms. [ENTITIES_FILTER_PROJECT_URL] should
- * be set to a project that contains the "100k Entities Filter" benchmark form and the
- * "entities_100k" entity list.
- *
- * Devices that currently pass:
- * - Fairphone 3
- * - Pixel 3
- *
- */
 
 @RunWith(AndroidJUnit4::class)
 class EntitiesBenchmarkTest {
@@ -39,8 +29,18 @@ class EntitiesBenchmarkTest {
     @get:Rule
     var chain: RuleChain = chain(TestDependencies(true)).around(rule)
 
+    /**
+     * Benchmarks the performance of entity follow up forms. [ENTITIES_FILTER_PROJECT_URL] should
+     * be set to a project that contains the "100k Entities Filter" benchmark form and the
+     * "entities_100k" entity list.
+     *
+     * Devices that currently pass:
+     * - Fairphone 3
+     * - Pixel 3
+     *
+     */
     @Test
-    fun run() {
+    fun oneHundredThousandEntities() {
         assertThat(
             "Need to set ENTITIES_FILTER_PROJECT_URL before running!",
             ENTITIES_FILTER_PROJECT_URL,
@@ -94,6 +94,48 @@ class EntitiesBenchmarkTest {
             .answerQuestion("Which value do you want to filter by?", "1024")
             .benchmark("Filtering select", 3, benchmarker) {
                 it.swipeToNextQuestion("Filtered select")
+            }
+
+        benchmarker.assertResults()
+    }
+
+    /**
+     * Benchmarks the performance of updating forms with entity lists and many media files.
+     * [THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL] should be set to a project that contains the
+     * "1000-media-files-entity-list" form.
+     *
+     * Devices that currently pass:
+     * - Fairphone 3
+     */
+    @Test
+    fun oneThousandMediaFilesWithEntityList() {
+        assertThat(
+            "Need to set THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL before running!",
+            THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL,
+            not(blankOrNullString())
+        )
+
+        val benchmarker = Benchmarker()
+
+        rule.startAtFirstLaunch()
+            .clickManuallyEnterProjectDetails()
+            .inputUrl(THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL)
+            .addProject()
+
+            // Download all forms
+            .clickGetBlankForm()
+            .clickGetSelected()
+            .clickOKOnDialog(MainMenuPage())
+
+            .clickGetBlankForm()
+            .benchmark(
+                "Redownloading a form with 1k media files and entity list when there are no updates",
+                15,
+                benchmarker
+            ) {
+                it
+                    .clickGetSelected()
+                    .clickOKOnDialog(MainMenuPage())
             }
 
         benchmarker.assertResults()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -8,7 +8,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.odk.collect.android.application.FeatureFlags
 import org.odk.collect.android.benchmark.support.Benchmarker
 import org.odk.collect.android.benchmark.support.benchmark
 import org.odk.collect.android.support.TestDependencies
@@ -105,7 +104,7 @@ class FormsUpdateBenchmarkTest {
             .clickGetBlankForm()
             .benchmark(
                 "Redownloading a form with 1k media files and entity list when there are no updates",
-                if (FeatureFlags.FASTER_FORM_UPDATES) 5 else 15,
+                15,
                 benchmarker
             ) {
                 it

--- a/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/benchmark/FormsUpdateBenchmarkTest.kt
@@ -14,7 +14,6 @@ import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
-import org.odk.collect.android.test.BuildConfig.THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL
 import org.odk.collect.android.test.BuildConfig.THOUSAND_MEDIA_FILE_PROJECT_URL
 
 @RunWith(AndroidJUnit4::class)
@@ -25,7 +24,7 @@ class FormsUpdateBenchmarkTest {
     val chain: RuleChain = chain(TestDependencies(true)).around(rule)
 
     /**
-     * Benchmarks the performance of updating forms. [THOUSAND_MEDIA_FILE_PROJECT_URL] should
+     * Benchmarks the performance of check for updates. [THOUSAND_MEDIA_FILE_PROJECT_URL] should
      * be set to a project that contains the "1000-media-files" benchmark form.
      *
      * Devices that currently pass:
@@ -59,57 +58,6 @@ class FormsUpdateBenchmarkTest {
                 it
                     .clickGetBlankForm()
                     .clickSelectAll()
-            }
-
-            .benchmark(
-                "Redownloading a form with 1k media files when there are no updates",
-                12,
-                benchmarker
-            ) {
-                it
-                    .clickGetSelected()
-                    .clickOKOnDialog(MainMenuPage())
-            }
-
-        benchmarker.assertResults()
-    }
-
-    /**
-     * Benchmarks the performance of updating forms. [THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL] should
-     * be set to a project that contains the "1000-media-files-entity-list" form.
-     *
-     * Devices that currently pass:
-     * - Fairphone 3
-     */
-    @Test
-    fun oneThousandMediaFilesWithEntityList() {
-        assertThat(
-            "Need to set THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL before running!",
-            THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL,
-            not(blankOrNullString())
-        )
-
-        val benchmarker = Benchmarker()
-
-        rule.startAtFirstLaunch()
-            .clickManuallyEnterProjectDetails()
-            .inputUrl(THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL)
-            .addProject()
-
-            // Download all forms
-            .clickGetBlankForm()
-            .clickGetSelected()
-            .clickOKOnDialog(MainMenuPage())
-
-            .clickGetBlankForm()
-            .benchmark(
-                "Redownloading a form with 1k media files and entity list when there are no updates",
-                15,
-                benchmarker
-            ) {
-                it
-                    .clickGetSelected()
-                    .clickOKOnDialog(MainMenuPage())
             }
 
         benchmarker.assertResults()

--- a/collect_app/src/main/java/org/odk/collect/android/application/FeatureFlags.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/FeatureFlags.kt
@@ -3,6 +3,5 @@ package org.odk.collect.android.application
 object FeatureFlags {
 
     const val NO_THEME_SETTING = true
-    const val FASTER_FORM_UPDATES = false
     const val FOREGROUND_SERVICE_UPDATES = true
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDetails.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDetails.kt
@@ -24,11 +24,10 @@ data class ServerFormDetails @JvmOverloads constructor(
     val hash: String?,
     val isNotOnDevice: Boolean,
     val isUpdated: Boolean,
-    val manifest: ManifestFile?,
-    val mediaOnlyUpdate: Boolean = false
+    val manifest: ManifestFile?
 ) : Serializable {
 
     companion object {
-        private const val serialVersionUID = 2L
+        private const val serialVersionUID = 3L
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -144,9 +144,7 @@ object ServerFormUseCases {
                     val existingFileHash = existingFile.getMd5Hash()
 
                     if (existingFileHash.contentEquals(mediaFile.hash)) {
-                        if (!formToDownload.mediaOnlyUpdate) {
-                            copyFileToDirectory(existingFile, tempMediaDir)
-                        }
+                        copyFileToDirectory(existingFile, tempMediaDir)
                     } else {
                         downloadMediaFile(
                             formSource,

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.kt
@@ -15,7 +15,6 @@
  */
 package org.odk.collect.android.formmanagement
 
-import org.odk.collect.android.application.FeatureFlags
 import org.odk.collect.android.utilities.FormUtils
 import org.odk.collect.android.utilities.WebCredentialsUtils
 import org.odk.collect.forms.Form
@@ -85,8 +84,7 @@ open class ServerFormsDetailsFetcher(
                 listItem.hash,
                 !thisFormAlreadyDownloaded,
                 isNewerFormVersionAvailable || areNewerMediaFilesAvailable,
-                manifestFile,
-                FeatureFlags.FASTER_FORM_UPDATES && (!isNewerFormVersionAvailable && areNewerMediaFilesAvailable)
+                manifestFile
             )
         }
     }


### PR DESCRIPTION
This removes the optimizations we made for a fork - they were hidden behind a feature flag anyway. Instead, I've written an issue to drive out the changes properly (https://github.com/getodk/collect/issues/6843).

I've also fixed the configuration code for benchmarks that weren't working.