### PR TITLE
Use `master` rather than `pr` build for hotfix branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ workflows:
             branches:
               ignore:
                 - master
-                - /^v((20)[0-9]{2})\.\d+\.\d+$/
+                - ^v((20)[0-9]{2})\.\d+\.\x$
       - compile:
           requires:
             - hold_pr
@@ -370,7 +370,7 @@ workflows:
             branches:
               only:
                 - master
-                - /^v((20)[0-9]{2})\.\d+\.\d+$/
+                - ^v((20)[0-9]{2})\.\d+\.\x$
       - check_quality:
           requires:
             - compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ workflows:
             branches:
               ignore:
                 - master
-                - ^v((20)[0-9]{2})\.\d+\.\x$
+                - ^v((20)[0-9]{2})\.\d+\.x$
       - compile:
           requires:
             - hold_pr
@@ -370,7 +370,7 @@ workflows:
             branches:
               only:
                 - master
-                - ^v((20)[0-9]{2})\.\d+\.\x$
+                - ^v((20)[0-9]{2})\.\d+\.x$
       - check_quality:
           requires:
             - compile


### PR DESCRIPTION
This wasn't working because the regex we were using only matches actual semvers and hour hotfix branches end with an `x`.