### PR TITLE
Fix the end of form view

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEnd.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEnd.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -46,88 +47,90 @@ fun FormEnd(
     finalizeEnabled: Boolean,
     onSave: (Boolean) -> Unit = {}
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(marginStandard()),
-        verticalArrangement = Arrangement.Center
-    ) {
-        Text(
-            text = stringResource(string.save_enter_data_description, formTitle),
-            style = MaterialTheme.typography.titleLarge
-        )
-
-        if (finalizeEnabled) {
-            val (icon, title, message) = getWarning(
-                isEditableAfterFinalization,
-                shouldBeSentAutomatically,
-                saveAsDraftEnabled
-            )
-
-            EditWarning(
-                icon = icon,
-                title = title,
-                message = message,
-                errorBackground = !isEditableAfterFinalization
-            )
-        }
-
-        Row(
+    Surface {
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 64.dp),
-            horizontalArrangement = Arrangement.spacedBy(marginStandard())
+                .fillMaxSize()
+                .padding(marginStandard()),
+            verticalArrangement = Arrangement.Center
         ) {
-            val screenName = stringResource(org.odk.collect.android.R.string.form_end_screen)
-
-            if (saveAsDraftEnabled) {
-                OutlinedButton(
-                    modifier = Modifier.weight(1f),
-                    onClick = {
-                        if (MultiClickGuard.allowClick(screenName)) {
-                            onSave(false)
-                        }
-                    }
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            Icons.Default.Save,
-                            contentDescription = null
-                        )
-
-                        Text(
-                            text = stringResource(string.save_as_draft),
-                            modifier = Modifier.padding(start = marginExtraSmall())
-                        )
-                    }
-                }
-            }
+            Text(
+                text = stringResource(string.save_enter_data_description, formTitle),
+                style = MaterialTheme.typography.titleLarge
+            )
 
             if (finalizeEnabled) {
-                val finalizeText = if (shouldBeSentAutomatically) {
-                    string.send
-                } else {
-                    string.finalize
-                }
+                val (icon, title, message) = getWarning(
+                    isEditableAfterFinalization,
+                    shouldBeSentAutomatically,
+                    saveAsDraftEnabled
+                )
 
-                Button(
-                    modifier = Modifier.weight(1f),
-                    onClick = {
-                        if (MultiClickGuard.allowClick(screenName)) {
-                            onSave(true)
+                EditWarning(
+                    icon = icon,
+                    title = title,
+                    message = message,
+                    errorBackground = !isEditableAfterFinalization
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 64.dp),
+                horizontalArrangement = Arrangement.spacedBy(marginStandard())
+            ) {
+                val screenName = stringResource(org.odk.collect.android.R.string.form_end_screen)
+
+                if (saveAsDraftEnabled) {
+                    OutlinedButton(
+                        modifier = Modifier.weight(1f),
+                        onClick = {
+                            if (MultiClickGuard.allowClick(screenName)) {
+                                onSave(false)
+                            }
+                        }
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                Icons.Default.Save,
+                                contentDescription = null
+                            )
+
+                            Text(
+                                text = stringResource(string.save_as_draft),
+                                modifier = Modifier.padding(start = marginExtraSmall())
+                            )
                         }
                     }
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            Icons.AutoMirrored.Default.Send,
-                            contentDescription = null
-                        )
+                }
 
-                        Text(
-                            text = stringResource(finalizeText),
-                            modifier = Modifier.padding(start = marginExtraSmall())
-                        )
+                if (finalizeEnabled) {
+                    val finalizeText = if (shouldBeSentAutomatically) {
+                        string.send
+                    } else {
+                        string.finalize
+                    }
+
+                    Button(
+                        modifier = Modifier.weight(1f),
+                        onClick = {
+                            if (MultiClickGuard.allowClick(screenName)) {
+                                onSave(true)
+                            }
+                        }
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                Icons.AutoMirrored.Default.Send,
+                                contentDescription = null
+                            )
+
+                            Text(
+                                text = stringResource(finalizeText),
+                                modifier = Modifier.padding(start = marginExtraSmall())
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Closes #7171

#### Why is this the best possible solution? Were any other approaches considered?
We need to use `Surface` for `Text` to use theme colors similar to https://github.com/getodk/collect/pull/7061

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should simply fix the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
