### PR TITLE
Attempt to alleviate flakiness switchting to hierarchy

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -206,6 +206,7 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public FormHierarchyPage clickGoToArrow() {
+        // This click sometimes ends up turning into a long press
         tryFlakyAction(() -> {
             onView(withId(R.id.menu_goto)).perform(click());
         });

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -206,8 +206,11 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public FormHierarchyPage clickGoToArrow() {
-        onView(withId(R.id.menu_goto)).perform(click());
-        return new FormHierarchyPage(formName).assertOnPage();
+        tryFlakyAction(() -> {
+            onView(withId(R.id.menu_goto)).perform(click());
+        });
+
+        return new FormHierarchyPage(formName);
     }
 
     public FormEntryPage clickWidgetButton() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuProvider.kt
@@ -14,6 +14,7 @@ import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationVi
 import org.odk.collect.android.formentry.questions.AnswersProvider
 import org.odk.collect.android.formhierarchy.FormHierarchyFragmentHostActivity
 import org.odk.collect.android.preferences.screens.ProjectPreferencesActivity
+import org.odk.collect.android.utilities.ActionRegister
 import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.androidshared.system.PlayServicesChecker
 import org.odk.collect.androidshared.ui.DialogFragmentUtils.showIfNotShowing
@@ -121,6 +122,8 @@ class FormEntryMenuProvider(
                 true
             }
             R.id.menu_goto -> {
+                ActionRegister.actionDetected()
+
                 if (audioRecorder.isRecording() && !backgroundAudioViewModel.isBackgroundRecording) {
                     showIfNotShowing(RecordingWarningDialogFragment::class.java, activity.supportFragmentManager)
                 } else {


### PR DESCRIPTION
We've seen the click to move to the hierarchy fail a few times on CI due to the click becoming a long press. I've wrapped the action in `tryFlakyAction` to try and fix this.