### PR TITLE
Disable automatic backups feature

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -79,7 +79,7 @@ the specific language governing permissions and limitations under the License.
 
     <application
         android:name=".application.Collect"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@drawable/notes"
         android:installLocation="auto"
         android:label="@string/collect_app_name"


### PR DESCRIPTION
Closes #6948

#### Why is this the best possible solution? Were any other approaches considered?

This disables cloud backups (via Google Drive) on all devices and "device to device" transfers (D2D) on [some devices](https://developer.android.com/guide/topics/manifest/application-element#allowbackup). The different options for this were discussed in the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

As well as testing that backup with Google Drive no longer work, it would be good to test some D2D transfers as well to get a sense of which devices this is still enabled for - I think that will require wiping a phone. My suspicion would be that basically all the major non-Google manufacturers (Samsung and Xiaomi specifically) force D2D transfers.

It would also be good to add a regression check around cloud backups being disabled - future OS changes might make our configuration obsolete, and we have no way to check with automated tests (other than verifying that config).

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
