### PR TITLE
Update language and add icons to the repeat dialog

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AddNewRepeatDialog.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AddNewRepeatDialog.kt
@@ -25,6 +25,6 @@ class AddNewRepeatDialog(private val repeatName: String?) : Page<AddNewRepeatDia
     }
 
     fun <D : Page<D>> clickOnDoNotAdd(destination: D): D {
-        return clickOnTextInDialog(R.string.cancel, destination)
+        return clickOnTextInDialog(R.string.do_not_add_repeat, destination)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/AddRepeatDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/AddRepeatDialog.kt
@@ -1,44 +1,40 @@
 package org.odk.collect.android.formentry.repeats
 
 import android.content.Context
-import android.content.DialogInterface
+import android.view.LayoutInflater
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import org.odk.collect.strings.R
+import com.google.android.material.textview.MaterialTextView
+import org.odk.collect.android.R
+import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+import org.odk.collect.strings.R.string
 
 object AddRepeatDialog {
 
     @JvmStatic
     fun show(context: Context, groupLabel: String?, listener: Listener) {
-        val alertDialog = MaterialAlertDialogBuilder(context).create()
+        val view = LayoutInflater.from(context).inflate(R.layout.add_repeat_dialog_layout, null)
 
-        val repeatListener =
-            DialogInterface.OnClickListener { _: DialogInterface?, i: Int ->
-                when (i) {
-                    DialogInterface.BUTTON_POSITIVE -> listener.onAddRepeatClicked()
-                    DialogInterface.BUTTON_NEGATIVE -> listener.onCancelClicked()
-                }
-            }
-
-        val dialogMessage = if (groupLabel.isNullOrBlank()) {
-            context.getString(R.string.add_another_question)
+        view.findViewById<MaterialTextView>(R.id.message).text = if (groupLabel.isNullOrBlank()) {
+            context.getString(string.add_another_question)
         } else {
-            context.getString(R.string.add_repeat_question, groupLabel)
+            context.getString(string.add_repeat_question, groupLabel)
         }
 
-        alertDialog.setTitle(dialogMessage)
+        val alertDialog = MaterialAlertDialogBuilder(context)
+            .setView(view)
+            .setCancelable(false)
+            .create()
 
-        alertDialog.setButton(
-            DialogInterface.BUTTON_POSITIVE,
-            context.getString(R.string.add_repeat),
-            repeatListener
-        )
-        alertDialog.setButton(
-            DialogInterface.BUTTON_NEGATIVE,
-            context.getString(R.string.cancel),
-            repeatListener
-        )
+        view.findViewById<MultiClickSafeMaterialButton>(R.id.add_button).setOnClickListener {
+            listener.onAddRepeatClicked()
+            alertDialog.dismiss()
+        }
 
-        alertDialog.setCancelable(false)
+        view.findViewById<MultiClickSafeMaterialButton>(R.id.do_not_add_button).setOnClickListener {
+            listener.onCancelClicked()
+            alertDialog.dismiss()
+        }
+
         alertDialog.show()
     }
 

--- a/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
@@ -1,0 +1,42 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="@dimen/margin_large"
+    android:paddingVertical="@dimen/margin_standard">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/message"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textColor="?colorOnSurface"
+        android:textAppearance="?textAppearanceHeadlineSmall"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:text="Add person?" />
+
+    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+        android:id="@+id/do_not_add_button"
+        style="?materialButtonOutlinedIconStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/do_not_add_repeat"
+        android:layout_marginEnd="@dimen/margin_standard"
+        app:icon="@drawable/ic_close_24"
+        app:layout_constraintTop_toTopOf="@id/add_button"
+        app:layout_constraintEnd_toStartOf="@id/add_button" />
+
+    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+        android:id="@+id/add_button"
+        style="?materialButtonIconStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/add_repeat"
+        android:layout_marginTop="@dimen/margin_standard"
+        app:icon="@drawable/ic_add_white_24"
+        app:layout_constraintTop_toBottomOf="@id/message"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
@@ -3,8 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingHorizontal="@dimen/margin_large"
-    android:paddingVertical="@dimen/margin_standard">
+    android:padding="@dimen/margin_standard">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/message"

--- a/collect_app/src/main/res/values/buttons.xml
+++ b/collect_app/src/main/res/values/buttons.xml
@@ -18,6 +18,7 @@
         <item name="android:paddingTop">@dimen/margin_small</item>
         <item name="android:paddingBottom">@dimen/margin_small</item>
         <item name="android:textAppearance">?textAppearanceBodyMedium</item>
+        <item name="iconSize">24dp</item>
     </style>
 
     <style name="Widget.Collect.Button.OutlinedButton" parent="Widget.Material3.Button.OutlinedButton">
@@ -32,6 +33,7 @@
         <item name="android:paddingBottom">@dimen/margin_small</item>
         <item name="android:textAppearance">?textAppearanceBodyMedium</item>
         <item name="strokeColor">@color/color_on_surface_low_emphasis</item>
+        <item name="iconSize">24dp</item>
     </style>
 
     <style name="Widget.Collect.Button.IconButton.Outlined" parent="Widget.Material3.Button.IconButton.Outlined">

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <!-- This sentence is used in the dialog for adding repeats and will be completed by a singular noun usually. Examples would be ‘Add “observation”?’ or ‘Add “Reading”?’. If the phrase doesn’t make sense in your language you can add a word like “new”, being careful of gender/plural.-->
     <string name="add_repeat_question">Add \"%s\"?</string>
     <string name="add_repeat">Add</string>
+    <string name="do_not_add_repeat">Don\'t add</string>
     <string name="add_another_menu">Add another</string>
     <string name="add_another_question">Add another?</string>
 

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -115,7 +115,9 @@
 
     <!-- This sentence is used in the dialog for adding repeats and will be completed by a singular noun usually. Examples would be ‘Add “observation”?’ or ‘Add “Reading”?’. If the phrase doesn’t make sense in your language you can add a word like “new”, being careful of gender/plural.-->
     <string name="add_repeat_question">Add \"%s\"?</string>
+    <!-- Text of button from the 'Add new repeat' dialog to confirm adding a repeat -->
     <string name="add_repeat">Add</string>
+    <!-- Text of button from the 'Add new repeat' dialog to cancel adding a repeat -->
     <string name="do_not_add_repeat">Don\'t add</string>
     <string name="add_another_menu">Add another</string>
     <string name="add_another_question">Add another?</string>


### PR DESCRIPTION
Closes #6968 

#### Why is this the best possible solution? Were any other approaches considered?
I considered using Jetpack Compose for the new UI, but it would be quite cumbersome since this activity doesn’t use Compose at all yet.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test the dialog displayed when adding a new repeat group for regression, not just the visual changes.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
