### PR TITLE
Tune large CI VM based on task needs observed locally

### DIFF
--- a/.circleci/gradle-large.properties
+++ b/.circleci/gradle-large.properties
@@ -1,6 +1,6 @@
 # Gradle config for "X-Large" Circle CI resource (https://circleci.com/pricing/price-list/)
 
-org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g
+org.gradle.jvmargs=-Xmx7g -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-Xmx2g
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=8

--- a/.circleci/gradle-large.properties
+++ b/.circleci/gradle-large.properties
@@ -1,6 +1,6 @@
 # Gradle config for "X-Large" Circle CI resource (https://circleci.com/pricing/price-list/)
 
-org.gradle.jvmargs=-Xmx7g -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-Xmx2g
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-Xmx2g
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=8


### PR DESCRIPTION
This tweaks the JVM memory config for our "large" CI Gradle config. The goal here was to avoid heap space errors (while also avoiding overconsuming RAM causing "Gradle daemon disappeared errors"). 

I used VisualVM to measure memory usage locally for `./gradlew assembleDebugAndroidTest` to get to these values.