### PR TITLE
Place buttons one below the other in the add repeat dialog

### DIFF
--- a/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
@@ -22,10 +22,12 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/do_not_add_repeat"
-        android:layout_marginEnd="@dimen/margin_standard"
+        android:layout_marginTop="@dimen/margin_standard"
         app:icon="@drawable/ic_close_24"
-        app:layout_constraintTop_toTopOf="@id/add_button"
-        app:layout_constraintEnd_toStartOf="@id/add_button" />
+        app:iconGravity="textStart"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/message" />
 
     <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
         android:id="@+id/add_button"
@@ -33,9 +35,11 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/add_repeat"
-        android:layout_marginTop="@dimen/margin_standard"
+        android:layout_marginTop="@dimen/margin_extra_small"
         app:icon="@drawable/ic_add_white_24"
-        app:layout_constraintTop_toBottomOf="@id/message"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:iconGravity="textStart"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/do_not_add_button"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Closes #6976 

#### Why is this the best possible solution? Were any other approaches considered?
As discussed in the issue, for some translations or on smaller screens, displaying the buttons in a row, even when expanded, might not be sufficient. Changing the layout to vertical is a safer solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should only change the button layout in the dialog from horizontal to vertical.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with repeats.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
