### PR TITLE
Use build_instrumented before smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,31 +275,10 @@ jobs:
           path: selfSignedRelease.apk
 
   test_smoke_instrumented:
-    <<: *android_config
+    <<: *android_config_small
     steps:
       - attach_workspace:
           at: ~/work
-      - restore_cache:
-          keys:
-            - intrumented-deps-{{ checksum "deps.txt" }}
-            - intrumented-deps
-            - compile-deps-
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-
-      - run:
-          name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
-
-      - run:
-          name: Assemble test build
-          command: ./gradlew assembleDebug assembleDebugAndroidTest
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches/modules-2/files-2.1
-          key: intrumented-deps-{{ checksum "deps.txt" }}
 
       - run:
           name: Authorize gcloud
@@ -373,13 +352,9 @@ workflows:
       - build_instrumented:
           requires:
             - compile
-          filters:
-            branches:
-              ignore:
-                - master
       - test_smoke_instrumented:
           requires:
-            - compile
+            - build_instrumented
           filters:
             branches:
               only:


### PR DESCRIPTION
This will hopefully prevent the memory problems we're having (as `build_instrumented` uses a larger machine) and also makes `test_smoke_instrumented` simpler.