### PR TITLE
Update EdgeToEdge to handle keyboard insets for bottom views

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
@@ -3,13 +3,14 @@ package org.odk.collect.androidshared.ui
 import android.app.Activity
 import android.content.Context
 import android.view.View
-import android.view.ViewGroup
 import android.view.Window
 import androidx.annotation.LayoutRes
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
+import android.view.ViewGroup
+import androidx.core.view.updatePadding
 import org.odk.collect.androidshared.system.ContextExt.isDarkTheme
 
 object EdgeToEdge {
@@ -26,7 +27,7 @@ object EdgeToEdge {
         setContentView(view)
     }
 
-    fun Window.handleEdgeToEdge(context: Context, edgeToEdge: Boolean = false) {
+    fun Window.handleEdgeToEdge(context: Context, edgeToEdge: Boolean = false, bottomView: View? = null) {
         WindowCompat.enableEdgeToEdge(this)
         WindowCompat.getInsetsController(this, this.decorView).let {
             val darkTheme = context.isDarkTheme()
@@ -35,25 +36,30 @@ object EdgeToEdge {
         }
 
         if (!edgeToEdge) {
-            avoidEdgeToEdge()
+            avoidEdgeToEdge(bottomView)
         }
     }
 
-    private fun Window.avoidEdgeToEdge() {
+    private fun Window.avoidEdgeToEdge(bottomView: View? = null) {
         val contentView = decorView.findViewById<View>(android.R.id.content)
-        contentView.addSystemBarInsetMargins()
+        contentView.addSystemBarInsetMargins(bottomView)
     }
 
-    private fun View.addSystemBarInsetMargins() {
+    private fun View.addSystemBarInsetMargins(bottomView: View? = null) {
         ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
-            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                topMargin = insets.top
-                bottomMargin = insets.bottom
+            val systemBarsInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val keyboardInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
 
-                leftMargin = insets.left
-                rightMargin = insets.right
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = systemBarsInsets.top
+                leftMargin = systemBarsInsets.left
+                rightMargin = systemBarsInsets.right
+                bottomMargin = if (bottomView == null) systemBarsInsets.bottom else 0
             }
+
+            bottomView?.updatePadding(
+                bottom = maxOf(systemBarsInsets.bottom, keyboardInsets.bottom)
+            )
 
             WindowInsetsCompat.CONSUMED
         }

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
@@ -3,13 +3,13 @@ package org.odk.collect.androidshared.ui
 import android.app.Activity
 import android.content.Context
 import android.view.View
+import android.view.ViewGroup
 import android.view.Window
 import androidx.annotation.LayoutRes
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
-import android.view.ViewGroup
 import androidx.core.view.updatePadding
 import org.odk.collect.androidshared.system.ContextExt.isDarkTheme
 
@@ -27,7 +27,7 @@ object EdgeToEdge {
         setContentView(view)
     }
 
-    fun Window.handleEdgeToEdge(context: Context, edgeToEdge: Boolean = false, bottomView: View? = null) {
+    fun Window.handleEdgeToEdge(context: Context, edgeToEdge: Boolean = false) {
         WindowCompat.enableEdgeToEdge(this)
         WindowCompat.getInsetsController(this, this.decorView).let {
             val darkTheme = context.isDarkTheme()
@@ -36,32 +36,40 @@ object EdgeToEdge {
         }
 
         if (!edgeToEdge) {
-            avoidEdgeToEdge(bottomView)
+            avoidEdgeToEdge()
         }
     }
 
-    private fun Window.avoidEdgeToEdge(bottomView: View? = null) {
-        val contentView = decorView.findViewById<View>(android.R.id.content)
-        contentView.addSystemBarInsetMargins(bottomView)
-    }
-
-    private fun View.addSystemBarInsetMargins(bottomView: View? = null) {
+    fun View.applyBottomBarInsetMargins() {
         ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
             val systemBarsInsets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
             val keyboardInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
 
-            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                topMargin = systemBarsInsets.top
-                leftMargin = systemBarsInsets.left
-                rightMargin = systemBarsInsets.right
-                bottomMargin = if (bottomView == null) systemBarsInsets.bottom else 0
-            }
-
-            bottomView?.updatePadding(
-                bottom = maxOf(systemBarsInsets.bottom, keyboardInsets.bottom)
+            v.updatePadding(
+                bottom = maxOf(0, keyboardInsets.bottom - systemBarsInsets.bottom)
             )
 
-            WindowInsetsCompat.CONSUMED
+            windowInsets
+        }
+    }
+
+    private fun Window.avoidEdgeToEdge() {
+        val contentView = decorView.findViewById<View>(android.R.id.content)
+        contentView.addSystemBarInsetMargins()
+    }
+
+    private fun View.addSystemBarInsetMargins() {
+        ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = insets.top
+                bottomMargin = insets.bottom
+
+                leftMargin = insets.left
+                rightMargin = insets.right
+            }
+
+            windowInsets
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -150,4 +150,6 @@ class ManualProjectCreatorDialog :
     }
 
     override fun cancel() {}
+
+    override fun getBottomView() = binding.bottomContainer
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -18,6 +18,7 @@ import org.odk.collect.android.projects.DuplicateProjectConfirmationKeys.MATCHIN
 import org.odk.collect.android.projects.DuplicateProjectConfirmationKeys.SETTINGS_JSON
 import org.odk.collect.android.utilities.SoftKeyboardController
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
+import org.odk.collect.androidshared.ui.EdgeToEdge.applyBottomBarInsetMargins
 import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.androidshared.utils.Validator
 import org.odk.collect.material.MaterialFullScreenDialogFragment
@@ -87,6 +88,8 @@ class ManualProjectCreatorDialog :
         binding.addButton.setOnClickListener {
             handleAddingNewProject()
         }
+
+        binding.bottomContainer.applyBottomBarInsetMargins()
     }
 
     override fun onCloseClicked() {
@@ -150,6 +153,4 @@ class ManualProjectCreatorDialog :
     }
 
     override fun cancel() {}
-
-    override fun getBottomView() = binding.bottomContainer
 }

--- a/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
@@ -18,7 +18,7 @@
             android:id="@+id/scrollable_container"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="@+id/shadow_up"
+            app:layout_constraintBottom_toTopOf="@+id/bottom_container"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
@@ -111,32 +111,39 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>
 
-        <ImageView
-            android:id="@+id/shadow_up"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/bottom_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:src="@drawable/shadow_up"
-            app:layout_constraintBottom_toTopOf="@+id/cancel_button" />
+            app:layout_constraintBottom_toBottomOf="parent">
 
-        <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
-            android:id="@+id/cancel_button"
-            style="?borderlessButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/cancel"
-            app:layout_constraintBottom_toBottomOf="@+id/add_button"
-            app:layout_constraintEnd_toStartOf="@+id/add_button"
-            app:layout_constraintTop_toTopOf="@+id/add_button" />
+            <ImageView
+                android:id="@+id/shadow_up"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:src="@drawable/shadow_up"
+                app:layout_constraintBottom_toTopOf="@+id/cancel_button" />
 
-        <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
-            android:id="@+id/add_button"
-            style="?borderlessButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/margin_extra_extra_small"
-            android:enabled="false"
-            android:text="@string/add"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+                android:id="@+id/cancel_button"
+                style="?borderlessButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/cancel"
+                app:layout_constraintEnd_toStartOf="@+id/add_button"
+                app:layout_constraintTop_toTopOf="@+id/add_button"
+                app:layout_constraintBottom_toBottomOf="@+id/add_button" />
+
+            <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton
+                android:id="@+id/add_button"
+                style="?borderlessButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_extra_extra_small"
+                android:enabled="false"
+                android:text="@string/add"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/material/src/main/java/org/odk/collect/material/MaterialFullScreenDialogFragment.kt
+++ b/material/src/main/java/org/odk/collect/material/MaterialFullScreenDialogFragment.kt
@@ -42,7 +42,7 @@ abstract class MaterialFullScreenDialogFragment : DialogFragment() {
                 }
             })
 
-            handleEdgeToEdge(requireContext(), bottomView = getBottomView())
+            handleEdgeToEdge(requireContext())
         }
     }
 
@@ -63,6 +63,4 @@ abstract class MaterialFullScreenDialogFragment : DialogFragment() {
     protected open fun shouldShowSoftKeyboard(): Boolean {
         return false
     }
-
-    protected open fun getBottomView(): View? = null
 }

--- a/material/src/main/java/org/odk/collect/material/MaterialFullScreenDialogFragment.kt
+++ b/material/src/main/java/org/odk/collect/material/MaterialFullScreenDialogFragment.kt
@@ -42,7 +42,7 @@ abstract class MaterialFullScreenDialogFragment : DialogFragment() {
                 }
             })
 
-            handleEdgeToEdge(requireContext())
+            handleEdgeToEdge(requireContext(), bottomView = getBottomView())
         }
     }
 
@@ -63,4 +63,6 @@ abstract class MaterialFullScreenDialogFragment : DialogFragment() {
     protected open fun shouldShowSoftKeyboard(): Boolean {
         return false
     }
+
+    protected open fun getBottomView(): View? = null
 }


### PR DESCRIPTION
Closes #7158 

#### Why is this the best possible solution? Were any other approaches considered?
I was considering adding special handling only in the affected dialog, but I’m fairly sure similar issues could occur in other parts of the app, so it’s better to make the EdgeToEdge utilities handle this on their own.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Only the mentioned dialog (for manually adding projects) should be affected (fixed by displaying the bottom layout above the keyboard), so in theory, testing could be limited to it. However, similar issues might occur in other parts of the app, so please keep an eye out for them as well.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
