### PR TITLE
Fix back button handling in full screen dialogs

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -72,11 +72,6 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
     }
 
     @Override
-    protected void onBackPressed() {
-        dismiss();
-    }
-
-    @Override
     protected Toolbar getToolbar() {
         return getView().findViewById(org.odk.collect.androidshared.R.id.toolbar);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
@@ -9,6 +9,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 
+import androidx.activity.ComponentDialog;
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProvider;
@@ -28,6 +30,17 @@ public class IdentifyUserPromptDialogFragment extends MaterialFullScreenDialogFr
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        ((ComponentDialog) requireDialog()).getOnBackPressedDispatcher().addCallback(
+                getViewLifecycleOwner(),
+                new OnBackPressedCallback(true) {
+                    @Override
+                    public void handleOnBackPressed() {
+                        dismiss();
+                        viewModel.promptDismissed();
+                    }
+                }
+        );
 
         Toolbar toolbar = getToolbar();
         toolbar.setTitle(viewModel.getFormTitle());
@@ -76,12 +89,6 @@ public class IdentifyUserPromptDialogFragment extends MaterialFullScreenDialogFr
 
     @Override
     protected void onCloseClicked() {
-        dismiss();
-        viewModel.promptDismissed();
-    }
-
-    @Override
-    protected void onBackPressed() {
         dismiss();
         viewModel.promptDismissed();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialog.java
@@ -8,6 +8,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.activity.ComponentDialog;
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
@@ -75,6 +77,17 @@ public abstract class SelectMinimalDialog extends MaterialFullScreenDialogFragme
     @Override
     public void onViewCreated(@NotNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        ((ComponentDialog) requireDialog()).getOnBackPressedDispatcher().addCallback(
+                getViewLifecycleOwner(),
+                new OnBackPressedCallback(true) {
+                    @Override
+                    public void handleOnBackPressed() {
+                        closeDialogAndSaveAnswers();
+                    }
+                }
+        );
+
         initRecyclerView();
         initToolbar();
     }
@@ -88,11 +101,6 @@ public abstract class SelectMinimalDialog extends MaterialFullScreenDialogFragme
 
     @Override
     protected void onCloseClicked() {
-        closeDialogAndSaveAnswers();
-    }
-
-    @Override
-    protected void onBackPressed() {
         closeDialogAndSaveAnswers();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -92,10 +92,6 @@ class ManualProjectCreatorDialog :
     override fun onCloseClicked() {
     }
 
-    override fun onBackPressed() {
-        dismiss()
-    }
-
     override fun getToolbar(): Toolbar {
         return binding.toolbarLayout.toolbar
     }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -232,10 +232,6 @@ class QrCodeProjectCreatorDialog :
     override fun onCloseClicked() {
     }
 
-    override fun onBackPressed() {
-        dismiss()
-    }
-
     override fun getToolbar(): Toolbar? {
         return binding.toolbarLayout.toolbar
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/WidgetAnswerDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/WidgetAnswerDialogFragment.kt
@@ -68,10 +68,6 @@ abstract class WidgetAnswerDialogFragment<T : Fragment>(
         return null
     }
 
-    override fun onBackPressed() {
-        dismiss()
-    }
-
     override fun onCloseClicked() {
         // No toolbar so not relevant
     }

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialogTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialogTest.java
@@ -8,6 +8,7 @@ import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.Espresso;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.javarosa.core.model.SelectChoice;
@@ -70,7 +71,7 @@ public class SelectMinimalDialogTest {
         RobolectricHelpers.runLooper();
 
         assertThat(isDialogVisible(), is(true));
-        dialogFragment.onBackPressed();
+        Espresso.pressBack();
         assertThat(isDialogVisible(), is(false));
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectMultiMinimalDialogTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectMultiMinimalDialogTest.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.fragments.dialogs;
 
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.Espresso;
 
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.helper.Selection;
@@ -30,11 +31,11 @@ public class SelectMultiMinimalDialogTest extends SelectMinimalDialogTest {
         dialogFragment.show(fragmentManager, "TAG");
         RobolectricHelpers.runLooper();
 
-        dialogFragment.onBackPressed();
+        Espresso.pressBack();
         verify(listener, times(0)).updateSelectedItems(anyList());
         dialogFragment.show(fragmentManager, "TAG");
         dialogFragment.adapter.clearAnswer();
-        dialogFragment.onBackPressed();
+        Espresso.pressBack();
         verify(listener, times(1)).updateSelectedItems(anyList());
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectOneMinimalDialogTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectOneMinimalDialogTest.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.fragments.dialogs;
 
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.Espresso;
 
 import org.javarosa.core.model.SelectChoice;
 import org.junit.Test;
@@ -25,11 +26,11 @@ public class SelectOneMinimalDialogTest extends SelectMinimalDialogTest {
 
         dialogFragment.show(fragmentManager, "TAG");
         RobolectricHelpers.runLooper();
-        dialogFragment.onBackPressed();
+        Espresso.pressBack();
         verify(listener, times(0)).updateSelectedItems(anyList());
         dialogFragment.show(fragmentManager, "TAG");
         dialogFragment.adapter.clearAnswer();
-        dialogFragment.onBackPressed();
+        Espresso.pressBack();
         verify(listener, times(1)).updateSelectedItems(anyList());
     }
 

--- a/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersImporterDialogFragment.kt
+++ b/maps/src/main/java/org/odk/collect/maps/layers/OfflineMapLayersImporterDialogFragment.kt
@@ -88,10 +88,6 @@ class OfflineMapLayersImporterDialogFragment(
 
     override fun onCloseClicked() = Unit
 
-    override fun onBackPressed() {
-        dismiss()
-    }
-
     override fun getToolbar(): Toolbar {
         return OfflineMapLayersImporterBinding.bind(requireView()).toolbarLayout.toolbar
     }

--- a/material/src/main/java/org/odk/collect/material/MaterialFullScreenDialogFragment.kt
+++ b/material/src/main/java/org/odk/collect/material/MaterialFullScreenDialogFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.activity.ComponentDialog
-import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.DialogFragment
 import org.odk.collect.androidshared.ui.EdgeToEdge.handleEdgeToEdge
@@ -35,13 +34,6 @@ abstract class MaterialFullScreenDialogFragment : DialogFragment() {
                 setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
             }
 
-            setCancelable(false)
-            dialog.onBackPressedDispatcher.addCallback(this@MaterialFullScreenDialogFragment, object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    onBackPressed()
-                }
-            })
-
             handleEdgeToEdge(requireContext())
         }
     }
@@ -55,8 +47,6 @@ abstract class MaterialFullScreenDialogFragment : DialogFragment() {
     }
 
     protected abstract fun onCloseClicked()
-
-    protected abstract fun onBackPressed()
 
     protected abstract fun getToolbar(): Toolbar?
 


### PR DESCRIPTION
Closes #7151 
Closes #7154 

#### Why is this the best possible solution? Were any other approaches considered?
The issue was that `MaterialFullScreenDialogFragment`, which is a parent for several full-screen dialogs, registered a back button callback that provided default behavior for all its subclasses. However, if any child dialog wanted to override that behavior, it had to register its own callback afterward. Otherwise, if the order was reversed, the Android OS would ignore the child dialog’s callback because the parent’s callback had already been executed and consumed the event.

I could have fixed this by simply changing the registration order, but that would still be error-prone. Instead, I decided it’s better not to register any callback in the base fragment and only do so in the child fragments that actually need it, since a simple back press already results in a default dismiss() behavior and does not require a custom callback.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should simply fix the reported issue. I don’t see any particular risks here, so please just confirm that the back buttons work correctly across the app.

#### Do we need any specific form for testing your changes? If so, please attach one.
The `All question types` form will suffice. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
