### PR TITLE
Protect points list by returning a defensive copy

### DIFF
--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -25,7 +25,10 @@ internal class DynamicPolyLineFeature(
     private val featureDragEndListener: MapFragment.FeatureListener?,
     private val lineDescription: LineDescription
 ) : LineFeature {
-    override val points = mutableListOf<MapPoint>()
+    override val points: List<MapPoint>
+        get() = _points.toList()
+
+    private val _points = mutableListOf<MapPoint>()
     private val pointAnnotations = mutableListOf<PointAnnotation>()
     private val pointAnnotationClickListener = ClickListener()
     private val pointAnnotationDragListener = DragListener()
@@ -33,7 +36,7 @@ internal class DynamicPolyLineFeature(
 
     init {
         lineDescription.points.forEachIndexed { index, point ->
-            points.add(point)
+            _points.add(point)
 
             val markerIconDescription = if (index == lineDescription.points.lastIndex) {
                 MarkerIconDescription.LinePoint(lineDescription.getStrokeWidth(), MapConsts.DEFAULT_HIGHLIGHT_COLOR)
@@ -82,7 +85,7 @@ internal class DynamicPolyLineFeature(
         }
 
         pointAnnotations.clear()
-        points.clear()
+        _points.clear()
     }
 
     private fun updateLine() {
@@ -131,7 +134,7 @@ internal class DynamicPolyLineFeature(
         override fun onAnnotationDrag(annotation: com.mapbox.maps.plugin.annotation.Annotation<*>) {
             pointAnnotations.forEachIndexed { index, pointAnnotation ->
                 if (annotation.id == pointAnnotation.id) {
-                    points[index] = MapUtils.mapPointFromPointAnnotation(pointAnnotation)
+                    _points[index] = MapUtils.mapPointFromPointAnnotation(pointAnnotation)
                 }
             }
             updateLine()

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
@@ -25,7 +25,10 @@ internal class DynamicPolygonFeature(
     private val featureDragEndListener: MapFragment.FeatureListener?,
     private val polygonDescription: PolygonDescription
 ) : LineFeature {
-    override val points = mutableListOf<MapPoint>()
+    override val points: List<MapPoint>
+        get() = _points.toList()
+
+    private val _points = mutableListOf<MapPoint>()
     private val pointAnnotations = mutableListOf<PointAnnotation>()
     private val pointAnnotationClickListener = ClickListener()
     private val pointAnnotationDragListener = DragListener()
@@ -33,7 +36,7 @@ internal class DynamicPolygonFeature(
 
     init {
         polygonDescription.points.forEachIndexed { index, point ->
-            points.add(point)
+            _points.add(point)
 
             val markerIconDescription = if (index == polygonDescription.points.lastIndex) {
                 MarkerIconDescription.LinePoint(polygonDescription.getStrokeWidth(), MapConsts.DEFAULT_HIGHLIGHT_COLOR)
@@ -82,7 +85,7 @@ internal class DynamicPolygonFeature(
         }
 
         pointAnnotations.clear()
-        points.clear()
+        _points.clear()
     }
 
     private fun updateLine() {
@@ -125,7 +128,7 @@ internal class DynamicPolygonFeature(
         override fun onAnnotationDrag(annotation: com.mapbox.maps.plugin.annotation.Annotation<*>) {
             pointAnnotations.forEachIndexed { index, pointAnnotation ->
                 if (annotation.id == pointAnnotation.id) {
-                    points[index] = MapUtils.mapPointFromPointAnnotation(pointAnnotation)
+                    _points[index] = MapUtils.mapPointFromPointAnnotation(pointAnnotation)
                 }
             }
             updateLine()


### PR DESCRIPTION
Closes #7040 
Closes #7011 

#### Why is this the best possible solution? Were any other approaches considered?
Mapbox poly features used to return the original points, so the scenario was as follows:
1. A user added **x** points.
2. The user moved one of the points.
3. We read the updated list of points from the map fragment to update the ViewModel.
4. Before updating the ViewModel, the poly features were disposed, which cleared the points and also emptied the list we had just read in step 3.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should simply fix the issue. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms can be found in the issues.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
