### PR TITLE
Remove duplicate map points when zooming to them

### DIFF
--- a/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
@@ -31,7 +31,7 @@ class MapViewModel(
     }
 
     fun zoomTo(boundingBox: List<MapPoint>, scaleFactor: Double, animate: Boolean) {
-        _zoom.value = Zoom.Box(boundingBox, scaleFactor, _zoom.value?.level ?: DEFAULT_ZOOM, animate)
+        _zoom.value = Zoom.Box(boundingBox.distinct(), scaleFactor, _zoom.value?.level ?: DEFAULT_ZOOM, animate)
     }
 
     fun zoomToCurrentLocation(location: MapPoint?) {

--- a/maps/src/test/java/org/odk/collect/maps/MapViewModelTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/MapViewModelTest.kt
@@ -1,0 +1,23 @@
+package org.odk.collect.maps
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.shared.settings.InMemSettings
+
+@RunWith(AndroidJUnit4::class)
+class MapViewModelTest {
+    @Test
+    fun `zoomTo removes duplicate MapPoints`() {
+        val viewModel = MapViewModel(InMemSettings(), InMemSettings())
+        val point = MapPoint(43.0, 7.0)
+        viewModel.zoomTo(
+            listOf(point, point),
+            0.0,
+            false
+        )
+        assertThat((viewModel.zoom.value as Zoom.Box).box, contains(point))
+    }
+}


### PR DESCRIPTION
Closes #6921

#### Why is this the best possible solution? Were any other approaches considered?
It looks like the problem is in OSM, not in our code. OSM is no longer maintained, so there’s no chance of getting a fix. That’s why I decided to handle it by removing duplicates, which are actually redundant in this case.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to verify that zooming to points (in all map engines) works without regression. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form mentioned in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
