### PR TITLE
Fix crash when rotating shape/trace screen

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/DisplayString.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/DisplayString.kt
@@ -1,0 +1,16 @@
+package org.odk.collect.androidshared.ui
+
+import android.content.Context
+
+sealed class DisplayString {
+
+    data class Raw(val value: String) : DisplayString()
+    data class Resource(val resource: Int) : DisplayString()
+
+    fun getString(context: Context): String {
+        return when (this) {
+            is Raw -> value
+            is Resource -> context.getString(resource)
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -66,7 +66,7 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
             retainMockAccuracy,
             inputPolygon,
             constraintValidationResult.map {
-                if (it is FailedValidationResult && it.index == prompt.index) {
+                if (it is FailedValidationResult) {
                     if (it.customErrorMessage != null) {
                         DisplayString.Raw(it.customErrorMessage)
                     } else {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -58,6 +58,7 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
             else -> throw IllegalArgumentException()
         }
 
+        val application = requireContext().applicationContext
         return GeoPolyFragment(
             { (requireDialog() as ComponentDialog).onBackPressedDispatcher },
             outputMode,
@@ -67,7 +68,8 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
             constraintValidationResult.map {
                 val validationResult = it.value
                 if (validationResult is FailedValidationResult && validationResult.index == prompt.index) {
-                    validationResult.customErrorMessage ?: getString(validationResult.defaultErrorMessage)
+                    validationResult.customErrorMessage
+                        ?: application.getString(validationResult.defaultErrorMessage)
                 } else {
                     null
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -66,10 +66,8 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
             retainMockAccuracy,
             inputPolygon,
             constraintValidationResult.map {
-                val validationResult = it.value
-                if (validationResult is FailedValidationResult && validationResult.index == prompt.index) {
-                    validationResult.customErrorMessage
-                        ?: application.getString(validationResult.defaultErrorMessage)
+                if (it is FailedValidationResult && it.index == prompt.index) {
+                    it.customErrorMessage ?: application.getString(it.defaultErrorMessage)
                 } else {
                     null
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragment.kt
@@ -12,6 +12,7 @@ import org.odk.collect.android.javarosawrapper.FailedValidationResult
 import org.odk.collect.android.utilities.FormEntryPromptUtils
 import org.odk.collect.android.widgets.utilities.AdditionalAttributes.INCREMENTAL
 import org.odk.collect.android.widgets.utilities.BindAttributes.ALLOW_MOCK_ACCURACY
+import org.odk.collect.androidshared.ui.DisplayString
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.geopoly.GeoPolyFragment
 import org.odk.collect.geo.geopoly.GeoPolyFragment.OutputMode
@@ -58,7 +59,6 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
             else -> throw IllegalArgumentException()
         }
 
-        val application = requireContext().applicationContext
         return GeoPolyFragment(
             { (requireDialog() as ComponentDialog).onBackPressedDispatcher },
             outputMode,
@@ -67,7 +67,11 @@ class GeoPolyDialogFragment(viewModelFactory: ViewModelProvider.Factory) :
             inputPolygon,
             constraintValidationResult.map {
                 if (it is FailedValidationResult && it.index == prompt.index) {
-                    it.customErrorMessage ?: application.getString(it.defaultErrorMessage)
+                    if (it.customErrorMessage != null) {
+                        DisplayString.Raw(it.customErrorMessage)
+                    } else {
+                        DisplayString.Resource(it.defaultErrorMessage)
+                    }
                 } else {
                     null
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/viewmodels/QuestionViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/viewmodels/QuestionViewModel.kt
@@ -9,7 +9,6 @@ import org.odk.collect.android.formentry.FormSession
 import org.odk.collect.android.formentry.FormSessionRepository
 import org.odk.collect.android.javarosawrapper.FormController
 import org.odk.collect.android.javarosawrapper.ValidationResult
-import org.odk.collect.androidshared.data.Consumable
 import org.odk.collect.androidshared.livedata.LiveDataUtils
 import org.odk.collect.async.Scheduler
 
@@ -18,8 +17,8 @@ class QuestionViewModel(
     formSessionRepository: FormSessionRepository,
     sessionId: String
 ) : ViewModel() {
-    private val _constraintValidationResult: MutableLiveData<Consumable<ValidationResult>> = MutableLiveData()
-    val constraintValidationResult: LiveData<Consumable<ValidationResult>> = _constraintValidationResult
+    private val _constraintValidationResult: MutableLiveData<ValidationResult> = MutableLiveData()
+    val constraintValidationResult: LiveData<ValidationResult> = _constraintValidationResult
     private var formController: FormController? = null
     private var formSessionObserver = LiveDataUtils.observe(
         formSessionRepository.get(sessionId)
@@ -30,7 +29,7 @@ class QuestionViewModel(
     fun validate(index: FormIndex, answer: IAnswerData?) {
         scheduler.immediate {
             formController?.validateAnswerConstraint(index, answer)?.let {
-                _constraintValidationResult.postValue(Consumable(it))
+                _constraintValidationResult.postValue(it)
             }
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -34,7 +34,6 @@ import org.odk.collect.android.support.MockFormEntryPromptBuilder
 import org.odk.collect.android.widgets.utilities.AdditionalAttributes.INCREMENTAL
 import org.odk.collect.android.widgets.utilities.WidgetAnswerDialogFragment.Companion.ARG_FORM_INDEX
 import org.odk.collect.android.widgets.viewmodels.QuestionViewModel
-import org.odk.collect.androidshared.data.Consumable
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.geo.geopoly.GeoPolyFragment
@@ -46,9 +45,7 @@ import org.odk.collect.testshared.getOrAwaitValue
 class GeoPolyDialogFragmentTest {
 
     private var prompt = MockFormEntryPromptBuilder().build()
-    private val constraintValidationResult = MutableLiveData<Consumable<ValidationResult>>(
-        Consumable(SuccessValidationResult)
-    )
+    private val constraintValidationResult = MutableLiveData<ValidationResult>(SuccessValidationResult)
     private val formEntryViewModel = mock<FormEntryViewModel> {
         on { getQuestionPrompt(prompt.index) } doReturn prompt
     }
@@ -483,7 +480,7 @@ class GeoPolyDialogFragmentTest {
             0,
             TreeReference()
         )
-        constraintValidationResult.value = Consumable(FailedValidationResult(anotherQuestionFormIndex, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, "blah", 0))
+        constraintValidationResult.value = FailedValidationResult(anotherQuestionFormIndex, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, "blah", 0)
         launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
             GeoPolyDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
@@ -505,7 +502,7 @@ class GeoPolyDialogFragmentTest {
             assertThat(it.invalidMessage.getOrAwaitValue(), equalTo(null))
         }
 
-        constraintValidationResult.value = Consumable(FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, "blah", 0))
+        constraintValidationResult.value = FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, "blah", 0)
         launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
             GeoPolyDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
@@ -528,7 +525,7 @@ class GeoPolyDialogFragmentTest {
         }
 
         constraintValidationResult.value =
-            Consumable(FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, null, R.string.cancel))
+            FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, null, R.string.cancel)
         launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
             GeoPolyDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
@@ -555,7 +552,7 @@ class GeoPolyDialogFragmentTest {
 
         scenario.recreate()
         constraintValidationResult.value =
-            Consumable(FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, null, R.string.cancel))
+            FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, null, R.string.cancel)
     }
 
     private fun geoTraceOf(points: List<MapPoint>): GeoTraceData {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -514,7 +514,7 @@ class GeoPolyDialogFragmentTest {
 
     /**
      * This scenario can cause a crash if there's a [androidx.fragment.app.Fragment.getString]
-     * call the evaluation chain for however [GeoPolyDialogFragment] or its children deal with
+     * call in the evaluation chain for however [GeoPolyDialogFragment] or its children deal with
      * the invalid message [LiveData].
      */
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -537,6 +537,27 @@ class GeoPolyDialogFragmentTest {
         }
     }
 
+    /**
+     * This scenario can cause a crash if there's a [androidx.fragment.app.Fragment.getString]
+     * call the evaluation chain for however [GeoPolyDialogFragment] or its children deal with
+     * the invalid message [LiveData].
+     */
+    @Test
+    fun `recreating and setting a default failed constraint does not crash`() {
+        prompt = MockFormEntryPromptBuilder(prompt)
+            .withDataType(Constants.DATATYPE_GEOTRACE)
+            .build()
+
+        val scenario = launcherRule.launch(
+            GeoPolyDialogFragment::class.java,
+            bundleOf(ARG_FORM_INDEX to prompt.index)
+        )
+
+        scenario.recreate()
+        constraintValidationResult.value =
+            Consumable(FailedValidationResult(prompt.index, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, null, R.string.cancel))
+    }
+
     private fun geoTraceOf(points: List<MapPoint>): GeoTraceData {
         return GeoTraceData(
             GeoTraceData.GeoTrace(

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -34,6 +34,7 @@ import org.odk.collect.android.support.MockFormEntryPromptBuilder
 import org.odk.collect.android.widgets.utilities.AdditionalAttributes.INCREMENTAL
 import org.odk.collect.android.widgets.utilities.WidgetAnswerDialogFragment.Companion.ARG_FORM_INDEX
 import org.odk.collect.android.widgets.viewmodels.QuestionViewModel
+import org.odk.collect.androidshared.ui.DisplayString
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.geo.geopoly.GeoPolyFragment
@@ -507,7 +508,7 @@ class GeoPolyDialogFragmentTest {
             GeoPolyDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
         ) {
-            assertThat(it.invalidMessage.getOrAwaitValue(), equalTo("blah"))
+            assertThat(it.invalidMessage.getOrAwaitValue(), equalTo(DisplayString.Raw("blah")))
         }
     }
 
@@ -530,7 +531,7 @@ class GeoPolyDialogFragmentTest {
             GeoPolyDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
         ) {
-            assertThat(it.invalidMessage.getOrAwaitValue(), equalTo("Cancel"))
+            assertThat(it.invalidMessage.getOrAwaitValue(), equalTo(DisplayString.Resource(R.string.cancel)))
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -11,10 +11,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.javarosa.core.model.Constants
-import org.javarosa.core.model.FormIndex
 import org.javarosa.core.model.data.GeoShapeData
 import org.javarosa.core.model.data.GeoTraceData
-import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.form.api.FormEntryController
 import org.junit.Before
 import org.junit.Rule
@@ -466,27 +464,6 @@ class GeoPolyDialogFragmentTest {
         ).onFragment {
             it.childFragmentManager.setFragmentResult(GeoPolyFragment.REQUEST_GEOPOLY, Bundle.EMPTY)
             assertThat(it.dialog!!.isShowing, equalTo(false))
-        }
-    }
-
-    @Test
-    fun `ignores the validation message if it belongs to a different question`() {
-        prompt = MockFormEntryPromptBuilder(prompt)
-            .withDataType(Constants.DATATYPE_GEOTRACE)
-            .build()
-
-        val anotherQuestionFormIndex = FormIndex(
-            null,
-            prompt.index.localIndex + 1,
-            0,
-            TreeReference()
-        )
-        constraintValidationResult.value = FailedValidationResult(anotherQuestionFormIndex, FormEntryController.ANSWER_CONSTRAINT_VIOLATED, "blah", 0)
-        launcherRule.launchAndAssertOnChild<GeoPolyFragment>(
-            GeoPolyDialogFragment::class,
-            bundleOf(ARG_FORM_INDEX to prompt.index)
-        ) {
-            assertThat(it.invalidMessage.getOrAwaitValue(), equalTo(null))
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/viewmodels/QuestionViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/viewmodels/QuestionViewModelTest.kt
@@ -53,7 +53,7 @@ class QuestionViewModelTest {
 
         viewModel.validate(formIndex, StringData("answer"))
         assertThat(
-            viewModel.constraintValidationResult.getOrAwaitValue(scheduler).value,
+            viewModel.constraintValidationResult.getOrAwaitValue(scheduler),
             equalTo(failedValidationResult)
         )
     }

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import org.odk.collect.androidshared.ui.DialogFragmentUtils.showIfNotShowing
+import org.odk.collect.androidshared.ui.DisplayString
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.SnackbarUtils
 import org.odk.collect.androidshared.ui.SnackbarUtils.showSnackbar
@@ -50,7 +51,7 @@ class GeoPolyFragment @JvmOverloads constructor(
     val readOnly: Boolean = false,
     val retainMockAccuracy: Boolean = false,
     val inputPolygon: List<MapPoint> = emptyList(),
-    val invalidMessage: LiveData<String?> = MutableLiveData(null)
+    val invalidMessage: LiveData<DisplayString?> = MutableLiveData(null)
 ) : Fragment(R.layout.geopoly_layout), SettingsDialogCallback {
 
     @Inject
@@ -252,10 +253,11 @@ class GeoPolyFragment @JvmOverloads constructor(
             },
             displayDismissButton = true
         )
+
         viewModel.viewData.observe(viewLifecycleOwner) { (points, invalidMessage) ->
             val isValid = invalidMessage == null
             if (!isValid) {
-                snackbar.setText(invalidMessage)
+                snackbar.setText(invalidMessage.getString(requireContext()))
                 SnackbarUtils.show(snackbar)
             } else {
                 snackbar.dismiss()

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import org.odk.collect.androidshared.data.Consumable
 import org.odk.collect.androidshared.livedata.LiveDataExt.combine
 import org.odk.collect.androidshared.livedata.LiveDataExt.withLast
+import org.odk.collect.androidshared.ui.DisplayString
 import org.odk.collect.async.Cancellable
 import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.geopoly.GeoPolyFragment.OutputMode
@@ -21,7 +22,7 @@ class GeoPolyViewModel(
     private val retainMockAccuracy: Boolean,
     private val locationTracker: LocationTracker,
     private val scheduler: Scheduler,
-    val invalidMessage: LiveData<String?>
+    val invalidMessage: LiveData<DisplayString?>
 ) : ViewModel() {
 
     enum class RecordingMode {

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -23,6 +23,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.odk.collect.androidshared.ui.DisplayString
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.SnackbarUtils
 import org.odk.collect.androidshared.utils.opaque
@@ -620,7 +621,7 @@ class GeoPolyFragmentTest {
 
     @Test
     fun whenInvalidMessageIsNotNull_pointsCannotBeAddedByClicking() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -630,14 +631,14 @@ class GeoPolyFragmentTest {
 
         startInput(R.id.placement_mode)
 
-        invalidMessage.value = "Blah"
+        invalidMessage.value = DisplayString.Raw("Blah")
         mapFragment.click(MapPoint(0.0, 0.0))
         assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(0))
     }
 
     @Test
     fun whenInvalidMessageIsNotNull_pointsCannotBeAddedManually() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -647,14 +648,14 @@ class GeoPolyFragmentTest {
 
         startInput(R.id.manual_mode)
 
-        invalidMessage.value = "Blah"
+        invalidMessage.value = DisplayString.Raw("Blah")
         Interactions.clickOn(withContentDescription(string.record_geopoint))
         assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(0))
     }
 
     @Test
     fun whenInvalidMessageIsNotNull_automaticRecordingStops() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -664,7 +665,7 @@ class GeoPolyFragmentTest {
 
         startInput(R.id.automatic_mode)
 
-        invalidMessage.value = "Blah"
+        invalidMessage.value = DisplayString.Raw("Blah")
         locationTracker.currentLocation = Location(1.0, 1.0, 1.0, 1f)
         scheduler.runForeground(0)
         assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(0))
@@ -672,7 +673,7 @@ class GeoPolyFragmentTest {
 
     @Test
     fun showsAndHidesInvalidMessageSnackbarBasedOnValue() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -681,7 +682,7 @@ class GeoPolyFragmentTest {
         }
 
         val message = "Something is wrong"
-        invalidMessage.value = message
+        invalidMessage.value = DisplayString.Raw(message)
         assertVisible(withText(message))
 
         invalidMessage.value = null
@@ -695,7 +696,7 @@ class GeoPolyFragmentTest {
 
     @Test
     fun invalidSnackbarCanBeDismissed() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -704,14 +705,14 @@ class GeoPolyFragmentTest {
         }
 
         val message = "Something is wrong"
-        invalidMessage.value = message
+        invalidMessage.value = DisplayString.Raw(message)
         Interactions.clickOn(withContentDescription(string.close_snackbar))
         assertNotVisible(withText(message))
     }
 
     @Test
     fun changesPolyLineColorBasedOnInvalidMessage() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -722,7 +723,7 @@ class GeoPolyFragmentTest {
         startInput(R.id.placement_mode)
         mapFragment.click(MapPoint(0.0, 0.0))
 
-        invalidMessage.value = "blah"
+        invalidMessage.value = DisplayString.Raw("blah")
         val errorPolyLine = mapFragment.getPolyLines()[0]
         assertThat(errorPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_ERROR_COLOR))
         assertThat(errorPolyLine.highlightLastPoint, equalTo(false))
@@ -735,7 +736,7 @@ class GeoPolyFragmentTest {
 
     @Test
     fun changesPolygonColorBasedOnInvalidMessage() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -747,7 +748,7 @@ class GeoPolyFragmentTest {
         startInput(R.id.placement_mode)
         mapFragment.click(MapPoint(0.0, 0.0))
 
-        invalidMessage.value = "blah"
+        invalidMessage.value = DisplayString.Raw("blah")
         val errorPolyLine = mapFragment.getPolygons()[0]
         assertThat(errorPolyLine.getStrokeColor(), equalTo(MapConsts.DEFAULT_ERROR_COLOR))
         assertThat(errorPolyLine.highlightLastPoint, equalTo(false))
@@ -768,7 +769,7 @@ class GeoPolyFragmentTest {
 
     @Test
     fun disablesSaveButtonWhenInvalid() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
                 { OnBackPressedDispatcher() },
@@ -776,7 +777,7 @@ class GeoPolyFragmentTest {
             )
         }
 
-        invalidMessage.value = "Blah"
+        invalidMessage.value = DisplayString.Raw("Blah")
         Assertions.assertDisabled(withContentDescription(string.save))
 
         invalidMessage.value = null

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyViewModelTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyViewModelTest.kt
@@ -7,6 +7,7 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.odk.collect.androidshared.ui.DisplayString
 import org.odk.collect.androidtest.MainDispatcherRule
 import org.odk.collect.testshared.getOrAwaitValue
 
@@ -20,7 +21,7 @@ class GeoPolyViewModelTest {
 
     @Test
     fun `#fixedAlerts is null until after invalid message is non-null`() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         val viewModel = GeoPolyViewModel(
             GeoPolyFragment.OutputMode.GEOTRACE,
             emptyList(),
@@ -32,7 +33,7 @@ class GeoPolyViewModelTest {
 
         assertThat(viewModel.fixedAlerts.getOrAwaitValue(), equalTo(null))
 
-        invalidMessage.value = "OH NO"
+        invalidMessage.value = DisplayString.Raw("OH NO")
         assertThat(viewModel.fixedAlerts.getOrAwaitValue(), equalTo(null))
 
         invalidMessage.value = null
@@ -41,7 +42,7 @@ class GeoPolyViewModelTest {
 
     @Test
     fun `#fixedAlerts is null after repeated invalid message nulls after a non-null`() {
-        val invalidMessage = MutableLiveData<String?>(null)
+        val invalidMessage = MutableLiveData<DisplayString?>(null)
         val viewModel = GeoPolyViewModel(
             GeoPolyFragment.OutputMode.GEOTRACE,
             emptyList(),
@@ -51,7 +52,7 @@ class GeoPolyViewModelTest {
             invalidMessage
         )
 
-        invalidMessage.value = "OH NO"
+        invalidMessage.value = DisplayString.Raw("OH NO")
         invalidMessage.value = null
         invalidMessage.value = null
         assertThat(viewModel.fixedAlerts.getOrAwaitValue(), equalTo(null))


### PR DESCRIPTION
Closes #7066

#### Why is this the best possible solution? Were any other approaches considered?

There were a couple of features of the code that causes this issue:
1. The `invalidMessage` object passed to `GeoPolyFragment` was the product of `LiveData` which had been created via a `map` that referenced `getString` - implicitly requiring the `Fragment` where it was executed.
2. That `LiveData` is then passed to a `ViewModel` meaning it would be retained between configuration changes - the "original" instance would be reused, and the new one created as part of recreation would effectively be ignored

Combining 1 with 2 gets you a crash as re-executing the `map` operation after recreation requires a `Fragment` that's been destroyed.

1 was definitely an issue - `map` operations should never have side-effects and shouldn't rely on life-cycleable objects. I did also consider changing 2, but alternatives (like using a mediator that both ViewModels could share) felt over-architected. I think this is just a quirk of any stateful view component (be it a Fragment or a Composable or a View): initial state will be ignored when the component is recreated.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue. No maps code has been touched.

#### Before submitting this PR, please make sure you have:
- [ ] added or modified tests for any new or changed behavior
- [ ] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [ ] added a comment above any new strings describing it for translators
- [ ] added any new strings with date formatting to `DateFormatsTest`
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
