### PR TITLE
Allow adding points inside shapes or on trace lines in Google Maps

### DIFF
--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -928,7 +928,6 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
                     .zIndex(1)
                     .width(lineDescription.getStrokeWidth())
                     .addAll(latLngs)
-                    .clickable(true)
                 );
             } else {
                 polyline.setPoints(latLngs);
@@ -1014,7 +1013,6 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
                         .strokeWidth(polygonDescription.getStrokeWidth())
                         .fillColor(polygonDescription.getFillColor())
                         .addAll(latLngs)
-                        .clickable(true)
                 );
             } else {
                 polygon.setPoints(latLngs);

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -1005,7 +1005,7 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
                 latLngs.add(marker.getPosition());
             }
             if (markers.isEmpty()) {
-                clearPolyline();
+                clearPolygon();
             } else if (polygon == null) {
                 polygon = map.addPolygon(new PolygonOptions()
                         .strokeColor(polygonDescription.getStrokeColor())
@@ -1021,7 +1021,7 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
 
         @Override
         public void dispose() {
-            clearPolyline();
+            clearPolygon();
             for (Marker marker : markers) {
                 marker.remove();
             }
@@ -1036,7 +1036,7 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
             return points;
         }
 
-        private void clearPolyline() {
+        private void clearPolygon() {
             if (polygon != null) {
                 polygon.remove();
                 polygon = null;


### PR DESCRIPTION
Closes #7039

#### Why is this the best possible solution? Were any other approaches considered?
It wasn’t possible to add points on trace lines in earlier versions with Google Maps, so when we created `DynamicPolygonFeature` for polygons, we simply copied that behavior.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change simply unblocks adding points inside shapes or on trace lines in Google Maps.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with a `geotrace`/`geoshape` question.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
