### PR TITLE
Improve scrolling to questions and highlighting questions with errors

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -566,7 +566,7 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
             if (indexAndValidationResult != null) {
                 FormIndex screenIndex = indexAndValidationResult.getFirst();
                 FormIndex questionIndex = indexAndValidationResult.getSecond();
-                FailedValidationResult validationResult = indexAndValidationResult.getThird();
+                ValidationResult validationResult = indexAndValidationResult.getThird();
                 formIndexAnimationHandler.handle(screenIndex);
                 if (validationResult != null) {
                     handleValidationResult(validationResult);
@@ -587,15 +587,6 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
                 createErrorDialog(error);
                 formEntryViewModel.errorDisplayed();
             }
-        });
-
-        formEntryViewModel.getValidationResult().observe(this, consumable -> {
-            if (consumable.isConsumed()) {
-                return;
-            }
-            ValidationResult validationResult = consumable.getValue();
-            handleValidationResult(validationResult);
-            consumable.consume();
         });
 
         formSaveViewModel = viewModelProvider.get(FormSaveViewModel.class);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -1814,7 +1814,7 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
             if (validationResult != null) {
                 handleValidationResult(view, validationResult);
             } else if (index.getQuestionIndex() != null) {
-                view.scrollToTopOf(index.getQuestionIndex());
+                view.focusToTopOf(index.getQuestionIndex());
             } else {
                 view.setFocus(this);
             }
@@ -2261,7 +2261,7 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
                         updateFieldListQuestions(changedWidget.getFormEntryPrompt().getIndex());
                         odkView.post(() -> {
                             if (odkView != null && !odkView.isDisplayed(changedWidget)) {
-                                odkView.scrollToTopOf(changedWidget);
+                                odkView.focusToTopOf(changedWidget);
                             }
                         });
                     } catch (RepeatsInFieldListException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/CurrentFormIndex.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/CurrentFormIndex.kt
@@ -1,0 +1,24 @@
+package org.odk.collect.android.formentry
+
+import org.javarosa.core.model.FormIndex
+import org.odk.collect.android.javarosawrapper.ValidationResult
+
+data class CurrentFormIndex(
+    /**
+     * The index of the screen to navigate to or refresh.
+     */
+    val screenIndex: FormIndex,
+    /**
+     * The index of the particular question to focus on and scroll to within a screen
+     * containing multiple questions. Can be null if navigation is intended
+     * only to the screen without focusing on a specific question.
+     */
+    val questionIndex: FormIndex?,
+    /**
+     * The result of validating the current form state.
+     * Contains information necessary to highlight a question with an invalid
+     * answer if validation was performed and failed. Can be null if validation
+     * has not been executed.
+     */
+    val validationResult: ValidationResult?
+)

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -52,7 +52,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import kotlin.Triple;
 import timber.log.Timber;
 
 public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader {
@@ -61,7 +60,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
     private final MutableLiveData<FormError> error = new MutableLiveData<>(null);
     private final MutableNonNullLiveData<Boolean> hasBackgroundRecording = new MutableNonNullLiveData<>(false);
-    private final MutableLiveData<Triple<FormIndex, FormIndex, ValidationResult>> currentIndex = new MutableLiveData<>(null);
+    private final MutableLiveData<CurrentFormIndex> currentIndex = new MutableLiveData<>(null);
     @NonNull
     private final FormSessionRepository formSessionRepository;
     private final String sessionId;
@@ -114,7 +113,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         return formController;
     }
 
-    public LiveData<Triple<FormIndex, FormIndex, ValidationResult>> getCurrentIndex() {
+    public LiveData<CurrentFormIndex> getCurrentIndex() {
         return currentIndex;
     }
 
@@ -371,9 +370,9 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
             AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), clock.get());
             if (isAsync) {
-                currentIndex.postValue(new Triple<>(formController.getFormIndex(), questionIndex, validationResult));
+                currentIndex.postValue(new CurrentFormIndex(formController.getFormIndex(), questionIndex, validationResult));
             } else {
-                currentIndex.setValue(new Triple<>(formController.getFormIndex(), questionIndex, validationResult));
+                currentIndex.setValue(new CurrentFormIndex(formController.getFormIndex(), questionIndex, validationResult));
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -36,7 +36,6 @@ import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.ChangeLocks;
 import org.odk.collect.android.widgets.interfaces.SelectChoiceLoader;
 import org.odk.collect.androidshared.async.TrackableWorker;
-import org.odk.collect.androidshared.data.Consumable;
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData;
 import org.odk.collect.androidshared.livedata.NonNullLiveData;
 import org.odk.collect.async.Cancellable;
@@ -62,9 +61,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
 
     private final MutableLiveData<FormError> error = new MutableLiveData<>(null);
     private final MutableNonNullLiveData<Boolean> hasBackgroundRecording = new MutableNonNullLiveData<>(false);
-    private final MutableLiveData<Triple<FormIndex, FormIndex, FailedValidationResult>> currentIndex = new MutableLiveData<>(null);
-    private final MutableLiveData<Consumable<ValidationResult>>
-            validationResult = new MutableLiveData<>(new Consumable<>(null));
+    private final MutableLiveData<Triple<FormIndex, FormIndex, ValidationResult>> currentIndex = new MutableLiveData<>(null);
     @NonNull
     private final FormSessionRepository formSessionRepository;
     private final String sessionId;
@@ -117,16 +114,12 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         return formController;
     }
 
-    public LiveData<Triple<FormIndex, FormIndex, FailedValidationResult>> getCurrentIndex() {
+    public LiveData<Triple<FormIndex, FormIndex, ValidationResult>> getCurrentIndex() {
         return currentIndex;
     }
 
     public LiveData<FormError> getError() {
         return error;
-    }
-
-    public LiveData<Consumable<ValidationResult>> getValidationResult() {
-        return validationResult;
     }
 
     public NonNullLiveData<Boolean> isLoading() {
@@ -265,7 +258,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         try {
             ValidationResult result = formController.saveAllScreenAnswers(answers, evaluateConstraints);
             if (result instanceof FailedValidationResult) {
-                validationResult.postValue(new Consumable<>(result));
+                updateIndex(true, result);
                 return false;
             }
         } catch (JavaRosaException e) {
@@ -296,7 +289,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                 ValidationResult result = formController.saveOneScreenAnswer(index, answer, autoAdvance);
 
                 if (result instanceof FailedValidationResult) {
-                    updateIndex(true, (FailedValidationResult) result);
+                    updateIndex(true, result);
                 } else {
                     if (autoAdvance) {
                         formController.stepToNextScreenEvent();
@@ -344,11 +337,11 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         }, ignored -> {});
     }
 
-    private void updateIndex(boolean isAsync, @Nullable FailedValidationResult validationResult) {
+    private void updateIndex(boolean isAsync, @Nullable ValidationResult validationResult) {
         updateIndex(isAsync, validationResult, null);
     }
 
-    private void updateIndex(boolean isAsync, @Nullable FailedValidationResult validationResult, @Nullable FormIndex questionIndex) {
+    private void updateIndex(boolean isAsync, @Nullable ValidationResult validationResult, @Nullable FormIndex questionIndex) {
         choices.clear();
 
         if (formController != null) {
@@ -401,13 +394,7 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
                         error.postValue(new FormError.NonFatal(e.getMessage()));
                     }
 
-                    // JavaRosa moves to the index where the contraint failed
-                    if (result instanceof FailedValidationResult) {
-                        updateIndex(true, (FailedValidationResult) result);
-                    } else {
-                        validationResult.postValue(new Consumable<>(result));
-                    }
-
+                    updateIndex(true, result);
                     return null;
                 }, ignored -> {}
         );

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -562,16 +562,16 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
         return qw.getLocalVisibleRect(scrollBounds);
     }
 
-    public void scrollToTopOf(FormIndex index) {
+    public void focusToTopOf(FormIndex index) {
         for (QuestionWidget widget : widgets) {
             if (widget.getFormEntryPrompt().getIndex().equals(index)) {
-                scrollToTopOf(widget);
+                focusToTopOf(widget);
                 break;
             }
         }
     }
 
-    public void scrollToTopOf(@Nullable QuestionWidget qw) {
+    public void focusToTopOf(@Nullable QuestionWidget qw) {
         if (qw != null && widgets.contains(qw)) {
             findViewById(R.id.odk_view_container).scrollTo(0, qw.getTop());
             qw.setFocus(getContext());
@@ -701,7 +701,7 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
         for (QuestionWidget questionWidget : getWidgets()) {
             if (formIndex.equals(questionWidget.getFormEntryPrompt().getIndex())) {
                 questionWidget.displayError(errorMessage);
-                scrollToTopOf(questionWidget);
+                focusToTopOf(questionWidget);
             } else {
                 questionWidget.hideError();
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -573,7 +573,8 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
 
     public void scrollToTopOf(@Nullable QuestionWidget qw) {
         if (qw != null && widgets.contains(qw)) {
-            postDelayed(() -> findViewById(R.id.odk_view_container).scrollTo(0, qw.getTop()), 400);
+            findViewById(R.id.odk_view_container).scrollTo(0, qw.getTop());
+            qw.setFocus(getContext());
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -37,7 +37,6 @@ import org.odk.collect.android.javarosawrapper.FakeFormController;
 import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.ChangeLocks;
-import org.odk.collect.androidshared.data.Consumable;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormsRepository;
 import org.odk.collect.formstest.InMemFormsRepository;
@@ -214,16 +213,16 @@ public class FormEntryViewModelTest {
 
     @Test
     public void moveForward_withEvaluateConstraints_whenThereIsAFailedConstraint_setsFailedConstraint() {
-        Consumable<FailedValidationResult> failedValidationResult =
-                new Consumable<>(new FailedValidationResult(startingIndex, 0, null, org.odk.collect.strings.R.string.invalid_answer_error));
-        formController.setFailedConstraint(failedValidationResult.getValue());
+        FailedValidationResult failedValidationResult =
+                new FailedValidationResult(startingIndex, 0, null, org.odk.collect.strings.R.string.invalid_answer_error);
+        formController.setFailedConstraint(failedValidationResult);
 
         HashMap<FormIndex, IAnswerData> answers = new HashMap<>();
         answers.put(startingIndex, new StringData("answer"));
         viewModel.moveForward(answers, true);
         scheduler.flush();
 
-        assertThat(getOrAwaitValue(viewModel.getValidationResult()), equalTo(failedValidationResult));
+        assertThat(getOrAwaitValue(viewModel.getCurrentIndex()).getThird(), equalTo(failedValidationResult));
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -222,7 +222,7 @@ public class FormEntryViewModelTest {
         viewModel.moveForward(answers, true);
         scheduler.flush();
 
-        assertThat(getOrAwaitValue(viewModel.getCurrentIndex()).getThird(), equalTo(failedValidationResult));
+        assertThat(getOrAwaitValue(viewModel.getCurrentIndex()).getValidationResult(), equalTo(failedValidationResult));
     }
 
     /**
@@ -488,7 +488,7 @@ public class FormEntryViewModelTest {
         FormIndex originalIndex = formController.getFormIndex();
         viewModel.answerQuestion(formIndex, new StringData("answer"));
         scheduler.flush(true);
-        assertThat(getOrAwaitValue(viewModel.getCurrentIndex()).getThird(), equalTo(failedValidationResult));
+        assertThat(getOrAwaitValue(viewModel.getCurrentIndex()).getValidationResult(), equalTo(failedValidationResult));
         assertThat(formController.getFormIndex(), equalTo(new FormIndex(null, originalIndex.getLocalIndex(), 0, new TreeReference())));
     }
 
@@ -505,11 +505,11 @@ public class FormEntryViewModelTest {
         viewModel.answerQuestion(formIndex, new StringData("answer"));
         scheduler.flush(true);
         assertThat(
-                getOrAwaitValue(viewModel.getCurrentIndex()).getFirst(),
+                getOrAwaitValue(viewModel.getCurrentIndex()).getScreenIndex(),
                 equalTo(originalIndex)
         );
         assertThat(
-                getOrAwaitValue(viewModel.getCurrentIndex()).getSecond(),
+                getOrAwaitValue(viewModel.getCurrentIndex()).getQuestionIndex(),
                 equalTo(formIndex)
         );
     }
@@ -529,11 +529,11 @@ public class FormEntryViewModelTest {
         viewModel.answerQuestion(formIndex, new StringData("answer"));
         scheduler.flush(true);
         assertThat(
-                getOrAwaitValue(viewModel.getCurrentIndex()).getFirst(),
+                getOrAwaitValue(viewModel.getCurrentIndex()).getScreenIndex(),
                 equalTo(new FormIndex(null, originalIndex.getLocalIndex() + 1, 0, new TreeReference()))
         );
         assertThat(
-                getOrAwaitValue(viewModel.getCurrentIndex()).getSecond(),
+                getOrAwaitValue(viewModel.getCurrentIndex()).getQuestionIndex(),
                 equalTo(null)
         );
     }
@@ -556,11 +556,11 @@ public class FormEntryViewModelTest {
         viewModel.answerQuestion(formIndex, new StringData("answer"));
         scheduler.flush(true);
         assertThat(
-                getOrAwaitValue(viewModel.getCurrentIndex()).getFirst(),
+                getOrAwaitValue(viewModel.getCurrentIndex()).getScreenIndex(),
                 equalTo(originalIndex)
         );
         assertThat(
-                getOrAwaitValue(viewModel.getCurrentIndex()).getSecond(),
+                getOrAwaitValue(viewModel.getCurrentIndex()).getQuestionIndex(),
                 equalTo(null)
         );
     }


### PR DESCRIPTION
Closes #7020

#### Why is this the best possible solution? Were any other approaches considered?
It seems that during some recent refactoring, we accidentally removed the logic that sets focus after highlighting a question with an error. I’ve fixed that, and also took the opportunity to make some improvements: we can now eliminate some `postDelayed` calls that were previously needed to ensure smooth scrolling to specific questions, which wasn’t working perfectly before so:
- it’s more reliable than using a fixed 0.4 s delay to wait for animations to finish
- it can be a little bit faster
- it works in a smarter way as it immediately sets focus on the expected question, instead of first focusing the first one and then switching (as before)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Here, we need to test form validation, especially cases that require scrolling to a specific question to highlight it (please also test success validations to see if the snackbar is displayed correctly). Another important case is answering select one from map questions, to ensure that scrolling to those questions works correctly, see: https://github.com/getodk/collect/issues/7028.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is linked in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
