### PR TITLE
Highlight shape/trace and disable save button when invalid

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/livedata/LiveDataExt.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/livedata/LiveDataExt.kt
@@ -1,0 +1,9 @@
+package org.odk.collect.androidshared.livedata
+
+import androidx.lifecycle.LiveData
+
+object LiveDataExt {
+    fun <T, U> LiveData<T>.zip(other: LiveData<U>): LiveData<Pair<T, U>> {
+        return LiveDataUtils.zip(this, other)
+    }
+}

--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/ColorUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/ColorUtils.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.androidshared.utils
 
 import androidx.annotation.ColorInt
+import androidx.core.graphics.ColorUtils
 import androidx.core.graphics.toColorInt
 
 @ColorInt
@@ -18,6 +19,10 @@ fun String.sanitizeToColorInt() = try {
     sanitizedColor.toColorInt()
 } catch (e: IllegalArgumentException) {
     null
+}
+
+fun Int.opaque(): Int {
+    return ColorUtils.setAlphaComponent(this, 100)
 }
 
 private fun shorthandToLonghandHexColor(shorthandColor: String): String {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -251,8 +251,7 @@ class GeoPolyFragment @JvmOverloads constructor(
         val viewData = viewModel.points.asLiveData().zip(invalidMessage)
         viewData.observe(viewLifecycleOwner) { (points, invalidMessage) ->
             val isValid = invalidMessage == null
-
-            if (invalidMessage != null) {
+            if (!isValid) {
                 snackbar.setText(invalidMessage)
                 SnackbarUtils.show(snackbar)
             } else {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -272,7 +272,8 @@ class GeoPolyFragment @JvmOverloads constructor(
                     points,
                     draggable = !readOnly,
                     strokeColor = color,
-                    fillColor = color
+                    fillColor = color,
+                    highlightLastPoint = !invalid
                 )
 
                 if (featureId == -1) {
@@ -284,7 +285,8 @@ class GeoPolyFragment @JvmOverloads constructor(
                 val lineDescription = LineDescription(
                     points,
                     draggable = !readOnly,
-                    strokeColor = color
+                    strokeColor = color,
+                    highlightLastPoint = !invalid
                 )
 
                 if (featureId == -1) {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -156,9 +156,9 @@ class GeoPolyFragment @JvmOverloads constructor(
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val mapFragment: MapFragment =
-            (view.findViewById<View?>(R.id.map_container) as FragmentContainerView).getFragment()
-        mapFragment.init({ initMap(it, GeopolyLayoutBinding.bind(view)) }, { this.cancel() })
+        val binding = GeopolyLayoutBinding.bind(view)
+        val mapFragment: MapFragment = binding.mapContainer.getFragment()
+        mapFragment.init({ initMap(it, binding) }, { this.cancel() })
 
         val snackbar = SnackbarUtils.make(requireView(), "", Snackbar.LENGTH_INDEFINITE)
         invalidMessage.observe(viewLifecycleOwner) {
@@ -168,6 +168,8 @@ class GeoPolyFragment @JvmOverloads constructor(
             } else {
                 snackbar.dismiss()
             }
+
+            binding.save.isEnabled = !readOnly && it == null
         }
 
         onBackPressedDispatcher().addCallback(viewLifecycleOwner, onBackPressedCallback)
@@ -483,7 +485,6 @@ class GeoPolyFragment @JvmOverloads constructor(
             binding.play.isEnabled = false
             binding.backspace.isEnabled = false
             binding.clear.isEnabled = false
-            binding.save.isEnabled = false
         }
 
         // Settings dialog

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -22,6 +22,7 @@ import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.androidshared.ui.multiclicksafe.setMultiClickSafeOnClickListener
+import org.odk.collect.androidshared.utils.sanitizeToColorInt
 import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.GeoDependencyComponentProvider
 import org.odk.collect.geo.databinding.SelectionMapLayoutBinding
@@ -408,10 +409,23 @@ class SelectionMapFragment(
 
         val pointIds = map.addMarkers(markerDescriptions)
         val lineIds = lines.fold(listOf<Int>()) { ids, item ->
-            ids + map.addPolyLine(LineDescription(item.points, item.strokeWidth, item.strokeColor))
+            ids + map.addPolyLine(
+                LineDescription(
+                    item.points,
+                    item.strokeWidth,
+                    item.strokeColor?.sanitizeToColorInt()
+                )
+            )
         }
         val polygonIds = polygons.fold(listOf<Int>()) { ids, item ->
-            ids + map.addPolygon(PolygonDescription(item.points, item.strokeWidth, item.strokeColor, item.fillColor))
+            ids + map.addPolygon(
+                PolygonDescription(
+                    item.points,
+                    item.strokeWidth,
+                    item.strokeColor?.sanitizeToColorInt(),
+                    item.fillColor?.sanitizeToColorInt()
+                )
+            )
         }
 
         (singlePoints + lines + polygons).zip(pointIds + lineIds + polygonIds).forEach { (item, featureId) ->

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -688,6 +688,24 @@ class GeoPolyFragmentTest {
     }
 
     @Test
+    fun disablesSaveButtonWhenInvalid() {
+        val invalidMessage = MutableLiveData<String?>(null)
+
+        fragmentLauncherRule.launchInContainer {
+            GeoPolyFragment(
+                { OnBackPressedDispatcher() },
+                invalidMessage = invalidMessage
+            )
+        }
+
+        invalidMessage.value = "Blah"
+        Assertions.assertDisabled(withContentDescription(string.save))
+
+        invalidMessage.value = null
+        Assertions.assertEnabled(withContentDescription(string.save))
+    }
+
+    @Test
     fun whenOutputModeIsGeoTrace_setsChangeResultWheneverAPointIsAddedAfterTheFirst() {
         val scenario = fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -645,10 +645,12 @@ class GeoPolyFragmentTest {
         invalidMessage.value = "blah"
         val errorPolyLine = mapFragment.getPolyLines()[0]
         assertThat(errorPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_ERROR_COLOR))
+        assertThat(errorPolyLine.highlightLastPoint, equalTo(false))
 
         invalidMessage.value = null
         val normalPolyLine = mapFragment.getPolyLines()[0]
         assertThat(normalPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
+        assertThat(normalPolyLine.highlightLastPoint, equalTo(true))
     }
 
     @Test
@@ -669,6 +671,7 @@ class GeoPolyFragmentTest {
         invalidMessage.value = "blah"
         val errorPolyLine = mapFragment.getPolygons()[0]
         assertThat(errorPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_ERROR_COLOR))
+        assertThat(errorPolyLine.highlightLastPoint, equalTo(false))
         assertThat(
             errorPolyLine.getFillColor().opaque(),
             equalTo(MapConsts.DEFAULT_ERROR_COLOR.opaque())
@@ -677,6 +680,7 @@ class GeoPolyFragmentTest {
         invalidMessage.value = null
         val normalPolyLine = mapFragment.getPolygons()[0]
         assertThat(normalPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
+        assertThat(normalPolyLine.highlightLastPoint, equalTo(true))
         assertThat(
             normalPolyLine.getFillColor().opaque(),
             equalTo(MapConsts.DEFAULT_STROKE_COLOR.opaque())

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
+import org.odk.collect.androidshared.utils.opaque
 import org.odk.collect.androidtest.FragmentScenarioExtensions.setFragmentResultListener
 import org.odk.collect.async.Scheduler
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
@@ -36,6 +37,7 @@ import org.odk.collect.geo.support.FakeMapFragment
 import org.odk.collect.geo.support.RobolectricApplication
 import org.odk.collect.location.Location
 import org.odk.collect.location.tracker.LocationTracker
+import org.odk.collect.maps.MapConsts
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragmentFactory
 import org.odk.collect.maps.MapPoint
@@ -624,6 +626,61 @@ class GeoPolyFragmentTest {
 
         invalidMessage.value = null
         assertNotVisible(withText(message))
+    }
+
+    @Test
+    fun changesPolyLineColorBasedOnInvalidMessage() {
+        val invalidMessage = MutableLiveData<String?>(null)
+
+        fragmentLauncherRule.launchInContainer {
+            GeoPolyFragment(
+                { OnBackPressedDispatcher() },
+                invalidMessage = invalidMessage
+            )
+        }
+
+        startInput(R.id.placement_mode)
+        mapFragment.click(MapPoint(0.0, 0.0))
+
+        invalidMessage.value = "blah"
+        val errorPolyLine = mapFragment.getPolyLines()[0]
+        assertThat(errorPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_ERROR_COLOR))
+
+        invalidMessage.value = null
+        val normalPolyLine = mapFragment.getPolyLines()[0]
+        assertThat(normalPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
+    }
+
+    @Test
+    fun changesPolygonColorBasedOnInvalidMessage() {
+        val invalidMessage = MutableLiveData<String?>(null)
+
+        fragmentLauncherRule.launchInContainer {
+            GeoPolyFragment(
+                { OnBackPressedDispatcher() },
+                outputMode = OutputMode.GEOSHAPE,
+                invalidMessage = invalidMessage
+            )
+        }
+
+        startInput(R.id.placement_mode)
+        mapFragment.click(MapPoint(0.0, 0.0))
+
+        invalidMessage.value = "blah"
+        val errorPolyLine = mapFragment.getPolygons()[0]
+        assertThat(errorPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_ERROR_COLOR))
+        assertThat(
+            errorPolyLine.getFillColor().opaque(),
+            equalTo(MapConsts.DEFAULT_ERROR_COLOR.opaque())
+        )
+
+        invalidMessage.value = null
+        val normalPolyLine = mapFragment.getPolygons()[0]
+        assertThat(normalPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
+        assertThat(
+            normalPolyLine.getFillColor().opaque(),
+            equalTo(MapConsts.DEFAULT_STROKE_COLOR.opaque())
+        )
     }
 
     @Test

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -14,7 +14,7 @@
 
 package org.odk.collect.googlemaps;
 
-import static org.odk.collect.maps.markers.MarkerIconDescriptionKt.getMarkerIconDescriptionForPoint;
+import static org.odk.collect.maps.markers.MarkerDescriptionKt.getMarkersForPoints;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -879,11 +879,9 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
                 return;
             }
 
-            List<MapPoint> points = lineDescription.getPoints();
-            for (int i = 0; i < points.size(); i++) {
-                MapPoint point = points.get(i);
-                MarkerIconDescription iconDescription = getMarkerIconDescriptionForPoint(lineDescription, i == lineDescription.getPoints().size() - 1);
-                Marker marker = createMarker(requireContext(), new MarkerDescription(point, true, CENTER, iconDescription), map);
+            List<MarkerDescription> markerDescriptions = getMarkersForPoints(lineDescription);
+            for (MarkerDescription markerDescription : markerDescriptions) {
+                Marker marker = createMarker(requireContext(), markerDescription, map);
                 markers.add(marker);
             }
 
@@ -968,11 +966,9 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
                 return;
             }
 
-            List<MapPoint> points = polygonDescription.getPoints();
-            for (int i = 0; i < points.size(); i++) {
-                MapPoint point = points.get(i);
-                MarkerIconDescription iconDescription = getMarkerIconDescriptionForPoint(polygonDescription, i == polygonDescription.getPoints().size() - 1);
-                Marker marker = createMarker(requireContext(), new MarkerDescription(point, true, CENTER, iconDescription), map);
+            List<MarkerDescription> markerDescriptions = getMarkersForPoints(polygonDescription);
+            for (MarkerDescription markerDescription : markerDescriptions) {
+                Marker marker = createMarker(requireContext(), markerDescription, map);
                 markers.add(marker);
             }
 

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -809,9 +809,6 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
 
             points = lineDescription.getPoints();
             List<LatLng> latLngs = StreamSupport.stream(points.spliterator(), false).map(mapPoint -> new LatLng(mapPoint.latitude, mapPoint.longitude)).collect(Collectors.toList());
-            if (lineDescription.getClosed() && !latLngs.isEmpty()) {
-                latLngs.add(latLngs.get(0));
-            }
             if (latLngs.isEmpty()) {
                 clearPolyline();
             } else if (polyline == null) {
@@ -908,9 +905,6 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
             List<LatLng> latLngs = new ArrayList<>();
             for (Marker marker : markers) {
                 latLngs.add(marker.getPosition());
-            }
-            if (lineDescription.getClosed() && !latLngs.isEmpty()) {
-                latLngs.add(latLngs.get(0));
             }
             if (markers.isEmpty()) {
                 clearPolyline();

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.googlemaps;
 
+import static org.odk.collect.maps.markers.MarkerIconDescriptionKt.getMarkerIconDescriptionForPoint;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.location.Location;
@@ -57,7 +59,6 @@ import org.odk.collect.googlemaps.scaleview.MapScaleView;
 import org.odk.collect.location.LocationClient;
 import org.odk.collect.maps.LineDescription;
 import org.odk.collect.maps.MapConfigurator;
-import org.odk.collect.maps.MapConsts;
 import org.odk.collect.maps.MapFragment;
 import org.odk.collect.maps.MapPoint;
 import org.odk.collect.maps.MapViewModel;
@@ -731,15 +732,6 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
         }).get(MapViewModel.class);
     }
 
-    @NonNull
-    private Marker getLinePointMarker(MapPoint point, float strokeWidth, boolean isLast) {
-        if (isLast) {
-            return createMarker(requireContext(), new MarkerDescription(point, true, CENTER, new MarkerIconDescription.LinePoint(strokeWidth, MapConsts.DEFAULT_HIGHLIGHT_COLOR)), map);
-        } else {
-            return createMarker(requireContext(), new MarkerDescription(point, true, CENTER, new MarkerIconDescription.LinePoint(strokeWidth, MapConsts.DEFAULT_STROKE_COLOR)), map);
-        }
-    }
-
     /**
      * A MapFeature is a physical feature on a map, such as a point, a road,
      * a building, a region, etc.  It is presented to the user as one editable
@@ -890,7 +882,9 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
             List<MapPoint> points = lineDescription.getPoints();
             for (int i = 0; i < points.size(); i++) {
                 MapPoint point = points.get(i);
-                markers.add(getLinePointMarker(point, lineDescription.getStrokeWidth(), i == points.size() - 1));
+                MarkerIconDescription iconDescription = getMarkerIconDescriptionForPoint(lineDescription, i == lineDescription.getPoints().size() - 1);
+                Marker marker = createMarker(requireContext(), new MarkerDescription(point, true, CENTER, iconDescription), map);
+                markers.add(marker);
             }
 
             update();
@@ -977,7 +971,9 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
             List<MapPoint> points = polygonDescription.getPoints();
             for (int i = 0; i < points.size(); i++) {
                 MapPoint point = points.get(i);
-                markers.add(getLinePointMarker(point, polygonDescription.getStrokeWidth(), i == polygonDescription.getPoints().size() - 1));
+                MarkerIconDescription iconDescription = getMarkerIconDescriptionForPoint(polygonDescription, i == polygonDescription.getPoints().size() - 1);
+                Marker marker = createMarker(requireContext(), new MarkerDescription(point, true, CENTER, iconDescription), map);
+                markers.add(marker);
             }
 
             update();

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -14,7 +14,7 @@
 
 package org.odk.collect.googlemaps;
 
-import static org.odk.collect.maps.markers.MarkerDescriptionKt.getMarkersForPoints;
+import static org.odk.collect.maps.TraceDescriptionKt.getMarkersForPoints;
 
 import android.annotation.SuppressLint;
 import android.content.Context;

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -39,9 +39,9 @@ internal class DynamicPolyLineFeature(
             _points.add(point)
 
             val markerIconDescription = if (index == lineDescription.points.lastIndex) {
-                MarkerIconDescription.LinePoint(lineDescription.getStrokeWidth(), MapConsts.DEFAULT_HIGHLIGHT_COLOR)
+                MarkerIconDescription.TracePoint(lineDescription.getStrokeWidth(), MapConsts.DEFAULT_HIGHLIGHT_COLOR)
             } else {
-                MarkerIconDescription.LinePoint(lineDescription.getStrokeWidth(), MapConsts.DEFAULT_STROKE_COLOR)
+                MarkerIconDescription.TracePoint(lineDescription.getStrokeWidth(), MapConsts.DEFAULT_STROKE_COLOR)
             }
             pointAnnotations.add(
                 MapUtils.createPointAnnotation(

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -78,11 +78,6 @@ internal class DynamicPolyLineFeature(
                 Point.fromLngLat(it.longitude, it.latitude, it.altitude)
             }
             .toMutableList()
-            .also {
-                if (lineDescription.closed && it.isNotEmpty()) {
-                    it.add(it.first())
-                }
-            }
 
         polylineAnnotation?.let {
             polylineAnnotationManager.delete(it)

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -10,11 +10,9 @@ import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions
 import org.odk.collect.maps.LineDescription
-import org.odk.collect.maps.MapConsts
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
-import org.odk.collect.maps.markers.MarkerDescription
-import org.odk.collect.maps.markers.MarkerIconDescription
+import org.odk.collect.maps.getMarkersForPoints
 
 internal class DynamicPolyLineFeature(
     private val context: Context,
@@ -35,25 +33,11 @@ internal class DynamicPolyLineFeature(
     private var polylineAnnotation: PolylineAnnotation? = null
 
     init {
-        lineDescription.points.forEachIndexed { index, point ->
-            _points.add(point)
-
-            val markerIconDescription = if (index == lineDescription.points.lastIndex) {
-                MarkerIconDescription.TracePoint(lineDescription.getStrokeWidth(), MapConsts.DEFAULT_HIGHLIGHT_COLOR)
-            } else {
-                MarkerIconDescription.TracePoint(lineDescription.getStrokeWidth(), MapConsts.DEFAULT_STROKE_COLOR)
-            }
+        val markerDescriptions = lineDescription.getMarkersForPoints()
+        markerDescriptions.forEach {
+            _points.add(it.point)
             pointAnnotations.add(
-                MapUtils.createPointAnnotation(
-                    pointAnnotationManager,
-                    context,
-                    MarkerDescription(
-                        point,
-                        true,
-                        MapFragment.CENTER,
-                        markerIconDescription
-                    )
-                )
+                MapUtils.createPointAnnotation(pointAnnotationManager, context, it)
             )
         }
 

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
@@ -39,9 +39,9 @@ internal class DynamicPolygonFeature(
             _points.add(point)
 
             val markerIconDescription = if (index == polygonDescription.points.lastIndex) {
-                MarkerIconDescription.LinePoint(polygonDescription.getStrokeWidth(), MapConsts.DEFAULT_HIGHLIGHT_COLOR)
+                MarkerIconDescription.TracePoint(polygonDescription.getStrokeWidth(), MapConsts.DEFAULT_HIGHLIGHT_COLOR)
             } else {
-                MarkerIconDescription.LinePoint(polygonDescription.getStrokeWidth(), MapConsts.DEFAULT_STROKE_COLOR)
+                MarkerIconDescription.TracePoint(polygonDescription.getStrokeWidth(), MapConsts.DEFAULT_STROKE_COLOR)
             }
             pointAnnotations.add(
                 MapUtils.createPointAnnotation(

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
@@ -9,12 +9,10 @@ import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
-import org.odk.collect.maps.MapConsts
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.PolygonDescription
-import org.odk.collect.maps.markers.MarkerDescription
-import org.odk.collect.maps.markers.MarkerIconDescription
+import org.odk.collect.maps.getMarkersForPoints
 
 internal class DynamicPolygonFeature(
     private val context: Context,
@@ -35,25 +33,11 @@ internal class DynamicPolygonFeature(
     private var polygonAnnotation: PolygonAnnotation? = null
 
     init {
-        polygonDescription.points.forEachIndexed { index, point ->
-            _points.add(point)
-
-            val markerIconDescription = if (index == polygonDescription.points.lastIndex) {
-                MarkerIconDescription.TracePoint(polygonDescription.getStrokeWidth(), MapConsts.DEFAULT_HIGHLIGHT_COLOR)
-            } else {
-                MarkerIconDescription.TracePoint(polygonDescription.getStrokeWidth(), MapConsts.DEFAULT_STROKE_COLOR)
-            }
+        val markerDescriptions = polygonDescription.getMarkersForPoints()
+        markerDescriptions.forEach {
+            _points.add(it.point)
             pointAnnotations.add(
-                MapUtils.createPointAnnotation(
-                    pointAnnotationManager,
-                    context,
-                    MarkerDescription(
-                        point,
-                        true,
-                        MapFragment.CENTER,
-                        markerIconDescription
-                    )
-                )
+                MapUtils.createPointAnnotation(pointAnnotationManager, context, it)
             )
         }
 

--- a/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/StaticPolyLineFeature.kt
@@ -28,11 +28,6 @@ internal class StaticPolyLineFeature(
                 Point.fromLngLat(it.longitude, it.latitude, it.altitude)
             }
             .toMutableList()
-            .also {
-                if (lineDescription.closed && it.isNotEmpty()) {
-                    it.add(it.first())
-                }
-            }
 
         polylineAnnotation?.let {
             polylineAnnotationManager.delete(it)

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -1,7 +1,7 @@
 package org.odk.collect.maps
 
 data class LineDescription(
-    val points: List<MapPoint> = emptyList(),
+    override val points: List<MapPoint> = emptyList(),
     private val strokeWidth: String? = null,
     private val strokeColor: Int? = null,
     override val highlightLastPoint: Boolean = false,

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -5,8 +5,7 @@ data class LineDescription(
     private val strokeWidth: String? = null,
     private val strokeColor: Int? = null,
     override val highlightLastPoint: Boolean = false,
-    val draggable: Boolean = false,
-    @Deprecated("Use PolygonDescription instead") val closed: Boolean = false
+    val draggable: Boolean = false
 ) : TraceDescription {
     override fun getStrokeWidth(): Float {
         return try {

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -4,11 +4,11 @@ data class LineDescription(
     val points: List<MapPoint> = emptyList(),
     private val strokeWidth: String? = null,
     private val strokeColor: Int? = null,
-    val highlightLastPoint: Boolean = false,
+    override val highlightLastPoint: Boolean = false,
     val draggable: Boolean = false,
     @Deprecated("Use PolygonDescription instead") val closed: Boolean = false
-) {
-    fun getStrokeWidth(): Float {
+) : TraceDescription {
+    override fun getStrokeWidth(): Float {
         return try {
             strokeWidth?.toFloat()?.let {
                 if (it >= 0) {
@@ -22,7 +22,7 @@ data class LineDescription(
         }
     }
 
-    fun getStrokeColor(): Int {
+    override fun getStrokeColor(): Int {
         return strokeColor ?: MapConsts.DEFAULT_STROKE_COLOR
     }
 }

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -1,11 +1,9 @@
 package org.odk.collect.maps
 
-import org.odk.collect.androidshared.utils.sanitizeToColorInt
-
 data class LineDescription(
     val points: List<MapPoint> = emptyList(),
     private val strokeWidth: String? = null,
-    private val strokeColor: String? = null,
+    private val strokeColor: Int? = null,
     val draggable: Boolean = false,
     @Deprecated("Use PolygonDescription instead") val closed: Boolean = false
 ) {
@@ -24,7 +22,6 @@ data class LineDescription(
     }
 
     fun getStrokeColor(): Int {
-        val customColor = strokeColor?.sanitizeToColorInt()
-        return customColor ?: MapConsts.DEFAULT_STROKE_COLOR
+        return strokeColor ?: MapConsts.DEFAULT_STROKE_COLOR
     }
 }

--- a/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/LineDescription.kt
@@ -4,6 +4,7 @@ data class LineDescription(
     val points: List<MapPoint> = emptyList(),
     private val strokeWidth: String? = null,
     private val strokeColor: Int? = null,
+    val highlightLastPoint: Boolean = false,
     val draggable: Boolean = false,
     @Deprecated("Use PolygonDescription instead") val closed: Boolean = false
 ) {

--- a/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapConsts.kt
@@ -9,6 +9,8 @@ object MapConsts {
     @JvmField
     val DEFAULT_HIGHLIGHT_COLOR = "#1F5976".toColorInt()
 
+    val DEFAULT_ERROR_COLOR = "#ba1a1a".toColorInt()
+
     const val DEFAULT_STROKE_WIDTH = 8f
     const val DEFAULT_FILL_COLOR_OPACITY = 68
 }

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -7,6 +7,7 @@ data class PolygonDescription(
     private val strokeWidth: String? = null,
     private val strokeColor: Int? = null,
     private val fillColor: Int? = null,
+    val highlightLastPoint: Boolean = false,
     val draggable: Boolean = false
 ) {
     fun getStrokeWidth(): Float {

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -7,10 +7,10 @@ data class PolygonDescription(
     private val strokeWidth: String? = null,
     private val strokeColor: Int? = null,
     private val fillColor: Int? = null,
-    val highlightLastPoint: Boolean = false,
+    override val highlightLastPoint: Boolean = false,
     val draggable: Boolean = false
-) {
-    fun getStrokeWidth(): Float {
+) : TraceDescription {
+    override fun getStrokeWidth(): Float {
         return try {
             strokeWidth?.toFloat()?.let {
                 if (it >= 0) {
@@ -24,7 +24,7 @@ data class PolygonDescription(
         }
     }
 
-    fun getStrokeColor(): Int {
+    override fun getStrokeColor(): Int {
         return strokeColor ?: MapConsts.DEFAULT_STROKE_COLOR
     }
 

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -1,13 +1,12 @@
 package org.odk.collect.maps
 
 import androidx.core.graphics.ColorUtils
-import org.odk.collect.androidshared.utils.sanitizeToColorInt
 
 data class PolygonDescription(
     val points: List<MapPoint> = emptyList(),
     private val strokeWidth: String? = null,
-    private val strokeColor: String? = null,
-    private val fillColor: String? = null,
+    private val strokeColor: Int? = null,
+    private val fillColor: Int? = null,
     val draggable: Boolean = false
 ) {
     fun getStrokeWidth(): Float {
@@ -25,22 +24,20 @@ data class PolygonDescription(
     }
 
     fun getStrokeColor(): Int {
-        val customColor = strokeColor?.sanitizeToColorInt()
-        return customColor ?: MapConsts.DEFAULT_STROKE_COLOR
+        return strokeColor ?: MapConsts.DEFAULT_STROKE_COLOR
     }
 
     fun getFillColor(): Int {
-        val customColor = fillColor?.sanitizeToColorInt()?.let {
+        val customColor = fillColor?.let {
             ColorUtils.setAlphaComponent(
                 it,
                 MapConsts.DEFAULT_FILL_COLOR_OPACITY
             )
         }
 
-        return customColor
-            ?: ColorUtils.setAlphaComponent(
-                MapConsts.DEFAULT_STROKE_COLOR,
-                MapConsts.DEFAULT_FILL_COLOR_OPACITY
-            )
+        return customColor ?: ColorUtils.setAlphaComponent(
+            MapConsts.DEFAULT_STROKE_COLOR,
+            MapConsts.DEFAULT_FILL_COLOR_OPACITY
+        )
     }
 }

--- a/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/PolygonDescription.kt
@@ -3,7 +3,7 @@ package org.odk.collect.maps
 import androidx.core.graphics.ColorUtils
 
 data class PolygonDescription(
-    val points: List<MapPoint> = emptyList(),
+    override val points: List<MapPoint> = emptyList(),
     private val strokeWidth: String? = null,
     private val strokeColor: Int? = null,
     private val fillColor: Int? = null,

--- a/maps/src/main/java/org/odk/collect/maps/TraceDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/TraceDescription.kt
@@ -1,0 +1,7 @@
+package org.odk.collect.maps
+
+interface TraceDescription {
+    val highlightLastPoint: Boolean
+    fun getStrokeWidth(): Float
+    fun getStrokeColor(): Int
+}

--- a/maps/src/main/java/org/odk/collect/maps/TraceDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/TraceDescription.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.maps
 
 interface TraceDescription {
+    val points: List<MapPoint>
     val highlightLastPoint: Boolean
     fun getStrokeWidth(): Float
     fun getStrokeColor(): Int

--- a/maps/src/main/java/org/odk/collect/maps/TraceDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/TraceDescription.kt
@@ -1,8 +1,24 @@
 package org.odk.collect.maps
 
+import org.odk.collect.maps.MapFragment.Companion.CENTER
+import org.odk.collect.maps.markers.MarkerDescription
+import org.odk.collect.maps.markers.MarkerIconDescription.TracePoint
+
 interface TraceDescription {
     val points: List<MapPoint>
     val highlightLastPoint: Boolean
     fun getStrokeWidth(): Float
     fun getStrokeColor(): Int
+}
+
+fun TraceDescription.getMarkersForPoints(): List<MarkerDescription> {
+    return points.mapIndexed { i, point ->
+        val color = if (highlightLastPoint && i == points.lastIndex) {
+            MapConsts.DEFAULT_HIGHLIGHT_COLOR
+        } else {
+            getStrokeColor()
+        }
+
+        MarkerDescription(point, true, CENTER, TracePoint(getStrokeWidth(), color))
+    }
 }

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerDescription.kt
@@ -1,7 +1,11 @@
 package org.odk.collect.maps.markers
 
+import org.odk.collect.maps.MapConsts
 import org.odk.collect.maps.MapFragment
+import org.odk.collect.maps.MapFragment.Companion.CENTER
 import org.odk.collect.maps.MapPoint
+import org.odk.collect.maps.TraceDescription
+import org.odk.collect.maps.markers.MarkerIconDescription.TracePoint
 
 data class MarkerDescription(
     val point: MapPoint,
@@ -9,3 +13,15 @@ data class MarkerDescription(
     @MapFragment.Companion.IconAnchor val iconAnchor: String,
     val iconDescription: MarkerIconDescription
 )
+
+fun TraceDescription.getMarkersForPoints(): List<MarkerDescription> {
+    return points.mapIndexed { i, point ->
+        val color = if (highlightLastPoint && i == points.lastIndex) {
+            MapConsts.DEFAULT_HIGHLIGHT_COLOR
+        } else {
+            getStrokeColor()
+        }
+
+        MarkerDescription(point, true, CENTER, TracePoint(getStrokeWidth(), color))
+    }
+}

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerDescription.kt
@@ -1,11 +1,7 @@
 package org.odk.collect.maps.markers
 
-import org.odk.collect.maps.MapConsts
 import org.odk.collect.maps.MapFragment
-import org.odk.collect.maps.MapFragment.Companion.CENTER
 import org.odk.collect.maps.MapPoint
-import org.odk.collect.maps.TraceDescription
-import org.odk.collect.maps.markers.MarkerIconDescription.TracePoint
 
 data class MarkerDescription(
     val point: MapPoint,
@@ -13,15 +9,3 @@ data class MarkerDescription(
     @MapFragment.Companion.IconAnchor val iconAnchor: String,
     val iconDescription: MarkerIconDescription
 )
-
-fun TraceDescription.getMarkersForPoints(): List<MarkerDescription> {
-    return points.mapIndexed { i, point ->
-        val color = if (highlightLastPoint && i == points.lastIndex) {
-            MapConsts.DEFAULT_HIGHLIGHT_COLOR
-        } else {
-            getStrokeColor()
-        }
-
-        MarkerDescription(point, true, CENTER, TracePoint(getStrokeWidth(), color))
-    }
-}

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconCreator.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconCreator.kt
@@ -25,7 +25,7 @@ object MarkerIconCreator {
     @JvmStatic
     fun getMarkerIcon(context: Context, markerIconDescription: MarkerIconDescription): Bitmap {
         return when (markerIconDescription) {
-            is MarkerIconDescription.LinePoint -> {
+            is MarkerIconDescription.TracePoint -> {
                 fromCache("LinePoint" + markerIconDescription.lineSize + markerIconDescription.color) {
                     createPoint(
                         markerIconDescription.lineSize * 6,

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
@@ -28,7 +28,7 @@ sealed interface MarkerIconDescription {
 }
 
 fun LineDescription.getMarkerIconDescriptionForPoint(isLast: Boolean): MarkerIconDescription {
-    val color = if (isLast) {
+    val color = if (highlightLastPoint && isLast) {
         MapConsts.DEFAULT_HIGHLIGHT_COLOR
     } else {
         getStrokeColor()
@@ -38,7 +38,7 @@ fun LineDescription.getMarkerIconDescriptionForPoint(isLast: Boolean): MarkerIco
 }
 
 fun PolygonDescription.getMarkerIconDescriptionForPoint(isLast: Boolean): MarkerIconDescription {
-    val color = if (isLast) {
+    val color = if (highlightLastPoint && isLast) {
         MapConsts.DEFAULT_HIGHLIGHT_COLOR
     } else {
         getStrokeColor()

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
@@ -1,6 +1,9 @@
 package org.odk.collect.maps.markers
 
 import org.odk.collect.androidshared.utils.sanitizeToColorInt
+import org.odk.collect.maps.LineDescription
+import org.odk.collect.maps.MapConsts
+import org.odk.collect.maps.PolygonDescription
 import org.odk.collect.shared.strings.StringUtils
 import java.util.Locale
 
@@ -22,4 +25,24 @@ sealed interface MarkerIconDescription {
     }
 
     class LinePoint(val lineSize: Float, val color: Int) : MarkerIconDescription
+}
+
+fun LineDescription.getMarkerIconDescriptionForPoint(isLast: Boolean): MarkerIconDescription {
+    val color = if (isLast) {
+        MapConsts.DEFAULT_HIGHLIGHT_COLOR
+    } else {
+        getStrokeColor()
+    }
+
+    return MarkerIconDescription.LinePoint(getStrokeWidth(), color)
+}
+
+fun PolygonDescription.getMarkerIconDescriptionForPoint(isLast: Boolean): MarkerIconDescription {
+    val color = if (isLast) {
+        MapConsts.DEFAULT_HIGHLIGHT_COLOR
+    } else {
+        getStrokeColor()
+    }
+
+    return MarkerIconDescription.LinePoint(getStrokeWidth(), color)
 }

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
@@ -1,8 +1,6 @@
 package org.odk.collect.maps.markers
 
 import org.odk.collect.androidshared.utils.sanitizeToColorInt
-import org.odk.collect.maps.MapConsts
-import org.odk.collect.maps.TraceDescription
 import org.odk.collect.shared.strings.StringUtils
 import java.util.Locale
 
@@ -24,14 +22,4 @@ sealed interface MarkerIconDescription {
     }
 
     class TracePoint(val lineSize: Float, val color: Int) : MarkerIconDescription
-}
-
-fun TraceDescription.getMarkerIconDescriptionForPoint(isLast: Boolean): MarkerIconDescription {
-    val color = if (highlightLastPoint && isLast) {
-        MapConsts.DEFAULT_HIGHLIGHT_COLOR
-    } else {
-        getStrokeColor()
-    }
-
-    return MarkerIconDescription.TracePoint(getStrokeWidth(), color)
 }

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
@@ -1,9 +1,8 @@
 package org.odk.collect.maps.markers
 
 import org.odk.collect.androidshared.utils.sanitizeToColorInt
-import org.odk.collect.maps.LineDescription
 import org.odk.collect.maps.MapConsts
-import org.odk.collect.maps.PolygonDescription
+import org.odk.collect.maps.TraceDescription
 import org.odk.collect.shared.strings.StringUtils
 import java.util.Locale
 
@@ -24,25 +23,15 @@ sealed interface MarkerIconDescription {
         }
     }
 
-    class LinePoint(val lineSize: Float, val color: Int) : MarkerIconDescription
+    class TracePoint(val lineSize: Float, val color: Int) : MarkerIconDescription
 }
 
-fun LineDescription.getMarkerIconDescriptionForPoint(isLast: Boolean): MarkerIconDescription {
+fun TraceDescription.getMarkerIconDescriptionForPoint(isLast: Boolean): MarkerIconDescription {
     val color = if (highlightLastPoint && isLast) {
         MapConsts.DEFAULT_HIGHLIGHT_COLOR
     } else {
         getStrokeColor()
     }
 
-    return MarkerIconDescription.LinePoint(getStrokeWidth(), color)
-}
-
-fun PolygonDescription.getMarkerIconDescriptionForPoint(isLast: Boolean): MarkerIconDescription {
-    val color = if (highlightLastPoint && isLast) {
-        MapConsts.DEFAULT_HIGHLIGHT_COLOR
-    } else {
-        getStrokeColor()
-    }
-
-    return MarkerIconDescription.LinePoint(getStrokeWidth(), color)
+    return MarkerIconDescription.TracePoint(getStrokeWidth(), color)
 }

--- a/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
+++ b/maps/src/main/java/org/odk/collect/maps/markers/MarkerIconDescription.kt
@@ -5,7 +5,7 @@ import org.odk.collect.shared.strings.StringUtils
 import java.util.Locale
 
 sealed interface MarkerIconDescription {
-    class DrawableResource @JvmOverloads constructor(
+    data class DrawableResource @JvmOverloads constructor(
         val drawable: Int,
         private val color: String? = null,
         private val symbol: String? = null
@@ -21,5 +21,5 @@ sealed interface MarkerIconDescription {
         }
     }
 
-    class TracePoint(val lineSize: Float, val color: Int) : MarkerIconDescription
+    data class TracePoint(val lineSize: Float, val color: Int) : MarkerIconDescription
 }

--- a/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/LineDescriptionTest.kt
@@ -45,14 +45,8 @@ class LineDescriptionTest {
     }
 
     @Test
-    fun `getStrokeColor returns the default color when the passed one is invalid`() {
-        val lineDescription = LineDescription(strokeColor = "blah")
-        assertThat(lineDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
-    }
-
-    @Test
-    fun `getStrokeColor returns custom color when it is valid`() {
-        val lineDescription = LineDescription(strokeColor = "#aaccee")
+    fun `getStrokeColor returns custom color`() {
+        val lineDescription = LineDescription(strokeColor = -5583634)
         assertThat(lineDescription.getStrokeColor(), equalTo(-5583634))
     }
 }

--- a/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/PolygonDescriptionTest.kt
@@ -45,14 +45,8 @@ class PolygonDescriptionTest {
     }
 
     @Test
-    fun `getStrokeColor returns the default color when the passed one is invalid`() {
-        val polygonDescription = PolygonDescription(strokeColor = "blah")
-        assertThat(polygonDescription.getStrokeColor(), equalTo(MapConsts.DEFAULT_STROKE_COLOR))
-    }
-
-    @Test
-    fun `getStrokeColor returns custom color when it is valid`() {
-        val polygonDescription = PolygonDescription(strokeColor = "#aaccee")
+    fun `getStrokeColor returns custom color`() {
+        val polygonDescription = PolygonDescription(strokeColor = -5583634)
         assertThat(polygonDescription.getStrokeColor(), equalTo(-5583634))
     }
 
@@ -63,14 +57,8 @@ class PolygonDescriptionTest {
     }
 
     @Test
-    fun `getFillColor returns the default color when the passed one is invalid`() {
-        val polygonDescription = PolygonDescription(fillColor = "blah")
-        assertThat(polygonDescription.getFillColor(), equalTo(1144954828))
-    }
-
-    @Test
-    fun `getFillColor returns custom color when it is valid`() {
-        val polygonDescription = PolygonDescription(fillColor = "#aaccee")
+    fun `getFillColor returns custom color`() {
+        val polygonDescription = PolygonDescription(fillColor = 1152044270)
         assertThat(polygonDescription.getFillColor(), equalTo(1152044270))
     }
 }

--- a/maps/src/test/java/org/odk/collect/maps/TraceDescriptionTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/TraceDescriptionTest.kt
@@ -1,0 +1,81 @@
+package org.odk.collect.maps
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.maps.markers.MarkerDescription
+import org.odk.collect.maps.markers.MarkerIconDescription
+
+@RunWith(AndroidJUnit4::class)
+class TraceDescriptionTest {
+
+    @Test
+    fun `#getMarkersForPoints returns MarkerDescriptions for points on trace`() {
+        val traceDescription = TestTraceDescription(
+            points = listOf(MapPoint(0.0, 0.0), MapPoint(1.0, 1.0)),
+            highlightLastPoint = false,
+            strokeWidth = 5f,
+            strokeColor = 123
+        )
+
+        val markers = traceDescription.getMarkersForPoints()
+        assertThat(
+            markers,
+            contains(
+                MarkerDescription(
+                    traceDescription.points[0],
+                    true,
+                    MapFragment.CENTER,
+                    MarkerIconDescription.TracePoint(
+                        traceDescription.getStrokeWidth(),
+                        traceDescription.getStrokeColor()
+                    )
+                ),
+                MarkerDescription(
+                    traceDescription.points[1],
+                    true,
+                    MapFragment.CENTER,
+                    MarkerIconDescription.TracePoint(
+                        traceDescription.getStrokeWidth(),
+                        traceDescription.getStrokeColor()
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `#getMarkersForPoints returns last marker with highlight color when highlightLastPoint is true`() {
+        val traceDescription = TestTraceDescription(
+            points = listOf(MapPoint(0.0, 0.0), MapPoint(1.0, 1.0)),
+            highlightLastPoint = true,
+            strokeWidth = 5f,
+            strokeColor = 123
+        )
+
+        val icons = traceDescription.getMarkersForPoints().map {
+            it.iconDescription as MarkerIconDescription.TracePoint
+        }
+
+        assertThat(icons[0].color, equalTo(traceDescription.getStrokeColor()))
+        assertThat(icons[1].color, equalTo(MapConsts.DEFAULT_HIGHLIGHT_COLOR))
+    }
+}
+
+private class TestTraceDescription(
+    override val points: List<MapPoint>,
+    override val highlightLastPoint: Boolean,
+    private val strokeWidth: Float,
+    private val strokeColor: Int
+) : TraceDescription {
+    override fun getStrokeWidth(): Float {
+        return strokeWidth
+    }
+
+    override fun getStrokeColor(): Int {
+        return strokeColor
+    }
+}

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -818,12 +818,10 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
     private class StaticPolyLineFeature implements LineFeature {
         final MapView map;
         final Polyline polyline;
-        final boolean closedPolygon;
         private final List<MapPoint> points;
 
         StaticPolyLineFeature(MapView map, LineDescription lineDescription) {
             this.map = map;
-            this.closedPolygon = lineDescription.getClosed();
             polyline = new Polyline();
             polyline.setColor(lineDescription.getStrokeColor());
             polyline.setOnClickListener((clickedPolyline, mapView, eventPos) -> {
@@ -840,9 +838,6 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
 
             points = lineDescription.getPoints();
             List<GeoPoint> geoPoints = StreamSupport.stream(points.spliterator(), false).map(mapPoint -> new GeoPoint(mapPoint.latitude, mapPoint.longitude, mapPoint.altitude)).collect(Collectors.toList());
-            if (closedPolygon && !geoPoints.isEmpty()) {
-                geoPoints.add(geoPoints.get(0));
-            }
             polyline.setPoints(geoPoints);
             map.invalidate();
         }

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -16,6 +16,7 @@ package org.odk.collect.osmdroid;
 
 import static androidx.core.graphics.drawable.BitmapDrawableKt.toDrawable;
 import static androidx.core.graphics.drawable.DrawableKt.toBitmap;
+import static org.odk.collect.maps.TraceDescriptionKt.getMarkersForPoints;
 import static org.odk.collect.maps.markers.MarkerIconCreator.toBitmap;
 
 import android.content.BroadcastReceiver;
@@ -47,7 +48,6 @@ import org.odk.collect.androidshared.system.ContextUtils;
 import org.odk.collect.location.LocationClient;
 import org.odk.collect.maps.LineDescription;
 import org.odk.collect.maps.MapConfigurator;
-import org.odk.collect.maps.MapConsts;
 import org.odk.collect.maps.MapFragment;
 import org.odk.collect.maps.MapPoint;
 import org.odk.collect.maps.MapViewModel;
@@ -734,15 +734,6 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
         return mapViewModel;
     }
 
-    @NonNull
-    private Marker getLinePointMarker(MapPoint point, float strokeWidth, boolean isLast) {
-        if (isLast) {
-            return createMarker(map, new MarkerDescription(point, true, CENTER, new MarkerIconDescription.TracePoint(strokeWidth, MapConsts.DEFAULT_HIGHLIGHT_COLOR)));
-        } else {
-            return createMarker(map, new MarkerDescription(point, true, CENTER, new MarkerIconDescription.TracePoint(strokeWidth, MapConsts.DEFAULT_STROKE_COLOR)));
-        }
-    }
-
     /**
      * A MapFeature is a physical feature on a map, such as a point, a road,
      * a building, a region, etc.  It is presented to the user as one editable
@@ -907,10 +898,9 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
             paint.setStrokeWidth(lineDescription.getStrokeWidth());
             map.getOverlays().add(polyline);
 
-            List<MapPoint> points = lineDescription.getPoints();
-            for (int i = 0; i < points.size(); i++) {
-                MapPoint point = points.get(i);
-                markers.add(getLinePointMarker(point, lineDescription.getStrokeWidth(), i == points.size() - 1));
+            List<MarkerDescription> markerDescriptions = getMarkersForPoints(lineDescription);
+            for (MarkerDescription markerDescription : markerDescriptions) {
+                markers.add(createMarker(map, markerDescription));
             }
             update();
         }
@@ -983,10 +973,9 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
 
             map.getOverlays().add(polygon);
 
-            List<MapPoint> points = polygonDescription.getPoints();
-            for (int i = 0; i < points.size(); i++) {
-                MapPoint point = points.get(i);
-                markers.add(getLinePointMarker(point, polygonDescription.getStrokeWidth(), i == polygonDescription.getPoints().size() - 1));
+            List<MarkerDescription> markerDescriptions = getMarkersForPoints(polygonDescription);
+            for (MarkerDescription markerDescription : markerDescriptions) {
+                markers.add(createMarker(map, markerDescription));
             }
             update();
         }

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -737,9 +737,9 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
     @NonNull
     private Marker getLinePointMarker(MapPoint point, float strokeWidth, boolean isLast) {
         if (isLast) {
-            return createMarker(map, new MarkerDescription(point, true, CENTER, new MarkerIconDescription.LinePoint(strokeWidth, MapConsts.DEFAULT_HIGHLIGHT_COLOR)));
+            return createMarker(map, new MarkerDescription(point, true, CENTER, new MarkerIconDescription.TracePoint(strokeWidth, MapConsts.DEFAULT_HIGHLIGHT_COLOR)));
         } else {
-            return createMarker(map, new MarkerDescription(point, true, CENTER, new MarkerIconDescription.LinePoint(strokeWidth, MapConsts.DEFAULT_STROKE_COLOR)));
+            return createMarker(map, new MarkerDescription(point, true, CENTER, new MarkerIconDescription.TracePoint(strokeWidth, MapConsts.DEFAULT_STROKE_COLOR)));
         }
     }
 


### PR DESCRIPTION
Work towards #6970

This felt like enough to merge and possibly go out as a beta - I'll follow up with the rest of the issue.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

As the title says this just adds the "invalid" style to traces and shapes (they should appear in red without the last point highlighted) and also disables the save button while constraints are violated. All three map engines should be working, but the changes are minimal so no need to dig in too deep.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
