### PR TITLE
Don't retry tasks when running in foreground

### DIFF
--- a/async/src/main/java/org/odk/collect/async/TaskSpecWorker.kt
+++ b/async/src/main/java/org/odk/collect/async/TaskSpecWorker.kt
@@ -61,12 +61,12 @@ class TaskSpecWorker(
 
         try {
             val completed =
-                taskSpec.getTask(applicationContext, stringInputData, isLastUniqueExecution(taskSpec)) { isStopped }.get()
+                taskSpec.getTask(applicationContext, stringInputData, foreground || isLastUniqueExecution(taskSpec)) { isStopped }.get()
             val maxRetries = taskSpec.maxRetries
 
             return if (completed) {
                 Result.success()
-            } else if (maxRetries == null || runAttemptCount < maxRetries) {
+            } else if (!foreground && (maxRetries == null || runAttemptCount < maxRetries)) {
                 Result.retry()
             } else {
                 Result.failure()

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModel.kt
@@ -211,7 +211,7 @@ class BlankFormListViewModel(
         private const val SYNC_NOTIFICATION_CHANNEL = "form_updates"
         private const val SYNC_NOTIFICATION_CHANNEL_NAME = "Form updates"
 
-        private const val SYNC_NOTIFICATION_ID = 1
+        private const val SYNC_NOTIFICATION_ID = 3
 
         private fun getSyncTag(projectId: String): String {
             return "match_exactly_foreground:$projectId"


### PR DESCRIPTION
This should fix a problem (pointed out by @lognaturel on Slack) where error notifications are not being shown after manually refreshing a project from the "Start new form" screen.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline. 

Also: the 3 changes here aren't tested - initially this was just because I wasn't confident about how to fix so was relying on manual testing between myself and QA to get things right. When then trying to write tests, I discovered we're going to need to rework things - our current `TaskSpecWorkerTest` crashes if `setForegroundAsync` is called and our `TestScheduler` is not set up to test real foreground service behaviour. I'll follow up with a PR that adds coverage for all three changes here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only thing affected here is that notifications should be shown for errors that happen when manually refreshing.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
