### PR TITLE
Optimize `build_instrumented` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
             if [[ -n "$GOOGLE_MAPS_API_KEY" ]]; then \
               ./check-size.sh 23117869
             else
-              ./check-size.sh 13785543
+              ./check-size.sh 13841204
             fi
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ references:
     working_directory: ~/work
     docker:
       - image: cimg/android:2025.09
-    resource_class: x-large
+    resource_class: xlarge
 
 jobs:
   compile:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,20 +27,13 @@ jobs:
     <<: *android_config
     steps:
       - checkout
-      - run:
-          name: Generate combined build.gradle file for cache key
-          command: cat build.gradle */build.gradle */build.gradle.kts .circleci/config.yml gradle/libs.versions.toml > deps.txt
       - restore_cache:
           keys:
-            - compile-deps-{{ checksum "deps.txt" }}
-            - compile-deps-
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-
       - run:
           name: Copy gradle config
           command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
-
       - run:
           name: Download Robolectric deps
           command: ./download-robolectric-deps.sh
@@ -51,12 +44,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.gradle/wrapper
-          key: gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-      - save_cache:
-          paths:
-            - ~/.gradle/caches/modules-2/files-2.1
-          key: compile-deps-{{ checksum "deps.txt" }}
+            - ~/.gradle/caches
+          key: compile-{{ checksum "gradle/libs.version.toml" }}
       - persist_to_workspace:
           root: ~/work
           paths:
@@ -69,11 +58,8 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - compile-deps-{{ checksum "deps.txt" }}
-            - compile-deps-
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-
 
       - run:
           name: Create Maven repo from dependencies
@@ -91,11 +77,8 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - compile-deps-{{ checksum "deps.txt" }}
-            - compile-deps-
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-
 
       - run:
           name: Copy gradle config
@@ -117,12 +100,10 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - test-modules-deps-{{ checksum "deps.txt" }}
-            - test-modules-deps-
-            - compile-deps-
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - test_modules-{{ checksum "gradle/libs.version.toml" }}
+            - test_modules
+            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-
 
       - run:
           name: Copy gradle config
@@ -145,8 +126,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.gradle/caches/modules-2/files-2.1
-          key: test-modules-deps-{{ checksum "deps.txt" }}
+            - ~/.gradle/caches
+          key: test_modules-{{ checksum "gradle/libs.version.toml" }}
 
   test_app:
     <<: *android_config
@@ -156,12 +137,10 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - test-app-deps-{{ checksum "deps.txt" }}
-            - test-app-deps-
-            - compile-deps-
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - test_app-{{ checksum "gradle/libs.version.toml" }}
+            - test_app-
+            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-
 
       - run:
           name: Copy gradle config
@@ -194,8 +173,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.gradle/caches/modules-2/files-2.1
-          key: test-app-deps-{{ checksum "deps.txt" }}
+            - ~/.gradle/caches
+          key: test_app-{{ checksum "gradle/libs.version.toml" }}
 
   build_instrumented:
     <<: *android_config_large
@@ -204,12 +183,10 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - intrumented-deps-{{ checksum "deps.txt" }}
-            - intrumented-deps-
-            - compile-deps-
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - build_instrumented-{{ checksum "gradle/libs.version.toml" }}
+            - build_instrumented-
+            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-
 
       - run:
           name: Copy gradle config
@@ -221,8 +198,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.gradle/caches/modules-2/files-2.1
-          key: intrumented-deps-{{ checksum "deps.txt" }}
+            - ~/.gradle/caches
+          key: build_instrumented-{{ checksum "gradle/libs.version.toml" }}
 
       - persist_to_workspace:
           root: ~/work
@@ -236,11 +213,8 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - compile-deps-{{ checksum "deps.txt" }}
-            - compile-deps
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-
 
       - run:
           name: Copy gradle config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,24 @@ workflows:
   version: 2
   commit:
     jobs:
-      - compile
+      - hold_pr:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - master
+      - compile:
+          filters:
+            branches:
+              only:
+                - master
+      - compile:
+          requires:
+            - hold_pr
+          filters:
+            branches:
+              ignore:
+                - master
       - check_quality:
           requires:
             - compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}
             - compile-
       - run:
           name: Copy gradle config
@@ -45,7 +45,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: compile-{{ checksum "gradle/libs.version.toml" }}
+          key: compile-{{ checksum "gradle/libs.versions.toml" }}
       - persist_to_workspace:
           root: ~/work
           paths:
@@ -58,7 +58,7 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}
             - compile-
 
       - run:
@@ -77,7 +77,7 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}
             - compile-
 
       - run:
@@ -100,9 +100,9 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - test_modules-{{ checksum "gradle/libs.version.toml" }}
+            - test_modules-{{ checksum "gradle/libs.versions.toml" }}
             - test_modules
-            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}
             - compile-
 
       - run:
@@ -127,7 +127,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: test_modules-{{ checksum "gradle/libs.version.toml" }}
+          key: test_modules-{{ checksum "gradle/libs.versions.toml" }}
 
   test_app:
     <<: *android_config
@@ -137,9 +137,9 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - test_app-{{ checksum "gradle/libs.version.toml" }}
+            - test_app-{{ checksum "gradle/libs.versions.toml" }}
             - test_app-
-            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}
             - compile-
 
       - run:
@@ -174,7 +174,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: test_app-{{ checksum "gradle/libs.version.toml" }}
+          key: test_app-{{ checksum "gradle/libs.versions.toml" }}
 
   build_instrumented:
     <<: *android_config_large
@@ -183,9 +183,9 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - build_instrumented-{{ checksum "gradle/libs.version.toml" }}
+            - build_instrumented-{{ checksum "gradle/libs.versions.toml" }}
             - build_instrumented-
-            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}
             - compile-
 
       - run:
@@ -199,7 +199,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: build_instrumented-{{ checksum "gradle/libs.version.toml" }}
+          key: build_instrumented-{{ checksum "gradle/libs.versions.toml" }}
 
       - persist_to_workspace:
           root: ~/work
@@ -213,7 +213,7 @@ jobs:
           at: ~/work
       - restore_cache:
           keys:
-            - compile-{{ checksum "gradle/libs.version.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}
             - compile-
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - save_cache:
           paths:
             - ~/work
-          key: workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+          key: workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
 
       - persist_to_workspace:
           root: ~/work
@@ -62,7 +62,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+            - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - compile-{{ checksum "gradle/libs.versions.toml" }}
@@ -83,7 +83,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+            - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - compile-{{ checksum "gradle/libs.versions.toml" }}
@@ -108,7 +108,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+            - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - test_modules-{{ checksum "gradle/libs.versions.toml" }}
@@ -147,7 +147,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+            - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - test_app-{{ checksum "gradle/libs.versions.toml" }}
@@ -195,7 +195,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+            - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - build_instrumented-{{ checksum "gradle/libs.versions.toml" }}
@@ -227,7 +227,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+            - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - compile-{{ checksum "gradle/libs.versions.toml" }}
@@ -271,7 +271,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+            - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - attach_workspace:
           at: ~/work
 
@@ -304,7 +304,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+            - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - attach_workspace:
           at: ~/work
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
 
       - run:
           name: Assemble connected test build
-          command: ./gradlew assembleDebug assembleDebugAndroidTest
+          command: ./gradlew assembleDebugAndroidTest
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,13 @@ references:
     working_directory: ~/work
     docker:
       - image: cimg/android:2025.09
-    resource_class: medium+
+    resource_class: large
 
   android_config_large: &android_config_large
     working_directory: ~/work
     docker:
       - image: cimg/android:2025.09
-    resource_class: large
+    resource_class: x-large
 
 jobs:
   compile:
@@ -39,7 +39,7 @@ jobs:
             - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle-compile.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
 
       - run:
           name: Download Robolectric deps
@@ -63,7 +63,7 @@ jobs:
             - .
 
   create_dependency_backup:
-    <<: *android_config
+    <<: *android_config_small
     steps:
       - attach_workspace:
           at: ~/work
@@ -85,7 +85,7 @@ jobs:
           path: maven.tar
 
   check_quality:
-    <<: *android_config_large
+    <<: *android_config
     steps:
       - attach_workspace:
           at: ~/work
@@ -99,7 +99,7 @@ jobs:
 
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle-large.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
 
       - run:
           name: Run code quality checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - compile-{{ checksum "gradle/libs.versions.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - compile-
       - run:
           name: Copy gradle config
@@ -45,7 +45,8 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: compile-{{ checksum "gradle/libs.versions.toml" }}
+            - ~/.gradle/wrapper
+          key: compile-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - save_cache:
           paths:
             - ~/work
@@ -65,7 +66,7 @@ jobs:
             - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
-            - compile-{{ checksum "gradle/libs.versions.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - compile-
 
       - run:
@@ -86,7 +87,7 @@ jobs:
             - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
-            - compile-{{ checksum "gradle/libs.versions.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - compile-
 
       - run:
@@ -111,9 +112,9 @@ jobs:
             - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
-            - test_modules-{{ checksum "gradle/libs.versions.toml" }}
+            - test_modules-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - test_modules
-            - compile-{{ checksum "gradle/libs.versions.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - compile-
 
       - run:
@@ -138,7 +139,8 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: test_modules-{{ checksum "gradle/libs.versions.toml" }}
+            - ~/.gradle/wrapper
+          key: test_modules-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 
   test_app:
     <<: *android_config
@@ -150,9 +152,9 @@ jobs:
             - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
-            - test_app-{{ checksum "gradle/libs.versions.toml" }}
+            - test_app-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - test_app-
-            - compile-{{ checksum "gradle/libs.versions.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - compile-
 
       - run:
@@ -187,7 +189,8 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: test_app-{{ checksum "gradle/libs.versions.toml" }}
+            - ~/.gradle/wrapper
+          key: test_app-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 
   build_instrumented:
     <<: *android_config_large
@@ -198,9 +201,9 @@ jobs:
             - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
-            - build_instrumented-{{ checksum "gradle/libs.versions.toml" }}
+            - build_instrumented-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - build_instrumented-
-            - compile-{{ checksum "gradle/libs.versions.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - compile-
 
       - run:
@@ -214,7 +217,8 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle/caches
-          key: build_instrumented-{{ checksum "gradle/libs.versions.toml" }}
+            - ~/.gradle/wrapper
+          key: build_instrumented-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 
       - persist_to_workspace:
           root: ~/work
@@ -230,7 +234,7 @@ jobs:
             - workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
-            - compile-{{ checksum "gradle/libs.versions.toml" }}
+            - compile-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
             - compile-
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ jobs:
       - persist_to_workspace:
           root: ~/work
           paths:
-            - .
+            - collect_app/build/outputs/apk
 
   build_release:
     <<: *android_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,16 +46,23 @@ jobs:
           paths:
             - ~/.gradle/caches
           key: compile-{{ checksum "gradle/libs.versions.toml" }}
+      - save_cache:
+          paths:
+            - ~/work
+          key: workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
+
       - persist_to_workspace:
           root: ~/work
           paths:
-            - .
+            - collect_app/build/outputs/apk
 
   create_dependency_backup:
     <<: *android_config_small
     steps:
-      - attach_workspace:
-          at: ~/work
+      - checkout
+      - restore_cache:
+          keys:
+            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - compile-{{ checksum "gradle/libs.versions.toml" }}
@@ -73,8 +80,10 @@ jobs:
   check_quality:
     <<: *android_config
     steps:
-      - attach_workspace:
-          at: ~/work
+      - checkout
+      - restore_cache:
+          keys:
+            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - compile-{{ checksum "gradle/libs.versions.toml" }}
@@ -96,8 +105,10 @@ jobs:
     <<: *android_config
     parallelism: 4
     steps:
-      - attach_workspace:
-          at: ~/work
+      - checkout
+      - restore_cache:
+          keys:
+            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - test_modules-{{ checksum "gradle/libs.versions.toml" }}
@@ -133,8 +144,10 @@ jobs:
     <<: *android_config
     parallelism: 4
     steps:
-      - attach_workspace:
-          at: ~/work
+      - checkout
+      - restore_cache:
+          keys:
+            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - test_app-{{ checksum "gradle/libs.versions.toml" }}
@@ -179,8 +192,10 @@ jobs:
   build_instrumented:
     <<: *android_config_large
     steps:
-      - attach_workspace:
-          at: ~/work
+      - checkout
+      - restore_cache:
+          keys:
+            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - build_instrumented-{{ checksum "gradle/libs.versions.toml" }}
@@ -209,8 +224,10 @@ jobs:
   build_release:
     <<: *android_config
     steps:
-      - attach_workspace:
-          at: ~/work
+      - checkout
+      - restore_cache:
+          keys:
+            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
       - restore_cache:
           keys:
             - compile-{{ checksum "gradle/libs.versions.toml" }}
@@ -251,6 +268,10 @@ jobs:
   test_smoke_instrumented:
     <<: *android_config_small
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
       - attach_workspace:
           at: ~/work
 
@@ -280,6 +301,10 @@ jobs:
   test_instrumented:
     <<: *android_config_small
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - workflow-{{ echo $CIRCLE_WORKFLOW_ID }}
       - attach_workspace:
           at: ~/work
 

--- a/.circleci/gradle-compile.properties
+++ b/.circleci/gradle-compile.properties
@@ -1,5 +1,0 @@
-org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=1g
-org.gradle.daemon=false
-org.gradle.parallel=true
-org.gradle.workers.max=3
-kotlin.compiler.execution.strategy=in-process

--- a/.circleci/gradle-large.properties
+++ b/.circleci/gradle-large.properties
@@ -1,6 +1,6 @@
 # Gradle config for "X-Large" Circle CI resource (https://circleci.com/pricing/price-list/)
 
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=8

--- a/.circleci/gradle-large.properties
+++ b/.circleci/gradle-large.properties
@@ -1,6 +1,7 @@
+# Gradle config for "X-Large" Circle CI resource (https://circleci.com/pricing/price-list/)
+
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 org.gradle.daemon=false
 org.gradle.parallel=true
-org.gradle.workers.max=4
+org.gradle.workers.max=8
 test.heap.max=1g
-kotlin.compiler.execution.strategy=in-process

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,6 +1,7 @@
+# Gradle config for "Large" Circle CI resource (https://circleci.com/pricing/price-list/)
+
 org.gradle.jvmargs=-Xmx2560m -XX:MaxMetaspaceSize=1g
 org.gradle.daemon=false
 org.gradle.parallel=true
-org.gradle.workers.max=2
+org.gradle.workers.max=4
 test.heap.max=1g
-kotlin.compiler.execution.strategy=in-process

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 #https://issuetracker.google.com/issues/283715193
 android.jetifier.ignorelist = jackson-core
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx2560m -XX:MaxMetaspaceSize=1g
 org.gradle.parallel=true
 test.heap.max=1g
 android.nonTransitiveRClass=true


### PR DESCRIPTION
This fixes the `build_instrumented` step by giving it a larger resource and better suited memory config. I've also done some general touch ups on caching etc and added manual approval to PR CI runs. I'm hoping all of this increases CI run time and stability without massively increasing costs.