### PR TITLE
Fix crashes editing geopoly questions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
         mavenLocal() // Only used for javarosa_local dependency
         mavenCentral()
 
-        maven { url 'https://oss.sonatype.org/content/groups/public' }
+        maven { url 'https://central.sonatype.com/repository/maven-snapshots' }
         maven { url 'https://jitpack.io' }
         maven {
             url 'https://staging.dev.medicmobile.org/_couch/maven-repo'

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/handler/ExternalDataHandlerPull.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/handler/ExternalDataHandlerPull.java
@@ -24,6 +24,7 @@ import android.database.sqlite.SQLiteException;
 
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.xpath.expr.XPathFuncExpr;
+import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.dynamicpreload.ExternalDataManager;
 import org.odk.collect.android.dynamicpreload.ExternalDataUtil;
 import org.odk.collect.android.dynamicpreload.ExternalSQLiteOpenHelper;
@@ -52,7 +53,7 @@ public class ExternalDataHandlerPull extends ExternalDataHandlerBase {
     }
 
     @Override
-    public List<Class[]> getPrototypes() {
+    public @NotNull List<@NotNull Class<?>@NotNull []> getPrototypes() {
         return new ArrayList<>();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/handler/ExternalDataHandlerSearch.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/handler/ExternalDataHandlerSearch.java
@@ -18,18 +18,21 @@
 
 package org.odk.collect.android.dynamicpreload.handler;
 
+import static org.odk.collect.strings.localization.LocalizedApplicationKt.getLocalizedString;
+
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.xpath.expr.XPathFuncExpr;
+import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.exception.ExternalDataException;
 import org.odk.collect.android.dynamicpreload.ExternalDataManager;
 import org.odk.collect.android.dynamicpreload.ExternalDataUtil;
 import org.odk.collect.android.dynamicpreload.ExternalSQLiteOpenHelper;
 import org.odk.collect.android.dynamicpreload.ExternalSelectChoice;
+import org.odk.collect.android.exception.ExternalDataException;
 import org.odk.collect.shared.strings.StringUtils;
 
 import java.util.ArrayList;
@@ -39,8 +42,6 @@ import java.util.List;
 import java.util.Set;
 
 import timber.log.Timber;
-
-import static org.odk.collect.strings.localization.LocalizedApplicationKt.getLocalizedString;
 
 /**
  * Author: Meletis Margaritis
@@ -81,7 +82,7 @@ public class ExternalDataHandlerSearch extends ExternalDataHandlerBase {
     }
 
     @Override
-    public List<Class[]> getPrototypes() {
+    public @NotNull List<@NotNull Class<?>@NotNull []> getPrototypes() {
         return new ArrayList<>();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -296,8 +296,6 @@ public class SaveFormToDisk {
 
     @NonNull
     private JSONObject toGeoJson(GeoPointData data) throws JSONException {
-        // For a GeoPointData object, the four fields exposed by getPart() are
-        // latitude, longitude, altitude, and accuracy radius, in that order.
         MapPoint mapPoint = toMapPoint(data);
         double lat = mapPoint.latitude;
         double lon = mapPoint.longitude;

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -15,6 +15,7 @@
 package org.odk.collect.android.tasks;
 
 import static org.odk.collect.android.analytics.AnalyticsEvents.ENCRYPT_SUBMISSION;
+import static org.odk.collect.geo.GeoUtils.toMapPoint;
 import static org.odk.collect.strings.localization.LocalizedApplicationKt.getLocalizedString;
 
 import android.content.ContentValues;
@@ -60,6 +61,7 @@ import org.odk.collect.entities.storage.EntitiesRepository;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.instances.Instance;
 import org.odk.collect.forms.instances.InstancesRepository;
+import org.odk.collect.maps.MapPoint;
 import org.odk.collect.shared.files.FileExt;
 
 import java.io.File;
@@ -296,8 +298,9 @@ public class SaveFormToDisk {
     private JSONObject toGeoJson(GeoPointData data) throws JSONException {
         // For a GeoPointData object, the four fields exposed by getPart() are
         // latitude, longitude, altitude, and accuracy radius, in that order.
-        double lat = data.getPart(0);
-        double lon = data.getPart(1);
+        MapPoint mapPoint = toMapPoint(data);
+        double lat = mapPoint.latitude;
+        double lon = mapPoint.longitude;
 
         // In GeoJSON, longitude comes before latitude.
         JSONArray coordinates = new JSONArray();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -74,7 +74,7 @@ public class GeoShapeWidget extends QuestionWidget {
 
     @Override
     public IAnswerData getAnswer() {
-        return getAnswerText().isEmpty() ? null : new StringData(getAnswerText());
+        return getFormEntryPrompt().getAnswerValue();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -20,7 +20,6 @@ import android.util.TypedValue;
 import android.view.View;
 
 import org.javarosa.core.model.data.IAnswerData;
-import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.databinding.GeoshapeQuestionBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -21,7 +21,6 @@ import android.util.TypedValue;
 import android.view.View;
 
 import org.javarosa.core.model.data.IAnswerData;
-import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.databinding.GeotraceQuestionBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -88,7 +88,7 @@ public class GeoTraceWidget extends QuestionWidget {
 
     @Override
     public IAnswerData getAnswer() {
-        return getAnswerText().isEmpty() ? null : new StringData(getAnswerText());
+        return getFormEntryPrompt().getAnswerValue();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -50,6 +50,7 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
 
         val inputPolygon = when (val answer = prompt.answerValue) {
             is GeoTraceData -> answer.points.map { it.toMapPoint() }
+            is GeoShapeData -> answer.points.map { it.toMapPoint() }
             null -> emptyList()
             else -> throw IllegalArgumentException()
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -23,7 +23,8 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
     override fun onCreateFragment(prompt: FormEntryPrompt): GeoPolyFragment {
         val outputMode = when (prompt.dataType) {
             Constants.DATATYPE_GEOSHAPE -> OutputMode.GEOSHAPE
-            else -> OutputMode.GEOTRACE
+            Constants.DATATYPE_GEOTRACE -> OutputMode.GEOTRACE
+            else -> throw IllegalArgumentException()
         }
 
         childFragmentManager.setFragmentResultListener(

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -21,7 +21,6 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
     ) {
 
     override fun onCreateFragment(prompt: FormEntryPrompt): GeoPolyFragment {
-        val incremental = FormEntryPromptUtils.getAdditionalAttribute(prompt, INCREMENTAL)
         val outputMode = when (prompt.dataType) {
             Constants.DATATYPE_GEOSHAPE -> OutputMode.GEOSHAPE
             else -> OutputMode.GEOTRACE
@@ -35,6 +34,7 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
             val geopoly = result.getString(GeoPolyFragment.RESULT_GEOPOLY)
 
             if (geopolyChange != null) {
+                val incremental = FormEntryPromptUtils.getAdditionalAttribute(prompt, INCREMENTAL)
                 if (incremental == "true") {
                     onAnswer(geopolyChange, outputMode, dismiss = false, validate = true)
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.map
 import org.javarosa.core.model.Constants
 import org.javarosa.core.model.data.GeoTraceData
-import org.javarosa.core.model.data.UncastData
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.utilities.FormEntryPromptUtils
 import org.odk.collect.android.widgets.utilities.AdditionalAttributes.INCREMENTAL
@@ -13,7 +12,6 @@ import org.odk.collect.android.widgets.utilities.BindAttributes.ALLOW_MOCK_ACCUR
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.geopoly.GeoPolyFragment
 import org.odk.collect.geo.geopoly.GeoPolyFragment.OutputMode
-import org.odk.collect.maps.MapPoint
 
 class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
     WidgetAnswerDialogFragment<GeoPolyFragment>(
@@ -32,10 +30,10 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
 
             if (geopolyChange != null) {
                 if (incremental == "true") {
-                    onAnswer(GeoTraceData().cast(UncastData(geopolyChange)), dismiss = false, validate = true)
+                    onAnswer(GeoTraceData().also { it.value = geopolyChange }, dismiss = false, validate = true)
                 }
             } else if (geopoly != null) {
-                onAnswer(GeoTraceData().cast(UncastData(geopoly)))
+                onAnswer(GeoTraceData().also { it.value = geopoly })
             } else {
                 dismiss()
             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -10,6 +10,7 @@ import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.utilities.FormEntryPromptUtils
 import org.odk.collect.android.widgets.utilities.AdditionalAttributes.INCREMENTAL
 import org.odk.collect.android.widgets.utilities.BindAttributes.ALLOW_MOCK_ACCURACY
+import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.geopoly.GeoPolyFragment
 import org.odk.collect.geo.geopoly.GeoPolyFragment.OutputMode
 import org.odk.collect.maps.MapPoint
@@ -49,15 +50,7 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
             FormEntryPromptUtils.getBindAttribute(prompt, ALLOW_MOCK_ACCURACY).toBoolean()
 
         val inputPolygon = when (val answer = prompt.answerValue) {
-            is GeoTraceData -> answer.points.map {
-                MapPoint(
-                    it.getPart(0),
-                    it.getPart(1),
-                    it.getPart(2),
-                    it.getPart(3)
-                )
-            }
-
+            is GeoTraceData -> answer.points.map { it.toMapPoint() }
             null -> emptyList()
             else -> throw IllegalArgumentException()
         }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -69,7 +69,11 @@ class GeoPolyDialogFragmentTest {
 
     @Test
     fun `configures GeoPolyFragment with readOnly from prompt`() {
-        prompt = MockFormEntryPromptBuilder(prompt).withReadOnly(true).build()
+        prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
+            .withReadOnly(true)
+            .build()
+
         launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
             GeoPolyDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
@@ -114,8 +118,8 @@ class GeoPolyDialogFragmentTest {
         }
     }
 
-    @Test
-    fun `configures GeoPolyFragment with geotrace output mode when prompt is something else`() {
+    @Test(expected = IllegalArgumentException::class)
+    fun `throws exception when prompt is something else`() {
         prompt = MockFormEntryPromptBuilder(prompt)
             .withDataType(Constants.DATATYPE_DATE)
             .build()
@@ -131,6 +135,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `configures GeoPolyFragment with retainMockAccruacy from allow-mock-accuracy bind attribute`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .build()
 
         launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
@@ -166,6 +171,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `configures GeoPolyFragment inputPolygon with existing answer`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .build()
 
         launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
@@ -202,6 +208,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `sets answer when REQUEST_GEOPOLY is returned`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .build()
 
         val answer = "0.0 0.0 1.0 1.0; 0.0 1.0 1.0 1.0"
@@ -241,6 +248,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `dismisses when REQUEST_GEOPOLY is returned`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .build()
 
         val answer = "0.0 0.0 1.0 1.0; 0.0 1.0 1.0 1.0"
@@ -262,6 +270,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `sets answer with validate when REQUEST_GEOPOLY_CHANGE is returned if question is incremental`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .withAdditionalAttribute(INCREMENTAL, "true")
             .build()
 
@@ -303,6 +312,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `does not set answer when REQUEST_GEOPOLY_CHANGE is returned if question is not incremental`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .build()
 
         val answer = "0.0 0.0 1.0 1.0; 0.0 1.0 1.0 1.0"
@@ -338,6 +348,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `does not dismiss when REQUEST_GEOPOLY_CHANGE is returned regardless of incremental value`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .withAdditionalAttribute(INCREMENTAL, "true")
             .build()
 
@@ -376,6 +387,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `does not set answer when REQUEST_GEOPOLY is cancelled`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .build()
 
         launcherRule.launch(
@@ -391,6 +403,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `dismisses when REQUEST_GEOPOLY is cancelled`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .build()
 
         launcherRule.launch(
@@ -405,6 +418,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `uses validation result message for invalidMessage`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .build()
 
         index.value = Pair(prompt.index, null)
@@ -427,6 +441,7 @@ class GeoPolyDialogFragmentTest {
     @Test
     fun `uses validation result default message for invalidMessage if there's no custom message`() {
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .build()
 
         index.value = Pair(prompt.index, null)

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -186,6 +186,17 @@ class GeoPolyDialogFragmentTest {
         ) {
             assertThat(it.inputPolygon, equalTo(points))
         }
+
+        prompt = MockFormEntryPromptBuilder(prompt)
+            .withAnswer(geoShapeOf(points))
+            .build()
+
+        launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
+            GeoPolyDialogFragment::class,
+            bundleOf(ARG_FORM_INDEX to prompt.index)
+        ) {
+            assertThat(it.inputPolygon, equalTo(points))
+        }
     }
 
     @Test
@@ -439,6 +450,23 @@ class GeoPolyDialogFragmentTest {
     private fun geoTraceOf(points: List<MapPoint>): GeoTraceData {
         return GeoTraceData(
             GeoTraceData.GeoTrace(
+                ArrayList(
+                    points.map {
+                        doubleArrayOf(
+                            it.latitude,
+                            it.longitude,
+                            it.altitude,
+                            it.accuracy
+                        )
+                    }
+                )
+            )
+        )
+    }
+
+    private fun geoShapeOf(points: List<MapPoint>): GeoShapeData {
+        return GeoShapeData(
+            GeoShapeData.GeoShape(
                 ArrayList(
                     points.map {
                         doubleArrayOf(

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -183,6 +183,7 @@ class GeoPolyDialogFragmentTest {
 
         val points = listOf(MapPoint(0.0, 0.0, 1.0, 1.0), MapPoint(0.0, 1.0, 1.0, 1.0))
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
             .withAnswer(geoTraceOf(points))
             .build()
 
@@ -194,6 +195,7 @@ class GeoPolyDialogFragmentTest {
         }
 
         prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOSHAPE)
             .withAnswer(geoShapeOf(points))
             .build()
 

--- a/geo/src/main/java/org/odk/collect/geo/GeoUtils.kt
+++ b/geo/src/main/java/org/odk/collect/geo/GeoUtils.kt
@@ -2,6 +2,7 @@ package org.odk.collect.geo
 
 import android.content.Context
 import android.location.Location
+import org.javarosa.core.model.data.GeoPointData
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.shared.strings.StringUtils.removeEnd
 import org.odk.collect.strings.R
@@ -85,5 +86,10 @@ object GeoUtils {
         } else {
             return null
         }
+    }
+
+    @JvmStatic
+    fun GeoPointData.toMapPoint(): MapPoint {
+        return MapPoint(this.getPart(0), this.getPart(1), this.getPart(2), this.getPart(3))
     }
 }

--- a/geo/src/main/java/org/odk/collect/geo/javarosa/IntersectsFunctionHandler.kt
+++ b/geo/src/main/java/org/odk/collect/geo/javarosa/IntersectsFunctionHandler.kt
@@ -17,18 +17,7 @@ class IntersectsFunctionHandler : IFunctionHandler {
         return listOf(arrayOf(String::class.java))
     }
 
-    override fun rawArgs(): Boolean {
-        return false
-    }
-
-    override fun realTime(): Boolean {
-        TODO("Not yet implemented")
-    }
-
-    override fun eval(
-        args: Array<out Any?>,
-        ec: EvaluationContext
-    ): Any {
+    override fun eval(args: Array<out Any>, ec: EvaluationContext): Any {
         try {
             val mapPoints = parseGeometry(args[0] as String, strict = true)
             val trace = Trace(mapPoints.map { it.toPoint() })

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ danlewAndroidJoda = { group = "net.danlew", name = "android.joda", version = "2.
 rarepebbleColorpicker = { group = "com.github.martin-stone", name = "hsv-alpha-color-picker-android", version = "3.1.0" }
 commonsIo = { group = "commons-io", name = "commons-io", version = "2.5" } # Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
 opencsv = { group = "com.opencsv", name = "opencsv", version = "5.12.0" }
-javarosa = { group = "org.getodk", name = "javarosa", version = "5.1.0" } # Online
+javarosa = { group = "org.getodk", name = "javarosa", version = "5.2.0-2e10861-SNAPSHOT" } # Online
 # javarosa = { group = "org.getodk", name = "javarosa", version = "local" } # Local
 karumiDexter = { group = "com.karumi", name = "dexter", version = "6.2.3" }
 zxingAndroidEmbedded = { group = "com.journeyapps", name = "zxing-android-embedded", version = "4.3.0" }


### PR DESCRIPTION
Closes #7002
Closes #7003
~~Blocked by https://github.com/getodk/javarosa/pull/840~~

#### Why is this the best possible solution? Were any other approaches considered?

The cause of the crashes was just that the underlying types being used for geoshape/trace answers was inconsistent: sometimes it was a string (`StringData`) and sometimes it was geo data (`GeoShapeData`/`GeoTraceData`). I could have updated the code to treat everything as strings, but instead I chose to use the geo specific data types throughout.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issues! Nothing is affected other than the geoshape/trace questions.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
