### PR TITLE
Don't allow rotation on larger devices when drawing

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -127,7 +127,8 @@ the specific language governing permissions and limitations under the License.
             android:name="org.odk.collect.draw.DrawActivity"
             android:theme="@style/Theme.Collect"
             tools:replace="android:theme"
-            android:screenOrientation="landscape" />
+            android:screenOrientation="landscape"
+            android:resizeableActivity="false"/>
         <activity android:name=".activities.InstanceChooserList" />
         <activity
             android:name=".formlists.blankformlist.BlankFormListActivity"

--- a/draw/src/main/java/org/odk/collect/draw/DrawView.kt
+++ b/draw/src/main/java/org/odk/collect/draw/DrawView.kt
@@ -72,7 +72,7 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        resetImage(w, h)
+        setImage(w, h)
     }
 
     override fun onDraw(canvas: Canvas) {
@@ -107,7 +107,7 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
 
     fun reset() {
         val metrics = resources.displayMetrics
-        resetImage(metrics.widthPixels, metrics.heightPixels)
+        setImage(metrics.widthPixels, metrics.heightPixels)
     }
 
     fun setColor(color: Int) {
@@ -168,7 +168,11 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
         paint.color = originalColor
     }
 
-    private fun resetImage(w: Int, h: Int) {
+    private fun setImage(w: Int, h: Int) {
+        if (::bitmap.isInitialized) {
+            return
+        }
+
         val backgroundBitmapFile = File(imagePath)
         if (backgroundBitmapFile.exists()) {
             bitmap = ImageFileUtils.getBitmapScaledToDisplay(backgroundBitmapFile, h, w, true)!!

--- a/draw/src/main/java/org/odk/collect/draw/DrawView.kt
+++ b/draw/src/main/java/org/odk/collect/draw/DrawView.kt
@@ -72,7 +72,10 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        setImage(w, h)
+
+        if (!::bitmap.isInitialized) {
+            resetImage(w, h)
+        }
     }
 
     override fun onDraw(canvas: Canvas) {
@@ -107,7 +110,7 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
 
     fun reset() {
         val metrics = resources.displayMetrics
-        setImage(metrics.widthPixels, metrics.heightPixels)
+        resetImage(metrics.widthPixels, metrics.heightPixels)
     }
 
     fun setColor(color: Int) {
@@ -168,18 +171,14 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
         paint.color = originalColor
     }
 
-    private fun setImage(w: Int, h: Int) {
-        if (::bitmap.isInitialized) {
-            return
-        }
-
+    private fun resetImage(width: Int, height: Int) {
         val backgroundBitmapFile = File(imagePath)
         if (backgroundBitmapFile.exists()) {
-            bitmap = ImageFileUtils.getBitmapScaledToDisplay(backgroundBitmapFile, h, w, true)!!
+            bitmap = ImageFileUtils.getBitmapScaledToDisplay(backgroundBitmapFile, height, width, true)!!
                 .copy(Bitmap.Config.ARGB_8888, true)
             canvas = Canvas(bitmap)
         } else {
-            bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+            bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
             canvas = Canvas(bitmap)
             canvas.drawColor(Color.WHITE)
             if (isSignature) {


### PR DESCRIPTION
Closes #7124

#### Why is this the best possible solution? Were any other approaches considered?

On larger devices, even if the orientation is locked an Activity can still be resized when switching orientation as the device shows the locked screen letterboxd and still rotates it. This causes Activity recreation and leads to the drawing screen getting wiped when rotating. We can avoid this (for the current target Android version) by disabling resizing for the Activity (`android:resizeableActivity="false"`). 

That doesn't quite solve the problem for larger devices though: when switching from landscape to portrait orientation we still end up being resized even without recreation. The `DrawView` used did not have to deal with this on smaller devices/older Android versions so we also needed to disable resetting the `Canvas` on every size change (rather than just the first render).

Ideally the drawing screens should just handle resizing, but that's a new feature we'll need to discuss for either our Android 16 target version (or potentially Android 17 if opt-outs let us kick this can down the road). I'm not confident these fixes will work across the board as [manufacturers are able to override a lot of the large screen behaviour here](https://developer.android.com/guide/topics/manifest/activity-element#resizeableActivity).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

On smaller devices, the app should behave exactly as before. On tablets, the drawing screens should no longer clear the user's work when rotating, but the image/canvas will not scale appropriately: whatever dimensions they first open in will be used regardless of orientation.  

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
