### PR TITLE
Allows no-buttons columns-n appearance to include 1 column

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -178,7 +178,7 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
         void bind(final int index) {
             if (noButtonsMode) {
                 File imageFile = getImageFile(index);
-                noButtonsItem.setUpNoButtonsItem(imageFile, getChoiceText(index), getErrorMsg(imageFile), numColumns > 1);
+                noButtonsItem.setUpNoButtonsItem(imageFile, getChoiceText(index), getErrorMsg(imageFile), numColumns >= 1);
                 noButtonsItem.setOnClickListener(v -> onItemClick(filteredItems.get(index).selection(), v));
             } else {
                 addMediaFromChoice(audioVideoImageTextLabel, index, createButton(index, audioVideoImageTextLabel), filteredItems);


### PR DESCRIPTION
This is my first issue/PR/etc. so if there is anything I should be doing differently, let me know.

#### Why is this the best possible solution? Were any other approaches considered?

This is the most minimal change and keeps current behavior the most consistent. 


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should only affect select questions that use an appearance with "no-buttons columns-n" that use images for responses. Changing ">1" to ">=1" includes 1 column was well as multiple. 

#### Do we need any specific form for testing your changes? If so, please attach one.
Probably not. Details can be found on the forum: https://forum.getodk.org/t/adding-columns-1-as-appearance-option/56463/4

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Probably not


#### Before submitting this PR, please make sure you have:
- [ ] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
I think I have some some of Gradle dependency issues, but I don't think this is related to the change I made.
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
