### PR TITLE
Add details on create release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,13 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - when creating a major release:
   - Tag the commit for the release (`vX.X.0`)
   - Run `./create-release.sh <last release version code> <release tag>`
-- when creating a hotfix release:
-  - Tag the commit for the release (`vX.X.X`)
-  - Run `./create-release.sh <last release version code> <release tag> <last beta tag>`
+- when creating a patch release:
+  - Tag the commit for the patch release (`vX.X.X`)
+  - (If beta has started for next release) Tag the commit for the beta release (`vX.X.X-beta.X`)
+  - Run `./create-release.sh <last release version code> <patch release tag> <beta release tag>`
 - when creating a beta release:
-  - Tag the commit for the release (`vX.X.X-beta.X`)
-  - Run `./create-release.sh <last release version code> <release tag>`
+  - Tag the commit for the beta release (`vX.X.X-beta.X`)
+  - Run `./create-release.sh <last release version code> <beta release tag>`
 - add a release to Github [here](https://github.com/getodk/collect/releases), generate release notes and attach the APK
 - upload APK(s) to Play Store
   - When creating a hotfix, the beta APK should be uploaded second as it will have a higher version code

--- a/create-release.sh
+++ b/create-release.sh
@@ -1,5 +1,14 @@
 set -e
 
+[ "$1" = "-h" -o "$1" = "--help" ] && echo "
+    Usage: `basename $0` lastReleasedVersionCode nextReleaseTag [additionalReleaseTag]
+
+    Creates up to two releases with versionCodes incremented from lastReleasedVersionCode. The last
+    released version code will typically be the last version code published on the Play Store (beta
+    or production). Two releases are needed when a patch is needed to the last production release
+    and a beta is already ongoing for the next release.
+" && exit
+
 mkdir -p apks
 rm -f apks/*
 


### PR DESCRIPTION
I found the readme docs a little confusing the first time I used them so tried to add some more details. The goal is for someone without context to be able to use the script.

There's no shell type specified so I used the simplest-possible POSIX-compliant approach I could think of to add help text. I was initially going to write a comment but I find this more helpful and discoverable.

Technically you can run the script without any options and it will build based on the versioncode in the config. I don't think we need to document this or do more for validation since it's now clear what the intended usage is.

I changed the wording from hotfix to patch just to match [semantic versioning](https://semver.org/). I don't feel super strongly about this, it just makes it more obvious to me what the tag should be.