### PR TITLE
Use NetworkRequest transport types for auto-send constraints

### DIFF
--- a/async/src/main/java/org/odk/collect/async/CoroutineAndWorkManagerScheduler.kt
+++ b/async/src/main/java/org/odk/collect/async/CoroutineAndWorkManagerScheduler.kt
@@ -1,5 +1,7 @@
 package org.odk.collect.async
 
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -57,14 +59,23 @@ class CoroutineAndWorkManagerScheduler(
         inputData: Map<String, String>,
         networkConstraint: Scheduler.NetworkType?
     ) {
-        val constraintNetworkType = when (networkConstraint) {
+        val networkRequest = NetworkRequest.Builder().apply {
+            when (networkConstraint) {
+                Scheduler.NetworkType.WIFI -> addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                Scheduler.NetworkType.CELLULAR -> addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+                else -> Unit
+            }
+        }.build()
+
+        val networkType = when (networkConstraint) {
             Scheduler.NetworkType.WIFI -> NetworkType.UNMETERED
             Scheduler.NetworkType.CELLULAR -> NetworkType.METERED
             else -> NetworkType.CONNECTED
         }
 
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(constraintNetworkType)
+        val constraints = Constraints
+            .Builder()
+            .setRequiredNetworkRequest(networkRequest, networkType)
             .build()
 
         val workManagerInputData = Data.Builder()

--- a/async/src/main/java/org/odk/collect/async/CoroutineAndWorkManagerScheduler.kt
+++ b/async/src/main/java/org/odk/collect/async/CoroutineAndWorkManagerScheduler.kt
@@ -60,6 +60,8 @@ class CoroutineAndWorkManagerScheduler(
         networkConstraint: Scheduler.NetworkType?
     ) {
         val networkRequest = NetworkRequest.Builder().apply {
+            addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+
             when (networkConstraint) {
                 Scheduler.NetworkType.WIFI -> addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
                 Scheduler.NetworkType.CELLULAR -> addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)


### PR DESCRIPTION
Closes #6937 

#### Why is this the best possible solution? Were any other approaches considered?
The issue states that we should keep the current code for older Android versions and only use the new approach on newer ones. However, it seems we can use `setRequiredNetworkRequest` on all API levels, as it performs its own version check and internally uses the appropriate implementation:
```
        fun setRequiredNetworkRequest(
            networkRequest: NetworkRequest,
            networkType: NetworkType
        ): Builder {
            if (Build.VERSION.SDK_INT >= 28) {
                if (
                    Build.VERSION.SDK_INT >= 31 &&
                        NetworkRequest30.getNetworkSpecifier(networkRequest) != null
                ) {
                    throw IllegalArgumentException(
                        "NetworkRequests with NetworkSpecifiers set aren't supported."
                    )
                }
                requiredNetworkRequest = NetworkRequestCompat(networkRequest)
                requiredNetworkType = NetworkType.NOT_REQUIRED
            } else {
                requiredNetworkType = networkType
            }
            return this
        }
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
For users on Android 9 (API 28) and above, auto-send behavior becomes more accurate and dependable. Instead of relying on “metered vs unmetered” detection, which incorrectly triggers sending on metered Wi-Fi hotspots when “Cellular only” is selected, the app now uses explicit network transport types (Wi-Fi vs cellular). 

For users on older devices (API 27 and below), behavior remains unchanged because the existing metered-based logic is retained.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
