### PR TITLE
Don't expand rotate button in full screen mode

### DIFF
--- a/qr-code/src/main/java/org/odk/collect/qrcode/ScannerControls.kt
+++ b/qr-code/src/main/java/org/odk/collect/qrcode/ScannerControls.kt
@@ -59,7 +59,7 @@ fun ScannerControls(
                         Icon(Icons.Filled.ScreenRotation, stringResource(R.string.rotate_device))
                     },
                     text = { Text(stringResource(R.string.rotate_device)) },
-                    expanded = fullScreenToggleExtended,
+                    expanded = fullScreenToggleExtended && !fullScreenViewFinder,
                     modifier = Modifier
                         .safeDrawingPadding()
                         .constrainAs(fullScreenToggle) {


### PR DESCRIPTION
Closes #6932

Just a tiny change here so that the "Rotate" button in the barcode scanner never shows in "full screen" mode.