### PR TITLE
Add setting for MLKit scan threshold

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/SettingsBarcodeScannerViewFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/SettingsBarcodeScannerViewFactory.kt
@@ -13,7 +13,9 @@ import org.odk.collect.shared.settings.Settings
 class SettingsBarcodeScannerViewFactory(
     private val settings: Settings
 ) : BarcodeScannerViewContainer.Factory {
-    private val playServicesFallbackFactory = PlayServicesFallbackBarcodeScannerViewFactory()
+    private val playServicesFallbackFactory = PlayServicesFallbackBarcodeScannerViewFactory(
+        settings.getInt(ProjectKeys.KEY_MLKIT_SCAN_THRESHOLD)
+    )
     private val zxingFactory = ZxingBarcodeScannerViewFactory()
 
     override fun create(

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
@@ -54,6 +54,7 @@ object Defaults {
             // experimental_preferences.xml
             hashMap[ProjectKeys.KEY_DEBUG_FILTERS] = BuildConfig.BUILD_TYPE == "selfSignedRelease"
             hashMap[ProjectKeys.KEY_MLKIT_SCANNING] = true
+            hashMap[ProjectKeys.KEY_MLKIT_SCAN_THRESHOLD] = 10
             return hashMap
         }
 

--- a/collect_app/src/main/res/xml/experimental_preferences.xml
+++ b/collect_app/src/main/res/xml/experimental_preferences.xml
@@ -10,9 +10,17 @@
 
     <SwitchPreference
         android:key="mlkit_scanning"
-        android:title="@string/use_mlkit_for_barcode_scanning"
         android:summary="@string/mlkit_is_always_used_for_scanning_project_qr_codes"
+        android:title="@string/use_mlkit_for_barcode_scanning"
         app:iconSpaceReserved="false" />
+
+    <SeekBarPreference
+        android:key="mlkit_scan_threshold"
+        android:max="20"
+        android:title="@string/mlkit_scan_threshold"
+        app:iconSpaceReserved="false"
+        app:min="1"
+        app:showSeekBarValue="true" />
 
     <PreferenceCategory
         android:title="@string/entities_title"

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/MlKitBarcodeScannerViewFactory.kt
@@ -25,7 +25,7 @@ import org.odk.collect.qrcode.BarcodeScannerViewContainer
 import org.odk.collect.qrcode.DetectedBarcode
 import org.odk.collect.qrcode.databinding.MlkitBarcodeScannerLayoutBinding
 
-class MlKitBarcodeScannerViewFactory : BarcodeScannerViewContainer.Factory {
+class MlKitBarcodeScannerViewFactory(private val scanThreshold: Int) : BarcodeScannerViewContainer.Factory {
     override fun create(
         activity: Activity,
         lifecycleOwner: LifecycleOwner,
@@ -33,7 +33,7 @@ class MlKitBarcodeScannerViewFactory : BarcodeScannerViewContainer.Factory {
         prompt: String,
         useFrontCamera: Boolean
     ): BarcodeScannerView {
-        return MlKitBarcodeScannerView(activity, lifecycleOwner, qrOnly, useFrontCamera, prompt)
+        return MlKitBarcodeScannerView(activity, lifecycleOwner, qrOnly, useFrontCamera, prompt, scanThreshold)
     }
 
     companion object {
@@ -66,7 +66,8 @@ private class MlKitBarcodeScannerView(
     private val lifecycleOwner: LifecycleOwner,
     private val qrOnly: Boolean,
     private val useFrontCamera: Boolean,
-    prompt: String
+    prompt: String,
+    private val scanThreshold: Int
 ) : BarcodeScannerView(context) {
 
     private val binding =
@@ -107,7 +108,7 @@ private class MlKitBarcodeScannerView(
         val barcodeScanner = BarcodeScanning.getClient(options)
 
         val executor = ContextCompat.getMainExecutor(context)
-        val barcodeFilter = BarcodeFilter(binding.scannerOverlay.viewFinderRect, 10)
+        val barcodeFilter = BarcodeFilter(binding.scannerOverlay.viewFinderRect, scanThreshold)
         cameraController.setImageAnalysisAnalyzer(
             executor,
             MlKitAnalyzer(

--- a/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/PlayServicesFallbackBarcodeScannerViewFactory.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/mlkit/PlayServicesFallbackBarcodeScannerViewFactory.kt
@@ -6,9 +6,9 @@ import org.odk.collect.qrcode.BarcodeScannerView
 import org.odk.collect.qrcode.BarcodeScannerViewContainer
 import org.odk.collect.qrcode.zxing.ZxingBarcodeScannerViewFactory
 
-class PlayServicesFallbackBarcodeScannerViewFactory : BarcodeScannerViewContainer.Factory {
+class PlayServicesFallbackBarcodeScannerViewFactory(mlkitScanThreshold: Int) : BarcodeScannerViewContainer.Factory {
 
-    private val mlKitBarcodeScannerViewFactory = MlKitBarcodeScannerViewFactory()
+    private val mlKitBarcodeScannerViewFactory = MlKitBarcodeScannerViewFactory(mlkitScanThreshold)
     private val zxingBarcodeScannerViewFactory = ZxingBarcodeScannerViewFactory()
 
     override fun create(

--- a/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.settings.keys
 
 object ProjectKeys {
+
     // server_preferences.xml
     const val KEY_PROTOCOL = "protocol"
 
@@ -53,6 +54,7 @@ object ProjectKeys {
     // experimental_preferences.xml
     const val KEY_DEBUG_FILTERS = "experimental_debug_filters"
     const val KEY_MLKIT_SCANNING = "mlkit_scanning"
+    const val KEY_MLKIT_SCAN_THRESHOLD = "mlkit_scan_threshold"
 
     // values
     const val PROTOCOL_SERVER = "odk_default"

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1252,8 +1252,8 @@
     <string name="use_mlkit_for_barcode_scanning">Use ML Kit for barcode scanning</string>
     <string name="mlkit_is_always_used_for_scanning_project_qr_codes">ML Kit is always used for scanning project QR codes</string>
 
-    <!-- Experimental setting that allows the number of repeated scans required for MLKit to process a barcode to be tweaked -->
-    <string name="mlkit_scan_threshold">MLKit scan threshold</string>
+    <!-- Experimental setting that allows the number of repeated scans required for ML Kit to process a barcode to be tweaked -->
+    <string name="mlkit_scan_threshold">ML Kit scan threshold</string>
 
     <string name="permission_dialog_title">About permissions</string>
     <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1252,6 +1252,9 @@
     <string name="use_mlkit_for_barcode_scanning">Use ML Kit for barcode scanning</string>
     <string name="mlkit_is_always_used_for_scanning_project_qr_codes">ML Kit is always used for scanning project QR codes</string>
 
+    <!-- Experimental setting that allows the number of repeated scans required for MLKit to process a barcode to be tweaked -->
+    <string name="mlkit_scan_threshold">MLKit scan threshold</string>
+
     <string name="permission_dialog_title">About permissions</string>
     <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>
     <string name="notifications">Notifications</string>


### PR DESCRIPTION
This adds an experimental setting that allows the number of repeated scans required for MLKit to process a barcode to be tweaked so that we (and potentially beta users) are able to experiment with works best.