### PR TITLE
Add info button to trace/shape questions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
             if [[ -n "$GOOGLE_MAPS_API_KEY" ]]; then \
               ./check-size.sh 23117869
             else
-              ./check-size.sh 13841204
+              ./check-size.sh 13853041
             fi
 
       - run:

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequesterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequesterTest.java
@@ -2,6 +2,7 @@ package org.odk.collect.android.widgets.utilities;
 
 import androidx.activity.ComponentActivity;
 import androidx.lifecycle.MutableLiveData;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.javarosa.form.api.FormEntryPrompt;
@@ -31,6 +32,7 @@ public class InternalRecordingRequesterTest {
 
     @Before
     public void setup() {
+        ApplicationProvider.getApplicationContext().setTheme(com.google.android.material.R.style.Theme_MaterialComponents);
         ComponentActivity activity = Robolectric.buildActivity(ComponentActivity.class).get();
         when(audioRecorder.getCurrentSession()).thenReturn(new MutableLiveData<>(null));
 

--- a/geo/build.gradle.kts
+++ b/geo/build.gradle.kts
@@ -87,4 +87,6 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.androidxTestEspressoCore)
     testImplementation(libs.androidxArchCoreTesting)
+    testImplementation(libs.androidXComposeUiTestJunit4)
+    debugImplementation(libs.androidXComposeUiTestManifest)
 }

--- a/geo/build.gradle.kts
+++ b/geo/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.kotlinKapt)
+    alias(libs.plugins.composeCompiler)
 }
 
 apply(from = "../config/quality.gradle")
@@ -68,6 +69,11 @@ dependencies {
         exclude(group = "joda-time")
         exclude(group = "org.hamcrest", module = "hamcrest-all")
     }
+
+    implementation(libs.androidXComposeMaterial)
+    implementation(libs.androidXComposeMaterialIcons)
+    implementation(libs.androidXComposePreview)
+    debugImplementation(libs.androidXComposeTooling)
 
     debugImplementation(project(":fragments-test"))
 

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -183,7 +183,7 @@ class GeoPolyFragment @JvmOverloads constructor(
     fun initMap(newMapFragment: MapFragment?, binding: GeopolyLayoutBinding) {
         map = newMapFragment
 
-        binding.info.setOnClickListener { showInfoDialog() }
+        binding.info.setOnClickListener { showInfoDialog(false) }
         binding.clear.setOnClickListener { showClearDialog() }
         binding.pause.setOnClickListener {
             viewModel.stopRecording()
@@ -254,7 +254,7 @@ class GeoPolyFragment @JvmOverloads constructor(
             "",
             Snackbar.LENGTH_INDEFINITE,
             action = SnackbarUtils.Action(getString(string.how_to_modify)) {
-                showInfoDialog()
+                showInfoDialog(true)
             }
         )
         val viewData = viewModel.points.asLiveData().zip(invalidMessage)
@@ -561,8 +561,13 @@ class GeoPolyFragment @JvmOverloads constructor(
         }
     }
 
-    private fun showInfoDialog() {
-        InfoDialog.show(requireContext(), InfoDialog.Type.MANUAL_FROM_INFO_BUTTON)
+    private fun showInfoDialog(fromSnackbar: Boolean) {
+        val type = if (recordingAutomatic || recordingEnabled) {
+            InfoDialog.Type.MANUAL_OR_AUTOMATIC
+        } else {
+            InfoDialog.Type.PLACEMENT
+        }
+        InfoDialog.show(requireContext(), type, fromSnackbar)
     }
 
     private fun showClearDialog() {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -40,6 +40,7 @@ import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.maps.layers.OfflineMapLayersPickerBottomSheetDialogFragment
 import org.odk.collect.maps.layers.ReferenceLayerRepository
 import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.strings.R.string
 import org.odk.collect.webpage.WebPageService
 import javax.inject.Inject
 
@@ -182,7 +183,7 @@ class GeoPolyFragment @JvmOverloads constructor(
     fun initMap(newMapFragment: MapFragment?, binding: GeopolyLayoutBinding) {
         map = newMapFragment
 
-        binding.info.setOnClickListener { InfoDialog.show(requireContext(), InfoDialog.Type.MANUAL_FROM_INFO_BUTTON) }
+        binding.info.setOnClickListener { showInfoDialog() }
         binding.clear.setOnClickListener { showClearDialog() }
         binding.pause.setOnClickListener {
             viewModel.stopRecording()
@@ -248,7 +249,14 @@ class GeoPolyFragment @JvmOverloads constructor(
             }
         }
 
-        val snackbar = SnackbarUtils.make(requireView(), "", Snackbar.LENGTH_INDEFINITE)
+        val snackbar = SnackbarUtils.make(
+            requireView(),
+            "",
+            Snackbar.LENGTH_INDEFINITE,
+            action = SnackbarUtils.Action(getString(string.how_to_modify)) {
+                showInfoDialog()
+            }
+        )
         val viewData = viewModel.points.asLiveData().zip(invalidMessage)
         viewData.observe(viewLifecycleOwner) { (points, invalidMessage) ->
             val isValid = invalidMessage == null
@@ -551,6 +559,10 @@ class GeoPolyFragment @JvmOverloads constructor(
                 }
             }
         }
+    }
+
+    private fun showInfoDialog() {
+        InfoDialog.show(requireContext(), InfoDialog.Type.MANUAL_FROM_INFO_BUTTON)
     }
 
     private fun showClearDialog() {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -182,6 +182,7 @@ class GeoPolyFragment @JvmOverloads constructor(
     fun initMap(newMapFragment: MapFragment?, binding: GeopolyLayoutBinding) {
         map = newMapFragment
 
+        binding.info.setOnClickListener { InfoDialog.show(requireContext(), InfoDialog.Type.MANUAL_FROM_INFO_BUTTON) }
         binding.clear.setOnClickListener { showClearDialog() }
         binding.pause.setOnClickListener {
             viewModel.stopRecording()

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -550,12 +550,7 @@ class GeoPolyFragment @JvmOverloads constructor(
     }
 
     private fun showInfoDialog(fromSnackbar: Boolean) {
-        val type = if (viewModel.recordingMode != GeoPolyViewModel.RecordingMode.PLACEMENT) {
-            InfoDialog.Type.MANUAL_OR_AUTOMATIC
-        } else {
-            InfoDialog.Type.PLACEMENT
-        }
-        InfoDialog.show(requireContext(), type, fromSnackbar)
+        InfoDialog.show(requireContext(), viewModel, fromSnackbar)
     }
 
     private fun showClearDialog() {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
@@ -17,6 +17,16 @@ class GeoPolyViewModel(
     private val scheduler: Scheduler
 ) : ViewModel() {
 
+    enum class RecordingMode {
+        PLACEMENT, MANUAL, AUTOMATIC
+    }
+
+    var recordingMode: RecordingMode = RecordingMode.PLACEMENT
+        private set
+
+    var inputActive: Boolean = false
+        private set
+
     private val _points = MutableStateFlow(
         if (points.isNotEmpty()) {
             if (outputMode == OutputMode.GEOSHAPE) {
@@ -69,8 +79,21 @@ class GeoPolyViewModel(
     }
 
     fun stopRecording() {
+        disableInput()
         recording?.cancel()
         locationTracker.stop()
+    }
+
+    fun setRecordingMode(mode: RecordingMode) {
+        recordingMode = mode
+    }
+
+    fun enableInput() {
+        inputActive = true
+    }
+
+    fun disableInput() {
+        inputActive = false
     }
 
     override fun onCleared() {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
@@ -86,7 +86,7 @@ private fun PlacementFromSnackbarInfo(onDone: () -> Unit) {
 @Composable
 private fun PlacementFromInfoButtonInfo(onDone: () -> Unit) {
     InfoContent(
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.tap_to_add_a_point_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.AddLocation, stringResource(string.tap_to_add_a_point_info_item)),
         InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
         InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
         InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item)),
@@ -108,7 +108,7 @@ private fun ManualOrAutomaticFromSnackbarInfo(onDone: () -> Unit) {
 @Composable
 private fun ManualOrAutomaticFromInfoButtonInfo(onDone: () -> Unit) {
     InfoContent(
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.tap_to_add_a_point_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.AddLocation, stringResource(string.tap_to_add_a_point_info_item)),
         InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, stringResource(string.physically_move_to_correct_info_item)),
         InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
         InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
@@ -1,0 +1,198 @@
+package org.odk.collect.geo.geopoly
+
+import android.content.Context
+import androidx.appcompat.app.AlertDialog
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Backspace
+import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
+import androidx.compose.material.icons.filled.AddLocation
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.TouchApp
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.odk.collect.androidshared.R.dimen
+import org.odk.collect.androidshared.ui.ComposeThemeProvider.Companion.setContextThemedContent
+
+object InfoDialog {
+    data class InfoItem(
+        val icon: ImageVector,
+        val text: String
+    )
+
+    enum class Type {
+        PLACEMENT_FROM_SNACKBAR,
+        PLACEMENT_FROM_INFO_BUTTON,
+        MANUAL_FROM_SNACKBAR,
+        MANUAL_FROM_INFO_BUTTON,
+    }
+
+    fun show(context: Context, type: Type) {
+        var dialog: AlertDialog? = null
+
+        val info = ComposeView(context).apply {
+            setContextThemedContent {
+                when (type) {
+                    Type.PLACEMENT_FROM_SNACKBAR -> PlacementFromSnackbarInfo { dialog?.dismiss() }
+                    Type.PLACEMENT_FROM_INFO_BUTTON -> PlacementFromInfoButtonInfo { dialog?.dismiss() }
+                    Type.MANUAL_FROM_SNACKBAR -> ManualFromSnackbarInfo { dialog?.dismiss() }
+                    Type.MANUAL_FROM_INFO_BUTTON -> ManualFromInfoButtonInfo { dialog?.dismiss() }
+                }
+            }
+        }
+
+        dialog = MaterialAlertDialogBuilder(context)
+            .setView(info)
+            .show()
+    }
+}
+
+@Composable
+private fun PlacementFromSnackbarInfo(onDone: () -> Unit) {
+    InfoContent(
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Long press to move point"),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, "Remove last point"),
+        InfoDialog.InfoItem(Icons.Filled.Delete, "Delete shape to start over"),
+        InfoDialog.InfoItem(Icons.Filled.AddLocation, "Add point"),
+        onDone = onDone
+    )
+}
+
+@Composable
+private fun PlacementFromInfoButtonInfo(onDone: () -> Unit) {
+    InfoContent(
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Tap to add a point"),
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Long press to move point"),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, "Remove last point"),
+        InfoDialog.InfoItem(Icons.Filled.Delete, "Delete entire shape"),
+        onDone = onDone
+    )
+}
+
+@Composable
+private fun ManualFromSnackbarInfo(onDone: () -> Unit) {
+    InfoContent(
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, "Physically move to correct"),
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Long press to move point"),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, "Remove last point"),
+        InfoDialog.InfoItem(Icons.Filled.Delete, "Delete entire shape"),
+        onDone = onDone
+    )
+}
+
+@Composable
+private fun ManualFromInfoButtonInfo(onDone: () -> Unit) {
+    InfoContent(
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Tap to add a point"),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, "Physically move to correct"),
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Long press to move point"),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, "Remove last point"),
+        InfoDialog.InfoItem(Icons.Filled.Delete, "Delete entire shape"),
+        onDone = onDone
+    )
+}
+
+@Composable
+private fun Title() {
+    Text(
+        modifier = Modifier.padding(
+            start = dimensionResource(id = dimen.margin_standard),
+            top = dimensionResource(id = dimen.margin_extra_small),
+            bottom = dimensionResource(id = dimen.margin_standard)
+        ),
+        text = "How to modify the map",
+        style = MaterialTheme.typography.titleLarge
+    )
+}
+
+@Composable
+private fun Info(icon: ImageVector, text: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(dimensionResource(id = dimen.margin_standard)),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+        )
+        Text(
+            modifier = Modifier.padding(start = dimensionResource(id = dimen.margin_small)),
+            text = text,
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}
+
+@Composable
+private fun InfoContent(
+    vararg items: InfoDialog.InfoItem,
+    onDone: () -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(dimensionResource(id = dimen.margin_standard))
+    ) {
+        Title()
+        items.forEachIndexed { index, item ->
+            Info(item.icon, item.text)
+            if (index < items.lastIndex) {
+                HorizontalDivider(
+                    Modifier.padding(horizontal = dimensionResource(id = dimen.margin_small))
+                )
+            }
+        }
+        DoneButton(onDone)
+    }
+}
+
+@Composable
+private fun DoneButton(onDone: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = dimensionResource(id = dimen.margin_standard)),
+        horizontalArrangement = Arrangement.End
+    ) {
+        TextButton(onClick = onDone) {
+            Text("Done")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PlacementFromSnackbarInfoPreview() {
+    PlacementFromSnackbarInfo {}
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PlacementFromInfoButtonInfoPreview() {
+    PlacementFromInfoButtonInfo {}
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ManualFromSnackbarInfoPreview() {
+    ManualFromSnackbarInfo {}
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ManualFromInfoButtonInfoPreview() {
+    ManualFromInfoButtonInfo {}
+}

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
@@ -39,24 +39,20 @@ object InfoDialog {
         val text: String
     )
 
-    enum class Type {
-        PLACEMENT, MANUAL_OR_AUTOMATIC
-    }
-
-    fun show(context: Context, type: Type, fromSnackbar: Boolean) {
+    fun show(context: Context, viewModel: GeoPolyViewModel, fromSnackbar: Boolean) {
         var dialog: AlertDialog? = null
 
         val info = ComposeView(context).apply {
             setContextThemedContent {
-                when (type) {
-                    Type.PLACEMENT -> {
+                when (viewModel.recordingMode) {
+                    GeoPolyViewModel.RecordingMode.PLACEMENT -> {
                         if (fromSnackbar) {
                             PlacementFromSnackbarInfo { dialog?.dismiss() }
                         } else {
                             PlacementFromInfoButtonInfo { dialog?.dismiss() }
                         }
                     }
-                    Type.MANUAL_OR_AUTOMATIC -> {
+                    GeoPolyViewModel.RecordingMode.MANUAL, GeoPolyViewModel.RecordingMode.AUTOMATIC -> {
                         if (fromSnackbar) {
                             ManualOrAutomaticFromSnackbarInfo { dialog?.dismiss() }
                         } else {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
@@ -24,10 +24,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.androidshared.R.dimen
 import org.odk.collect.androidshared.ui.ComposeThemeProvider.Companion.setContextThemedContent
+import org.odk.collect.strings.R.string
 
 object InfoDialog {
     data class InfoItem(
@@ -64,11 +66,10 @@ object InfoDialog {
 
 @Composable
 private fun PlacementFromSnackbarInfo(onDone: () -> Unit) {
-    InfoContent(
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Long press to move point"),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, "Remove last point"),
-        InfoDialog.InfoItem(Icons.Filled.Delete, "Delete shape to start over"),
-        InfoDialog.InfoItem(Icons.Filled.AddLocation, "Add point"),
+    InfoContent(InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_shape_to_start_over_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.AddLocation, stringResource(string.add_point_info_item)),
         onDone = onDone
     )
 }
@@ -76,10 +77,10 @@ private fun PlacementFromSnackbarInfo(onDone: () -> Unit) {
 @Composable
 private fun PlacementFromInfoButtonInfo(onDone: () -> Unit) {
     InfoContent(
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Tap to add a point"),
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Long press to move point"),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, "Remove last point"),
-        InfoDialog.InfoItem(Icons.Filled.Delete, "Delete entire shape"),
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.tap_to_add_a_point_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item)),
         onDone = onDone
     )
 }
@@ -87,10 +88,10 @@ private fun PlacementFromInfoButtonInfo(onDone: () -> Unit) {
 @Composable
 private fun ManualFromSnackbarInfo(onDone: () -> Unit) {
     InfoContent(
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, "Physically move to correct"),
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Long press to move point"),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, "Remove last point"),
-        InfoDialog.InfoItem(Icons.Filled.Delete, "Delete entire shape"),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, stringResource(string.physically_move_to_correct_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item)),
         onDone = onDone
     )
 }
@@ -98,11 +99,11 @@ private fun ManualFromSnackbarInfo(onDone: () -> Unit) {
 @Composable
 private fun ManualFromInfoButtonInfo(onDone: () -> Unit) {
     InfoContent(
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Tap to add a point"),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, "Physically move to correct"),
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, "Long press to move point"),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, "Remove last point"),
-        InfoDialog.InfoItem(Icons.Filled.Delete, "Delete entire shape"),
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.tap_to_add_a_point_info_item)),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, stringResource(string.physically_move_to_correct_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
+        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
+        InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item)),
         onDone = onDone
     )
 }
@@ -115,7 +116,7 @@ private fun Title() {
             top = dimensionResource(id = dimen.margin_extra_small),
             bottom = dimensionResource(id = dimen.margin_standard)
         ),
-        text = "How to modify the map",
+        text = stringResource(string.how_to_modify_map),
         style = MaterialTheme.typography.titleLarge
     )
 }
@@ -164,11 +165,13 @@ private fun InfoContent(
 @Composable
 private fun DoneButton(onDone: () -> Unit) {
     Row(
-        modifier = Modifier.fillMaxWidth().padding(top = dimensionResource(id = dimen.margin_standard)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = dimensionResource(id = dimen.margin_standard)),
         horizontalArrangement = Arrangement.End
     ) {
         TextButton(onClick = onDone) {
-            Text("Done")
+            Text(stringResource(string.done))
         }
     }
 }

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Backspace
 import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
@@ -146,8 +148,12 @@ private fun InfoContent(
     vararg items: InfoDialog.InfoItem,
     onDone: () -> Unit
 ) {
+    val scrollState = rememberScrollState()
+
     Column(
-        modifier = Modifier.padding(dimensionResource(id = dimen.margin_standard))
+        modifier = Modifier
+            .padding(dimensionResource(id = dimen.margin_standard))
+            .verticalScroll(scrollState)
     ) {
         Title()
         items.forEachIndexed { index, item ->

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.androidshared.R.dimen
 import org.odk.collect.androidshared.ui.ComposeThemeProvider.Companion.setContextThemedContent
@@ -44,22 +43,7 @@ object InfoDialog {
 
         val info = ComposeView(context).apply {
             setContextThemedContent {
-                when (viewModel.recordingMode) {
-                    GeoPolyViewModel.RecordingMode.PLACEMENT -> {
-                        if (fromSnackbar) {
-                            PlacementFromSnackbarInfo { dialog?.dismiss() }
-                        } else {
-                            PlacementFromInfoButtonInfo { dialog?.dismiss() }
-                        }
-                    }
-                    GeoPolyViewModel.RecordingMode.MANUAL, GeoPolyViewModel.RecordingMode.AUTOMATIC -> {
-                        if (fromSnackbar) {
-                            ManualOrAutomaticFromSnackbarInfo { dialog?.dismiss() }
-                        } else {
-                            ManualOrAutomaticFromInfoButtonInfo { dialog?.dismiss() }
-                        }
-                    }
-                }
+                InfoContent(viewModel, fromSnackbar) { dialog?.dismiss() }
             }
         }
 
@@ -70,47 +54,67 @@ object InfoDialog {
 }
 
 @Composable
-private fun PlacementFromSnackbarInfo(onDone: () -> Unit) {
-    InfoContent(InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
-        InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_shape_to_start_over_info_item)),
-        InfoDialog.InfoItem(Icons.Filled.AddLocation, stringResource(string.add_point_info_item)),
-        onDone = onDone
-    )
-}
+fun InfoContent(
+    viewModel: GeoPolyViewModel,
+    fromSnackbar: Boolean,
+    onDone: () -> Unit
+) {
+    val items = when (viewModel.recordingMode) {
+        GeoPolyViewModel.RecordingMode.PLACEMENT -> {
+            if (fromSnackbar) {
+                listOf(
+                    InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
+                    InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
+                    InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_shape_to_start_over_info_item)),
+                    InfoDialog.InfoItem(Icons.Filled.AddLocation, stringResource(string.add_point_info_item))
+                )
+            } else {
+                listOf(
+                    InfoDialog.InfoItem(Icons.Filled.AddLocation, stringResource(string.tap_to_add_a_point_info_item)),
+                    InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
+                    InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
+                    InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item))
+                )
+            }
+        }
+        GeoPolyViewModel.RecordingMode.MANUAL, GeoPolyViewModel.RecordingMode.AUTOMATIC -> {
+            if (fromSnackbar) {
+                listOf(
+                    InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, stringResource(string.physically_move_to_correct_info_item)),
+                    InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
+                    InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
+                    InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item)),
+                )
+            } else {
+                listOf(
+                    InfoDialog.InfoItem(Icons.Filled.AddLocation, stringResource(string.tap_to_add_a_point_info_item)),
+                    InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, stringResource(string.physically_move_to_correct_info_item)),
+                    InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
+                    InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
+                    InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item))
+                )
+            }
+        }
+    }
 
-@Composable
-private fun PlacementFromInfoButtonInfo(onDone: () -> Unit) {
-    InfoContent(
-        InfoDialog.InfoItem(Icons.Filled.AddLocation, stringResource(string.tap_to_add_a_point_info_item)),
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
-        InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item)),
-        onDone = onDone
-    )
-}
+    val scrollState = rememberScrollState()
 
-@Composable
-private fun ManualOrAutomaticFromSnackbarInfo(onDone: () -> Unit) {
-    InfoContent(
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, stringResource(string.physically_move_to_correct_info_item)),
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
-        InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item)),
-        onDone = onDone
-    )
-}
-
-@Composable
-private fun ManualOrAutomaticFromInfoButtonInfo(onDone: () -> Unit) {
-    InfoContent(
-        InfoDialog.InfoItem(Icons.Filled.AddLocation, stringResource(string.tap_to_add_a_point_info_item)),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, stringResource(string.physically_move_to_correct_info_item)),
-        InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
-        InfoDialog.InfoItem(Icons.AutoMirrored.Filled.Backspace, stringResource(string.remove_last_point_info_item)),
-        InfoDialog.InfoItem(Icons.Filled.Delete, stringResource(string.delete_entire_shape_info_item)),
-        onDone = onDone
-    )
+    Column(
+        modifier = Modifier
+            .padding(dimensionResource(id = dimen.margin_standard))
+            .verticalScroll(scrollState)
+    ) {
+        Title()
+        items.forEachIndexed { index, item ->
+            Info(item.icon, item.text)
+            if (index < items.lastIndex) {
+                HorizontalDivider(
+                    Modifier.padding(horizontal = dimensionResource(id = dimen.margin_small))
+                )
+            }
+        }
+        DoneButton(onDone)
+    }
 }
 
 @Composable
@@ -147,31 +151,6 @@ private fun Info(icon: ImageVector, text: String) {
 }
 
 @Composable
-private fun InfoContent(
-    vararg items: InfoDialog.InfoItem,
-    onDone: () -> Unit
-) {
-    val scrollState = rememberScrollState()
-
-    Column(
-        modifier = Modifier
-            .padding(dimensionResource(id = dimen.margin_standard))
-            .verticalScroll(scrollState)
-    ) {
-        Title()
-        items.forEachIndexed { index, item ->
-            Info(item.icon, item.text)
-            if (index < items.lastIndex) {
-                HorizontalDivider(
-                    Modifier.padding(horizontal = dimensionResource(id = dimen.margin_small))
-                )
-            }
-        }
-        DoneButton(onDone)
-    }
-}
-
-@Composable
 private fun DoneButton(onDone: () -> Unit) {
     Row(
         modifier = Modifier
@@ -183,28 +162,4 @@ private fun DoneButton(onDone: () -> Unit) {
             Text(stringResource(string.done))
         }
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun PlacementFromSnackbarInfoPreview() {
-    PlacementFromSnackbarInfo {}
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun PlacementFromInfoButtonInfoPreview() {
-    PlacementFromInfoButtonInfo {}
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun ManualOrAutomaticFromSnackbarInfoPreview() {
-    ManualOrAutomaticFromSnackbarInfo {}
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun ManualOrAutomaticFromInfoButtonInfoPreview() {
-    ManualOrAutomaticFromInfoButtonInfo {}
 }

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
@@ -40,22 +40,29 @@ object InfoDialog {
     )
 
     enum class Type {
-        PLACEMENT_FROM_SNACKBAR,
-        PLACEMENT_FROM_INFO_BUTTON,
-        MANUAL_FROM_SNACKBAR,
-        MANUAL_FROM_INFO_BUTTON,
+        PLACEMENT, MANUAL_OR_AUTOMATIC
     }
 
-    fun show(context: Context, type: Type) {
+    fun show(context: Context, type: Type, fromSnackbar: Boolean) {
         var dialog: AlertDialog? = null
 
         val info = ComposeView(context).apply {
             setContextThemedContent {
                 when (type) {
-                    Type.PLACEMENT_FROM_SNACKBAR -> PlacementFromSnackbarInfo { dialog?.dismiss() }
-                    Type.PLACEMENT_FROM_INFO_BUTTON -> PlacementFromInfoButtonInfo { dialog?.dismiss() }
-                    Type.MANUAL_FROM_SNACKBAR -> ManualFromSnackbarInfo { dialog?.dismiss() }
-                    Type.MANUAL_FROM_INFO_BUTTON -> ManualFromInfoButtonInfo { dialog?.dismiss() }
+                    Type.PLACEMENT -> {
+                        if (fromSnackbar) {
+                            PlacementFromSnackbarInfo { dialog?.dismiss() }
+                        } else {
+                            PlacementFromInfoButtonInfo { dialog?.dismiss() }
+                        }
+                    }
+                    Type.MANUAL_OR_AUTOMATIC -> {
+                        if (fromSnackbar) {
+                            ManualOrAutomaticFromSnackbarInfo { dialog?.dismiss() }
+                        } else {
+                            ManualOrAutomaticFromInfoButtonInfo { dialog?.dismiss() }
+                        }
+                    }
                 }
             }
         }
@@ -88,7 +95,7 @@ private fun PlacementFromInfoButtonInfo(onDone: () -> Unit) {
 }
 
 @Composable
-private fun ManualFromSnackbarInfo(onDone: () -> Unit) {
+private fun ManualOrAutomaticFromSnackbarInfo(onDone: () -> Unit) {
     InfoContent(
         InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, stringResource(string.physically_move_to_correct_info_item)),
         InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.long_press_to_move_point_info_item)),
@@ -99,7 +106,7 @@ private fun ManualFromSnackbarInfo(onDone: () -> Unit) {
 }
 
 @Composable
-private fun ManualFromInfoButtonInfo(onDone: () -> Unit) {
+private fun ManualOrAutomaticFromInfoButtonInfo(onDone: () -> Unit) {
     InfoContent(
         InfoDialog.InfoItem(Icons.Filled.TouchApp, stringResource(string.tap_to_add_a_point_info_item)),
         InfoDialog.InfoItem(Icons.AutoMirrored.Filled.DirectionsWalk, stringResource(string.physically_move_to_correct_info_item)),
@@ -196,12 +203,12 @@ private fun PlacementFromInfoButtonInfoPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun ManualFromSnackbarInfoPreview() {
-    ManualFromSnackbarInfo {}
+private fun ManualOrAutomaticFromSnackbarInfoPreview() {
+    ManualOrAutomaticFromSnackbarInfo {}
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun ManualFromInfoButtonInfoPreview() {
-    ManualFromInfoButtonInfo {}
+private fun ManualOrAutomaticFromInfoButtonInfoPreview() {
+    ManualOrAutomaticFromInfoButtonInfo {}
 }

--- a/geo/src/main/res/drawable/ic_info.xml
+++ b/geo/src/main/res/drawable/ic_info.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?colorOnSurface">
+      
+    <path
+        android:fillColor="?colorOnSurface"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"/>
+</vector>

--- a/geo/src/main/res/layout-land/geopoly_layout.xml
+++ b/geo/src/main/res/layout-land/geopoly_layout.xml
@@ -60,6 +60,19 @@
         app:srcCompat="@drawable/ic_layers" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/info"
+        style="@style/Widget.Geo.FloatingActionButton.Map.Small.Surface"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_standard"
+        android:theme="@style/Theme.Geo.ForceLightSurface.Overlay"
+        android:layout_marginEnd="@dimen/margin_standard"
+        android:contentDescription="@string/show_how_to_modify_map"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layers"
+        app:srcCompat="@drawable/ic_info" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/play"
         style="@style/Widget.Geo.FloatingActionButton.Map.Surface"
         android:layout_width="wrap_content"

--- a/geo/src/main/res/layout/geopoly_layout.xml
+++ b/geo/src/main/res/layout/geopoly_layout.xml
@@ -40,7 +40,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_standard"
         android:layout_marginEnd="@dimen/margin_standard"
-        android:contentDescription="@string/show_my_location"
+        android:contentDescription="@string/show_how_to_modify_map"
         android:theme="@style/Theme.Geo.ForceLightSurface.Overlay"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/location_status"
@@ -58,6 +58,19 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/zoom"
         app:srcCompat="@drawable/ic_layers" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/info"
+        style="@style/Widget.Geo.FloatingActionButton.Map.Small.Surface"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_standard"
+        android:layout_marginEnd="@dimen/margin_standard"
+        android:contentDescription="@string/layer_data_file"
+        android:theme="@style/Theme.Geo.ForceLightSurface.Overlay"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layers"
+        app:srcCompat="@drawable/ic_info" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/play"

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/InfoContentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/InfoContentTest.kt
@@ -14,7 +14,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
-class InfoDialogTest {
+class InfoContentTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/InfoContentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/InfoContentTest.kt
@@ -4,9 +4,12 @@ import android.app.Application
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,7 +31,7 @@ class InfoContentTest {
         }
 
         composeTestRule.setContent {
-            InfoContent(viewModel, fromSnackbar = true, {})
+            InfoContent(viewModel, fromSnackbar = true) {}
         }
 
         assertInfo(
@@ -48,7 +51,7 @@ class InfoContentTest {
         }
 
         composeTestRule.setContent {
-            InfoContent(viewModel, fromSnackbar = false, {})
+            InfoContent(viewModel, fromSnackbar = false) {}
         }
 
         assertInfo(
@@ -68,7 +71,7 @@ class InfoContentTest {
         }
 
         composeTestRule.setContent {
-            InfoContent(viewModel, fromSnackbar = true, {})
+            InfoContent(viewModel, fromSnackbar = true) {}
         }
 
         assertInfo(
@@ -88,7 +91,7 @@ class InfoContentTest {
         }
 
         composeTestRule.setContent {
-            InfoContent(viewModel, fromSnackbar = false, {})
+            InfoContent(viewModel, fromSnackbar = false) {}
         }
 
         assertInfo(
@@ -109,7 +112,7 @@ class InfoContentTest {
         }
 
         composeTestRule.setContent {
-            InfoContent(viewModel, fromSnackbar = true, {})
+            InfoContent(viewModel, fromSnackbar = true) {}
         }
 
         assertInfo(
@@ -129,7 +132,7 @@ class InfoContentTest {
         }
 
         composeTestRule.setContent {
-            InfoContent(viewModel, fromSnackbar = false, {})
+            InfoContent(viewModel, fromSnackbar = false) {}
         }
 
         assertInfo(
@@ -141,6 +144,26 @@ class InfoContentTest {
                 org.odk.collect.strings.R.string.delete_entire_shape_info_item,
             )
         )
+    }
+
+    @Test
+    fun `calls onDone when Done button is clicked`() {
+        val viewModel = mock<GeoPolyViewModel>().apply {
+            whenever(recordingMode).thenReturn(GeoPolyViewModel.RecordingMode.PLACEMENT)
+        }
+
+        var onDoneCalled = false
+
+        composeTestRule.setContent {
+            InfoContent(viewModel, false) { onDoneCalled = true }
+        }
+
+        composeTestRule
+            .onNodeWithText(context.getString(org.odk.collect.strings.R.string.done))
+            .assertIsDisplayed()
+            .performClick()
+
+        assertThat(onDoneCalled, equalTo(true))
     }
 
     private fun assertInfo(items: List<Int>) {

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/InfoDialogTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/InfoDialogTest.kt
@@ -1,0 +1,154 @@
+package org.odk.collect.geo.geopoly
+
+import android.app.Application
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class InfoDialogTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    @Test
+    fun `shows dialog content from snackbar in PLACEMENT mode`() {
+        val viewModel = mock<GeoPolyViewModel>().apply {
+            whenever(recordingMode).thenReturn(GeoPolyViewModel.RecordingMode.PLACEMENT)
+        }
+
+        composeTestRule.setContent {
+            InfoContent(viewModel, fromSnackbar = true, {})
+        }
+
+        assertInfo(
+            listOf(
+                org.odk.collect.strings.R.string.long_press_to_move_point_info_item,
+                org.odk.collect.strings.R.string.remove_last_point_info_item,
+                org.odk.collect.strings.R.string.delete_shape_to_start_over_info_item,
+                org.odk.collect.strings.R.string.add_point_info_item,
+            )
+        )
+    }
+
+    @Test
+    fun `shows dialog content from info button in PLACEMENT mode`() {
+        val viewModel = mock<GeoPolyViewModel>().apply {
+            whenever(recordingMode).thenReturn(GeoPolyViewModel.RecordingMode.PLACEMENT)
+        }
+
+        composeTestRule.setContent {
+            InfoContent(viewModel, fromSnackbar = false, {})
+        }
+
+        assertInfo(
+            listOf(
+                org.odk.collect.strings.R.string.tap_to_add_a_point_info_item,
+                org.odk.collect.strings.R.string.long_press_to_move_point_info_item,
+                org.odk.collect.strings.R.string.remove_last_point_info_item,
+                org.odk.collect.strings.R.string.delete_entire_shape_info_item,
+            )
+        )
+    }
+
+    @Test
+    fun `shows dialog content from snackbar in MANUAL mode`() {
+        val viewModel = mock<GeoPolyViewModel>().apply {
+            whenever(recordingMode).thenReturn(GeoPolyViewModel.RecordingMode.MANUAL)
+        }
+
+        composeTestRule.setContent {
+            InfoContent(viewModel, fromSnackbar = true, {})
+        }
+
+        assertInfo(
+            listOf(
+                org.odk.collect.strings.R.string.physically_move_to_correct_info_item,
+                org.odk.collect.strings.R.string.long_press_to_move_point_info_item,
+                org.odk.collect.strings.R.string.remove_last_point_info_item,
+                org.odk.collect.strings.R.string.delete_entire_shape_info_item,
+            )
+        )
+    }
+
+    @Test
+    fun `shows dialog content from info button in MANUAL mode`() {
+        val viewModel = mock<GeoPolyViewModel>().apply {
+            whenever(recordingMode).thenReturn(GeoPolyViewModel.RecordingMode.MANUAL)
+        }
+
+        composeTestRule.setContent {
+            InfoContent(viewModel, fromSnackbar = false, {})
+        }
+
+        assertInfo(
+            listOf(
+                org.odk.collect.strings.R.string.tap_to_add_a_point_info_item,
+                org.odk.collect.strings.R.string.physically_move_to_correct_info_item,
+                org.odk.collect.strings.R.string.long_press_to_move_point_info_item,
+                org.odk.collect.strings.R.string.remove_last_point_info_item,
+                org.odk.collect.strings.R.string.delete_entire_shape_info_item,
+            )
+        )
+    }
+
+    @Test
+    fun `shows dialog content from snackbar in AUTOMATIC mode`() {
+        val viewModel = mock<GeoPolyViewModel>().apply {
+            whenever(recordingMode).thenReturn(GeoPolyViewModel.RecordingMode.AUTOMATIC)
+        }
+
+        composeTestRule.setContent {
+            InfoContent(viewModel, fromSnackbar = true, {})
+        }
+
+        assertInfo(
+            listOf(
+                org.odk.collect.strings.R.string.physically_move_to_correct_info_item,
+                org.odk.collect.strings.R.string.long_press_to_move_point_info_item,
+                org.odk.collect.strings.R.string.remove_last_point_info_item,
+                org.odk.collect.strings.R.string.delete_entire_shape_info_item,
+            )
+        )
+    }
+
+    @Test
+    fun `shows dialog content from info button in AUTOMATIC mode`() {
+        val viewModel = mock<GeoPolyViewModel>().apply {
+            whenever(recordingMode).thenReturn(GeoPolyViewModel.RecordingMode.AUTOMATIC)
+        }
+
+        composeTestRule.setContent {
+            InfoContent(viewModel, fromSnackbar = false, {})
+        }
+
+        assertInfo(
+            listOf(
+                org.odk.collect.strings.R.string.tap_to_add_a_point_info_item,
+                org.odk.collect.strings.R.string.physically_move_to_correct_info_item,
+                org.odk.collect.strings.R.string.long_press_to_move_point_info_item,
+                org.odk.collect.strings.R.string.remove_last_point_info_item,
+                org.odk.collect.strings.R.string.delete_entire_shape_info_item,
+            )
+        )
+    }
+
+    private fun assertInfo(items: List<Int>) {
+        items.forEach {
+            composeTestRule
+                .onNodeWithText(context.getString(it))
+                .performScrollTo()
+                .assertIsDisplayed()
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ androidXComposeMaterialIconsExtended = { group = "androidx.compose.material", na
 androidXComposePreview = { group = "androidx.compose.ui", name = "ui-tooling-preview"}
 androidXComposeTooling = { group = "androidx.compose.ui", name = "ui-tooling"}
 androidXComposeUiTestJunit4 = { group = "androidx.compose.ui", name = "ui-test-junit4"}
+androidXComposeUiTestManifest = { group = "androidx.compose.ui", name = "ui-test-manifest"}
 androidXConstraintLayoutCompose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version = "1.1.1" }
 androidXComposeMaterialIcons = { group = "androidx.compose.material", name = "material-icons-extended", version ="1.7.8"}
 playServicesMaps = { group = "com.google.android.gms", name = "play-services-maps", version = "19.2.0" }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -683,6 +683,9 @@
     <!-- Description for button that removes the last recorded point -->
     <string name="remove_last_point">Remove last point</string>
 
+    <!-- Description for button that explains how to modify the map -->
+    <string name="show_how_to_modify_map">Show how to modify the map</string>
+
     <!--
     ##############################################
     # SEND FINALIZED FORM

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -686,6 +686,33 @@
     <!-- Description for button that explains how to modify the map -->
     <string name="show_how_to_modify_map">Show how to modify the map</string>
 
+    <!-- Title for instructions on how to modify map features -->
+    <string name="how_to_modify_map">How to modify the map</string>
+
+    <!-- Instruction in a list on how to move a point -->
+    <string name="long_press_to_move_point_info_item">Long press to move point</string>
+
+    <!-- Instruction in a list on how to remove the most recently added point -->
+    <string name="remove_last_point_info_item">Remove last point</string>
+
+    <!-- Instruction in a list on how to delete the current shape to start over -->
+    <string name="delete_shape_to_start_over_info_item">Delete shape to start over</string>
+
+    <!-- Instruction in a list on how to add a new point -->
+    <string name="add_point_info_item">Add point</string>
+
+    <!-- Instruction in a list on how to tap to add a point -->
+    <string name="tap_to_add_a_point_info_item">Tap to add a point</string>
+
+    <!-- Instruction in a list on how to delete the entire shape -->
+    <string name="delete_entire_shape_info_item">Delete entire shape</string>
+
+    <!-- Instruction in a list on how to correct map features -->
+    <string name="physically_move_to_correct_info_item">Physically move to correct</string>
+
+    <!-- Button text to close the instructions dialog -->
+    <string name="done">Done</string>
+
     <!--
     ##############################################
     # SEND FINALIZED FORM

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -713,6 +713,9 @@
     <!-- Button text to close the instructions dialog -->
     <string name="done">Done</string>
 
+    <!-- Button text to open the instructions dialog from the error snackbar -->
+    <string name="how_to_modify">How to modify</string>
+
     <!--
     ##############################################
     # SEND FINALIZED FORM


### PR DESCRIPTION
Closes #6961 

#### Why is this the best possible solution? Were any other approaches considered?
The main thing worth mentioning is that I built the dialog’s UI using `Jetpack Compose`, but I wrapped it inside a `ComposeView` so it can be used from a regular `DialogFragment`. The rest of the screen where this “info” dialog is opened is still based on the legacy XML view system, so embedding `Compose` this way keeps the integration simple and avoids a bigger refactor.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is a fairly isolated change. It should be enough to ensure that the correct content is displayed depending on the circumstances described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `geotrace`/`geoshape` questions.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
