### PR TITLE
Avoid crash when scanning barcode

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/SnackbarUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/SnackbarUtils.kt
@@ -90,7 +90,7 @@ object SnackbarUtils {
 
             if (action != null) {
                 setAction(action.text) {
-                    action.listener.invoke()
+                    action.beforeDismiss.invoke()
                     dismiss()
                 }
             }
@@ -109,7 +109,7 @@ object SnackbarUtils {
         val action: Action? = null
     )
 
-    data class Action(val text: String, val listener: () -> Unit)
+    data class Action(val text: String, val beforeDismiss: () -> Unit = {})
 
     abstract class SnackbarPresenterObserver<T : Any?>(private val parentView: View) :
         Observer<Consumable<T>?> {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.kt
@@ -92,8 +92,7 @@ abstract class BarCodeScannerFragment : Fragment() {
                         getString(org.odk.collect.strings.R.string.barcode_scanned),
                         duration = 2000,
                         action = SnackbarUtils.Action(
-                            getString(org.odk.collect.strings.R.string.exit_scanning),
-                            listener = {}
+                            getString(org.odk.collect.strings.R.string.exit_scanning)
                         ),
                         onDismiss = {
                             handleScanningResult(result)

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.kt
@@ -92,10 +92,9 @@ abstract class BarCodeScannerFragment : Fragment() {
                         getString(org.odk.collect.strings.R.string.barcode_scanned),
                         duration = 2000,
                         action = SnackbarUtils.Action(
-                            getString(org.odk.collect.strings.R.string.exit_scanning)
-                        ) {
-                            handleScanningResult(result)
-                        },
+                            getString(org.odk.collect.strings.R.string.exit_scanning),
+                            listener = {}
+                        ),
                         onDismiss = {
                             handleScanningResult(result)
                         }


### PR DESCRIPTION
This should prevent a crash we've seen [on Crashlytics](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/3d0d5445831b97eb95cfbc9324b1cd9e?versions=v2025.3.0%20(5519)&time=last-ninety-days&types=crash&sessionEventKey=68CA185402FE00016AD05FC12843D410_2129327723289308038).

#### Why is this the best possible solution? Were any other approaches considered?

The original code would end up calling `handleScannerResult` twice: once when the action is clicked and once when the snackbar is dismissed. This didn't cause any obvious problems, but ran the risk of a `requireActivity` call after the first call's `finish` had already happened. I've now made it so that `handleScannerResult` is only called once, and hopefully made our API around snackbars clearer to avoid a similar mistake in future.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's probably impossible to reliably reproduce the crash. So just testing normal barcode scanning is enough here.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
