### PR TITLE
Add analytics for `no-buttons columns-n`

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -117,7 +117,8 @@ object AnalyticsEvents {
     const val ADD_SHORTCUT = "AddShortcut"
 
     /**
-     * Tracks how many forms include the `no-buttons columns-n` appearance
+     * Tracks how many forms include the `no-buttons` appearance combined with `columns` or
+     * `columns-n`
      */
     const val GALLERY_SELECT = "GallerySelect"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -115,4 +115,9 @@ object AnalyticsEvents {
      * Tracks how often shortcuts for forms are added
      */
     const val ADD_SHORTCUT = "AddShortcut"
+
+    /**
+     * Tracks how many forms include the `no-buttons columns-n` appearance
+     */
+    const val GALLERY_SELECT = "GallerySelect"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -26,6 +26,8 @@ import androidx.lifecycle.LifecycleOwner;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.analytics.Analytics;
+import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.formentry.FormEntryViewModel;
 import org.odk.collect.android.formentry.PrinterWidgetViewModel;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
@@ -55,7 +57,6 @@ import org.odk.collect.android.widgets.range.RangeIntegerWidget;
 import org.odk.collect.android.widgets.range.RangePickerDecimalWidget;
 import org.odk.collect.android.widgets.range.RangePickerIntegerWidget;
 import org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester;
-import org.odk.collect.audioclips.AudioPlayer;
 import org.odk.collect.android.widgets.utilities.AudioRecorderRecordingStatusHandler;
 import org.odk.collect.android.widgets.utilities.DateTimeWidgetUtils;
 import org.odk.collect.android.widgets.utilities.FileRequester;
@@ -66,6 +67,7 @@ import org.odk.collect.android.widgets.utilities.StringRequester;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 import org.odk.collect.androidshared.system.CameraUtils;
 import org.odk.collect.androidshared.system.IntentLauncherImpl;
+import org.odk.collect.audioclips.AudioPlayer;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.permissions.PermissionsProvider;
 import org.odk.collect.webpage.ExternalWebPageHelper;
@@ -250,6 +252,7 @@ public class WidgetFactory {
                 break;
             case Constants.CONTROL_SELECT_ONE:
                 questionWidget = getSelectOneWidget(appearance, questionDetails, dependencies);
+                logGallerySelect(appearance);
                 break;
             case Constants.CONTROL_SELECT_MULTI:
                 // search() appearance/function (not part of XForms spec) added by SurveyCTO gets
@@ -267,6 +270,8 @@ public class WidgetFactory {
                 } else {
                     questionWidget = new SelectMultiWidget(activity, questionDetails, formEntryViewModel, dependencies);
                 }
+
+                logGallerySelect(appearance);
                 break;
             case Constants.CONTROL_RANK:
                 questionWidget = new RankingWidget(activity, questionDetails, waitingForDataRegistry, formEntryViewModel, dependencies);
@@ -332,4 +337,9 @@ public class WidgetFactory {
         return questionWidget;
     }
 
+    private void logGallerySelect(String appearance) {
+        if (appearance.contains(Appearances.NO_BUTTONS) && appearance.contains(Appearances.COLUMNS_N)) {
+            Analytics.log(AnalyticsEvents.GALLERY_SELECT, "form");
+        }
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -338,7 +338,8 @@ public class WidgetFactory {
     }
 
     private void logGallerySelect(String appearance) {
-        if (appearance.contains(Appearances.NO_BUTTONS) && appearance.contains(Appearances.COLUMNS_N)) {
+        if (appearance.contains(Appearances.NO_BUTTONS) &&
+                (appearance.contains(Appearances.COLUMNS_N) || appearance.contains(Appearances.COLUMNS))) {
             Analytics.log(AnalyticsEvents.GALLERY_SELECT, "form");
         }
     }


### PR DESCRIPTION
This adds analytics so we can get insight into how many people are currently using the "gallery" appearance for selects. This will hopefully let us make more informed decisions when discussing https://github.com/getodk/collect/issues/6920.

#### Why is this the best possible solution? Were any other approaches considered?

Nothing to discuss here!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No testing needed.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
