### PR TITLE
Make delete trigger translatable

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectManagementPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectManagementPage.kt
@@ -19,7 +19,7 @@ class ProjectManagementPage : Page<ProjectManagementPage>() {
 
     fun deleteProject(): MainMenuPage {
         scrollToRecyclerViewItemAndClickText(org.odk.collect.strings.R.string.delete_project)
-        inputText("delete")
+        inputText(getTranslatedString(org.odk.collect.strings.R.string.delete_trigger))
         clickOnString(org.odk.collect.strings.R.string.delete_project_confirm_button_text)
         return MainMenuPage()
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/DeleteProjectDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/DeleteProjectDialog.kt
@@ -127,12 +127,16 @@ class DeleteProjectDialog(
             getString(org.odk.collect.strings.R.string.form_definitions_count, formDefinitionsCount)
         val sent = getString(org.odk.collect.strings.R.string.sent_count, sentCount)
         val drafts = getString(org.odk.collect.strings.R.string.drafts_count, draftsCount)
-        val instructions = getString(org.odk.collect.strings.R.string.delete_project_instructions)
         val unsent = if (unsentCount > 0) {
             "${getString(org.odk.collect.strings.R.string.unsent_count, unsentCount)} ⚠\uFE0F"
         } else {
             getString(org.odk.collect.strings.R.string.unsent_count, unsentCount)
         }
+
+        val instructions = getString(
+            org.odk.collect.strings.R.string.delete_project_instructions,
+            "<b>${getString(org.odk.collect.strings.R.string.delete_trigger)}</b>"
+        )
 
         return """
         $message:<br/>

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/DeleteProjectDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/DeleteProjectDialog.kt
@@ -72,12 +72,10 @@ class DeleteProjectDialog(
                 org.odk.collect.strings.R.string.delete_project_dialog_title,
                 projectData.projectName
             )
-            val message = getString(
-                org.odk.collect.strings.R.string.delete_project_dialog_message,
+            val message = createDeleteMessage(
                 projectData.numberOfForms,
                 projectData.numberOfSentForms,
                 projectData.numberOfUnsentForms,
-                if (projectData.numberOfUnsentForms > 0) "⚠\uFE0F" else "",
                 projectData.numberOfDraftForms
             )
             binding.message.text = HtmlCompat.fromHtml(message, HtmlCompat.FROM_HTML_MODE_LEGACY)
@@ -116,6 +114,32 @@ class DeleteProjectDialog(
         return MaterialAlertDialogBuilder(requireContext())
             .setView(binding.root)
             .create()
+    }
+
+    private fun createDeleteMessage(
+        formDefinitionsCount: Int,
+        sentCount: Int,
+        unsentCount: Int,
+        draftsCount: Int
+    ): String {
+        val message = getString(org.odk.collect.strings.R.string.delete_project_message)
+        val formDefinitions =
+            getString(org.odk.collect.strings.R.string.form_definitions_count, formDefinitionsCount)
+        val sent = getString(org.odk.collect.strings.R.string.sent_count, sentCount)
+        val unsent = getString(org.odk.collect.strings.R.string.unsent_count, unsentCount)
+        val drafts = getString(org.odk.collect.strings.R.string.drafts_count, draftsCount)
+        val instructions = getString(org.odk.collect.strings.R.string.delete_project_instructions)
+
+        return """
+        $message:<br/>
+            <br/>
+        • $formDefinitions<br/>
+        • $sent<br/>
+        • $unsent<br/>
+        • $drafts<br/>
+        <br/>
+        $instructions
+        """
     }
 
     class DeleteProjectViewModel(

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/DeleteProjectDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/DeleteProjectDialog.kt
@@ -126,9 +126,13 @@ class DeleteProjectDialog(
         val formDefinitions =
             getString(org.odk.collect.strings.R.string.form_definitions_count, formDefinitionsCount)
         val sent = getString(org.odk.collect.strings.R.string.sent_count, sentCount)
-        val unsent = getString(org.odk.collect.strings.R.string.unsent_count, unsentCount)
         val drafts = getString(org.odk.collect.strings.R.string.drafts_count, draftsCount)
         val instructions = getString(org.odk.collect.strings.R.string.delete_project_instructions)
+        val unsent = if (unsentCount > 0) {
+            "${getString(org.odk.collect.strings.R.string.unsent_count, unsentCount)} ⚠\uFE0F"
+        } else {
+            getString(org.odk.collect.strings.R.string.unsent_count, unsentCount)
+        }
 
         return """
         $message:<br/>

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/DeleteProjectDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/DeleteProjectDialog.kt
@@ -54,7 +54,8 @@ class DeleteProjectDialog(
             deleteButton.setOnClickListener { viewModel.deleteProject() }
 
             confirmationFieldInput.doAfterTextChanged { text ->
-                deleteButton.isEnabled = "delete".equals(text.toString().trim(), true)
+                val deleteTrigger = getString(org.odk.collect.strings.R.string.delete_trigger)
+                deleteButton.isEnabled = deleteTrigger.equals(text.toString().trim(), true)
             }
         }
 
@@ -98,12 +99,14 @@ class DeleteProjectDialog(
                         )
                     )
                 }
+
                 is DeleteProjectResult.DeletedSuccessfullyLastProject -> {
                     ActivityUtils.startActivityAndCloseAllOthers(
                         requireActivity(),
                         FirstLaunchActivity::class.java
                     )
                 }
+
                 is DeleteProjectResult.DeletedSuccessfullyInactiveProject -> {
                     // not possible here
                 }
@@ -140,7 +143,8 @@ class DeleteProjectDialog(
                 instancesDataService.update(project.uuid)
 
                 val numberOfForms = formsDataService.getFormsCount(project.uuid).value
-                val numberOfSentForms = instancesDataService.getSuccessfullySentCount(project.uuid).value
+                val numberOfSentForms =
+                    instancesDataService.getSuccessfullySentCount(project.uuid).value
                 val numberOfUnsentForms = instancesDataService.getSendableCount(project.uuid).value
                 val numberOfDraftForms = instancesDataService.getEditableCount(project.uuid).value
                 _projectData.postValue(

--- a/collect_app/src/main/res/layout/delete_project_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/delete_project_dialog_layout.xml
@@ -1,5 +1,4 @@
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -16,22 +15,22 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_standard"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/delete_project_dialog_title"
-            android:textAppearance="?textAppearanceHeadlineSmall"
             android:ellipsize="end"
             android:maxLines="1"
+            android:text="@string/delete_project_dialog_title"
+            android:textAppearance="?textAppearanceHeadlineSmall"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/progress_bar"
             app:layout_goneMarginTop="@dimen/margin_standard"
-            tools:text="Delete X project"/>
+            tools:text="Delete X project" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/message"
@@ -41,7 +40,7 @@
             android:textAppearance="?textAppearanceBodyMedium"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title"
-            tools:text="@string/delete_project_dialog_message"/>
+            tools:text="@string/delete_project_dialog_message" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/confirmation_field"
@@ -49,25 +48,25 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_standard"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/message">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/confirmation_field_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingVertical="@dimen/margin_standard"
                 android:inputType="text"
-                android:lines="1" />
+                android:lines="1"
+                android:paddingVertical="@dimen/margin_standard" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/barrierTopViews"
-            app:barrierDirection="bottom"
-            app:constraint_referenced_ids="progress_bar, confirmation_field"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="progress_bar, confirmation_field" />
 
         <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
             android:id="@+id/cancel_button"
@@ -76,25 +75,25 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_large"
             android:text="@string/cancel"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/barrierTopViews" />
 
         <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
             android:id="@+id/delete_button"
             style="?materialButtonIconStyle"
-            android:textColor="@android:color/white"
-            android:backgroundTint="@color/color_error_button_icon"
-            android:enabled="false"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_small"
+            android:backgroundTint="@color/color_error_button_icon"
+            android:enabled="false"
             android:text="@string/delete_project_confirm_button_text"
+            android:textColor="@android:color/white"
             app:icon="@drawable/ic_delete"
             app:iconGravity="textStart"
             app:iconTint="@android:color/white"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cancel_button" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/collect_app/src/main/res/layout/delete_project_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/delete_project_dialog_layout.xml
@@ -40,7 +40,7 @@
             android:textAppearance="?textAppearanceBodyMedium"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title"
-            tools:text="@string/delete_project_dialog_message" />
+            tools:text="Delete project message" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/confirmation_field"

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1142,14 +1142,9 @@
     <string name="switch_to_project">Switch to %s</string>
     <!-- Text for the dialog title displayed when a user attempts to delete the current project -->
     <string name="delete_project_dialog_title">Delete %s</string>
-    <!-- Text for the dialog message displayed when a user attempts to delete the current project -->
-    <string name="delete_project_dialog_message">By deleting this project, you will permanently delete the following:&lt;br/&gt;&lt;br/&gt;
-        • Form definitions: %1$d&lt;br/&gt;
-        • Sent: %2$d&lt;br/&gt;
-        • Unsent: %3$d %4$s&lt;br/&gt;
-        • Drafts: %5$d&lt;br/&gt;&lt;br/&gt;
-        Type &lt;b&gt;Delete&lt;/b&gt; to confirm this action.
-    </string>
+
+    <string name="delete_project_message">By deleting this project, you will permanently delete the following</string>
+    <string name="delete_project_instructions">Type Delete to confirm this action.</string>
     <string name="form_definitions_count">Form definitions: %1$d</string>
     <string name="sent_count">Sent: %1$d</string>
     <string name="unsent_count">Unsent: %1$d</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1144,7 +1144,7 @@
     <string name="delete_project_dialog_title">Delete %s</string>
 
     <string name="delete_project_message">By deleting this project, you will permanently delete the following</string>
-    <string name="delete_project_instructions">Type Delete to confirm this action.</string>
+    <string name="delete_project_instructions">Type %1$s to confirm this action.</string>
     <string name="form_definitions_count">Form definitions: %1$d</string>
     <string name="sent_count">Sent: %1$d</string>
     <string name="unsent_count">Unsent: %1$d</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1144,12 +1144,17 @@
     <string name="delete_project_dialog_title">Delete %s</string>
     <!-- Text for the dialog message displayed when a user attempts to delete the current project -->
     <string name="delete_project_dialog_message">By deleting this project, you will permanently delete the following:&lt;br/&gt;&lt;br/&gt;
-        • Form Definitions: %1$d&lt;br/&gt;
+        • Form definitions: %1$d&lt;br/&gt;
         • Sent: %2$d&lt;br/&gt;
         • Unsent: %3$d %4$s&lt;br/&gt;
         • Drafts: %5$d&lt;br/&gt;&lt;br/&gt;
         Type &lt;b&gt;Delete&lt;/b&gt; to confirm this action.
     </string>
+    <string name="form_definitions_count">Form definitions: %1$d</string>
+    <string name="sent_count">Sent: %1$d</string>
+    <string name="unsent_count">Unsent: %1$d</string>
+    <string name="drafts_count">Drafts: %1$d</string>
+
     <string name="delete_trigger">delete</string>
     <!-- Text for the button that confirms deleting the project -->
     <string name="delete_project_confirm_button_text">Delete project</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1150,6 +1150,7 @@
         • Drafts: %5$d&lt;br/&gt;&lt;br/&gt;
         Type &lt;b&gt;Delete&lt;/b&gt; to confirm this action.
     </string>
+    <string name="delete_trigger">delete</string>
     <!-- Text for the button that confirms deleting the project -->
     <string name="delete_project_confirm_button_text">Delete project</string>
     <string name="or">OR</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1143,14 +1143,21 @@
     <!-- Text for the dialog title displayed when a user attempts to delete the current project -->
     <string name="delete_project_dialog_title">Delete %s</string>
 
+    <!-- Text that appears above the list of counts of different kinds of forms shown before deleting a project -->
     <string name="delete_project_message">By deleting this project, you will permanently delete the following</string>
+    <!-- Instructions telling the user they need to type a specific word to confirm deletion of the project -->
     <string name="delete_project_instructions">Type %1$s to confirm this action.</string>
+    <!-- The word that needs to be typed to confirm deletion of the form. Should be all lowercase to allow for case insensitive matching -->
+    <string name="delete_trigger">delete</string>
+    <!-- The list item for form definition count in the project delete confirmation dialog -->
     <string name="form_definitions_count">Form definitions: %1$d</string>
+    <!-- The list item for sent count in the project delete confirmation dialog -->
     <string name="sent_count">Sent: %1$d</string>
+    <!-- The list item for unsent count in the project delete confirmation dialog -->
     <string name="unsent_count">Unsent: %1$d</string>
+    <!-- The list item for draft count in the project delete confirmation dialog -->
     <string name="drafts_count">Drafts: %1$d</string>
 
-    <string name="delete_trigger">delete</string>
     <!-- Text for the button that confirms deleting the project -->
     <string name="delete_project_confirm_button_text">Delete project</string>
     <string name="or">OR</string>


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?

The advantage of implementing the delete dialog message this way is that the "delete" trigger can be translated for users that wouldn't be able to easily type it with their soft keyboard. Additionally, I've changed extracted the HTML parts of the message to our view code so that translators don't have to deal with it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
