### PR TITLE
Build maps APK on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,7 +328,7 @@ jobs:
       - run:
           name: Authorize gcloud
           command: |
-            if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
+            if [[ -n "$GCLOUD_SERVICE_KEY" ]]; then \
               gcloud config set project api-project-322300403941
               echo $GCLOUD_SERVICE_KEY | base64 --decode > client-secret.json
               gcloud auth activate-service-account --key-file client-secret.json
@@ -336,8 +336,7 @@ jobs:
       - run:
           name: Run integration tests
           command: |
-            if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
-              echo "y" | gcloud beta firebase test android run \
+            echo "y" | gcloud beta firebase test android run \
               --type instrumentation \
               --num-uniform-shards=25 \
               --app collect_app/build/outputs/apk/debug/ODK-Collect-debug.apk \
@@ -347,7 +346,6 @@ jobs:
               --directories-to-pull /sdcard --timeout 20m \
               --test-targets "notPackage org.odk.collect.android.regression" \
               --test-targets "notPackage org.odk.collect.android.benchmark"
-            fi
           no_output_timeout: 25m
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,9 @@ jobs:
           name: Set up secrets.properties for Maps frameworks
           command:
             if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
-              echo "GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY" > secrets.properties
+              echo "GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY" >> secrets.properties
+              echo "MAPBOX_ACCESS_TOKEN=$MAPBOX_ACCESS_TOKEN" >> secrets.properties
+              echo "MAPBOX_DOWNLOADS_TOKEN=MAPBOX_DOWNLOADS_TOKEN" >> secrets.properties
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,13 @@ jobs:
           command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
 
       - run:
+          name: Set up secrets.properties for Maps frameworks
+          command:
+            if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
+              echo "GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY" > secrets.properties
+            fi
+
+      - run:
           name: Assemble self signed release build
           command: ./gradlew assembleSelfSignedRelease
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ jobs:
 
       - run:
           name: Set up secrets.properties for Maps frameworks
-          command:
+          command: |
             if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
               echo "GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY" >> secrets.properties
               echo "MAPBOX_ACCESS_TOKEN=$MAPBOX_ACCESS_TOKEN" >> secrets.properties

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
       - run:
           name: Set up secrets.properties for Maps frameworks
           command: |
-            if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
+            if [[ -n "$GOOGLE_MAPS_API_KEY" ]]; then \
               echo "GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY" >> secrets.properties
               echo "MAPBOX_ACCESS_TOKEN=$MAPBOX_ACCESS_TOKEN" >> secrets.properties
               echo "MAPBOX_DOWNLOADS_TOKEN=MAPBOX_DOWNLOADS_TOKEN" >> secrets.properties


### PR DESCRIPTION
This will set up `secrets.properties` in `build_release` where the following env variables are available:

- `GOOGLE_MAPS_API_KEY`
- `MAPBOX_ACCESS_TOKEN`
- `MAPBOX_DOWNLOADS_TOKEN`

@lognaturel as far as I can tell from docs (and from playing with SSH builds and the existing`GCLOUD_SERVICE_KEY` env variable) we can add these variables in Circle CI and they will only be available to builds running on branches on the main `getodk/collect` repo.