### PR TITLE
Downgrade com.google.android.material to fix the cut-off slider

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ androidxWorkRuntime = { group = "androidx.work", name = "work-runtime-ktx", vers
 androidxExinterface = { group = "androidx.exifinterface", name = "exifinterface", version = "1.4.1" }
 androidxPreferenceKtx = { group = "androidx.preference", name = "preference-ktx", version = "1.2.1" }
 androidxFragmentKtx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragment" }
-androidMaterial = { group = "com.google.android.material", name = "material", version = "1.13.0" }
+androidMaterial = { group = "com.google.android.material", name = "material", version = "1.12.0" } # Check if https://github.com/getodk/collect/issues/6974 is still an issue before upgrading
 androidFlexbox = { group = "com.google.android.flexbox", name = "flexbox", version = "3.0.0" }
 androidxComposeBom = { group = "androidx.compose", name = "compose-bom", version = "2025.09.00" }
 androidXComposeMaterial = { group = "androidx.compose.material3", name = "material3" }


### PR DESCRIPTION
Closes #6974 

#### Why is this the best possible solution? Were any other approaches considered?
The issue occurred after upgrading `com.google.android.material` at the beginning of the current release cycle. The problem is that the slider provided by that dependency does not support null values. There must always be a default value within the start–end range, but we want to support a `no value` state, just like in every other question type.

To achieve this, we created an extension of the slider class and tried to mimic that behavior by setting the value to the range’s start while hiding the thumb see https://github.com/getodk/collect/blob/f725a3bf4aa6da2b59079d8596dd3e25c42d587c/collect_app/src/main/java/org/odk/collect/android/views/TrackingTouchSlider.kt. It looks like in the newest version the way the slider is drawn has changed, and now the space behind the thumb is not drawn at all. As a result, when we hide it, a blank gap appears, making the slider look cut off.

Unfortunately, there’s no easy fix for this, so the best option for now seems to be downgrading to the version that worked for us previously.

I think we may need to consider building our own slider if we want to keep supporting `no value` states. The current solution with hiding the thumb is already a workaround, and even if we found a way to fill the blank space behind it, it would be convoluted. This might actually be a good moment to consider implementing our own slider entirely, especially since we’re also thinking about adding a new appearance for the range question type that supports translatable labels.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should simply fix the issue. We don't need to spend time testing the behavior of range question types, since the only change is reverting to the previously well-tested version of `com.google.android.material`.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
