### PR TITLE
Switch to ML Kit as default scanner

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/SettingsBarcodeScannerViewFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/SettingsBarcodeScannerViewFactory.kt
@@ -22,10 +22,10 @@ class SettingsBarcodeScannerViewFactory(
         qrOnly: Boolean,
         useFrontCamera: Boolean
     ): BarcodeScannerView {
-        val factory = if (qrOnly || settings.getExperimentalOptIn(ProjectKeys.KEY_MLKIT_SCANNING)) {
-            playServicesFallbackFactory
-        } else {
+        val factory = if (settings.getExperimentalOptIn(ProjectKeys.KEY_ZXING_SCANNING)) {
             zxingFactory
+        } else {
+            playServicesFallbackFactory
         }
 
         return factory.create(activity, lifecycleOwner, qrOnly, useFrontCamera)

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
@@ -53,7 +53,7 @@ object Defaults {
             hashMap[ProjectKeys.KEY_MAPBOX_MAP_STYLE] = "mapbox://styles/mapbox/streets-v11"
             // experimental_preferences.xml
             hashMap[ProjectKeys.KEY_DEBUG_FILTERS] = BuildConfig.BUILD_TYPE == "selfSignedRelease"
-            hashMap[ProjectKeys.KEY_MLKIT_SCANNING] = true
+            hashMap[ProjectKeys.KEY_ZXING_SCANNING] = false
             return hashMap
         }
 

--- a/collect_app/src/main/res/xml/dev_tools_preferences.xml
+++ b/collect_app/src/main/res/xml/dev_tools_preferences.xml
@@ -15,4 +15,9 @@
         android:summary="@string/debug_filters_summary"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreferenceCompat
+        android:key="zxing_scanning"
+        android:title="@string/use_zxing_for_barcode_scanning"
+        app:iconSpaceReserved="false" />
+
 </PreferenceScreen>

--- a/collect_app/src/main/res/xml/experimental_preferences.xml
+++ b/collect_app/src/main/res/xml/experimental_preferences.xml
@@ -9,9 +9,8 @@
         app:persistent="false" />
 
     <SwitchPreference
-        android:key="mlkit_scanning"
-        android:summary="@string/mlkit_is_always_used_for_scanning_project_qr_codes"
-        android:title="@string/use_mlkit_for_barcode_scanning"
+        android:key="zxing_scanning"
+        android:title="@string/use_zxing_for_barcode_scanning"
         app:iconSpaceReserved="false" />
 
     <PreferenceCategory

--- a/collect_app/src/main/res/xml/experimental_preferences.xml
+++ b/collect_app/src/main/res/xml/experimental_preferences.xml
@@ -8,11 +8,6 @@
         android:title="@string/dev_tools"
         app:persistent="false" />
 
-    <SwitchPreference
-        android:key="zxing_scanning"
-        android:title="@string/use_zxing_for_barcode_scanning"
-        app:iconSpaceReserved="false" />
-
     <PreferenceCategory
         android:title="@string/entities_title"
         app:allowDividerAbove="false"

--- a/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
@@ -53,7 +53,7 @@ object ProjectKeys {
 
     // experimental_preferences.xml
     const val KEY_DEBUG_FILTERS = "experimental_debug_filters"
-    const val KEY_MLKIT_SCANNING = "mlkit_scanning"
+    const val KEY_ZXING_SCANNING = "zxing_scanning"
 
     // values
     const val PROTOCOL_SERVER = "odk_default"

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1262,9 +1262,8 @@
     <string name="debug_filters">Debug filters</string>
     <string name="debug_filters_summary">Show debug information for filter expression executions during form entry</string>
 
-    <!-- Option provided in the Experimental settings to opt in/out of the newer ML Kit based barcode scanner -->
-    <string name="use_mlkit_for_barcode_scanning">Use ML Kit for barcode scanning</string>
-    <string name="mlkit_is_always_used_for_scanning_project_qr_codes">ML Kit is always used for scanning project QR codes</string>
+    <!-- Option provided in the Experimental settings to rever to the old Zxing based barcode scanner -->
+    <string name="use_zxing_for_barcode_scanning">Revert to older barcode scanner</string>
 
     <string name="permission_dialog_title">About permissions</string>
     <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1262,7 +1262,7 @@
     <string name="debug_filters">Debug filters</string>
     <string name="debug_filters_summary">Show debug information for filter expression executions during form entry</string>
 
-    <!-- Option provided in the Experimental settings to rever to the old Zxing based barcode scanner -->
+    <!-- Option provided in the Experimental settings to revert to the old ZXing based barcode scanner -->
     <string name="use_zxing_for_barcode_scanning">Revert to older barcode scanner</string>
 
     <string name="permission_dialog_title">About permissions</string>


### PR DESCRIPTION
This removes the experimental ML Kit opt-in so that it'll always be used in release builds. Instead, I've added a switch in "Developer tools" that allows us to switch back to ZXing scanning so that we can test that without needing a device that doesn't have Play Services.

@getodk/testers it's probably worth doing a pass of project QR and form entry barcode scanning with "Revert to older barcode scanner" enabled as we've not really been using the ZXing barcode scanner since all the recent changes were made.