### PR TITLE
Fix size limits for builds with and without Google Maps API key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,9 +263,9 @@ jobs:
           name: Check APK size hasn't increased
           command: |
             if [[ -n "$GOOGLE_MAPS_API_KEY" ]]; then \
-              ./check-size.sh 13736346
-            else
               ./check-size.sh 23068672
+            else
+              ./check-size.sh 13736346
             fi
 
       - run:


### PR DESCRIPTION
This is a fix for https://github.com/getodk/collect/pull/6938 where the size limits were swapped.