### PR TITLE
Upgrade Mapbox to fix 16 KB alignment issues

### DIFF
--- a/config/lint.xml
+++ b/config/lint.xml
@@ -12,6 +12,9 @@
     <!-- require inputType attribute on all text fields -->
     <issue id="TextFields" severity="error" />
 
+    <!-- require 16KB alignment -->
+    <issue id="Aligned16KB" severity="error"/>
+
     <issue id="GradleOverrides" severity="error" />
     <issue id="FragmentTagUsage" severity="error" />
     <issue id="UseCompatLoadingForDrawables" severity="error" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ androidXConstraintLayoutCompose = { group = "androidx.constraintlayout", name = 
 playServicesMaps = { group = "com.google.android.gms", name = "play-services-maps", version = "19.2.0" }
 playServicesLocation = { group = "com.google.android.gms", name = "play-services-location", version = "21.3.0" }
 playServicesOssLicenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version = "17.1.0" }
-mapboxAndroidSdk = { group = "com.mapbox.maps", name = "android", version = "10.16.4" } # Check if https://github.com/mapbox/mapbox-maps-android/issues/2389#issuecomment-2432018812 no longer takes place before upgrading
+mapboxAndroidSdk = { group = "com.mapbox.maps", name = "android-ndk27", version = "10.19.0" } # Check if https://github.com/mapbox/mapbox-maps-android/issues/2389#issuecomment-2432018812 no longer takes place before upgrading
 osmdroid = { group = "org.osmdroid", name = "osmdroid-android", version = "6.1.20" }
 okHttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp3" }
 okHttpTls = { group = "com.squareup.okhttp3", name = "okhttp-tls", version.ref = "okhttp3" }


### PR DESCRIPTION
Closes #6798 

#### Why is this the best possible solution? Were any other approaches considered?

Updating our lint revealed that it was only Mapbox libs causing problems here. We had frozen the version of Mapbox we use until an issue was addressed (https://github.com/mapbox/mapbox-maps-android/issues/2389#issuecomment-2432018812), but being able to deploy to the Play Store will obviously take precedence.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There should be no changes visible here. I've tested that the app (using Mapbox) works in a 16 KB environment using the steps from [Android's docs](https://developer.android.com/guide/practices/page-sizes#test), so that shouldn't need validated. The main things to check manually here will be maps using Mapbox. It could be that https://github.com/mapbox/mapbox-maps-android/issues/2389#issuecomment-2432018812, is still present, and if so we'll want to take the plunge in upgrading to the newest version to see if that helps.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
