### PR TITLE
Fix dark theming for InfoDialog

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/ComposeTheme.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/ComposeTheme.kt
@@ -22,20 +22,26 @@ fun CollectTheme(content: @Composable () -> Unit) {
         primary = colorResource(R.color.colorPrimaryLight),
         onPrimary = colorResource(R.color.colorOnPrimaryLight),
         surface = colorResource(R.color.colorSurfaceLight),
+        onSurface = colorResource(R.color.colorOnSurfaceLight),
         primaryContainer = colorResource(R.color.colorPrimaryContainerLight),
         onPrimaryContainer = colorResource(R.color.colorOnPrimaryContainerLight)
     )
+
     val darkColors = darkColorScheme(
         primary = colorResource(R.color.colorPrimaryDark),
         onPrimary = colorResource(R.color.colorOnPrimaryDark),
         surface = colorResource(R.color.colorSurfaceDark),
+        onSurface = colorResource(R.color.colorOnSurfaceDark),
         primaryContainer = colorResource(R.color.colorPrimaryContainerDark),
         onPrimaryContainer = colorResource(R.color.colorOnPrimaryContainerDark)
     )
+
     val colorScheme = if (isSystemInDarkTheme()) darkColors else lightColors
 
     val typography = Typography(
-        bodyMedium = MaterialTheme.typography.bodyMedium
+        bodyMedium = MaterialTheme.typography.bodyMedium,
+        bodyLarge = MaterialTheme.typography.bodyLarge,
+        titleLarge = MaterialTheme.typography.titleLarge,
     )
 
     val shapes = Shapes(

--- a/collect_app/src/main/res/values-night/material_colors.xml
+++ b/collect_app/src/main/res/values-night/material_colors.xml
@@ -13,7 +13,7 @@
 
     <color name="colorSurface">@color/colorSurfaceDark</color>
     <color name="colorSurfaceVariant">#40484c</color>
-    <color name="colorOnSurface">#d3e5ef</color>
+    <color name="colorOnSurface">@color/colorOnSurfaceDark</color>
     <color name="colorOnSurfaceVariant">#c0c8cd</color>
     <color name="colorSurfaceContainerLowest">#001117</color>
     <color name="colorSurfaceContainerLow">#293134</color>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -5,10 +5,12 @@
     <color name="colorPrimaryContainerLight">#bfe9ff</color>
     <color name="colorOnPrimaryContainerLight">#001f2a</color>
     <color name="colorSurfaceLight">#ffffff</color>
+    <color name="colorOnSurfaceLight">#001f2a</color>
 
     <color name="colorPrimaryDark">#4cbcf0</color>
     <color name="colorOnPrimaryDark">#003547</color>
     <color name="colorPrimaryContainerDark">#004d65</color>
     <color name="colorOnPrimaryContainerDark">#bfe9ff</color>
     <color name="colorSurfaceDark">#001117</color>
+    <color name="colorOnSurfaceDark">#d3e5ef</color>
 </resources>

--- a/collect_app/src/main/res/values/material_colors.xml
+++ b/collect_app/src/main/res/values/material_colors.xml
@@ -13,7 +13,7 @@
 
     <color name="colorSurface">@color/colorSurfaceLight</color>
     <color name="colorSurfaceVariant">#dce3e9</color>
-    <color name="colorOnSurface">#001f2a</color>
+    <color name="colorOnSurface">@color/colorOnSurfaceLight</color>
     <color name="colorOnSurfaceVariant">#40484c</color>
     <color name="colorSurfaceContainerLowest">#ffffff</color>
     <color name="colorSurfaceContainerLow">#f7f7f7</color>

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/InfoDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -99,21 +100,23 @@ fun InfoContent(
 
     val scrollState = rememberScrollState()
 
-    Column(
-        modifier = Modifier
-            .padding(dimensionResource(id = dimen.margin_standard))
-            .verticalScroll(scrollState)
-    ) {
-        Title()
-        items.forEachIndexed { index, item ->
-            Info(item.icon, item.text)
-            if (index < items.lastIndex) {
-                HorizontalDivider(
-                    Modifier.padding(horizontal = dimensionResource(id = dimen.margin_small))
-                )
+    Surface {
+        Column(
+            modifier = Modifier
+                .padding(dimensionResource(id = dimen.margin_standard))
+                .verticalScroll(scrollState)
+        ) {
+            Title()
+            items.forEachIndexed { index, item ->
+                Info(item.icon, item.text)
+                if (index < items.lastIndex) {
+                    HorizontalDivider(
+                        Modifier.padding(horizontal = dimensionResource(id = dimen.margin_small))
+                    )
+                }
             }
+            DoneButton(onDone)
         }
-        DoneButton(onDone)
     }
 }
 


### PR DESCRIPTION
Closes #7059

#### Why is this the best possible solution? Were any other approaches considered?

It turns out you need to be in a `Surface` for `Text` to use theme colors. Otherwise, `LocalContentColor` will still be set to `Black`. This feels overly complex, but my guess is you don't have to deal with this if you're building Compose code for everything and using high level helpers like `Scaffold`.

I've also updated our theme for the dark and light text colors and styles.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The dialog is the only thing affected.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
