### PR TITLE
Block adding point when invalid

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/livedata/LiveDataExt.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/livedata/LiveDataExt.kt
@@ -1,9 +1,32 @@
 package org.odk.collect.androidshared.livedata
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 
 object LiveDataExt {
     fun <T, U> LiveData<T>.zip(other: LiveData<U>): LiveData<Pair<T, U>> {
         return LiveDataUtils.zip(this, other)
+    }
+
+    fun <T, U> LiveData<T>.runningFold(initial: U, operation: (U, T) -> U): LiveData<U> {
+        val mediator = MediatorLiveData<U>()
+
+        var accum = initial
+        mediator.addSource(this) {
+            accum = operation(accum, it)
+            mediator.value = accum
+        }
+
+        return mediator
+    }
+
+    /**
+     * Returns a [LiveData] where each value is a [Pair] made up of the latest value and the
+     * previous value.
+    */
+    fun <T : Any?> LiveData<T>.withLast(): LiveData<Pair<T?, T?>> {
+        return this.runningFold(Pair(null, null) as Pair<T?, T?>) { last, current ->
+            Pair(last.second, current)
+        }
     }
 }

--- a/androidshared/src/main/java/org/odk/collect/androidshared/livedata/LiveDataExt.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/livedata/LiveDataExt.kt
@@ -23,7 +23,7 @@ object LiveDataExt {
     /**
      * Returns a [LiveData] where each value is a [Pair] made up of the latest value and the
      * previous value.
-    */
+     */
     fun <T : Any?> LiveData<T>.withLast(): LiveData<Pair<T?, T?>> {
         return this.runningFold(Pair(null, null) as Pair<T?, T?>) { last, current ->
             Pair(last.second, current)

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/SnackbarUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/SnackbarUtils.kt
@@ -19,6 +19,8 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import com.google.android.material.R
 import com.google.android.material.snackbar.BaseTransientBottomBar
@@ -161,5 +163,13 @@ object SnackbarUtils {
                 consumable.consume()
             }
         }
+    }
+
+    fun <T : Any?> LiveData<Consumable<T>?>.showSnackbar(lifecycleOwner: LifecycleOwner, parentView: View, details: (T) -> SnackbarDetails) {
+        observe(lifecycleOwner, object : SnackbarPresenterObserver<T>(parentView) {
+            override fun getSnackbarDetails(value: T): SnackbarDetails {
+                return details(value)
+            }
+        })
     }
 }

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -98,7 +98,8 @@ class GeoPolyFragment @JvmOverloads constructor(
                     inputPolygon,
                     retainMockAccuracy,
                     locationTracker,
-                    scheduler
+                    scheduler,
+                    invalidMessage
                 )
             }
         }
@@ -242,7 +243,7 @@ class GeoPolyFragment @JvmOverloads constructor(
                 showInfoDialog(true)
             }
         )
-        val viewData = viewModel.points.asLiveData().zip(invalidMessage)
+        val viewData = viewModel.points.asLiveData().zip(viewModel.invalidMessage)
         viewData.observe(viewLifecycleOwner) { (points, invalidMessage) ->
             val isValid = invalidMessage == null
             if (!isValid) {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -19,6 +19,7 @@ import org.odk.collect.androidshared.livedata.LiveDataExt.zip
 import org.odk.collect.androidshared.ui.DialogFragmentUtils.showIfNotShowing
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.SnackbarUtils
+import org.odk.collect.androidshared.ui.SnackbarUtils.showSnackbar
 import org.odk.collect.androidshared.ui.ToastUtils.showShortToastInMiddle
 import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.GeoActivityUtils.requireLocationPermissions
@@ -150,6 +151,10 @@ class GeoPolyFragment @JvmOverloads constructor(
         mapFragment.init({ initMap(it, binding) }, { this.cancel() })
 
         onBackPressedDispatcher().addCallback(viewLifecycleOwner, onBackPressedCallback)
+
+        viewModel.fixedAlerts.showSnackbar(viewLifecycleOwner, view) {
+            SnackbarUtils.SnackbarDetails("✅ Error fixed")
+        }
     }
 
     override fun onSaveInstanceState(state: Bundle) {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -153,7 +153,7 @@ class GeoPolyFragment @JvmOverloads constructor(
         onBackPressedDispatcher().addCallback(viewLifecycleOwner, onBackPressedCallback)
 
         viewModel.fixedAlerts.showSnackbar(viewLifecycleOwner, view) {
-            SnackbarUtils.SnackbarDetails("✅ Error fixed")
+            SnackbarUtils.SnackbarDetails(getString(string.error_fixed))
         }
     }
 

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -461,7 +461,6 @@ class GeoPolyFragment @JvmOverloads constructor(
     }
 
     private fun clear() {
-        viewModel.disableInput()
         viewModel.update(emptyList())
     }
 

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -246,7 +246,8 @@ class GeoPolyFragment @JvmOverloads constructor(
             Snackbar.LENGTH_INDEFINITE,
             action = SnackbarUtils.Action(getString(string.how_to_modify)) {
                 showInfoDialog(true)
-            }
+            },
+            displayDismissButton = true
         )
         val viewData = viewModel.points.asLiveData().zip(viewModel.invalidMessage)
         viewData.observe(viewLifecycleOwner) { (points, invalidMessage) ->

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.map
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.odk.collect.androidshared.data.Consumable
+import org.odk.collect.androidshared.livedata.LiveDataExt.withLast
 import org.odk.collect.async.Cancellable
 import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.geopoly.GeoPolyFragment.OutputMode
@@ -44,13 +45,10 @@ class GeoPolyViewModel(
     )
     val points: StateFlow<List<MapPoint>> = _points
 
-    private var lastInvalidMessage: String? = null
-    val fixedAlerts = invalidMessage.map {
-        if (it == null && lastInvalidMessage != null) {
-            lastInvalidMessage = it
+    val fixedAlerts = invalidMessage.withLast().map {
+        if (it.second == null && it.first != null) {
             Consumable(Unit)
         } else {
-            lastInvalidMessage = it
             null
         }
     }

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.geo.geopoly
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,7 +15,8 @@ class GeoPolyViewModel(
     points: List<MapPoint>,
     private val retainMockAccuracy: Boolean,
     private val locationTracker: LocationTracker,
-    private val scheduler: Scheduler
+    private val scheduler: Scheduler,
+    val invalidMessage: LiveData<String?>
 ) : ViewModel() {
 
     enum class RecordingMode {
@@ -43,9 +45,11 @@ class GeoPolyViewModel(
     private var recording: Cancellable? = null
 
     fun add(point: MapPoint) {
-        val points = _points.value
-        if (points.isEmpty() || point != points.last()) {
-            _points.value = points + point
+        if (invalidMessage.value == null) {
+            val points = _points.value
+            if (points.isEmpty() || point != points.last()) {
+                _points.value = points + point
+            }
         }
     }
 

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
@@ -2,8 +2,10 @@ package org.odk.collect.geo.geopoly
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import org.odk.collect.androidshared.data.Consumable
 import org.odk.collect.async.Cancellable
 import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.geopoly.GeoPolyFragment.OutputMode
@@ -41,6 +43,18 @@ class GeoPolyViewModel(
         }
     )
     val points: StateFlow<List<MapPoint>> = _points
+
+    private var lastInvalidMessage: String? = null
+    val fixedAlerts = invalidMessage.map {
+        if (it == null && lastInvalidMessage != null) {
+            lastInvalidMessage = it
+            Consumable(Unit)
+        } else {
+            lastInvalidMessage = it
+            null
+        }
+    }
+
     private var accuracyThreshold: Int = 0
     private var recording: Cancellable? = null
 

--- a/geo/src/main/res/layout/geopoly_layout.xml
+++ b/geo/src/main/res/layout/geopoly_layout.xml
@@ -26,6 +26,7 @@
         android:layout_marginStart="@dimen/margin_standard"
         android:layout_marginTop="@dimen/margin_standard"
         android:layout_marginEnd="@dimen/margin_standard"
+        android:contentDescription="@string/record_geopoint"
         android:text="@string/record_geopoint"
         android:visibility="gone"
         app:icon="@drawable/ic_distance"

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -694,6 +694,22 @@ class GeoPolyFragmentTest {
     }
 
     @Test
+    fun invalidSnackbarCanBeDismissed() {
+        val invalidMessage = MutableLiveData<String?>(null)
+        fragmentLauncherRule.launchInContainer {
+            GeoPolyFragment(
+                { OnBackPressedDispatcher() },
+                invalidMessage = invalidMessage
+            )
+        }
+
+        val message = "Something is wrong"
+        invalidMessage.value = message
+        Interactions.clickOn(withContentDescription(string.close_snackbar))
+        assertNotVisible(withText(message))
+    }
+
+    @Test
     fun changesPolyLineColorBasedOnInvalidMessage() {
         val invalidMessage = MutableLiveData<String?>(null)
         fragmentLauncherRule.launchInContainer {

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -610,9 +610,60 @@ class GeoPolyFragmentTest {
     }
 
     @Test
+    fun whenInvalidMessageIsNotNull_pointsCannotBeAddedByClicking() {
+        val invalidMessage = MutableLiveData<String?>(null)
+        fragmentLauncherRule.launchInContainer {
+            GeoPolyFragment(
+                { OnBackPressedDispatcher() },
+                invalidMessage = invalidMessage
+            )
+        }
+
+        startInput(R.id.placement_mode)
+
+        invalidMessage.value = "Blah"
+        mapFragment.click(MapPoint(0.0, 0.0))
+        assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(0))
+    }
+
+    @Test
+    fun whenInvalidMessageIsNotNull_pointsCannotBeAddedManually() {
+        val invalidMessage = MutableLiveData<String?>(null)
+        fragmentLauncherRule.launchInContainer {
+            GeoPolyFragment(
+                { OnBackPressedDispatcher() },
+                invalidMessage = invalidMessage
+            )
+        }
+
+        startInput(R.id.manual_mode)
+
+        invalidMessage.value = "Blah"
+        Interactions.clickOn(withContentDescription(string.record_geopoint))
+        assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(0))
+    }
+
+    @Test
+    fun whenInvalidMessageIsNotNull_automaticRecordingStops() {
+        val invalidMessage = MutableLiveData<String?>(null)
+        fragmentLauncherRule.launchInContainer {
+            GeoPolyFragment(
+                { OnBackPressedDispatcher() },
+                invalidMessage = invalidMessage
+            )
+        }
+
+        startInput(R.id.automatic_mode)
+
+        invalidMessage.value = "Blah"
+        locationTracker.currentLocation = Location(1.0, 1.0, 1.0, 1f)
+        scheduler.runForeground(0)
+        assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(0))
+    }
+
+    @Test
     fun showsAndHidesInvalidMessageSnackbarBasedOnValue() {
         val invalidMessage = MutableLiveData<String?>(null)
-
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -631,7 +682,6 @@ class GeoPolyFragmentTest {
     @Test
     fun changesPolyLineColorBasedOnInvalidMessage() {
         val invalidMessage = MutableLiveData<String?>(null)
-
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -656,7 +706,6 @@ class GeoPolyFragmentTest {
     @Test
     fun changesPolygonColorBasedOnInvalidMessage() {
         val invalidMessage = MutableLiveData<String?>(null)
-
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -690,7 +739,6 @@ class GeoPolyFragmentTest {
     @Test
     fun disablesSaveButtonWhenInvalid() {
         val invalidMessage = MutableLiveData<String?>(null)
-
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -17,12 +17,14 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
+import org.odk.collect.androidshared.ui.SnackbarUtils
 import org.odk.collect.androidshared.utils.opaque
 import org.odk.collect.androidtest.FragmentScenarioExtensions.setFragmentResultListener
 import org.odk.collect.async.Scheduler
@@ -105,6 +107,13 @@ class GeoPolyFragmentTest {
                 }
             })
             .build()
+
+        SnackbarUtils.alertStore.enabled = true
+    }
+
+    @After
+    fun teardown() {
+        SnackbarUtils.alertStore.enabled = false
     }
 
     @Test
@@ -677,6 +686,11 @@ class GeoPolyFragmentTest {
 
         invalidMessage.value = null
         assertNotVisible(withText(message))
+        Assertions.assertAlert(
+            SnackbarUtils.alertStore,
+            "✅ Error fixed",
+            "No error fixed message shown!"
+        )
     }
 
     @Test

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -688,7 +688,7 @@ class GeoPolyFragmentTest {
         assertNotVisible(withText(message))
         Assertions.assertAlert(
             SnackbarUtils.alertStore,
-            "✅ Error fixed",
+            application.getString(string.error_fixed),
             "No error fixed message shown!"
         )
     }

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyViewModelTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyViewModelTest.kt
@@ -1,0 +1,55 @@
+package org.odk.collect.geo.geopoly
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.odk.collect.testshared.getOrAwaitValue
+
+class GeoPolyViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun `#fixedAlerts is null until after invalid message is non-null`() {
+        val invalidMessage = MutableLiveData<String?>(null)
+        val viewModel = GeoPolyViewModel(
+            GeoPolyFragment.OutputMode.GEOTRACE,
+            emptyList(),
+            false,
+            mock(),
+            mock(),
+            invalidMessage
+        )
+
+        assertThat(viewModel.fixedAlerts.getOrAwaitValue(), equalTo(null))
+
+        invalidMessage.value = "OH NO"
+        assertThat(viewModel.fixedAlerts.getOrAwaitValue(), equalTo(null))
+
+        invalidMessage.value = null
+        assertThat(viewModel.fixedAlerts.getOrAwaitValue()!!.value, equalTo(Unit))
+    }
+
+    @Test
+    fun `#fixedAlerts is null after repeated invalid message nulls after a non-null`() {
+        val invalidMessage = MutableLiveData<String?>(null)
+        val viewModel = GeoPolyViewModel(
+            GeoPolyFragment.OutputMode.GEOTRACE,
+            emptyList(),
+            false,
+            mock(),
+            mock(),
+            invalidMessage
+        )
+
+        invalidMessage.value = "OH NO"
+        invalidMessage.value = null
+        invalidMessage.value = null
+        assertThat(viewModel.fixedAlerts.getOrAwaitValue(), equalTo(null))
+    }
+}

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -683,6 +683,9 @@
     <!-- Description for button that removes the last recorded point -->
     <string name="remove_last_point">Remove last point</string>
 
+    <!-- Message shown when an error with the trace/shape has been fixed  -->
+    <string name="error_fixed">✅ Error fixed</string>
+
     <!-- Description for button that explains how to modify the map -->
     <string name="show_how_to_modify_map">Show how to modify the map</string>
 


### PR DESCRIPTION
Closes #6970
~~Blocked by #7021~~
~~Blocked by #7050~~

This removes the ability to add new points while the trace/shape is invalid and also:

- Adds a success message when the invalid state is fixed
- Makes the error snackbar dismissible

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just the new features here: no map code was affected so can be tested in any one of them.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
