### PR TITLE
Switch to JavaRosa snapshot version that still exists

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ danlewAndroidJoda = { group = "net.danlew", name = "android.joda", version = "2.
 rarepebbleColorpicker = { group = "com.github.martin-stone", name = "hsv-alpha-color-picker-android", version = "3.1.0" }
 commonsIo = { group = "commons-io", name = "commons-io", version = "2.21.0" }
 opencsv = { group = "com.opencsv", name = "opencsv", version = "5.12.0" }
-javarosa = { group = "org.getodk", name = "javarosa", version = "5.2.0-2e10861-SNAPSHOT" } # Online
+javarosa = { group = "org.getodk", name = "javarosa", version = "5.2.0-0dfdce0-SNAPSHOT" } # Online
 # javarosa = { group = "org.getodk", name = "javarosa", version = "local" } # Local
 karumiDexter = { group = "com.karumi", name = "dexter", version = "6.2.3" }
 zxingAndroidEmbedded = { group = "com.journeyapps", name = "zxing-android-embedded", version = "4.3.0" }


### PR DESCRIPTION
For some reason `5.2.0-2e10861-SNAPSHOT` is no longer available.