### PR TITLE
Warn users Collect will soon require Android 8+

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -7,10 +7,13 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.StringContains.containsString;
+
+import androidx.test.espresso.matcher.ViewMatchers;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.StorageUtils;
@@ -26,7 +29,10 @@ public class MainMenuPage extends Page<MainMenuPage> {
     public MainMenuPage assertOnPage() {
         return WaitFor.waitFor(() -> {
             onView(withText(org.odk.collect.strings.R.string.enter_data)).check(matches(isDisplayed()));
-            onView(withText(containsString(getTranslatedString(org.odk.collect.strings.R.string.collect_app_name)))).perform(scrollTo()).check(matches(isDisplayed()));
+            onView(allOf(
+                    withText(containsString(getTranslatedString(org.odk.collect.strings.R.string.collect_app_name))),
+                    withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))
+            ).perform(scrollTo()).check(matches(isDisplayed()));
             return this;
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
@@ -2,7 +2,6 @@ package org.odk.collect.android.mainmenu
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -106,14 +105,6 @@ class MainMenuFragment(
                 },
                 displayDismissButton = true
             )
-        }
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O && !isMinSdkDeprecationBannerDismissed) {
-            binding.minSdkDeprecationBanner.root.visibility = View.VISIBLE
-            binding.minSdkDeprecationBanner.dismissButton.setOnClickListener {
-                isMinSdkDeprecationBannerDismissed = true
-                binding.minSdkDeprecationBanner.root.visibility = View.GONE
-            }
         }
 
         currentProjectViewModel.currentProject.observe(viewLifecycleOwner) {
@@ -270,9 +261,5 @@ class MainMenuFragment(
             if (mainMenuViewModel.shouldGetBlankFormButtonBeVisible()) View.VISIBLE else View.GONE
         binding.manageForms.visibility =
             if (mainMenuViewModel.shouldDeleteSavedFormButtonBeVisible()) View.VISIBLE else View.GONE
-    }
-
-    companion object {
-        var isMinSdkDeprecationBannerDismissed = false
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.mainmenu
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -105,6 +106,14 @@ class MainMenuFragment(
                 },
                 displayDismissButton = true
             )
+        }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O && !isMinSdkDeprecationBannerDismissed) {
+            binding.minSdkDeprecationBanner.root.visibility = View.VISIBLE
+            binding.minSdkDeprecationBanner.dismissButton.setOnClickListener {
+                isMinSdkDeprecationBannerDismissed = true
+                binding.minSdkDeprecationBanner.root.visibility = View.GONE
+            }
         }
 
         currentProjectViewModel.currentProject.observe(viewLifecycleOwner) {
@@ -261,5 +270,9 @@ class MainMenuFragment(
             if (mainMenuViewModel.shouldGetBlankFormButtonBeVisible()) View.VISIBLE else View.GONE
         binding.manageForms.visibility =
             if (mainMenuViewModel.shouldDeleteSavedFormButtonBeVisible()) View.VISIBLE else View.GONE
+    }
+
+    companion object {
+        var isMinSdkDeprecationBannerDismissed = false
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
@@ -28,7 +28,9 @@ import org.odk.collect.android.projects.ProjectIconView
 import org.odk.collect.android.projects.ProjectSettingsDialog
 import org.odk.collect.android.utilities.ActionRegister
 import org.odk.collect.androidshared.data.consume
+import org.odk.collect.androidshared.data.getState
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
+import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.SnackbarUtils
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
 import org.odk.collect.strings.R.string
@@ -50,6 +52,12 @@ class MainMenuFragment(
         }
 
     override fun onAttach(context: Context) {
+        childFragmentManager.fragmentFactory = FragmentFactoryBuilder()
+            .forClass(MinSdkDeprecationBanner::class) {
+                MinSdkDeprecationBanner(context.getState())
+            }
+            .build()
+
         super.onAttach(context)
         val viewModelProvider = ViewModelProvider(requireActivity(), viewModelFactory)
         mainMenuViewModel = viewModelProvider[MainMenuViewModel::class.java]

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MinSdkDeprecationBanner.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MinSdkDeprecationBanner.kt
@@ -1,0 +1,31 @@
+package org.odk.collect.android.mainmenu
+
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import org.odk.collect.android.databinding.MinSdkDeprecationBannerBinding
+
+class MinSdkDeprecationBanner : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val binding = MinSdkDeprecationBannerBinding.inflate(inflater, container, false)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O && !isMinSdkDeprecationBannerDismissed) {
+            binding.root.visibility = View.VISIBLE
+            binding.dismissButton.setOnClickListener {
+                isMinSdkDeprecationBannerDismissed = true
+                binding.root.visibility = View.GONE
+            }
+        }
+        return binding.root
+    }
+
+    companion object {
+        var isMinSdkDeprecationBannerDismissed = false
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MinSdkDeprecationBanner.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MinSdkDeprecationBanner.kt
@@ -7,18 +7,19 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import org.odk.collect.android.databinding.MinSdkDeprecationBannerBinding
+import org.odk.collect.androidshared.data.AppState
 
-class MinSdkDeprecationBanner : Fragment() {
+class MinSdkDeprecationBanner(private val appState: AppState) : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         val binding = MinSdkDeprecationBannerBinding.inflate(inflater, container, false)
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O && !isMinSdkDeprecationBannerDismissed) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O && !appState.get(IS_MIN_SDK_DEPRECATION_BANNER_DISMISSED, false)) {
             binding.root.visibility = View.VISIBLE
             binding.dismissButton.setOnClickListener {
-                isMinSdkDeprecationBannerDismissed = true
+                appState.set(IS_MIN_SDK_DEPRECATION_BANNER_DISMISSED, true)
                 binding.root.visibility = View.GONE
             }
         }
@@ -26,6 +27,6 @@ class MinSdkDeprecationBanner : Fragment() {
     }
 
     companion object {
-        var isMinSdkDeprecationBannerDismissed = false
+        private const val IS_MIN_SDK_DEPRECATION_BANNER_DISMISSED = "isMinSdkDeprecationBannerDismissed"
     }
 }

--- a/collect_app/src/main/res/layout/google_drive_deprecation_banner.xml
+++ b/collect_app/src/main/res/layout/google_drive_deprecation_banner.xml
@@ -42,7 +42,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/learn_more_button_text"
-            android:textAllCaps="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/message" />

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -32,7 +32,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:name="org.odk.collect.android.mainmenu.MinSdkDeprecationBanner"
-                android:layout_marginHorizontal="@dimen/margin_extra_extra_small"
+                android:layout_marginHorizontal="@dimen/margin_standard"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/map_box_initialization_fragment" />
@@ -43,7 +43,7 @@
                 android:id="@+id/google_drive_deprecation_banner"
                 layout="@layout/google_drive_deprecation_banner"
                 android:layout_marginTop="@dimen/margin_extra_extra_small"
-                android:layout_marginHorizontal="@dimen/margin_extra_extra_small"
+                android:layout_marginHorizontal="@dimen/margin_standard"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/min_sdk_deprecation_banner" />

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -27,11 +27,11 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <include
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/min_sdk_deprecation_banner"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:id="@+id/min_sdk_deprecation_banner"
-                layout="@layout/min_sdk_deprecation_banner"
+                android:name="org.odk.collect.android.mainmenu.MinSdkDeprecationBanner"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/map_box_initialization_fragment" />

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -30,11 +30,21 @@
             <include
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:id="@+id/google_drive_deprecation_banner"
-                layout="@layout/google_drive_deprecation_banner"
+                android:id="@+id/min_sdk_deprecation_banner"
+                layout="@layout/min_sdk_deprecation_banner"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/map_box_initialization_fragment" />
+                app:layout_constraintTop_toBottomOf="@id/map_box_initialization_fragment" />
+
+            <include
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/google_drive_deprecation_banner"
+                layout="@layout/google_drive_deprecation_banner"
+                android:layout_marginTop="@dimen/margin_extra_extra_small"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/min_sdk_deprecation_banner" />
 
             <org.odk.collect.android.mainmenu.StartNewFormButton
                 android:id="@+id/enter_data"

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -32,6 +32,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:name="org.odk.collect.android.mainmenu.MinSdkDeprecationBanner"
+                android:layout_marginHorizontal="@dimen/margin_extra_extra_small"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/map_box_initialization_fragment" />
@@ -42,6 +43,7 @@
                 android:id="@+id/google_drive_deprecation_banner"
                 layout="@layout/google_drive_deprecation_banner"
                 android:layout_marginTop="@dimen/margin_extra_extra_small"
+                android:layout_marginHorizontal="@dimen/margin_extra_extra_small"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/min_sdk_deprecation_banner" />

--- a/collect_app/src/main/res/layout/min_sdk_deprecation_banner.xml
+++ b/collect_app/src/main/res/layout/min_sdk_deprecation_banner.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:visibility="gone"
+    app:shapeAppearance="?shapeAppearanceLargeComponent"
+    app:cardBackgroundColor="?colorSurfaceContainerHighest"
+    tools:visibility="visible">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/margin_standard"
+        android:paddingHorizontal="@dimen/margin_standard">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_outline_info_24"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?colorPrimary" />
+
+        <TextView
+            android:id="@+id/min_sdk_deprecation_banner_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_standard"
+            android:text="@string/min_sdk_deprecation_banner_title"
+            android:textAppearance="?textAppearanceTitleMedium"
+            android:textColor="?colorOnSurface"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toTopOf="@id/icon" />
+
+        <TextView
+            android:id="@+id/min_sdk_deprecation_banner_message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_standard"
+            android:layout_marginTop="@dimen/margin_extra_extra_small"
+            android:text="@string/min_sdk_deprecation_banner_message"
+            android:textAppearance="?textAppearanceBody2"
+            android:textColor="?colorOnSurface"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toBottomOf="@id/min_sdk_deprecation_banner_title" />
+
+        <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+            android:id="@+id/dismiss_button"
+            style="?borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/min_sdk_deprecation_banner_button"
+            android:textAllCaps="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/min_sdk_deprecation_banner_message" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/collect_app/src/main/res/layout/min_sdk_deprecation_banner.xml
+++ b/collect_app/src/main/res/layout/min_sdk_deprecation_banner.xml
@@ -55,7 +55,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/min_sdk_deprecation_banner_button"
-            android:textAllCaps="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/min_sdk_deprecation_banner_message" />

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -12,7 +12,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.android.material.card.MaterialCardView
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.notNullValue
@@ -44,7 +43,6 @@ import org.odk.collect.android.utilities.FormsRepositoryProvider
 import org.odk.collect.android.utilities.InstancesRepositoryProvider
 import org.odk.collect.android.version.VersionInformation
 import org.odk.collect.androidshared.system.BroadcastReceiverRegister
-import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
 import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.async.Scheduler
 import org.odk.collect.crashhandler.CrashHandler
@@ -58,7 +56,6 @@ import org.odk.collect.settings.ODKAppSettingsImporter
 import org.odk.collect.settings.SettingsProvider
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
-import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 class MainMenuActivityTest {
@@ -476,36 +473,6 @@ class MainMenuActivityTest {
             val startedActivityName = shadowOf(it.get()).nextStartedActivity.component?.className
             assertThat(startedActivityName, equalTo(CrashHandlerActivity::class.qualifiedName))
             assertThat(it.get().isFinishing, equalTo(true))
-        }
-    }
-
-    @Test
-    @Config(sdk = [26])
-    fun `minSdkDeprecationBanner is not displayed on API 26 and above`() {
-        val scenario = launcherRule.launch(MainMenuActivity::class.java)
-        scenario.onActivity { activity: MainMenuActivity ->
-            val minSdkDeprecationBanner = activity.findViewById<MaterialCardView>(R.id.min_sdk_deprecation_banner)
-            assertThat(minSdkDeprecationBanner.visibility, equalTo(View.GONE))
-        }
-    }
-
-    @Test
-    @Config(sdk = [25])
-    fun `minSdkDeprecationBanner is displayed on API below 26 and disappears after clicking the dismiss button`() {
-        val scenario = launcherRule.launch(MainMenuActivity::class.java)
-        scenario.onActivity { activity: MainMenuActivity ->
-            val minSdkDeprecationBanner = activity.findViewById<MaterialCardView>(R.id.min_sdk_deprecation_banner)
-            assertThat(minSdkDeprecationBanner.visibility, equalTo(View.VISIBLE))
-
-            val dismissButton = activity.findViewById<MultiClickSafeMaterialButton>(R.id.dismiss_button)
-            dismissButton.performClick()
-            assertThat(minSdkDeprecationBanner.visibility, equalTo(View.GONE))
-        }
-
-        val newScenario = scenario.recreate()
-        newScenario.onActivity { activity: MainMenuActivity ->
-            val minSdkDeprecationBanner = activity.findViewById<MaterialCardView>(R.id.min_sdk_deprecation_banner)
-            assertThat(minSdkDeprecationBanner.visibility, equalTo(View.GONE))
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -12,6 +12,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.card.MaterialCardView
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.notNullValue
@@ -43,6 +44,7 @@ import org.odk.collect.android.utilities.FormsRepositoryProvider
 import org.odk.collect.android.utilities.InstancesRepositoryProvider
 import org.odk.collect.android.version.VersionInformation
 import org.odk.collect.androidshared.system.BroadcastReceiverRegister
+import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
 import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.async.Scheduler
 import org.odk.collect.crashhandler.CrashHandler
@@ -56,6 +58,7 @@ import org.odk.collect.settings.ODKAppSettingsImporter
 import org.odk.collect.settings.SettingsProvider
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 class MainMenuActivityTest {
@@ -473,6 +476,36 @@ class MainMenuActivityTest {
             val startedActivityName = shadowOf(it.get()).nextStartedActivity.component?.className
             assertThat(startedActivityName, equalTo(CrashHandlerActivity::class.qualifiedName))
             assertThat(it.get().isFinishing, equalTo(true))
+        }
+    }
+
+    @Test
+    @Config(sdk = [26])
+    fun `minSdkDeprecationBanner is not displayed on API 26 and above`() {
+        val scenario = launcherRule.launch(MainMenuActivity::class.java)
+        scenario.onActivity { activity: MainMenuActivity ->
+            val minSdkDeprecationBanner = activity.findViewById<MaterialCardView>(R.id.min_sdk_deprecation_banner)
+            assertThat(minSdkDeprecationBanner.visibility, equalTo(View.GONE))
+        }
+    }
+
+    @Test
+    @Config(sdk = [25])
+    fun `minSdkDeprecationBanner is displayed on API below 26 and disappears after clicking the dismiss button`() {
+        val scenario = launcherRule.launch(MainMenuActivity::class.java)
+        scenario.onActivity { activity: MainMenuActivity ->
+            val minSdkDeprecationBanner = activity.findViewById<MaterialCardView>(R.id.min_sdk_deprecation_banner)
+            assertThat(minSdkDeprecationBanner.visibility, equalTo(View.VISIBLE))
+
+            val dismissButton = activity.findViewById<MultiClickSafeMaterialButton>(R.id.dismiss_button)
+            dismissButton.performClick()
+            assertThat(minSdkDeprecationBanner.visibility, equalTo(View.GONE))
+        }
+
+        val newScenario = scenario.recreate()
+        newScenario.onActivity { activity: MainMenuActivity ->
+            val minSdkDeprecationBanner = activity.findViewById<MaterialCardView>(R.id.min_sdk_deprecation_banner)
+            assertThat(minSdkDeprecationBanner.visibility, equalTo(View.GONE))
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MinSdkDeprecationBannerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MinSdkDeprecationBannerTest.kt
@@ -1,0 +1,39 @@
+package org.odk.collect.android.mainmenu
+
+import android.view.View
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.button.MaterialButton
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.android.R
+import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+class MinSdkDeprecationBannerTest {
+    @get:Rule
+    val launcherRule = FragmentScenarioLauncherRule()
+
+    @Test
+    @Config(sdk = [26])
+    fun `Banner is not displayed on API 26 and above`() {
+        val scenario = launcherRule.launch(MinSdkDeprecationBanner::class.java)
+        scenario.onFragment { fragment ->
+            assertThat(fragment.requireView().visibility, equalTo(View.GONE))
+        }
+    }
+
+    @Test
+    @Config(sdk = [25])
+    fun `Banner is displayed on API below 26 and disappears after clicking the dismiss button`() {
+        val scenario = launcherRule.launch(MinSdkDeprecationBanner::class.java)
+        scenario.onFragment { fragment ->
+            assertThat(fragment.requireView().visibility, equalTo(View.VISIBLE))
+            fragment.requireView().findViewById<MaterialButton>(R.id.dismiss_button).performClick()
+            assertThat(fragment.requireView().visibility, equalTo(View.GONE))
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MinSdkDeprecationBannerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MinSdkDeprecationBannerTest.kt
@@ -9,13 +9,22 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.odk.collect.android.R
+import org.odk.collect.androidshared.data.AppState
+import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 class MinSdkDeprecationBannerTest {
+    private val appState = AppState()
+
     @get:Rule
-    val launcherRule = FragmentScenarioLauncherRule()
+    val launcherRule = FragmentScenarioLauncherRule(
+        FragmentFactoryBuilder()
+            .forClass(MinSdkDeprecationBanner::class) {
+                MinSdkDeprecationBanner(appState)
+            }.build()
+    )
 
     @Test
     @Config(sdk = [26])

--- a/download-robolectric-deps.sh
+++ b/download-robolectric-deps.sh
@@ -2,6 +2,8 @@ set -e
 
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/6.0.1_r3-robolectric-r1-i7/android-all-instrumented-6.0.1_r3-robolectric-r1-i7.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/7.0.0_r1-robolectric-r1-i7/android-all-instrumented-7.0.0_r1-robolectric-r1-i7.jar -P robolectric-deps
+wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/7.1.0_r7-robolectric-r1-i7/android-all-instrumented-7.1.0_r7-robolectric-r1-i7.jar -P robolectric-deps
+wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/8.0.0_r4-robolectric-r1-i7/android-all-instrumented-8.0.0_r4-robolectric-r1-i7.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/12.1-robolectric-8229987-i7/android-all-instrumented-12.1-robolectric-8229987-i7.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/13-robolectric-9030017-i7/android-all-instrumented-13-robolectric-9030017-i7.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/15-robolectric-12650502-i7/android-all-instrumented-15-robolectric-12650502-i7.jar -P robolectric-deps

--- a/robolectric-deps.properties
+++ b/robolectric-deps.properties
@@ -1,5 +1,7 @@
 org.robolectric\:android-all-instrumented\:6.0.1_r3-robolectric-r1-i7=../../../../../../../robolectric-deps/android-all-instrumented-6.0.1_r3-robolectric-r1-i7.jar
 org.robolectric\:android-all-instrumented\:7.0.0_r1-robolectric-r1-i7=../../../../../../../robolectric-deps/android-all-instrumented-7.0.0_r1-robolectric-r1-i7.jar
+org.robolectric\:android-all-instrumented\:7.1.0_r7-robolectric-r1-i7=../../../../../../../robolectric-deps/android-all-instrumented-7.1.0_r7-robolectric-r1-i7.jar
+org.robolectric\:android-all-instrumented\:8.0.0_r4-robolectric-r1-i7=../../../../../../../robolectric-deps/android-all-instrumented-8.0.0_r4-robolectric-r1-i7.jar
 org.robolectric\:android-all-instrumented\:12.1-robolectric-8229987-i7=../../../../../../../robolectric-deps/android-all-instrumented-12.1-robolectric-8229987-i7.jar
 org.robolectric\:android-all-instrumented\:13-robolectric-9030017-i7=../../../../../../../robolectric-deps/android-all-instrumented-13-robolectric-9030017-i7.jar
 org.robolectric\:android-all-instrumented\:15-robolectric-12650502-i7=../../../../../../../robolectric-deps/android-all-instrumented-15-robolectric-12650502-i7.jar

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1252,6 +1252,15 @@
 
     <!--
     ##############################################
+    # Min SDK deprecation banner
+    ##############################################
+    -->
+    <string name="min_sdk_deprecation_banner_title">Your device will soon no longer be supported.</string>
+    <string name="min_sdk_deprecation_banner_message">In the new year, ODK Collect will require Android 8 or higher. You won’t be able to upgrade because this device runs an older version of Android.</string>
+    <string name="min_sdk_deprecation_banner_button">Dismiss</string>
+
+    <!--
+    ##############################################
     # Developer tools
     ##############################################
     -->

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1256,9 +1256,9 @@
     ##############################################
     -->
     <!-- First part of the message shown in the banner, informing the user that their device will soon be unsupported -->
-    <string name="min_sdk_deprecation_banner_title">Your device will soon no longer be supported.</string>
+    <string name="min_sdk_deprecation_banner_title">Your device will soon no longer be able to upgrade.</string>
     <!-- Second part of the message shown in the banner, informing the user that their device will soon be unsupported -->
-    <string name="min_sdk_deprecation_banner_message">In the new year, ODK Collect will require Android 8 or higher. You won’t be able to upgrade because this device runs an older version of Android.</string>
+    <string name="min_sdk_deprecation_banner_message">Starting in early 2026, ODK Collect requires Android 8+.</string>
     <!-- Button text to dismiss the banner -->
     <string name="min_sdk_deprecation_banner_button">Dismiss</string>
 

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1255,8 +1255,11 @@
     # Min SDK deprecation banner
     ##############################################
     -->
+    <!-- First part of the message shown in the banner, informing the user that their device will soon be unsupported -->
     <string name="min_sdk_deprecation_banner_title">Your device will soon no longer be supported.</string>
+    <!-- Second part of the message shown in the banner, informing the user that their device will soon be unsupported -->
     <string name="min_sdk_deprecation_banner_message">In the new year, ODK Collect will require Android 8 or higher. You won’t be able to upgrade because this device runs an older version of Android.</string>
+    <!-- Button text to dismiss the banner -->
     <string name="min_sdk_deprecation_banner_button">Dismiss</string>
 
     <!--


### PR DESCRIPTION
Closes #6924

#### Why is this the best possible solution? Were any other approaches considered?
I’ve added the banner using the old XML layout approach, since it will be removed in v2026.1. For now, it’s more important to easily match the existing style used in components built with newer technologies (Jetpack Compose).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Nothing special here, the banner should appear on devices running Android 7 or lower and be dismissible as described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
