### PR TITLE
Adjust flexbox on repeat dialog

### DIFF
--- a/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
@@ -16,34 +16,35 @@
         app:layout_constraintEnd_toEndOf="parent"
         tools:text="Add person?" />
 
-    <com.google.android.flexbox.FlexboxLayout
-        android:layout_width="match_parent"
+    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+        android:id="@+id/do_not_add_button"
+        style="?materialButtonOutlinedIconStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/do_not_add_repeat"
+        app:icon="@drawable/ic_close_24"
+        app:iconGravity="textStart" />
+
+    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+        android:id="@+id/add_button"
+        style="?materialButtonIconStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/add_repeat"
+        app:icon="@drawable/ic_add_white_24"
+        app:iconGravity="textStart" />
+
+    <androidx.constraintlayout.helper.widget.Flow
+        android:id="@+id/button_flow"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_standard"
+        app:constraint_referenced_ids="do_not_add_button,add_button"
+        app:flow_wrapMode="chain"
+        app:flow_horizontalGap="@dimen/margin_standard"
+        app:flow_horizontalStyle="packed"
+        app:flow_horizontalBias="1"
         app:layout_constraintTop_toBottomOf="@id/message"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:flexDirection="row"
-        app:flexWrap="wrap"
-        app:justifyContent="flex_end">
-
-        <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
-            android:id="@+id/do_not_add_button"
-            style="?materialButtonOutlinedIconStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/do_not_add_repeat"
-            app:icon="@drawable/ic_close_24"
-            app:iconGravity="textStart" />
-
-        <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
-            android:id="@+id/add_button"
-            style="?materialButtonIconStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/add_repeat"
-            android:layout_marginStart="@dimen/margin_standard"
-            app:icon="@drawable/ic_add_white_24"
-            app:iconGravity="textStart" />
-    </com.google.android.flexbox.FlexboxLayout>
+        app:layout_constraintEnd_toEndOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/add_repeat_dialog_layout.xml
@@ -16,30 +16,34 @@
         app:layout_constraintEnd_toEndOf="parent"
         tools:text="Add person?" />
 
-    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
-        android:id="@+id/do_not_add_button"
-        style="?materialButtonOutlinedIconStyle"
-        android:layout_width="0dp"
+    <com.google.android.flexbox.FlexboxLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/do_not_add_repeat"
         android:layout_marginTop="@dimen/margin_standard"
-        app:icon="@drawable/ic_close_24"
-        app:iconGravity="textStart"
+        app:layout_constraintTop_toBottomOf="@id/message"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/message" />
+        app:flexDirection="row"
+        app:flexWrap="wrap"
+        app:justifyContent="flex_end">
 
-    <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
-        android:id="@+id/add_button"
-        style="?materialButtonIconStyle"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:text="@string/add_repeat"
-        android:layout_marginTop="@dimen/margin_extra_small"
-        app:icon="@drawable/ic_add_white_24"
-        app:iconGravity="textStart"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/do_not_add_button"/>
+        <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+            android:id="@+id/do_not_add_button"
+            style="?materialButtonOutlinedIconStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/do_not_add_repeat"
+            app:icon="@drawable/ic_close_24"
+            app:iconGravity="textStart" />
 
+        <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+            android:id="@+id/add_button"
+            style="?materialButtonIconStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/add_repeat"
+            android:layout_marginStart="@dimen/margin_standard"
+            app:icon="@drawable/ic_add_white_24"
+            app:iconGravity="textStart" />
+    </com.google.android.flexbox.FlexboxLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Closes #6994 

#### Why is this the best possible solution? Were any other approaches considered?
This is another attempt (hopefully the final one) to find the best approach for displaying the buttons in the `Add Repeat` dialog across devices with different screen sizes. The preferred layout is horizontal, but when there isn’t enough space, the buttons should be arranged vertically to avoid text being cut off.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The buttons should be displayed horizontally when there’s enough space, otherwise, they fall back to a vertical layout. However, I’m not entirely sure this works correctly on all devices as [the issue](https://github.com/getodk/collect/issues/6976) proves it can be tricky on some models, such as Redmi.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with repeats.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
