### PR TITLE
Display snackbar in geoshape/trace when automatic location recording is used

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -242,7 +242,6 @@ class GeoPolyFragment @JvmOverloads constructor(
         map!!.setRetainMockAccuracy(retainMockAccuracy)
         map!!.setDragEndListener {
             viewModel.update(map!!.getPolyPoints(it))
-            setChangeResult()
         }
 
         if (!map!!.hasCenter()) {
@@ -280,6 +279,7 @@ class GeoPolyFragment @JvmOverloads constructor(
             }
 
             updateUi()
+            setChangeResult()
         }
     }
 
@@ -395,7 +395,6 @@ class GeoPolyFragment @JvmOverloads constructor(
     private fun onClick(point: MapPoint) {
         if (inputActive && !recordingEnabled) {
             viewModel.add(point)
-            setChangeResult()
         }
     }
 
@@ -417,7 +416,6 @@ class GeoPolyFragment @JvmOverloads constructor(
     private fun recordPoint(point: MapPoint?) {
         if (point != null && isLocationAcceptable(point)) {
             viewModel.add(point)
-            setChangeResult()
         }
     }
 
@@ -438,14 +436,12 @@ class GeoPolyFragment @JvmOverloads constructor(
     private fun removeLastPoint() {
         if (featureId != -1) {
             viewModel.removeLast()
-            setChangeResult()
         }
     }
 
     private fun clear() {
         inputActive = false
         viewModel.update(emptyList())
-        setChangeResult()
     }
 
     /** Updates the state of various UI widgets to reflect internal state.  */


### PR DESCRIPTION
Closes #7036

#### Why is this the best possible solution? Were any other approaches considered?
We used to call `#setChangeResult` separately for each case (adding points manually, removing them, dragging, etc.). This was error-prone, as it could be missed in some scenarios, which is what caused this issue. Instead, we should call it whenever the list of points is updated.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should simply fix te issue. 

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is linked in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
