### PR TITLE
Keep Mapbox access token using keep.xml

### DIFF
--- a/collect_app/src/main/res/raw/keep.xml
+++ b/collect_app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@string/mapbox_access_token" />


### PR DESCRIPTION
Closes #7116

#### Why is this the best possible solution? Were any other approaches considered?
It’s the safest and most minimal solution because it explicitly preserves only the required Mapbox access token resource without disabling resource shrinking entirely.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should fix the issue without introducing any side effects. There’s no need to test maps, but it would be good to confirm that Google Maps does not crash, as it also relies on an access token.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
