### PR TITLE
Add "Silent" header to notification drawer search

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -190,6 +190,6 @@ class NotificationDrawer {
     companion object {
         val SUPPORTED_SDKS = listOf(30, 34)
 
-        private val DRAWER_SEARCH_CONDITION = By.text(Pattern.compile("Manage|No notifications"))
+        private val DRAWER_SEARCH_CONDITION = By.text(Pattern.compile("Manage|No notifications|Silent"))
     }
 }


### PR DESCRIPTION
Motivated by failure of our `nightly` job where the drawer was opened like this:

<img width="226" height="499" alt="Screenshot 2025-09-11 at 09 03 04" src="https://github.com/user-attachments/assets/6d55173e-5236-4899-8c56-ab0ef3b0b417" />