### PR TITLE
Filter out marker styling properties

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -252,6 +252,11 @@ internal class SelectChoicesMapData(
 
         private val FILTERED_PROPERTIES = arrayOf(
             GEOMETRY,
+            MARKER_COLOR,
+            MARKER_SYMBOL,
+            STROKE,
+            STROKE_WIDTH,
+            FILL,
             EntitySchema.VERSION,
             EntitySchema.TRUNK_VERSION,
             EntitySchema.BRANCH_ID

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -393,6 +393,34 @@ class SelectChoicesMapDataTest {
         assertThat(properties.size, equalTo(0))
     }
 
+    @Test
+    fun `marker styling properties are filtered out`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(SelectChoicesMapData.GEOMETRY, "12.0 -1.0 305 0"),
+                        treeElement(SelectChoicesMapData.MARKER_COLOR, "#ffffff"),
+                        treeElement(SelectChoicesMapData.MARKER_SYMBOL, "A"),
+                        treeElement(SelectChoicesMapData.STROKE, "#ffffff"),
+                        treeElement(SelectChoicesMapData.STROKE_WIDTH, "5"),
+                        treeElement(SelectChoicesMapData.FILL, "#ffffff"),
+                    )
+                )
+            )
+        )
+
+        val prompt = MockFormEntryPromptBuilder()
+            .withLongText("Which is your favourite place?")
+            .withSelectChoices(choices)
+            .build()
+
+        val data = loadDataForPrompt(prompt)
+        val properties = data.getMappableItems().getOrAwaitValue()!![0].properties
+        assertThat(properties.size, equalTo(0))
+    }
+
     private fun loadDataForPrompt(prompt: FormEntryPrompt): SelectChoicesMapData {
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
         val data = SelectChoicesMapData(resources, scheduler, prompt, null)


### PR DESCRIPTION
Closes #6959 

#### Why is this the best possible solution? Were any other approaches considered?
Nothing to discuss here. Displaying those properties is not useful in any way, so we can ignore them.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should simply make marker styling properties ignored (not displayed in the bottom sheet). Nothing else should be changed.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form mentioned in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
