### PR TITLE
Fixed building the list of projects

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
@@ -4,7 +4,6 @@ import android.app.Dialog
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import androidx.fragment.app.DialogFragment
@@ -48,7 +47,7 @@ class ProjectSettingsDialog(private val viewModelFactory: ViewModelProvider.Fact
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = ProjectSettingsDialogLayoutBinding.inflate(LayoutInflater.from(context))
+        binding = ProjectSettingsDialogLayoutBinding.inflate(layoutInflater)
 
         currentProjectViewModel.currentProject.observe(this) {
             if (it != null) {
@@ -88,6 +87,8 @@ class ProjectSettingsDialog(private val viewModelFactory: ViewModelProvider.Fact
     }
 
     private fun inflateListOfInActiveProjects(context: Context, currentProject: Project.Saved) {
+        binding.projectList.removeAllViews()
+
         if (projectsRepository.getAll().none { it.uuid != currentProject.uuid }) {
             binding.topDivider.visibility = INVISIBLE
         } else {


### PR DESCRIPTION
Closes #6829 

#### Why is this the best possible solution? Were any other approaches considered?
We populate the list of projects every time the LiveData emits a new current project. While the dialog is open, the current project doesn't change, but if the user leaves the phone idle for a few minutes, it might be emitted again when they return.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should resolve the issue without causing any side effects. It appears to be a safe change, and I can't identify any potential risks.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
