### PR TITLE
Separate validationResult and constraintValidationResult

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryViewModelFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryViewModelFactory.kt
@@ -1,9 +1,9 @@
 package org.odk.collect.android.activities
 
-import androidx.lifecycle.AbstractSavedStateViewModelFactory
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.savedstate.SavedStateRegistryOwner
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
 import org.javarosa.core.model.actions.recordaudio.RecordAudioActions
 import org.javarosa.core.model.instance.TreeReference
 import org.odk.collect.android.entities.EntitiesRepositoryProvider
@@ -28,6 +28,7 @@ import org.odk.collect.android.utilities.FormsRepositoryProvider
 import org.odk.collect.android.utilities.InstancesRepositoryProvider
 import org.odk.collect.android.utilities.MediaUtils
 import org.odk.collect.android.utilities.SavepointsRepositoryProvider
+import org.odk.collect.android.widgets.viewmodels.QuestionViewModel
 import org.odk.collect.async.Scheduler
 import org.odk.collect.audiorecorder.recording.AudioRecorder
 import org.odk.collect.location.LocationClient
@@ -39,7 +40,6 @@ import org.odk.collect.settings.SettingsProvider
 import java.util.function.BiConsumer
 
 class FormEntryViewModelFactory(
-    owner: SavedStateRegistryOwner,
     private val mode: String?,
     private val sessionId: String,
     private val scheduler: Scheduler,
@@ -60,13 +60,9 @@ class FormEntryViewModelFactory(
     private val htmlPrinter: HtmlPrinter,
     private val instancesDataService: InstancesDataService,
     private val changeLockProvider: ChangeLockProvider
-) : AbstractSavedStateViewModelFactory(owner, null) {
+) : ViewModelProvider.Factory {
 
-    override fun <T : ViewModel> create(
-        key: String,
-        modelClass: Class<T>,
-        handle: SavedStateHandle
-    ): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
         val projectId = projectsDataService.requireCurrentProject().uuid
 
         return when (modelClass) {
@@ -81,7 +77,7 @@ class FormEntryViewModelFactory(
 
             FormSaveViewModel::class.java -> {
                 FormSaveViewModel(
-                    handle,
+                    extras.createSavedStateHandle(),
                     System::currentTimeMillis,
                     DiskFormSaver(),
                     mediaUtils,
@@ -151,6 +147,8 @@ class FormEntryViewModelFactory(
             )
 
             PrinterWidgetViewModel::class.java -> PrinterWidgetViewModel(scheduler, qrCodeCreator, htmlPrinter)
+
+            QuestionViewModel::class.java -> QuestionViewModel(scheduler, formSessionRepository, sessionId)
 
             else -> throw IllegalArgumentException()
         } as T

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -412,7 +412,7 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
             sessionId = savedInstanceState.getString(KEY_SESSION_ID);
         }
 
-        viewModelFactory = new FormEntryViewModelFactory(this,
+        viewModelFactory = new FormEntryViewModelFactory(
                 getIntent().getStringExtra(FormOpeningMode.FORM_MODE_KEY),
                 sessionId,
                 scheduler,

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -65,6 +65,8 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
     private final MutableLiveData<Triple<FormIndex, FormIndex, FailedValidationResult>> currentIndex = new MutableLiveData<>(null);
     private final MutableLiveData<Consumable<ValidationResult>>
             validationResult = new MutableLiveData<>(new Consumable<>(null));
+    private final MutableLiveData<Consumable<ValidationResult>>
+            constraintValidationResult = new MutableLiveData<>(new Consumable<>(null));
     @NonNull
     private final FormSessionRepository formSessionRepository;
     private final String sessionId;
@@ -127,6 +129,10 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
     public LiveData<Consumable<ValidationResult>> getValidationResult() {
         return validationResult;
+    }
+
+    public LiveData<Consumable<ValidationResult>> getConstraintValidationResult() {
+        return constraintValidationResult;
     }
 
     public NonNullLiveData<Boolean> isLoading() {
@@ -394,11 +400,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
     public void validateAnswerConstraint(FormIndex index, IAnswerData answer) {
         worker.immediate(() -> {
             ValidationResult result = formController.validateAnswerConstraint(index, answer);
-            if (result instanceof FailedValidationResult) {
-                validationResult.postValue(new Consumable<>(result));
-            } else {
-                validationResult.postValue(new Consumable<>(null));
-            }
+            constraintValidationResult.postValue(new Consumable<>(result));
         });
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -65,8 +65,6 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
     private final MutableLiveData<Triple<FormIndex, FormIndex, FailedValidationResult>> currentIndex = new MutableLiveData<>(null);
     private final MutableLiveData<Consumable<ValidationResult>>
             validationResult = new MutableLiveData<>(new Consumable<>(null));
-    private final MutableLiveData<Consumable<ValidationResult>>
-            constraintValidationResult = new MutableLiveData<>(new Consumable<>(null));
     @NonNull
     private final FormSessionRepository formSessionRepository;
     private final String sessionId;
@@ -129,10 +127,6 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
     public LiveData<Consumable<ValidationResult>> getValidationResult() {
         return validationResult;
-    }
-
-    public LiveData<Consumable<ValidationResult>> getConstraintValidationResult() {
-        return constraintValidationResult;
     }
 
     public NonNullLiveData<Boolean> isLoading() {
@@ -395,13 +389,6 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         formSessionRepository.clear(sessionId);
         ReferenceManager.instance().reset();
         changeLocks.getFormsLock().unlock(FORM_ENTRY_TOKEN);
-    }
-
-    public void validateAnswerConstraint(FormIndex index, IAnswerData answer) {
-        worker.immediate(() -> {
-            ValidationResult result = formController.validateAnswerConstraint(index, answer);
-            constraintValidationResult.postValue(new Consumable<>(result));
-        });
     }
 
     public void validateForm() {

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragmentHostActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragmentHostActivity.kt
@@ -86,7 +86,6 @@ class FormHierarchyFragmentHostActivity : LocalizedActivity() {
     private val sessionId by lazy { intent.getStringExtra(EXTRA_SESSION_ID)!! }
     private val viewModelFactory by lazy {
         FormEntryViewModelFactory(
-            this,
             FormOpeningMode.EDIT_SAVED,
             sessionId,
             scheduler,

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -7,7 +7,6 @@ import org.javarosa.core.model.Constants
 import org.javarosa.core.model.data.GeoShapeData
 import org.javarosa.core.model.data.GeoTraceData
 import org.javarosa.core.model.data.IAnswerData
-import org.javarosa.form.api.FormEntryController
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.javarosawrapper.FailedValidationResult
 import org.odk.collect.android.utilities.FormEntryPromptUtils
@@ -65,12 +64,9 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
             prompt.isReadOnly,
             retainMockAccuracy,
             inputPolygon,
-            validationResult.map {
+            constraintValidationResult.map {
                 val validationResult = it.value
-                if (validationResult is FailedValidationResult &&
-                    validationResult.index == prompt.index &&
-                    validationResult.status == FormEntryController.ANSWER_CONSTRAINT_VIOLATED
-                ) {
+                if (validationResult is FailedValidationResult && validationResult.index == prompt.index) {
                     validationResult.customErrorMessage ?: getString(validationResult.defaultErrorMessage)
                 } else {
                     null

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/WidgetAnswerDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/WidgetAnswerDialogFragment.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import org.javarosa.core.model.FormIndex
 import org.javarosa.core.model.data.IAnswerData
@@ -16,6 +17,7 @@ import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.R
 import org.odk.collect.android.databinding.WidgetAnswerDialogLayoutBinding
 import org.odk.collect.android.formentry.FormEntryViewModel
+import org.odk.collect.android.widgets.viewmodels.QuestionViewModel
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.material.MaterialFullScreenDialogFragment
 import kotlin.reflect.KClass
@@ -26,18 +28,18 @@ abstract class WidgetAnswerDialogFragment<T : Fragment>(
 ) : MaterialFullScreenDialogFragment() {
 
     private val formEntryViewModel: FormEntryViewModel by activityViewModels { viewModelFactory }
+    private val questionViewModel: QuestionViewModel by viewModels { viewModelFactory }
     private val prompt: FormEntryPrompt by lazy {
         formEntryViewModel.getQuestionPrompt(requireArguments().getSerializable(ARG_FORM_INDEX) as FormIndex)
     }
     protected val constraintValidationResult by lazy {
-        formEntryViewModel.constraintValidationResult
+        questionViewModel.constraintValidationResult
     }
 
     abstract fun onCreateFragment(prompt: FormEntryPrompt): T
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-
         childFragmentManager.fragmentFactory = FragmentFactoryBuilder()
             .forClass(type) { onCreateFragment(prompt) }
             .build()
@@ -73,7 +75,7 @@ abstract class WidgetAnswerDialogFragment<T : Fragment>(
     }
 
     fun onValidate(answer: IAnswerData?) {
-        formEntryViewModel.validateAnswerConstraint(prompt.index, answer)
+        questionViewModel.validate(prompt.index, answer)
     }
 
     fun onAnswer(answer: IAnswerData?) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/WidgetAnswerDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/WidgetAnswerDialogFragment.kt
@@ -29,8 +29,8 @@ abstract class WidgetAnswerDialogFragment<T : Fragment>(
     private val prompt: FormEntryPrompt by lazy {
         formEntryViewModel.getQuestionPrompt(requireArguments().getSerializable(ARG_FORM_INDEX) as FormIndex)
     }
-    protected val validationResult by lazy {
-        formEntryViewModel.validationResult
+    protected val constraintValidationResult by lazy {
+        formEntryViewModel.constraintValidationResult
     }
 
     abstract fun onCreateFragment(prompt: FormEntryPrompt): T

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/viewmodels/QuestionViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/viewmodels/QuestionViewModel.kt
@@ -1,0 +1,41 @@
+package org.odk.collect.android.widgets.viewmodels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import org.javarosa.core.model.FormIndex
+import org.javarosa.core.model.data.IAnswerData
+import org.odk.collect.android.formentry.FormSession
+import org.odk.collect.android.formentry.FormSessionRepository
+import org.odk.collect.android.javarosawrapper.FormController
+import org.odk.collect.android.javarosawrapper.ValidationResult
+import org.odk.collect.androidshared.data.Consumable
+import org.odk.collect.androidshared.livedata.LiveDataUtils
+import org.odk.collect.async.Scheduler
+
+class QuestionViewModel(
+    private val scheduler: Scheduler,
+    formSessionRepository: FormSessionRepository,
+    sessionId: String
+) : ViewModel() {
+    private val _constraintValidationResult: MutableLiveData<Consumable<ValidationResult>> = MutableLiveData()
+    val constraintValidationResult: LiveData<Consumable<ValidationResult>> = _constraintValidationResult
+    private var formController: FormController? = null
+    private var formSessionObserver = LiveDataUtils.observe(
+        formSessionRepository.get(sessionId)
+    ) { formSession: FormSession ->
+        formController = formSession.formController
+    }
+
+    fun validate(index: FormIndex, answer: IAnswerData?) {
+        scheduler.immediate {
+            formController?.validateAnswerConstraint(index, answer)?.let {
+                _constraintValidationResult.postValue(Consumable(it))
+            }
+        }
+    }
+
+    override fun onCleared() {
+        formSessionObserver.cancel()
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -457,7 +457,7 @@ public class FormEntryViewModelTest {
     }
 
     @Test
-    public void validateAnswerConstraint_updatesValidationResult_ifIsIsFailedValidationResult() {
+    public void validateAnswerConstraint_updatesConstraintValidationResult_ifIsIsFailedValidationResult() {
         FormDef formDef = mock();
         when(formDef.evaluateConstraint(any(), any())).thenReturn(false);
         formController.setFormDef(formDef);
@@ -473,24 +473,7 @@ public class FormEntryViewModelTest {
 
         viewModel.validateAnswerConstraint(formIndex, new StringData("answer"));
         scheduler.flush(true);
-        assertThat(viewModel.getValidationResult().getValue().getValue(), equalTo(failedValidationResult));
-    }
-
-    @Test
-    public void validateAnswerConstraint_clearsResult_ifItIsSuccessValidationResult() {
-        FormDef formDef = mock();
-        when(formDef.evaluateConstraint(any(), any())).thenReturn(false);
-        formController.setFormDef(formDef);
-
-        TreeReference reference = new TreeReference();
-        reference.add("blah", TreeReference.INDEX_UNBOUND);
-        FormIndex formIndex = new FormIndex(null, 1, 1, reference);
-        FormEntryPrompt prompt = new MockFormEntryPromptBuilder().build();
-        formController.setPrompt(formIndex, prompt);
-
-        viewModel.validateAnswerConstraint(formIndex, new StringData("answer"));
-        scheduler.flush(true);
-        assertThat(viewModel.getValidationResult().getValue().getValue(), equalTo(null));
+        assertThat(viewModel.getConstraintValidationResult().getValue().getValue(), equalTo(failedValidationResult));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.javarosa.core.model.Constants.CONTROL_SELECT_ONE;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -454,26 +453,6 @@ public class FormEntryViewModelTest {
         viewModel.answerQuestion(formIndex, new StringData("answer"));
         scheduler.flush(true);
         assertThat(formController.getAnswer(formIndex.getReference()).getValue(), equalTo("answer"));
-    }
-
-    @Test
-    public void validateAnswerConstraint_updatesConstraintValidationResult_ifIsIsFailedValidationResult() {
-        FormDef formDef = mock();
-        when(formDef.evaluateConstraint(any(), any())).thenReturn(false);
-        formController.setFormDef(formDef);
-
-        TreeReference reference = new TreeReference();
-        reference.add("blah", TreeReference.INDEX_UNBOUND);
-        FormIndex formIndex = new FormIndex(null, 1, 1, reference);
-        FormEntryPrompt prompt = new MockFormEntryPromptBuilder().build();
-        formController.setPrompt(formIndex, prompt);
-
-        FailedValidationResult failedValidationResult = new FailedValidationResult(formIndex, 0, null, org.odk.collect.strings.R.string.invalid_answer_error);
-        formController.setFailedConstraint(failedValidationResult);
-
-        viewModel.validateAnswerConstraint(formIndex, new StringData("answer"));
-        scheduler.flush(true);
-        assertThat(viewModel.getConstraintValidationResult().getValue().getValue(), equalTo(failedValidationResult));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -45,12 +45,12 @@ import org.odk.collect.testshared.getOrAwaitValue
 class GeoPolyDialogFragmentTest {
 
     private var prompt = MockFormEntryPromptBuilder().build()
-    private val validationResult = MutableLiveData<Consumable<ValidationResult>>(
+    private val constraintValidationResult = MutableLiveData<Consumable<ValidationResult>>(
         Consumable(SuccessValidationResult)
     )
     private val formEntryViewModel = mock<FormEntryViewModel> {
         on { getQuestionPrompt(prompt.index) } doReturn prompt
-        on { validationResult } doReturn validationResult
+        on { constraintValidationResult } doReturn constraintValidationResult
     }
 
     private val viewModelFactory = object : ViewModelProvider.Factory {
@@ -475,22 +475,7 @@ class GeoPolyDialogFragmentTest {
             0,
             TreeReference()
         )
-        validationResult.value = Consumable(FailedValidationResult(anotherQuestionFormIndex, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, "blah", 0))
-        launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
-            GeoPolyDialogFragment::class,
-            bundleOf(ARG_FORM_INDEX to prompt.index)
-        ) {
-            assertThat(it.invalidMessage.getOrAwaitValue(), equalTo(null))
-        }
-    }
-
-    @Test
-    fun `ignores the validation message if it was triggered by a required but empty answer`() {
-        prompt = MockFormEntryPromptBuilder(prompt)
-            .withDataType(Constants.DATATYPE_GEOTRACE)
-            .build()
-
-        validationResult.value = Consumable(FailedValidationResult(prompt.index, FormEntryController.ANSWER_REQUIRED_BUT_EMPTY, "blah", 0))
+        constraintValidationResult.value = Consumable(FailedValidationResult(anotherQuestionFormIndex, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, "blah", 0))
         launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
             GeoPolyDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
@@ -512,7 +497,7 @@ class GeoPolyDialogFragmentTest {
             assertThat(it.invalidMessage.getOrAwaitValue(), equalTo(null))
         }
 
-        validationResult.value = Consumable(FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, "blah", 0))
+        constraintValidationResult.value = Consumable(FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, "blah", 0))
         launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
             GeoPolyDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
@@ -534,7 +519,7 @@ class GeoPolyDialogFragmentTest {
             assertThat(it.invalidMessage.getOrAwaitValue(), equalTo(null))
         }
 
-        validationResult.value =
+        constraintValidationResult.value =
             Consumable(FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, null, R.string.cancel))
         launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
             GeoPolyDialogFragment::class,

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -33,6 +33,7 @@ import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.MockFormEntryPromptBuilder
 import org.odk.collect.android.widgets.utilities.AdditionalAttributes.INCREMENTAL
 import org.odk.collect.android.widgets.utilities.WidgetAnswerDialogFragment.Companion.ARG_FORM_INDEX
+import org.odk.collect.android.widgets.viewmodels.QuestionViewModel
 import org.odk.collect.androidshared.data.Consumable
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
@@ -50,12 +51,19 @@ class GeoPolyDialogFragmentTest {
     )
     private val formEntryViewModel = mock<FormEntryViewModel> {
         on { getQuestionPrompt(prompt.index) } doReturn prompt
+    }
+
+    private val questionViewModel = mock<QuestionViewModel> {
         on { constraintValidationResult } doReturn constraintValidationResult
     }
 
     private val viewModelFactory = object : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
-            return formEntryViewModel as T
+            return when (modelClass) {
+                FormEntryViewModel::class.java -> formEntryViewModel as T
+                QuestionViewModel::class.java -> questionViewModel as T
+                else -> throw IllegalArgumentException()
+            }
         }
     }
 
@@ -333,7 +341,7 @@ class GeoPolyDialogFragmentTest {
             )
         }
 
-        verify(formEntryViewModel).validateAnswerConstraint(prompt.index, geoTraceOf(answer))
+        verify(questionViewModel).validate(prompt.index, geoTraceOf(answer))
     }
 
     @Test
@@ -354,7 +362,7 @@ class GeoPolyDialogFragmentTest {
             )
         }
 
-        verify(formEntryViewModel).validateAnswerConstraint(prompt.index, geoShapeOf(answer))
+        verify(questionViewModel).validate(prompt.index, geoShapeOf(answer))
     }
 
     @Test
@@ -390,7 +398,7 @@ class GeoPolyDialogFragmentTest {
             )
         }
 
-        verify(formEntryViewModel, never()).validateAnswerConstraint(prompt.index, geoTraceOf(answer))
+        verify(questionViewModel, never()).validate(prompt.index, geoTraceOf(answer))
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/viewmodels/QuestionViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/viewmodels/QuestionViewModelTest.kt
@@ -1,0 +1,60 @@
+package org.odk.collect.android.widgets.viewmodels
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.javarosa.core.model.FormDef
+import org.javarosa.core.model.FormIndex
+import org.javarosa.core.model.data.StringData
+import org.javarosa.core.model.instance.TreeReference
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.odk.collect.android.formentry.support.InMemFormSessionRepository
+import org.odk.collect.android.javarosawrapper.FailedValidationResult
+import org.odk.collect.android.javarosawrapper.FakeFormController
+import org.odk.collect.android.support.MockFormEntryPromptBuilder
+import org.odk.collect.strings.R
+import org.odk.collect.testshared.FakeScheduler
+import org.odk.collect.testshared.getOrAwaitValue
+
+@RunWith(AndroidJUnit4::class)
+class QuestionViewModelTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val scheduler: FakeScheduler = FakeScheduler()
+    private val startingIndex = FormIndex(null, 0, 0, TreeReference())
+    private val formController = FakeFormController(startingIndex, mock())
+    private val formSessionRepository = InMemFormSessionRepository().apply {
+        set("blah", formController, mock())
+    }
+    private val viewModel = QuestionViewModel(scheduler, formSessionRepository, "blah")
+
+    @Test
+    fun `validate updates constraintValidationResult`() {
+        val formDef: FormDef = mock()
+        whenever(formDef.evaluateConstraint(any(), any())).thenReturn(false)
+        formController.setFormDef(formDef)
+
+        val reference = TreeReference()
+        reference.add("blah", TreeReference.INDEX_UNBOUND)
+        val formIndex = FormIndex(null, 1, 1, reference)
+        val prompt = MockFormEntryPromptBuilder().build()
+        formController.setPrompt(formIndex, prompt)
+
+        val failedValidationResult =
+            FailedValidationResult(formIndex, 0, null, R.string.invalid_answer_error)
+        formController.setFailedConstraint(failedValidationResult)
+
+        viewModel.validate(formIndex, StringData("answer"))
+        assertThat(
+            viewModel.constraintValidationResult.getOrAwaitValue(scheduler).value,
+            equalTo(failedValidationResult)
+        )
+    }
+}


### PR DESCRIPTION
Closes #7033

#### Why is this the best possible solution? Were any other approaches considered?
We had a single `validationResult` LiveData observed by `FormFillingActivity` and the map fragment, used for two different cases: validating saved answers in the form view and validating polygons on the map. Initially, it seemed reasonable to reuse the same `LiveData` for both, but over time the two cases started to diverge.
We stopped saving answers when validating polygons, and later decided that only constraint errors were needed in that flow. As a result, sharing the same `LiveData` caused more problems than benefits.
We also don’t want to update the form view (e.g. display errors) when validation occurs in the map flow, so separating these cases turned out to be the best solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should now be no relationship between the errors displayed on the map and those shown in the form view, meaning that these two cases should not affect each ot. We already know how tricky these cases can be, so we need to be careful and test all related scenarios.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is linked in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
