### PR TITLE
Allow updating entities with empty labels

### DIFF
--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -27,17 +27,19 @@ object LocalEntityUseCases {
             val label = formEntity.label
             when (formEntity.action) {
                 EntityAction.CREATE -> {
-                    val list = entitiesRepository.getList(formEntity.dataset)
-                    if (list != null && !list.needsApproval) {
-                        val entity = Entity.New(
-                            id,
-                            label,
-                            1,
-                            formEntity.properties,
-                            branchId = UUID.randomUUID().toString()
-                        )
+                    if (label.isNotBlank()) {
+                        val list = entitiesRepository.getList(formEntity.dataset)
+                        if (list != null && !list.needsApproval) {
+                            val entity = Entity.New(
+                                id,
+                                label,
+                                1,
+                                formEntity.properties,
+                                branchId = UUID.randomUUID().toString()
+                            )
 
-                        entitiesRepository.save(formEntity.dataset, entity)
+                            entitiesRepository.save(formEntity.dataset, entity)
+                        }
                     }
                 }
 

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -27,19 +27,17 @@ object LocalEntityUseCases {
             val label = formEntity.label
             when (formEntity.action) {
                 EntityAction.CREATE -> {
-                    if (label.isNotBlank()) {
-                        val list = entitiesRepository.getList(formEntity.dataset)
-                        if (list != null && !list.needsApproval) {
-                            val entity = Entity.New(
-                                id,
-                                label,
-                                1,
-                                formEntity.properties,
-                                branchId = UUID.randomUUID().toString()
-                            )
+                    val list = entitiesRepository.getList(formEntity.dataset)
+                    if (list != null && !list.needsApproval) {
+                        val entity = Entity.New(
+                            id,
+                            label,
+                            1,
+                            formEntity.properties,
+                            branchId = UUID.randomUUID().toString()
+                        )
 
-                            entitiesRepository.save(formEntity.dataset, entity)
-                        }
+                        entitiesRepository.save(formEntity.dataset, entity)
                     }
                 }
 

--- a/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
+++ b/entities/src/main/java/org/odk/collect/entities/LocalEntityUseCases.kt
@@ -51,7 +51,7 @@ object LocalEntityUseCases {
                         entitiesRepository.save(
                             formEntity.dataset,
                             existing.copy(
-                                label = label,
+                                label = label.ifBlank { existing.label },
                                 properties = formEntity.properties,
                                 version = existing.version + 1
                             )

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.kt
@@ -79,7 +79,7 @@ class EntityFormFinalizationProcessor : FormEntryFinalizationProcessor {
             }
         }
 
-        return if (id.isV4UUID() && label.isNotBlank()) {
+        return if (id.isV4UUID()) {
             FormEntity(action, dataset, id, label, fields)
         } else {
             null

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.kt
@@ -55,7 +55,7 @@ class EntityFormFinalizationProcessor : FormEntryFinalizationProcessor {
     private fun createEntity(
         dataset: String,
         id: String?,
-        label: String?,
+        label: String,
         elementRef: TreeReference,
         saveTos: List<SaveTo>,
         action: EntityAction,
@@ -79,7 +79,7 @@ class EntityFormFinalizationProcessor : FormEntryFinalizationProcessor {
             }
         }
 
-        return if (id.isV4UUID() && !label.isNullOrBlank()) {
+        return if (id.isV4UUID() && label.isNotBlank()) {
             FormEntity(action, dataset, id, label, fields)
         } else {
             null

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/finalization/EntityFormFinalizationProcessor.kt
@@ -79,7 +79,7 @@ class EntityFormFinalizationProcessor : FormEntryFinalizationProcessor {
             }
         }
 
-        return if (id.isV4UUID()) {
+        return if (id.isV4UUID() && (action == EntityAction.UPDATE || label.isNotBlank())) {
             FormEntity(action, dataset, id, label, fields)
         } else {
             null

--- a/entities/src/main/java/org/odk/collect/entities/javarosa/spec/EntityFormParser.kt
+++ b/entities/src/main/java/org/odk/collect/entities/javarosa/spec/EntityFormParser.kt
@@ -16,9 +16,9 @@ object EntityFormParser {
     }
 
     @JvmStatic
-    fun parseLabel(entity: TreeElement): String? {
+    fun parseLabel(entity: TreeElement): String {
         val labelElement = entity.getFirstChild(ELEMENT_LABEL)
-        return labelElement?.value?.uncast()?.string
+        return labelElement?.value?.uncast()?.string ?: ""
     }
 
     fun parseId(entity: TreeElement): String? {

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -50,6 +50,19 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
+    fun `#updateLocalEntitiesFromForm does not save a new entity on create if the label is blank`() {
+        entitiesRepository.addList("things")
+
+        val formEntity =
+            FormEntity(EntityAction.CREATE, "things", "id", " ", listOf("property" to "value"))
+        val formEntities = EntitiesExtra(listOf(formEntity))
+        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
+
+        val entities = entitiesRepository.query("things")
+        assertThat(entities.size, equalTo(0))
+    }
+
+    @Test
     fun `#updateLocalEntitiesFromForm does not save a new entity on create if the list doesn't already exist`() {
         val formEntity =
             FormEntity(EntityAction.CREATE, "things", "id", "label", listOf("property" to "value"))

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -50,19 +50,6 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
-    fun `#updateLocalEntitiesFromForm does not save a new entity on create if the label is blank`() {
-        entitiesRepository.addList("things")
-
-        val formEntity =
-            FormEntity(EntityAction.CREATE, "things", "id", " ", listOf("property" to "value"))
-        val formEntities = EntitiesExtra(listOf(formEntity))
-        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
-
-        val entities = entitiesRepository.query("things")
-        assertThat(entities.size, equalTo(0))
-    }
-
-    @Test
     fun `#updateLocalEntitiesFromForm does not save a new entity on create if the list doesn't already exist`() {
         val formEntity =
             FormEntity(EntityAction.CREATE, "things", "id", "label", listOf("property" to "value"))

--- a/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/LocalEntityUseCasesTest.kt
@@ -105,6 +105,30 @@ class LocalEntityUseCasesTest {
     }
 
     @Test
+    fun `#updateLocalEntitiesFromForm updates properties and does not change label on update if label is blank`() {
+        entitiesRepository.save(
+            "things",
+            Entity.New(
+                "id",
+                "label",
+                version = 1,
+                properties = listOf("prop" to "value")
+            )
+        )
+
+        val formEntity =
+            FormEntity(EntityAction.UPDATE, "things", "id", " ", listOf("prop" to "value 2"))
+        val formEntities = EntitiesExtra(listOf(formEntity))
+
+        LocalEntityUseCases.updateLocalEntitiesFromForm(formEntities, entitiesRepository)
+        val entities = entitiesRepository.query("things")
+        assertThat(entities.size, equalTo(1))
+        assertThat(entities[0].label, equalTo("label"))
+        assertThat(entities[0].properties.size, equalTo(1))
+        assertThat(entities[0].properties[0], equalTo("prop" to "value 2"))
+    }
+
+    @Test
     fun `#updateLocalEntitiesFromForm does not override trunk version or branchId on update`() {
         entitiesRepository.save(
             "things",

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/EntityFormFinalizationProcessorTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/EntityFormFinalizationProcessorTest.kt
@@ -167,6 +167,45 @@ class EntityFormFinalizationProcessorTest {
     }
 
     @Test
+    fun `does not create entity with blank labels`() {
+        val scenario = Scenario.init(
+            "Create entity form",
+            html(
+                listOf(Pair("entities", "http://www.opendatakit.org/xforms/entities")),
+                head(
+                    title("Create entity form"),
+                    model(
+                        listOf(Pair("entities:entities-version", "2024.1.0")),
+                        mainInstance(
+                            t(
+                                "data id=\"create-entity-form\"",
+                                t("name"),
+                                t("meta", entityNode("people", CREATE))
+                            )
+                        ),
+                        bind("/data/name").type("date")
+                            .withSaveTo("name"),
+                        bind("/data/meta/entity/@id").type("string"),
+                        bind("/data/meta/entity/label").type("string")
+                            .calculate("/data/name"),
+                        setvalue("odk-instance-first-load", "/data/meta/entity/@id", "uuid()")
+                    )
+                ),
+                body(
+                    input("/data/name")
+                )
+            )
+        )
+
+        val processor = EntityFormFinalizationProcessor()
+        val model = scenario.formEntryController.model
+        processor.processForm(model)
+
+        val entities = model.extras.get(EntitiesExtra::class.java).entities
+        assertThat(entities.size, equalTo(0))
+    }
+
+    @Test
     fun `when saveTo is in not relevant group, it is not included in entity`() {
         val scenario = Scenario.init(
             "Create entity form",

--- a/entities/src/test/java/org/odk/collect/entities/javarosa/EntityFormParserTest.kt
+++ b/entities/src/test/java/org/odk/collect/entities/javarosa/EntityFormParserTest.kt
@@ -42,4 +42,14 @@ class EntityFormParserTest {
         val label = parseLabel(entityElement)
         assertThat(label, equalTo("0"))
     }
+
+    @Test
+    fun `parse label when label is null, returns an empty string`() {
+        val labelElement = TreeElement(ELEMENT_LABEL)
+        val entityElement = TreeElement(ELEMENT_ENTITY)
+        entityElement.addChild(labelElement)
+
+        val label = parseLabel(entityElement)
+        assertThat(label, equalTo(""))
+    }
 }


### PR DESCRIPTION
Closes #7131 

#### Why is this the best possible solution? Were any other approaches considered?
Nothing critical to discuss here. Empty labels should affect entities differently depending on whether they are being created or updated. For creation, an empty label should prevent the entity from being created. For updates, it should simply preserve the original label.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We can focus our testing on creating and updating entities. I can't think of any other risk that should be taken into account.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form mentioned in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
