### PR TITLE
Only detect exact collinear intersections in traces

### DIFF
--- a/shared/src/main/java/org/odk/collect/shared/geometry/Geometry.kt
+++ b/shared/src/main/java/org/odk/collect/shared/geometry/Geometry.kt
@@ -25,21 +25,21 @@ fun Trace.segments(): List<LineSegment> {
 /**
  * Returns `true` if any segment of the trace intersects with any other and `false` otherwise.
  */
-fun Trace.intersects(): Boolean {
+fun Trace.intersects(epsilon: Double = 0.0): Boolean {
     val points = this.points
     return if (points.size >= 3) {
         val segments = segments()
         if (segments.size == 2) {
-            segments[0].intersects(segments[1], allowConnection = true)
+            segments[0].intersects(segments[1], allowConnection = true, epsilon = epsilon)
         } else {
             segments.filterIndexed { line1Index, line1 ->
                 segments.filterIndexed { line2Index, line2 ->
                     if (isClosed() && line1Index == 0 && line2Index == segments.size - 1) {
                         false
                     } else if (line2Index == line1Index + 1) {
-                        line1.intersects(line2, allowConnection = true)
+                        line1.intersects(line2, allowConnection = true, epsilon = epsilon)
                     } else if (line2Index >= line1Index + 2) {
-                        line1.intersects(line2)
+                        line1.intersects(line2, epsilon = epsilon)
                     } else {
                         false
                     }
@@ -73,12 +73,12 @@ fun Point.within(segment: LineSegment): Boolean {
  * @param allowConnection will allow the end of `this` and the start of `other` to intersect
  * provided they are equivalent (the two segments are "connected")
  */
-fun LineSegment.intersects(other: LineSegment, allowConnection: Boolean = false): Boolean {
+fun LineSegment.intersects(other: LineSegment, allowConnection: Boolean = false, epsilon: Double = 0.0): Boolean {
     val (a, b) = this
     val (c, d) = other
 
-    val orientationA = orientation(a, c, d)
-    val orientationD = orientation(a, b, d)
+    val orientationA = orientation(a, c, d, epsilon)
+    val orientationD = orientation(a, b, d, epsilon)
 
     return if (orientationA == Orientation.Collinear && a.within(other)) {
         true
@@ -87,8 +87,8 @@ fun LineSegment.intersects(other: LineSegment, allowConnection: Boolean = false)
     } else if (b == c && allowConnection) {
         false
     } else {
-        val orientationB = orientation(b, c, d)
-        val orientationC = orientation(a, b, c)
+        val orientationB = orientation(b, c, d, epsilon)
+        val orientationC = orientation(a, b, c, epsilon)
 
         if (orientationA.isOpposing(orientationB) && orientationC.isOpposing(orientationD)) {
             true
@@ -122,9 +122,9 @@ fun LineSegment.interpolate(position: Double): Point {
  * @param epsilon the epsilon used to check for collinearity
  *
  */
-fun orientation(a: Point, b: Point, c: Point, epsilon: Double = 0.00000000001): Orientation {
+fun orientation(a: Point, b: Point, c: Point, epsilon: Double = 0.0): Orientation {
     val crossProduct = crossProduct(Pair(b.x - a.x, b.y - a.y), Pair(c.x - a.x, c.y - a.y))
-    return if (abs(crossProduct) < epsilon) {
+    return if (abs(crossProduct) <= epsilon) {
         Orientation.Collinear
     } else if (crossProduct > 0) {
         Orientation.AntiClockwise

--- a/shared/src/main/java/org/odk/collect/shared/geometry/Geometry.kt
+++ b/shared/src/main/java/org/odk/collect/shared/geometry/Geometry.kt
@@ -103,17 +103,6 @@ fun LineSegment.intersects(other: LineSegment, allowConnection: Boolean = false,
 }
 
 /**
- * Calculate a [Point] on this [LineSegment] based on the `position` using
- * [Linear interpolation](https://en.wikipedia.org/wiki/Linear_interpolation). `0` will return
- * [LineSegment.start] and `1` will return [LineSegment.end].
- */
-fun LineSegment.interpolate(position: Double): Point {
-    val x = start.x + position * (end.x - start.x)
-    val y = start.y + position * (end.y - start.y)
-    return Point(x, y)
-}
-
-/**
  * Calculate the "orientation" (or "direction") of three points using the cross product of the
  * vectors of the pairs of points (see
  * [here](https://en.wikipedia.org/wiki/Cross_product#Computational_geometry)). This can

--- a/shared/src/test/java/org/odk/collect/shared/geometry/GeometryTest.kt
+++ b/shared/src/test/java/org/odk/collect/shared/geometry/GeometryTest.kt
@@ -3,6 +3,10 @@ package org.odk.collect.shared.geometry
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
+import org.odk.collect.shared.geometry.support.GeometryTestUtils.addRandomIntersectingSegment
+import org.odk.collect.shared.geometry.support.GeometryTestUtils.getTraceGenerator
+import org.odk.collect.shared.geometry.support.GeometryTestUtils.reverse
+import org.odk.collect.shared.geometry.support.GeometryTestUtils.scale
 import org.odk.collect.shared.quickCheck
 import kotlin.random.Random
 
@@ -214,7 +218,7 @@ class GeometryTest {
             generator = getTraceGenerator()
         ) { trace, intersects ->
             // Check intersects is consistent when trace is reversed
-            val reversedTrace = Trace(trace.points.reversed())
+            val reversedTrace = trace.reverse()
             assertThat(
                 "Expected intersects=$intersects:\n$reversedTrace",
                 reversedTrace.intersects(),
@@ -222,10 +226,7 @@ class GeometryTest {
             )
 
             // Check intersects is consistent when trace is scaled
-            val scaleFactor = Random.nextDouble(0.1, 10.0)
-            val scaledTrace = Trace(trace.points.map {
-                Point(it.x * scaleFactor, it.y * scaleFactor)
-            })
+            val scaledTrace = trace.scale(Random.nextDouble(0.1, 10.0))
             assertThat(
                 "Expected intersects=$intersects:\n$scaledTrace",
                 scaledTrace.intersects(),
@@ -234,13 +235,7 @@ class GeometryTest {
 
             // Check adding an intersection makes intersects true
             if (!intersects && !trace.isClosed()) {
-                val intersectionSegment = trace.segments().dropLast(1).random()
-                val intersectPosition = Random.nextDouble(0.1, 1.0)
-                val intersectionPoint = intersectionSegment.interpolate(intersectPosition)
-                val lineSegment = LineSegment(trace.points.last(), intersectionPoint)
-                val intersectingSegment =
-                    LineSegment(lineSegment.start, lineSegment.interpolate(1.1))
-                val intersectingTrace = Trace(trace.points + intersectingSegment.end)
+                val intersectingTrace = trace.addRandomIntersectingSegment()
                 assertThat(
                     "Expected intersects=true:\n$intersectingTrace",
                     intersectingTrace.intersects(),
@@ -281,57 +276,5 @@ class GeometryTest {
         val segment2 = LineSegment(Point(0.0, -1.0), Point(0.0, 1.0))
 
         assertThat(segment1.intersects(segment2, allowConnection = true), equalTo(true))
-    }
-
-    @Test
-    fun `LineSegment#interpolate returns a point on the segment at a proportional distance`() {
-        val segment = LineSegment(Point(0.0, 0.0), Point(1.0, 0.0))
-
-        assertThat(segment.interpolate(0.0), equalTo(Point(0.0, 0.0)))
-        assertThat(segment.interpolate(0.5), equalTo(Point(0.5, 0.0)))
-        assertThat(segment.interpolate(1.0), equalTo(Point(1.0, 0.0)))
-    }
-
-    @Test
-    fun `LineSegment#interpolate returns a collinear point within the line's bounding box`() {
-        val segment = LineSegment(Point(0.0, 0.0), Point(1.0, 1.0))
-        val interpolatedPoint = segment.interpolate(0.5)
-
-        val orientation = orientation(interpolatedPoint, segment.start, segment.end)
-        assertThat(orientation, equalTo(Orientation.Collinear))
-        assertThat(interpolatedPoint.within(segment), equalTo(true))
-    }
-
-    @Test
-    fun `LineSegment#interpolate returns a collinear point within the line's bounding box for higher precision points with a suitable epsilon`() {
-        val segment = LineSegment(Point(56.6029153, 20.2311124), Point(56.6029192, 20.2310467))
-        val interpolatedPoint = segment.interpolate(0.5)
-
-        val orientation = orientation(interpolatedPoint, segment.start, segment.end, epsilon = 0.000001)
-        assertThat(orientation, equalTo(Orientation.Collinear))
-        assertThat(interpolatedPoint.within(segment), equalTo(true))
-    }
-
-    private fun getTraceGenerator(maxLength: Int = 10, maxCoordinate: Double = 100.0): Sequence<Trace> {
-        return generateSequence {
-            val length = Random.nextInt(3, maxLength)
-            val trace = Trace(0.until(length).map {
-                Point(
-                    Random.nextDouble(maxCoordinate * -1, maxCoordinate),
-                    Random.nextDouble(maxCoordinate * -1, maxCoordinate)
-                )
-            })
-
-            if (trace.isClosed()) {
-                trace
-            } else {
-                val shouldClose = Random.nextBoolean()
-                if (shouldClose) {
-                    trace.copy(points = trace.points + trace.points.first())
-                } else {
-                    trace
-                }
-            }
-        }
     }
 }

--- a/shared/src/test/java/org/odk/collect/shared/geometry/GeometryTest.kt
+++ b/shared/src/test/java/org/odk/collect/shared/geometry/GeometryTest.kt
@@ -233,15 +233,17 @@ class GeometryTest {
             )
 
             // Check adding an intersection makes intersects true
-            if (!intersects) {
-                val intersectionSegment = trace.segments().random()
+            if (!intersects && !trace.isClosed()) {
+                val intersectionSegment = trace.segments().dropLast(1).random()
                 val intersectPosition = Random.nextDouble(0.1, 1.0)
                 val intersectionPoint = intersectionSegment.interpolate(intersectPosition)
-                val intersectingTrace =
-                    Trace(trace.points + listOf(trace.points.last(), intersectionPoint))
+                val lineSegment = LineSegment(trace.points.last(), intersectionPoint)
+                val intersectingSegment =
+                    LineSegment(lineSegment.start, lineSegment.interpolate(1.1))
+                val intersectingTrace = Trace(trace.points + intersectingSegment.end)
                 assertThat(
                     "Expected intersects=true:\n$intersectingTrace",
-                    intersectingTrace.intersects(epsilon = 0.000001),
+                    intersectingTrace.intersects(),
                     equalTo(true)
                 )
             }
@@ -312,7 +314,7 @@ class GeometryTest {
 
     private fun getTraceGenerator(maxLength: Int = 10, maxCoordinate: Double = 100.0): Sequence<Trace> {
         return generateSequence {
-            val length = Random.nextInt(2, maxLength)
+            val length = Random.nextInt(3, maxLength)
             val trace = Trace(0.until(length).map {
                 Point(
                     Random.nextDouble(maxCoordinate * -1, maxCoordinate),

--- a/shared/src/test/java/org/odk/collect/shared/geometry/GeometryTest.kt
+++ b/shared/src/test/java/org/odk/collect/shared/geometry/GeometryTest.kt
@@ -234,7 +234,7 @@ class GeometryTest {
             )
 
             // Check adding an intersection makes intersects true
-            if (!intersects && !trace.isClosed()) {
+            if (!intersects) {
                 val intersectingTrace = trace.addRandomIntersectingSegment()
                 assertThat(
                     "Expected intersects=true:\n$intersectingTrace",

--- a/shared/src/test/java/org/odk/collect/shared/geometry/GeometryTest.kt
+++ b/shared/src/test/java/org/odk/collect/shared/geometry/GeometryTest.kt
@@ -241,7 +241,7 @@ class GeometryTest {
                     Trace(trace.points + listOf(trace.points.last(), intersectionPoint))
                 assertThat(
                     "Expected intersects=true:\n$intersectingTrace",
-                    intersectingTrace.intersects(),
+                    intersectingTrace.intersects(epsilon = 0.000001),
                     equalTo(true)
                 )
             }
@@ -296,6 +296,16 @@ class GeometryTest {
         val interpolatedPoint = segment.interpolate(0.5)
 
         val orientation = orientation(interpolatedPoint, segment.start, segment.end)
+        assertThat(orientation, equalTo(Orientation.Collinear))
+        assertThat(interpolatedPoint.within(segment), equalTo(true))
+    }
+
+    @Test
+    fun `LineSegment#interpolate returns a collinear point within the line's bounding box for higher precision points with a suitable epsilon`() {
+        val segment = LineSegment(Point(56.6029153, 20.2311124), Point(56.6029192, 20.2310467))
+        val interpolatedPoint = segment.interpolate(0.5)
+
+        val orientation = orientation(interpolatedPoint, segment.start, segment.end, epsilon = 0.000001)
         assertThat(orientation, equalTo(Orientation.Collinear))
         assertThat(interpolatedPoint.within(segment), equalTo(true))
     }

--- a/shared/src/test/java/org/odk/collect/shared/geometry/support/GeometryTestUtils.kt
+++ b/shared/src/test/java/org/odk/collect/shared/geometry/support/GeometryTestUtils.kt
@@ -4,6 +4,7 @@ import org.odk.collect.shared.geometry.LineSegment
 import org.odk.collect.shared.geometry.Point
 import org.odk.collect.shared.geometry.Trace
 import org.odk.collect.shared.geometry.segments
+import org.odk.collect.shared.geometry.support.GeometryTestUtils.interpolate
 import kotlin.random.Random
 
 object GeometryTestUtils {
@@ -41,6 +42,13 @@ object GeometryTestUtils {
         })
     }
 
+    /**
+     * Choose random segment, a random (interpolated) point on that segment and then create a new
+     * trace with an additional point just beyond that to create an intersecting trace.
+     *
+     * Never chooses the last segment as a target for intersecting as that can only create a
+     * collinear intersection which is unlikely to be accurate due to inaccuracies in [interpolate].
+     */
     fun Trace.addRandomIntersectingSegment(): Trace {
         val intersectionSegment = segments().dropLast(1).random()
         val intersectPosition = Random.nextDouble(0.1, 1.0)

--- a/shared/src/test/java/org/odk/collect/shared/geometry/support/GeometryTestUtils.kt
+++ b/shared/src/test/java/org/odk/collect/shared/geometry/support/GeometryTestUtils.kt
@@ -1,0 +1,64 @@
+package org.odk.collect.shared.geometry.support
+
+import org.odk.collect.shared.geometry.LineSegment
+import org.odk.collect.shared.geometry.Point
+import org.odk.collect.shared.geometry.Trace
+import org.odk.collect.shared.geometry.segments
+import kotlin.random.Random
+
+object GeometryTestUtils {
+
+    fun getTraceGenerator(maxLength: Int = 10, maxCoordinate: Double = 100.0): Sequence<Trace> {
+        return generateSequence {
+            val length = Random.nextInt(3, maxLength)
+            val trace = Trace(0.until(length).map {
+                Point(
+                    Random.nextDouble(maxCoordinate * -1, maxCoordinate),
+                    Random.nextDouble(maxCoordinate * -1, maxCoordinate)
+                )
+            })
+
+            if (trace.isClosed()) {
+                trace
+            } else {
+                val shouldClose = Random.nextBoolean()
+                if (shouldClose) {
+                    trace.copy(points = trace.points + trace.points.first())
+                } else {
+                    trace
+                }
+            }
+        }
+    }
+
+    fun Trace.reverse(): Trace {
+        return Trace(points.reversed())
+    }
+
+    fun Trace.scale(factor: Double): Trace {
+        return Trace(points.map {
+            Point(it.x * factor, it.y * factor)
+        })
+    }
+
+    fun Trace.addRandomIntersectingSegment(): Trace {
+        val intersectionSegment = segments().dropLast(1).random()
+        val intersectPosition = Random.nextDouble(0.1, 1.0)
+        val intersectionPoint = intersectionSegment.interpolate(intersectPosition)
+        val lineSegment = LineSegment(points.last(), intersectionPoint)
+        val intersectingSegment =
+            LineSegment(lineSegment.start, lineSegment.interpolate(1.1))
+        return Trace(points + intersectingSegment.end)
+    }
+
+    /**
+     * Calculate a [Point] on this [LineSegment] based on the `position` using
+     * [Linear interpolation](https://en.wikipedia.org/wiki/Linear_interpolation). `0` will return
+     * [LineSegment.start] and `1` will return [LineSegment.end].
+     */
+    fun LineSegment.interpolate(position: Double): Point {
+        val x = start.x + position * (end.x - start.x)
+        val y = start.y + position * (end.y - start.y)
+        return Point(x, y)
+    }
+}

--- a/shared/src/test/java/org/odk/collect/shared/geometry/support/GeometryTestUtilsTest.kt
+++ b/shared/src/test/java/org/odk/collect/shared/geometry/support/GeometryTestUtilsTest.kt
@@ -1,0 +1,43 @@
+package org.odk.collect.shared.geometry.support
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.odk.collect.shared.geometry.LineSegment
+import org.odk.collect.shared.geometry.Orientation
+import org.odk.collect.shared.geometry.Point
+import org.odk.collect.shared.geometry.orientation
+import org.odk.collect.shared.geometry.support.GeometryTestUtils.interpolate
+import org.odk.collect.shared.geometry.within
+
+class GeometryTestUtilsTest {
+
+    @Test
+    fun `LineSegment#interpolate returns a point on the segment at a proportional distance`() {
+        val segment = LineSegment(Point(0.0, 0.0), Point(1.0, 0.0))
+
+        assertThat(segment.interpolate(0.0), equalTo(Point(0.0, 0.0)))
+        assertThat(segment.interpolate(0.5), equalTo(Point(0.5, 0.0)))
+        assertThat(segment.interpolate(1.0), equalTo(Point(1.0, 0.0)))
+    }
+
+    @Test
+    fun `LineSegment#interpolate returns a collinear point within the line's bounding box`() {
+        val segment = LineSegment(Point(0.0, 0.0), Point(1.0, 1.0))
+        val interpolatedPoint = segment.interpolate(0.5)
+
+        val orientation = orientation(interpolatedPoint, segment.start, segment.end)
+        assertThat(orientation, equalTo(Orientation.Collinear))
+        assertThat(interpolatedPoint.within(segment), equalTo(true))
+    }
+
+    @Test
+    fun `LineSegment#interpolate returns a collinear point within the line's bounding box for higher precision points with a suitable epsilon`() {
+        val segment = LineSegment(Point(56.6029153, 20.2311124), Point(56.6029192, 20.2310467))
+        val interpolatedPoint = segment.interpolate(0.5)
+
+        val orientation = orientation(interpolatedPoint, segment.start, segment.end, epsilon = 0.000001)
+        assertThat(orientation, equalTo(Orientation.Collinear))
+        assertThat(interpolatedPoint.within(segment), equalTo(true))
+    }
+}


### PR DESCRIPTION
Closes #6979

#### Why is this the best possible solution? Were any other approaches considered?

I've removed the default epsilon from our orientation which is used as part of intersection detection. Instead, now an epsilon can be passed to both `LineSegment#intersects` and `Trace#intersects`. This allows us to only detect **exact** collinear intersections (one endpoint touching another line) in the app, while also allowing tolerance for testing with linear interpolation (which is hard to get 100% exact).

We may want to use an epsilon in the app as well, but until we get more feedback, avoiding false positives is safer - I think leaving the ability to add one in right now is a good idea.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should make it very hard to create an intersection where the endpoint of one segment is touching (or close to touching) another line.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
