### PR TITLE
Add a test to document that audio should not stop playing while navigating through a form

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AudioAutoplayTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AudioAutoplayTest.kt
@@ -27,4 +27,14 @@ class AudioAutoplayTest {
 
         assertThat(testDependencies.audioPlayerFactory.audioPlayer.playedClips, equalTo(1))
     }
+
+    @Test
+    fun audioContinuesWhenNavigatingInForm() {
+        rule.startAtMainMenu()
+            .copyForm("one-question-autoplay.xml", listOf("sampleAudio.wav"))
+            .startBlankForm("One Question Autoplay")
+            .swipeToEndScreen()
+
+        assertThat(testDependencies.audioPlayerFactory.audioPlayer.isPlaying, equalTo(true))
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
@@ -395,11 +395,11 @@ public class AudioWidgetTest {
 
         audioController.binding.play.performClick();
         assertThat(audioPlayer.getCurrentClip(), is(expectedClip));
-        assertThat(audioPlayer.isPaused(), is(true));
+        assertThat(audioPlayer.isPlaying(), is(false));
 
         audioController.binding.play.performClick();
         assertThat(audioPlayer.getCurrentClip(), is(expectedClip));
-        assertThat(audioPlayer.isPaused(), is(false));
+        assertThat(audioPlayer.isPlaying(), is(true));
     }
 
     @Test

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeAudioPlayer.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeAudioPlayer.kt
@@ -16,7 +16,7 @@ class FakeAudioPlayer : AudioPlayer {
 
     var playedClips: Int = 0
         private set
-    var isPaused: Boolean = false
+    var isPlaying: Boolean = false
         private set
     var currentClip: Clip? = null
         private set
@@ -28,12 +28,12 @@ class FakeAudioPlayer : AudioPlayer {
     override fun play(clip: Clip) {
         this.currentClip = clip
         playedClips++
-        isPaused = false
+        isPlaying = true
         playingChangedListeners[clip.clipID]!!.accept(true)
     }
 
     override fun pause() {
-        isPaused = true
+        isPlaying = false
         playingChangedListeners[currentClip!!.clipID]!!.accept(false)
     }
 
@@ -58,15 +58,13 @@ class FakeAudioPlayer : AudioPlayer {
             playingChangedListeners[it.clipID]?.accept(false)
         }
 
+        isPlaying = false
         currentClip = null
     }
 
     override fun playInOrder(clips: List<Clip>) {
         playedClips += clips.size
-    }
-
-    fun getPosition(clipId: String): Int? {
-        return positions[clipId]
+        isPlaying = true
     }
 }
 


### PR DESCRIPTION
Closes #6865 

#### Why is this the best possible solution? Were any other approaches considered?
We discussed in the issue that allowing audio files to continue playing when a user navigates through the form might actually be a feature. It’s better to leave it as is and just add a new test to document this behavior.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
