### PR TITLE
Remove "Learn more" link from form end screen

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.kt
@@ -1,24 +1,12 @@
 package org.odk.collect.android.formentry
 
 import android.content.Context
-import android.content.Intent
-import android.graphics.Color
-import android.text.SpannableStringBuilder
-import android.text.method.LinkMovementMethod
-import android.text.style.ClickableSpan
-import android.text.style.TextAppearanceSpan
 import android.view.LayoutInflater
 import android.view.View
-import androidx.core.text.color
-import androidx.core.text.inSpans
-import androidx.core.text.underline
 import androidx.core.view.isVisible
 import androidx.core.widget.NestedScrollView
 import org.odk.collect.android.R
 import org.odk.collect.android.databinding.FormEntryEndBinding
-import org.odk.collect.androidshared.system.ContextUtils
-import org.odk.collect.strings.localization.getLocalizedString
-import org.odk.collect.webpage.WebViewActivity
 
 class FormEndView(
     context: Context,
@@ -118,41 +106,10 @@ class FormEndView(
     private fun setWarning(icon: Int, title: Int, hint: Int?) {
         binding.formEditsIcon.setImageResource(icon)
         binding.formEditsWarningTitle.setText(title)
-        binding.formEditsWarningMessage.apply {
-            text = SpannableStringBuilder().apply {
-                if (hint != null) {
-                    append(context.getLocalizedString(hint))
-                    append(" ")
-                }
-                append(getLearnMoreLink())
-            }
-            movementMethod = LinkMovementMethod.getInstance()
-            highlightColor = Color.TRANSPARENT
-        }
-    }
 
-    private fun getLearnMoreLink(): SpannableStringBuilder {
-        return SpannableStringBuilder().inSpans(
-            span = object : ClickableSpan() {
-                override fun onClick(view: View) {
-                    val intent = Intent(context, WebViewActivity::class.java)
-                    intent.putExtra("url", "https://forum.getodk.org/t/42007")
-                    context.startActivity(intent)
-                }
-            },
-            builderAction = {
-                inSpans(
-                    span = TextAppearanceSpan(context, com.google.android.material.R.style.TextAppearance_Material3_TitleMedium),
-                    builderAction = {
-                        color(ContextUtils.getThemeAttributeValue(context, com.google.android.material.R.attr.colorAccent)) {
-                            underline {
-                                append(context.getLocalizedString(org.odk.collect.strings.R.string.form_edits_warning_learn_more))
-                            }
-                        }
-                    }
-                )
-            }
-        )
+        if (hint != null) {
+            binding.formEditsWarningMessage.setText(hint)
+        }
     }
 
     override fun shouldSuppressFlingGesture() = false

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
@@ -147,7 +147,7 @@ class FormEndViewTest {
         assertThat(
             view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
             equalTo(
-                "${context.getString(org.odk.collect.strings.R.string.form_editing_enabled_after_sending_hint)} ${context.getString(org.odk.collect.strings.R.string.form_edits_warning_learn_more)}"
+                context.getString(org.odk.collect.strings.R.string.form_editing_enabled_after_sending_hint)
             )
         )
     }
@@ -178,9 +178,7 @@ class FormEndViewTest {
         )
         assertThat(
             view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
-            equalTo(
-                "${context.getString(org.odk.collect.strings.R.string.form_editing_disabled_hint)} ${context.getString(org.odk.collect.strings.R.string.form_edits_warning_learn_more)}"
-            )
+            equalTo(context.getString(org.odk.collect.strings.R.string.form_editing_disabled_hint))
         )
     }
 
@@ -211,7 +209,7 @@ class FormEndViewTest {
         assertThat(
             view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
             equalTo(
-                "${context.getString(org.odk.collect.strings.R.string.form_editing_enabled_after_finalizing_hint)} ${context.getString(org.odk.collect.strings.R.string.form_edits_warning_learn_more)}"
+                context.getString(org.odk.collect.strings.R.string.form_editing_enabled_after_finalizing_hint)
             )
         )
     }
@@ -242,9 +240,7 @@ class FormEndViewTest {
         )
         assertThat(
             view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
-            equalTo(
-                "${context.getString(org.odk.collect.strings.R.string.form_editing_disabled_hint)} ${context.getString(org.odk.collect.strings.R.string.form_edits_warning_learn_more)}"
-            )
+            equalTo(context.getString(org.odk.collect.strings.R.string.form_editing_disabled_hint))
         )
     }
 
@@ -275,7 +271,7 @@ class FormEndViewTest {
         assertThat(
             view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
             equalTo(
-                "${context.getString(org.odk.collect.strings.R.string.form_editing_enabled_after_sending_hint)} ${context.getString(org.odk.collect.strings.R.string.form_edits_warning_learn_more)}"
+                context.getString(org.odk.collect.strings.R.string.form_editing_enabled_after_sending_hint)
             )
         )
     }
@@ -301,14 +297,6 @@ class FormEndViewTest {
             equalTo(
                 context.getString(
                     org.odk.collect.strings.R.string.form_editing_disabled_after_sending
-                )
-            )
-        )
-        assertThat(
-            view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
-            equalTo(
-                context.getString(
-                    org.odk.collect.strings.R.string.form_edits_warning_learn_more
                 )
             )
         )
@@ -341,7 +329,7 @@ class FormEndViewTest {
         assertThat(
             view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
             equalTo(
-                "${context.getString(org.odk.collect.strings.R.string.form_editing_enabled_after_finalizing_hint)} ${context.getString(org.odk.collect.strings.R.string.form_edits_warning_learn_more)}"
+                context.getString(org.odk.collect.strings.R.string.form_editing_enabled_after_finalizing_hint)
             )
         )
     }
@@ -367,14 +355,6 @@ class FormEndViewTest {
             equalTo(
                 context.getString(
                     org.odk.collect.strings.R.string.form_editing_disabled_after_finalizing
-                )
-            )
-        )
-        assertThat(
-            view.findViewById<MaterialTextView>(R.id.form_edits_warning_message).text.toString(),
-            equalTo(
-                context.getString(
-                    org.odk.collect.strings.R.string.form_edits_warning_learn_more
                 )
             )
         )

--- a/strings/src/main/res/values-bg/strings.xml
+++ b/strings/src/main/res/values-bg/strings.xml
@@ -115,7 +115,6 @@
   <string name="survey_internal_error">Вътрешна грешка: преминавенето към подсказката е неуспешно.</string>
   <string name="save_enter_data_description">Вие сте в края на %s</string>
   <string name="form_editing_disabled_hint">Ако се налага да правите промени във формуляра, използвайте \"Запази като чернова\" докато сте готови да го изпратите.</string>
-  <string name="form_edits_warning_learn_more">Научи повече</string>
   <string name="save_as_draft">Запази като чернова</string>
   <string name="finalize">Финализирай</string>
   <string name="send">Изпрати</string>

--- a/strings/src/main/res/values-cs/strings.xml
+++ b/strings/src/main/res/values-cs/strings.xml
@@ -116,7 +116,6 @@
   <string name="survey_internal_error">Vnitřní chyba: přechod k otázce selhal.</string>
   <string name="save_enter_data_description">Jste na konci %s.</string>
   <string name="form_editing_disabled_hint">Pokud potřebujete formulář upravit, uložte jej jako návrh, dokud nebudete připraveni k odeslání.</string>
-  <string name="form_edits_warning_learn_more">Více informací</string>
   <string name="save_as_draft">Uložit jako návrh</string>
   <string name="finalize">Dokončit</string>
   <string name="send">Odeslat</string>

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -123,7 +123,6 @@
   <string name="form_editing_disabled_hint">Wenn Sie Änderungen an Ihrem Formular vornehmen müssen, \"Als Entwurf speichern\", bis Sie bereit sind, es zu senden.</string>
   <string name="form_editing_enabled_after_finalizing_hint">Um Änderung nach dem Abschließen des Formulars durchzuführen, auf \"Bereit zum Senden\" gehen und das Bearbeiten-Icon betätigen.</string>
   <string name="form_editing_enabled_after_sending_hint">Um Änderung nach dem Senden des Formulars durchzuführen, auf \"Gesendet\" gehen und das Bearbeiten-Icon betätigen.</string>
-  <string name="form_edits_warning_learn_more">Mehr erfahren</string>
   <string name="save_as_draft">Als Entwurf speichern</string>
   <string name="finalize">Abschließen</string>
   <string name="send">Senden</string>

--- a/strings/src/main/res/values-es/strings.xml
+++ b/strings/src/main/res/values-es/strings.xml
@@ -118,7 +118,6 @@
   <string name="save_enter_data_description">Esta al final de \"%s\".</string>
   <string name="form_editing_disabled_after_finalizing">No es posible editar una vez completado</string>
   <string name="form_editing_disabled_hint">Si necesita hacer cambios, \"Guardar como borrador\" hasta que esté listo para enviar.</string>
-  <string name="form_edits_warning_learn_more">Aprende más</string>
   <string name="save_as_draft">Guardar como borrador</string>
   <string name="finalize">Finalizar</string>
   <string name="send">Enviar</string>

--- a/strings/src/main/res/values-fa-rAF/strings.xml
+++ b/strings/src/main/res/values-fa-rAF/strings.xml
@@ -114,7 +114,6 @@
   <string name="too_complex_form">این فرم برای این دستگاه بسیار پیچیده است. سعی کنید برای ساده سازی فرم  یا اصطلاحات کمک بخواهید.</string>
   <string name="survey_internal_error">خطای داخلی: گام به اعلان ناموفق بود.</string>
   <string name="save_enter_data_description">شما در پایان %sقرار دارید.</string>
-  <string name="form_edits_warning_learn_more">بیشتر بدانید</string>
   <string name="save_as_draft">ذخیره پیش نویس</string>
   <string name="finalize">نهایی</string>
   <string name="send">ارسال شد</string>

--- a/strings/src/main/res/values-fa/strings.xml
+++ b/strings/src/main/res/values-fa/strings.xml
@@ -114,7 +114,6 @@
   <string name="too_complex_form">این فرم برای این دستگاه بسیار پیچیده است. سعی کنید برای ساده سازی فرم  یا اصطلاحات کمک بخواهید.</string>
   <string name="survey_internal_error">خطای داخلی: گام به اعلان ناموفق بود.</string>
   <string name="save_enter_data_description">شما در پایان %sقرار دارید.</string>
-  <string name="form_edits_warning_learn_more">بیشتر بدانید</string>
   <string name="save_as_draft">ذخیره پیش نویس</string>
   <string name="finalize">نهایی</string>
   <string name="send">ارسال شد</string>

--- a/strings/src/main/res/values-fi/strings.xml
+++ b/strings/src/main/res/values-fi/strings.xml
@@ -123,7 +123,6 @@
   <string name="form_editing_disabled_hint">Jos sinun tarvitsee tehdä muutoksia lomakkeeseesi, \"Tallenna luonnoksena\" kunnes olet valmis lähettämään.</string>
   <string name="form_editing_enabled_after_finalizing_hint">Tehdäksesi muutoksia kun olet viimeistellyt lomakkeesi, mene kohtaan \"Valmis lähetettäväksi\" ja täppää muokkauskuvaketta.</string>
   <string name="form_editing_enabled_after_sending_hint">Tehdäksesi muutoksia kun olet lähettänyt lomakkeesi, mene kohtaan \"Lähetetty\" ja täppää muokkauskuvaketta.</string>
-  <string name="form_edits_warning_learn_more">Lisätietoja</string>
   <string name="save_as_draft">Tallenna luonnoksena</string>
   <string name="finalize">Viimeistele</string>
   <string name="send">Lähetä</string>

--- a/strings/src/main/res/values-fr/strings.xml
+++ b/strings/src/main/res/values-fr/strings.xml
@@ -123,7 +123,6 @@
   <string name="form_editing_disabled_hint">Si vous devrez modifier ce formulaire prochainement, choisissez \"Enregistrer comme ébauche\" jusqu\'à ce que vous soyez prêt à l\'envoyer.</string>
   <string name="form_editing_enabled_after_finalizing_hint">Pour modifier les données après avoir finalisé votre formulaire, trouvé le dans \"Prêt à envoyé\" et appuyez sur l\'icône d\'édition.</string>
   <string name="form_editing_enabled_after_sending_hint">Pour modifier les données après avoir envoyé votre formulaire, allez à \"Envoyé\" et appuyez sur l\'icône d\'édition.</string>
-  <string name="form_edits_warning_learn_more">En savoir plus</string>
   <string name="save_as_draft">Enregistrer comme ébauche</string>
   <string name="finalize">Finaliser</string>
   <string name="send">Envoyer</string>

--- a/strings/src/main/res/values-in/strings.xml
+++ b/strings/src/main/res/values-in/strings.xml
@@ -117,7 +117,6 @@
   <string name="survey_internal_error">Kesalahan internal: akses daftar isi tidak berhasil.</string>
   <string name="save_enter_data_description">Anda berada di akhir formulir\n\"%s\".</string>
   <string name="form_editing_disabled_hint">Jika Anda perlu mengedit formulir, simpan sebagai draf.</string>
-  <string name="form_edits_warning_learn_more">Pelajari lebih lanjut</string>
   <string name="save_as_draft">Simpan sebagai draf</string>
   <string name="finalize">Finalisasi</string>
   <string name="send">Kirim</string>

--- a/strings/src/main/res/values-it/strings.xml
+++ b/strings/src/main/res/values-it/strings.xml
@@ -117,7 +117,6 @@
   <string name="survey_internal_error">Errore interno: invio suggerimento fallito.</string>
   <string name="save_enter_data_description">Ti trovi alla fine di \"%s\".</string>
   <string name="form_editing_disabled_hint">Se devi apportare modifiche al modulo, \"Salva come bozza\" finché non sei pronto per l\'invio.</string>
-  <string name="form_edits_warning_learn_more">Saperne di più</string>
   <string name="save_as_draft">Salva come bozza</string>
   <string name="finalize">Finalizzare</string>
   <string name="send">Invia</string>

--- a/strings/src/main/res/values-pt/strings.xml
+++ b/strings/src/main/res/values-pt/strings.xml
@@ -124,7 +124,6 @@
   <string name="form_editing_disabled_hint">Se você precisa fazer alterações em seu formulário, utilize \"Salvar como rascunho\" até que você esteja pronto para enviar.</string>
   <string name="form_editing_enabled_after_finalizing_hint">Para fazer alterações após finalizar o seu formulário, vá para \"Pronto para Enviar\" e toque no ícone de edição.</string>
   <string name="form_editing_enabled_after_sending_hint">Para fazer alterações após enviar o seu formulário, vá para Enviados e toque no ícone de edição.</string>
-  <string name="form_edits_warning_learn_more">Saiba mais</string>
   <string name="save_as_draft">Salvar como rascunho</string>
   <string name="finalize">Finalizar</string>
   <string name="send">Enviar</string>

--- a/strings/src/main/res/values-ru/strings.xml
+++ b/strings/src/main/res/values-ru/strings.xml
@@ -115,7 +115,6 @@
   <string name="survey_internal_error">Внутренняя ошибка: step to prompt failed.</string>
   <string name="save_enter_data_description">Вы в конце опросника \"%s\"</string>
   <string name="form_editing_disabled_hint">Если вам необходимо внести изменения в форму, сохраните ее как черновик, пока не будете готовы к отправке</string>
-  <string name="form_edits_warning_learn_more">Узнать больше</string>
   <string name="save_as_draft">Сохранить как черновик</string>
   <string name="finalize">Завершить</string>
   <string name="send">Отправить</string>

--- a/strings/src/main/res/values-sl/strings.xml
+++ b/strings/src/main/res/values-sl/strings.xml
@@ -115,7 +115,6 @@
   <string name="survey_internal_error">Interna napaka: prehod ni uspel.</string>
   <string name="save_enter_data_description">Ste pri koncu %s.</string>
   <string name="form_editing_disabled_hint">Če želite spreminjati shranjene odgovore, shranite kot osnutek dokler niste pripravljeni za oddajo.</string>
-  <string name="form_edits_warning_learn_more">Preberi več</string>
   <string name="save_as_draft">Shrani kot osnutek</string>
   <string name="finalize">Zaključi</string>
   <string name="send">Pošlji</string>

--- a/strings/src/main/res/values-ur/strings.xml
+++ b/strings/src/main/res/values-ur/strings.xml
@@ -115,7 +115,6 @@
   <string name="survey_internal_error">اندرونی خرابی: فوری طور پر سیٹ اپ ناکام ہوگیا</string>
   <string name="save_enter_data_description">آپ ‎%s‏ کے آخر پر ہیں۔</string>
   <string name="form_editing_disabled_hint">اگر آپ فارم میں تبدیلی کرنا چاہتے ہیں تو فارم کو \"ڈرافٹ میں محفوط\" رکھے، جب تک فارم جمع کرانے کے لئے تیار نہیں۔</string>
-  <string name="form_edits_warning_learn_more">مزید جانیں</string>
   <string name="save_as_draft">ڈرافٹ میں محفوظ کریں</string>
   <string name="finalize">فائنل کریں</string>
   <string name="send">بھیجیں</string>

--- a/strings/src/main/res/values-zh-rTW/strings.xml
+++ b/strings/src/main/res/values-zh-rTW/strings.xml
@@ -115,7 +115,6 @@
   <string name="survey_internal_error">內部錯誤：提示步驟失敗。</string>
   <string name="save_enter_data_description">您已在 %s 的結尾。</string>
   <string name="form_editing_disabled_hint">如果您需要對表格進行編輯，請點選「儲存為草稿」，直到您準備好傳送為止。</string>
-  <string name="form_edits_warning_learn_more">瞭解更多</string>
   <string name="save_as_draft">儲存為草稿</string>
   <string name="finalize">確定完成</string>
   <string name="send">傳送</string>

--- a/strings/src/main/res/values-zh/strings.xml
+++ b/strings/src/main/res/values-zh/strings.xml
@@ -116,7 +116,6 @@
   <string name="survey_internal_error">内部错误：提示步骤失败。</string>
   <string name="save_enter_data_description">您已在 %s 的末尾.</string>
   <string name="form_editing_disabled_hint">如果您需要对表格进行编辑，请“另存为草稿”，直到您准备好发送为止。</string>
-  <string name="form_edits_warning_learn_more">了解更多</string>
   <string name="save_as_draft">保存为草稿</string>
   <string name="finalize">最终确定</string>
   <string name="send">发送</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -159,7 +159,6 @@
     <string name="form_editing_enabled_after_finalizing_hint">To make changes after finalizing your form, go to \"Ready to send\", open the form, and tap the edit icon.</string>
     <!-- Details shown in an information box on the end of form screen when the form allows edits after sending -->
     <string name="form_editing_enabled_after_sending_hint">To make changes after sending your form, go to \"Sent\", open the form, and tap the edit icon.</string>
-    <string name="form_edits_warning_learn_more">Learn more</string>
     <!-- Button text for saving as draft -->
     <string name="save_as_draft">Save as draft</string>
     <!-- Button text for finalizing a submission. Displayed instead of "Send" when auto-send is off or the device is offline -->


### PR DESCRIPTION
Closes #6879

#### Why is this the best possible solution? Were any other approaches considered?

As discussed in the issue, we don't need this any longer. That said, there is definitely a problem with forum links in the app - I'll file another issue for that.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only thing affected is the form end screen.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
