### PR TITLE
Correct and simplify branch/tag filtering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ workflows:
             branches:
               ignore:
                 - master
-                - ^v((20)[0-9]{2})\.\d+\.x$
+                - /^v\d+\.\d+.x/
       - compile:
           requires:
             - hold_pr
@@ -370,7 +370,7 @@ workflows:
             branches:
               only:
                 - master
-                - ^v((20)[0-9]{2})\.\d+\.x$
+                - /^v\d+\.\d+.x/
       - check_quality:
           requires:
             - compile
@@ -412,7 +412,7 @@ workflows:
       - compile:
           filters:
             tags:
-              only: /^v((20)[0-9]{2})\.\d+\.\d+$/ # matches semvers like v1.2.3
+              only: /^v\d+\.\d+.\d+/
             branches:
               ignore: /.*/
       - create_dependency_backup:
@@ -420,7 +420,7 @@ workflows:
             - compile
           filters:
             tags:
-              only: /^v((20)[0-9]{2})\.\d+\.\d+$/ # matches semvers like v1.2.3
+              only: /^v\d+\.\d+.\d+/
             branches:
               ignore: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ workflows:
             branches:
               ignore:
                 - master
-                - /^v\d+\.\d+.x/
+                - /^v\d+\.\d+.x$/
       - compile:
           requires:
             - hold_pr
@@ -370,7 +370,7 @@ workflows:
             branches:
               only:
                 - master
-                - /^v\d+\.\d+.x/
+                - /^v\d+\.\d+.x$/
       - check_quality:
           requires:
             - compile
@@ -412,7 +412,7 @@ workflows:
       - compile:
           filters:
             tags:
-              only: /^v\d+\.\d+.\d+/
+              only: /^v\d+\.\d+.\d+$/
             branches:
               ignore: /.*/
       - create_dependency_backup:
@@ -420,7 +420,7 @@ workflows:
             - compile
           filters:
             tags:
-              only: /^v\d+\.\d+.\d+/
+              only: /^v\d+\.\d+.\d+$/
             branches:
               ignore: /.*/
 


### PR DESCRIPTION
It looked to me like our branch filtering wasn't working correctly and from looking at the config I think we were just missing wrapping our regex in `/` (which it seems Circle CI needs). I've also simplified the regex(s) we use here. For double-checking:

- `pr` should run for branches that aren't `master` or hotfix branches (like `v123.123.x`)
- `master` is the opposite (it runs for `master` and hotfix branches)
- `release` should run for release tags (like `v123.123.123`).