### PR TITLE
Always save the answer before evaluating it

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredAndConstraintQuestionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredAndConstraintQuestionTest.kt
@@ -14,7 +14,7 @@ import org.odk.collect.android.support.rules.TestRuleChain.chain
 import org.odk.collect.strings.R
 
 @RunWith(AndroidJUnit4::class)
-class RequiredQuestionTest {
+class RequiredAndConstraintQuestionTest {
     var rule: CollectTestRule = CollectTestRule()
 
     @get:Rule

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredQuestionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredQuestionTest.kt
@@ -142,4 +142,14 @@ class RequiredQuestionTest {
             .clickSave()
             .swipeToNextQuestion("What is your age?")
     }
+
+    @Test // https://github.com/getodk/collect/issues/7078
+    fun navigatingToNextQuestion_withInvalidAnswer_keepsInvalidAnswer() {
+        rule.startAtMainMenu()
+            .copyForm("one-question-with-constraint.xml")
+            .startBlankForm("One Question With Constraint")
+            .answerQuestion("What is your age?", "17")
+            .swipeToNextQuestionWithConstraintViolation("Age must be at least 18")
+            .assertAnswer("What is your age?", "17")
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/JavaRosaFormController.java
@@ -659,13 +659,12 @@ public class JavaRosaFormController implements FormController {
     public ValidationResult saveOneScreenAnswer(FormIndex index, IAnswerData answer, boolean evaluateConstraints) throws JavaRosaException {
         // Within a group, you can only save for question events
         if (getEvent(index) == FormEntryController.EVENT_QUESTION) {
+            saveAnswer(index, answer);
             if (evaluateConstraints) {
                 int saveStatus = answerQuestion(index, answer);
                 if (saveStatus != FormEntryController.ANSWER_OK) {
                     return getFailedValidationResult(index, saveStatus);
                 }
-            } else {
-                saveAnswer(index, answer);
             }
         } else {
             Timber.w("Attempted to save an index referencing something other than a question: %s",

--- a/test-forms/src/main/resources/forms/one-question-with-constraint.xml
+++ b/test-forms/src/main/resources/forms/one-question-with-constraint.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<h:html
+    xmlns="http://www.w3.org/2002/xforms"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:odk="http://www.opendatakit.org/xforms">
+    <h:head>
+        <h:title>One Question With Constraint</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="one-question-with-constraint">
+                    <age/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/age" type="int" constraint=".&gt;=18" jr:constraintMsg="Age must be at least 18"/>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/age">
+            <label>What is your age?</label>
+        </input>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #7078

#### Why is this the best possible solution? Were any other approaches considered?
Recently, we introduced changes to how answering, validating, and navigating between questions is handled. We unified these flows by using the `#updateIndex` mechanism (see `FormEntryViewModel`). The main advantage of this approach is that there is now a single, shared way of handling these actions, which makes the code easier to maintain and less error-prone.

That said, there are some drawbacks. One of them appears when the current question is required or has a constraint, the user violates it (by not answering or providing an invalid answer), and then tries to navigate forward with `validate upon forward swipe` enabled in the settings. In this case, the new mechanism refreshes the entire view to correctly highlight the violated question. Previously, we only updated the question layout without refreshing the whole view, which was lighter but also less consistent with how we handle similar actions elsewhere.

Although refreshing the view may seem like overkill, I still believe it’s better than the old approach. Instead of reverting the change or introducing special-case handling (for highlighting violated questions), it makes more sense to adjust how answers are saved.

The reason the answer disappears after the refresh is that we currently don’t save an answer if it’s invalid when navigating forward. I don’t see a strong reason for this behavior - answers can be saved first and then evaluated. I introduced this change, which fixes the issue. We already save invalid answers (without evaluating them) when navigating backward or when opening the hierarchy view, so this is consistent with existing behavior and actually makes the overall flow more uniform.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As explained above, the main change is that when attempting to navigate to the next question while the current answer is invalid, the answer is now saved before it is evaluated. From a user’s perspective, there should be no visible difference this change only affects the internal flow.
While it’s always possible that there’s an edge case I haven’t considered, I don’t currently see a scenario where this behavior would cause issues.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is linked in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
