### PR TITLE
Improve parsing labels for range question

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeSliderState.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangeSliderState.kt
@@ -135,7 +135,7 @@ data class RangeSliderState(
 
         private fun getLabels(prompt: FormEntryPrompt, choices: List<SelectChoice>, start: BigDecimal, end: BigDecimal, step: BigDecimal): List<String> {
             val labelMap = choices.associate { choice ->
-                choice.value.toBigDecimalOrNull() to prompt.getSelectChoiceText(choice)
+                choice.value.toBigDecimalOrNull()?.stripTrailingZeros() to prompt.getSelectChoiceText(choice)
             }
 
             val labels = mutableListOf<String>()
@@ -143,7 +143,7 @@ data class RangeSliderState(
             val direction = if (end >= start) BigDecimal.ONE else -BigDecimal.ONE
 
             while (if (direction > BigDecimal.ZERO) current <= end else current >= end) {
-                labels.add(labelMap[current] ?: "")
+                labels.add(labelMap[current.stripTrailingZeros()] ?: "")
                 current += step * direction
             }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeSliderStateTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeSliderStateTest.kt
@@ -480,6 +480,40 @@ class RangeSliderStateTest {
     }
 
     @Test
+    fun `returns labels correctly when choices use integer values for decimal question`() {
+        mockDecimalQuestion(0.0F, 1.0F, 0.5F)
+
+        val choices = listOf(
+            SelectChoice("0", "0"),
+            SelectChoice("1", "1")
+        )
+        val prompt = promptBuilder
+            .withSelectChoices(choices)
+            .withDataType(DATATYPE_INTEGER)
+            .build()
+
+        val state = RangeSliderState.fromPrompt(prompt, choices)
+        assertThat(state.labels, equalTo(listOf("0", "", "1")))
+    }
+
+    @Test
+    fun `returns labels correctly when choices use decimal values for integer question`() {
+        mockIntQuestion(0, 1, 1)
+
+        val choices = listOf(
+            SelectChoice("0.0", "0"),
+            SelectChoice("1.0", "1")
+        )
+        val prompt = promptBuilder
+            .withSelectChoices(choices)
+            .withDataType(DATATYPE_INTEGER)
+            .build()
+
+        val state = RangeSliderState.fromPrompt(prompt, choices)
+        assertThat(state.labels, equalTo(listOf("0", "1")))
+    }
+
+    @Test
     fun `returns correct value for valid placeholder`() {
         mockIntQuestion(0, 10, 1, placeholder = 4)
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeSliderStateTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/range/RangeSliderStateTest.kt
@@ -489,7 +489,7 @@ class RangeSliderStateTest {
         )
         val prompt = promptBuilder
             .withSelectChoices(choices)
-            .withDataType(DATATYPE_INTEGER)
+            .withDataType(DATATYPE_DECIMAL)
             .build()
 
         val state = RangeSliderState.fromPrompt(prompt, choices)


### PR DESCRIPTION
Closes #7176 

#### Why is this the best possible solution? Were any other approaches considered?
Not much to discuss here. The problem occurred when choices were represented as decimal values for integer questions, and vice versa - integer values for decimal questions. I've fixed this and added automated tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should simply fix the issue. I can't think of any bigger risk here.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form mentioned in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
