### PR TITLE
Fix crash when Snackbar callback triggered after fragment detach

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarcodeWidgetScannerFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarcodeWidgetScannerFragment.kt
@@ -12,6 +12,8 @@ class BarcodeWidgetScannerFragment : BarCodeScannerFragment() {
     }
 
     override fun handleScanningResult(result: String) {
-        returnSingleValue(requireActivity(), result)
+        if (isAdded) {
+            returnSingleValue(requireActivity(), result)
+        }
     }
 }


### PR DESCRIPTION
This should prevent a crash we've seen [on Crashlytics](https://console.firebase.google.com/u/1/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/3d0d5445831b97eb95cfbc9324b1cd9e?time=90d&types=crash&versions=v2025.3.1%20(5520);v2025.3.0%20(5519)&sessionEventKey=68DA24B1014C000134C025965FB30280_2134254203955676537).

Steps to reproduce the issue:
1. Open the barcode widget
2. Scan any code
3. Press the device back button immediately after the code is scanned

The crash occurs because the fragment gets detached, and then the Snackbar callback still tries to handle the scanned code.

#### Why is this the best possible solution? Were any other approaches considered?
This is the easiest solution. One alternative approach could be to dismiss the Snackbar when the fragment is detached to avoid handling the callback, but that would likely be more complex.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue. I can't think of any risk here that we should take into account.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
