### PR TITLE
Use integrity URL to clean up offline entities when hash is unchanged

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
@@ -286,7 +286,7 @@ class EntityFormTest {
             .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("Name", "Logan Roy"))
 
             .also {
-                testDependencies.server.deleteEntity("people.csv", "Logan Roy")
+                testDependencies.server.deleteEntity("Logan Roy")
             }
 
             .clickFillBlankForm()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.kt
@@ -391,18 +391,8 @@ class StubOpenRosaServer : OpenRosaHttpInterface {
         )
     }
 
-    fun deleteEntity(list: String, id: String) {
+    fun deleteEntity(id: String) {
         deletedEntities.add(id)
-
-        for (form in forms) {
-            val entityList = form.mediaFiles.stream()
-                .filter { mediaFileItem: MediaFileItem -> mediaFileItem is EntityListItem && mediaFileItem.name == list }
-                .findFirst()
-
-            if (entityList.isPresent) {
-                (entityList.get() as EntityListItem).incrementVersion()
-            }
-        }
     }
 
     private class XFormItem(

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -126,6 +126,22 @@ object ServerFormUseCases {
                         throw EntityListUpdateException(t)
                     }
                 } else {
+                    /**
+                     * We wrap and then rethrow exceptions that happen here to make them easier to
+                     * track in Crashlytics. This can be removed in the next release once any
+                     * unexpected exceptions "in the wild" are identified.
+                     */
+                    try {
+                        LocalEntityUseCases.updateOfflineLocalEntitiesFromServer(
+                            entityListName,
+                            entitiesRepository,
+                            entitySource,
+                            mediaFile
+                        )
+                    } catch (t: Throwable) {
+                        throw EntityListUpdateException(t)
+                    }
+
                     val existingForm = formsRepository.getAllByFormIdAndVersion(
                         formToDownload.formId,
                         formToDownload.formVersion

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -109,21 +109,12 @@ object ServerFormUseCases {
                     newAttachmentsDownloaded = true
                     downloadMediaFile(formSource, mediaFile, tempMediaFile, tempDir, stateListener)
 
-                    /**
-                     * We wrap and then rethrow exceptions that happen here to make them easier to
-                     * track in Crashlytics. This can be removed in the next release once any
-                     * unexpected exceptions "in the wild" are identified.
-                     */
-                    try {
-                        LocalEntityUseCases.updateLocalEntitiesFromServer(
-                            entityListName,
-                            tempMediaFile,
-                            entitiesRepository,
-                            mediaFile
-                        )
-                    } catch (t: Throwable) {
-                        throw EntityListUpdateException(t)
-                    }
+                    LocalEntityUseCases.updateLocalEntitiesFromServer(
+                        entityListName,
+                        tempMediaFile,
+                        entitiesRepository,
+                        mediaFile
+                    )
                 } else {
                     val existingForm = formsRepository.getAllByFormIdAndVersion(
                         formToDownload.formId,
@@ -138,21 +129,12 @@ object ServerFormUseCases {
                     }
                 }
 
-                /**
-                 * We wrap and then rethrow exceptions that happen here to make them easier to
-                 * track in Crashlytics. This can be removed in the next release once any
-                 * unexpected exceptions "in the wild" are identified.
-                 */
-                try {
-                    LocalEntityUseCases.updateOfflineLocalEntitiesWithIntegrityUrl(
-                        entityListName,
-                        entitiesRepository,
-                        entitySource,
-                        mediaFile.integrityUrl
-                    )
-                } catch (t: Throwable) {
-                    throw EntityListUpdateException(t)
-                }
+                LocalEntityUseCases.updateOfflineLocalEntitiesWithIntegrityUrl(
+                    entityListName,
+                    entitiesRepository,
+                    entitySource,
+                    mediaFile.integrityUrl
+                )
             } else {
                 val existingFile = searchForExistingMediaFile(currentOrLastFormVersion, mediaFile)
                 if (existingFile != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -119,29 +119,12 @@ object ServerFormUseCases {
                             entityListName,
                             tempMediaFile,
                             entitiesRepository,
-                            entitySource,
                             mediaFile
                         )
                     } catch (t: Throwable) {
                         throw EntityListUpdateException(t)
                     }
                 } else {
-                    /**
-                     * We wrap and then rethrow exceptions that happen here to make them easier to
-                     * track in Crashlytics. This can be removed in the next release once any
-                     * unexpected exceptions "in the wild" are identified.
-                     */
-                    try {
-                        LocalEntityUseCases.updateOfflineLocalEntitiesFromServer(
-                            entityListName,
-                            entitiesRepository,
-                            entitySource,
-                            mediaFile
-                        )
-                    } catch (t: Throwable) {
-                        throw EntityListUpdateException(t)
-                    }
-
                     val existingForm = formsRepository.getAllByFormIdAndVersion(
                         formToDownload.formId,
                         formToDownload.formVersion
@@ -153,6 +136,22 @@ object ServerFormUseCases {
                             newAttachmentsDownloaded = true
                         }
                     }
+                }
+
+                /**
+                 * We wrap and then rethrow exceptions that happen here to make them easier to
+                 * track in Crashlytics. This can be removed in the next release once any
+                 * unexpected exceptions "in the wild" are identified.
+                 */
+                try {
+                    LocalEntityUseCases.updateOfflineLocalEntitiesWithIntegrityUrl(
+                        entityListName,
+                        entitiesRepository,
+                        entitySource,
+                        mediaFile.integrityUrl
+                    )
+                } catch (t: Throwable) {
+                    throw EntityListUpdateException(t)
                 }
             } else {
                 val existingFile = searchForExistingMediaFile(currentOrLastFormVersion, mediaFile)

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -129,11 +129,11 @@ object ServerFormUseCases {
                     }
                 }
 
-                LocalEntityUseCases.updateOfflineLocalEntitiesWithIntegrityUrl(
+                LocalEntityUseCases.cleanUpDeletedOfflineEntities(
                     entityListName,
                     entitiesRepository,
                     entitySource,
-                    mediaFile.integrityUrl
+                    mediaFile
                 )
             } else {
                 val existingFile = searchForExistingMediaFile(currentOrLastFormVersion, mediaFile)

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormUseCases.kt
@@ -129,6 +129,21 @@ object ServerFormUseCases {
                     }
                 }
 
+                /**
+                 * Ensures local offline Entities are cleaned up when they have been deleted on the server.
+                 *
+                 * Normally this cleanup is triggered during sync as part of a full update with the server
+                 * whenever the Entity list hash from Central changes.
+                 * However, there is a case where the hash stays the same:
+                 *  - a sync happens and the current hash is stored,
+                 *  - an Entity is created locally and a form is uploaded, creating the Entity on the server,
+                 *  - the Entity is then deleted on the server,
+                 *  - another sync occurs, but the hash is the same as the stored one because the list
+                 *    contents are identical to before the local Entity was added.
+                 *
+                 * In this case, the usual hash-based update will not detect the deletion. Collect must
+                 * use the integrityUrl to check for missing Entities and remove them locally.
+                 */
                 LocalEntityUseCases.cleanUpDeletedOfflineEntities(
                     entityListName,
                     entitiesRepository,

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -132,6 +132,27 @@ object LocalEntityUseCases {
         )
     }
 
+    fun updateOfflineLocalEntitiesFromServer(
+        list: String,
+        entitiesRepository: EntitiesRepository,
+        entitySource: EntitySource,
+        mediaFile: MediaFile
+    ) {
+        val offlineLocalEntities = entitiesRepository
+            .query(list)
+            .filter { it.state == Entity.State.OFFLINE }
+            .associateBy { it.id }
+            .toMutableMap()
+
+        handleMissingEntities(
+            list,
+            offlineLocalEntities.values,
+            entitiesRepository,
+            entitySource,
+            mediaFile.integrityUrl
+        )
+    }
+
     private fun handleMissingEntities(
         list: String,
         missingFromServer: Collection<Entity.Saved>,

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -145,16 +145,17 @@ object LocalEntityUseCases {
      * In this case, the usual hash-based update will not detect the deletion. Collect must
      * use the integrityUrl to check for missing Entities and remove them locally.
      */
-    fun updateOfflineLocalEntitiesWithIntegrityUrl(
+    fun cleanUpDeletedOfflineEntities(
         list: String,
         entitiesRepository: EntitiesRepository,
         entitySource: EntitySource,
-        integrityUrl: String?
+        mediaFile: MediaFile
     ) {
         val offlineLocalEntities = entitiesRepository
             .query(list)
             .filter { it.state == Entity.State.OFFLINE }
 
+        val integrityUrl = mediaFile.integrityUrl
         if (integrityUrl != null && offlineLocalEntities.isNotEmpty()) {
             entitySource.fetchDeletedStates(integrityUrl, offlineLocalEntities.map { it.id }).forEach {
                 if (it.second) {

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -132,6 +132,21 @@ object LocalEntityUseCases {
         )
     }
 
+    /**
+     * Ensures local offline Entities are cleaned up when they have been deleted on the server.
+     *
+     * Normally this cleanup is triggered during sync as part of a full update with the server
+     * whenever the Entity list hash from Central changes.
+     * However, there is a case where the hash stays the same:
+     *  - a sync happens and the current hash is stored,
+     *  - an Entity is created locally and a form is uploaded, creating the Entity on the server,
+     *  - the Entity is then deleted on the server,
+     *  - another sync occurs, but the hash is the same as the stored one because the list
+     *    contents are identical to before the local Entity was added.
+     *
+     * In this case, the usual hash-based update will not detect the deletion. Collect must
+     * use the integrityUrl to check for missing Entities and remove them locally.
+     */
     fun updateOfflineLocalEntitiesFromServer(
         list: String,
         entitiesRepository: EntitiesRepository,

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -130,21 +130,6 @@ object LocalEntityUseCases {
         )
     }
 
-    /**
-     * Ensures local offline Entities are cleaned up when they have been deleted on the server.
-     *
-     * Normally this cleanup is triggered during sync as part of a full update with the server
-     * whenever the Entity list hash from Central changes.
-     * However, there is a case where the hash stays the same:
-     *  - a sync happens and the current hash is stored,
-     *  - an Entity is created locally and a form is uploaded, creating the Entity on the server,
-     *  - the Entity is then deleted on the server,
-     *  - another sync occurs, but the hash is the same as the stored one because the list
-     *    contents are identical to before the local Entity was added.
-     *
-     * In this case, the usual hash-based update will not detect the deletion. Collect must
-     * use the integrityUrl to check for missing Entities and remove them locally.
-     */
     fun cleanUpDeletedOfflineEntities(
         list: String,
         entitiesRepository: EntitiesRepository,

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -231,7 +231,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         val songs = entitiesRepository.query("songs")
@@ -254,7 +253,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         val songs = entitiesRepository.query("songs")
@@ -277,7 +275,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         val songs = entitiesRepository.query("songs")
@@ -300,7 +297,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         val songs = entitiesRepository.query("songs")
@@ -322,7 +318,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv1,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         assertThat(entitiesRepository.savedEntities, equalTo(1))
@@ -332,7 +327,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv2,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         assertThat(entitiesRepository.savedEntities, equalTo(2))
@@ -348,7 +342,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv1,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
 
@@ -359,7 +352,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv2,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
 
@@ -389,7 +381,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         val songs = entitiesRepository.query("songs")
@@ -413,7 +404,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         val songs = entitiesRepository.query("songs")
@@ -434,7 +424,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         val songs = entitiesRepository.query("songs")
@@ -455,7 +444,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         assertThat(entitiesRepository.getLists().size, equalTo(0))
@@ -473,7 +461,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         assertThat(entitiesRepository.getLists().size, equalTo(0))
@@ -491,7 +478,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         assertThat(entitiesRepository.getLists().size, equalTo(0))
@@ -505,7 +491,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         val songs = entitiesRepository.query("songs")
@@ -521,7 +506,6 @@ class LocalEntityUseCasesTest {
             "songs",
             file,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         assertThat(entitiesRepository.getLists().size, equalTo(0))
@@ -536,51 +520,10 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
         val songs = entitiesRepository.query("songs")
         assertThat(songs.size, equalTo(2))
-    }
-
-    @Test
-    fun `updateLocalEntitiesFromServer removes offline entities that are not in online entities but are deleted according to the entity source`() {
-        entitiesRepository.save("songs", Entity.New("noah", "Noah"))
-        entitiesRepository.save("songs", Entity.New("midnightCity", "Midnight City"))
-        entitySource.delete("noah")
-        entitySource.delete("midnightCity")
-
-        val csv = createEntityList(Entity.New("cathedrals", "Cathedrals"))
-        LocalEntityUseCases.updateLocalEntitiesFromServer(
-            "songs",
-            csv,
-            entitiesRepository,
-            entitySource,
-            FormFixtures.mediaFile(integrityUrl = entitySource.integrityUrl)
-        )
-
-        val songs = entitiesRepository.query("songs")
-        assertThat(songs.size, equalTo(1))
-        assertThat(songs.first().id, equalTo("cathedrals"))
-    }
-
-    @Test
-    fun `updateLocalEntitiesFromServer only checks for deletions with the entity source once`() {
-        entitiesRepository.save("songs", Entity.New("noah", "Noah"))
-        entitiesRepository.save("songs", Entity.New("midnightCity", "Midnight City"))
-        entitySource.delete("noah")
-        entitySource.delete("midnightCity")
-
-        val csv = createEntityList()
-        LocalEntityUseCases.updateLocalEntitiesFromServer(
-            "songs",
-            csv,
-            entitiesRepository,
-            entitySource,
-            FormFixtures.mediaFile(integrityUrl = entitySource.integrityUrl)
-        )
-
-        assertThat(entitySource.accesses, equalTo(1))
     }
 
     @Test
@@ -590,7 +533,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile(integrityUrl = entitySource.integrityUrl)
         )
 
@@ -606,7 +548,6 @@ class LocalEntityUseCasesTest {
             "songs",
             firstCsv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
 
@@ -615,7 +556,6 @@ class LocalEntityUseCasesTest {
             "songs",
             secondCsv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
 
@@ -634,7 +574,6 @@ class LocalEntityUseCasesTest {
             "songs",
             firstCsv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
 
@@ -643,7 +582,6 @@ class LocalEntityUseCasesTest {
             "songs",
             secondCsv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile()
         )
 
@@ -658,7 +596,6 @@ class LocalEntityUseCasesTest {
             "songs",
             csv,
             entitiesRepository,
-            entitySource,
             FormFixtures.mediaFile(hash = "hash")
         )
 
@@ -702,11 +639,11 @@ class LocalEntityUseCasesTest {
 
         entitySource.delete("cathedrals")
 
-        LocalEntityUseCases.updateOfflineLocalEntitiesFromServer(
+        LocalEntityUseCases.updateOfflineLocalEntitiesWithIntegrityUrl(
             "songs",
             entitiesRepository,
             entitySource,
-            FormFixtures.mediaFile(integrityUrl = entitySource.integrityUrl)
+            FormFixtures.mediaFile(integrityUrl = entitySource.integrityUrl).integrityUrl
         )
 
         val songs = entitiesRepository.query("songs")

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -639,11 +639,11 @@ class LocalEntityUseCasesTest {
 
         entitySource.delete("cathedrals")
 
-        LocalEntityUseCases.updateOfflineLocalEntitiesWithIntegrityUrl(
+        LocalEntityUseCases.cleanUpDeletedOfflineEntities(
             "songs",
             entitiesRepository,
             entitySource,
-            FormFixtures.mediaFile(integrityUrl = entitySource.integrityUrl).integrityUrl
+            FormFixtures.mediaFile(integrityUrl = entitySource.integrityUrl)
         )
 
         val songs = entitiesRepository.query("songs")


### PR DESCRIPTION
Closes #6768 

#### Why is this the best possible solution? Were any other approaches considered?
This is a result of the discussion we had in the issue. To sum up:
When Collect is set to `only access own Entities`, deleted Entities on Central may stay on the device if the hash doesn’t change. The team debated whether Central should update hashes on every delete or whether Collect should always run an integrity check. The decision: treat the hash as list contents and have Collect run an integrity check whenever offline Entities exist.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
With this change, during form sync, even if the entity list hash hasn’t changed, Collect will use the integrity URL whenever offline entities exist to check for deletions and clear them if needed. The only known case is described in the issue. If you can think of other ways to reproduce it, please share them.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form from the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
