### PR TITLE
Prevent crashes if OSMDroidMapFragment is destroyed before view is created

### DIFF
--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -391,8 +391,12 @@ public class OsmDroidMapFragment extends MapViewModelMapFragment implements
         for (MapFeature feature : features.values()) {
             feature.dispose();
         }
-        map.invalidate();
         features.clear();
+
+        if (map != null) {
+            map.invalidate();
+        }
+
         nextFeatureId = 1;
     }
 


### PR DESCRIPTION
Closes #7051 

#### Why is this the best possible solution? Were any other approaches considered?

This was a pretty simple fix once I'd worked out the problem: the OSM map implementation would hit a `NullPointerException` when being destroyed due to an Activity being finished early in this scenario because the view might not have been created yet. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just a very small change to just OSM, so nothing else needs looked at.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
