### PR TITLE
Add offline-first submission sync engine with conflict resolution

### DIFF
--- a/sync-engine/package.json
+++ b/sync-engine/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@fieldform/sync-engine",
+  "version": "0.1.0",
+  "description": "Offline-first submission sync engine with conflict resolution for ODK-compatible data collection",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "idb": "^8.0.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.1.0",
+    "fake-indexeddb": "^6.0.0"
+  }
+}

--- a/sync-engine/src/__tests__/setup.ts
+++ b/sync-engine/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import 'fake-indexeddb/auto';

--- a/sync-engine/src/__tests__/submission-queue.test.ts
+++ b/sync-engine/src/__tests__/submission-queue.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SubmissionQueue } from '../submission-queue.js';
+import type { Submission, SyncEvent } from '../types.js';
+
+function makeSubmission(overrides: Partial<Submission> = {}): Submission {
+  return {
+    instanceId: overrides.instanceId ?? crypto.randomUUID(),
+    formId: 'form-1',
+    data: { field1: 'value1' },
+    submittedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function mockFetch(handler: (url: string, init: RequestInit) => Response) {
+  return vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    return handler(String(url), init ?? {});
+  }) as unknown as typeof globalThis.fetch;
+}
+
+const noDelay = async () => {};
+
+let dbCounter = 0;
+function uniqueDbName() {
+  return `test-sync-${++dbCounter}-${Date.now()}`;
+}
+
+describe('SubmissionQueue', () => {
+  describe('queue persistence across page reloads', () => {
+    it('should persist enqueued submissions and retrieve them after re-instantiation', async () => {
+      const dbName = uniqueDbName();
+      const fetchFn = mockFetch(() => new Response(null, { status: 200 }));
+
+      const queue1 = new SubmissionQueue({ dbName, fetch: fetchFn, delay: noDelay });
+      const sub1 = makeSubmission({ instanceId: 'persist-1' });
+      const sub2 = makeSubmission({ instanceId: 'persist-2' });
+      await queue1.enqueue(sub1);
+      await queue1.enqueue(sub2);
+
+      const status1 = await queue1.getStatus();
+      expect(status1.pending).toBe(2);
+
+      // Simulate page reload: new instance, same DB
+      const queue2 = new SubmissionQueue({ dbName, fetch: fetchFn, delay: noDelay });
+      const status2 = await queue2.getStatus();
+      expect(status2.pending).toBe(2);
+
+      const result = await queue2.sync();
+      expect(result.synced).toBe(2);
+      expect(result.failed).toBe(0);
+
+      const status3 = await queue2.getStatus();
+      expect(status3.pending).toBe(0);
+    });
+
+    it('should persist failed status across re-instantiation', async () => {
+      const dbName = uniqueDbName();
+      let callCount = 0;
+      const fetchFn = mockFetch(() => {
+        callCount++;
+        return new Response(null, { status: 500 });
+      });
+
+      const queue1 = new SubmissionQueue({ dbName, fetch: fetchFn, delay: noDelay });
+      await queue1.enqueue(makeSubmission({ instanceId: 'fail-persist' }));
+      await queue1.sync();
+
+      // 1 initial + 3 retries = 4 total calls
+      expect(callCount).toBe(4);
+
+      // "Reload" — failed items should still be tracked
+      const queue2 = new SubmissionQueue({ dbName, fetch: fetchFn, delay: noDelay });
+      const status = await queue2.getStatus();
+      expect(status.failed).toBe(1);
+      expect(status.pending).toBe(0);
+    });
+  });
+
+  describe('conflict detection and resolution', () => {
+    it('should detect 409 conflict and resolve with last-write-wins', async () => {
+      const dbName = uniqueDbName();
+      const events: SyncEvent[] = [];
+
+      const fetchFn = mockFetch((_url, init) => {
+        const headers = init.headers as Record<string, string> | undefined;
+        if (headers?.['X-Conflict-Resolution'] === 'overwrite') {
+          return new Response(null, { status: 200 });
+        }
+        return new Response(null, { status: 409 });
+      });
+
+      const queue = new SubmissionQueue({ dbName, fetch: fetchFn, delay: noDelay });
+      queue.events.onAny((event) => events.push(event));
+
+      await queue.enqueue(makeSubmission({ instanceId: 'conflict-1' }));
+      const result = await queue.sync();
+
+      expect(result.synced).toBe(1);
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0].instanceId).toBe('conflict-1');
+      expect(result.conflicts[0].resolution).toBe('last-write-wins');
+
+      const eventTypes = events.map((e) => e.type);
+      expect(eventTypes).toContain('queued');
+      expect(eventTypes).toContain('syncing');
+      expect(eventTypes).toContain('conflict');
+      expect(eventTypes).toContain('synced');
+    });
+
+    it('should mark as failed if conflict resolution POST also fails', async () => {
+      const dbName = uniqueDbName();
+      const fetchFn = mockFetch(() => new Response(null, { status: 409 }));
+
+      const queue = new SubmissionQueue({ dbName, fetch: fetchFn, delay: noDelay });
+      await queue.enqueue(makeSubmission({ instanceId: 'conflict-fail' }));
+      const result = await queue.sync();
+
+      expect(result.synced).toBe(0);
+      expect(result.failed).toBe(1);
+    });
+  });
+
+  describe('partial sync recovery', () => {
+    it('should resume from item 3 after items 1-2 succeed and item 3 fails', async () => {
+      const dbName = uniqueDbName();
+      const submissions = Array.from({ length: 5 }, (_, i) =>
+        makeSubmission({ instanceId: `partial-${i + 1}` })
+      );
+
+      // Items 1,2 ok; item 3 retries all fail (500); items 4,5 ok
+      let syncCallNum = 0;
+      const fetchRound1 = mockFetch(() => {
+        syncCallNum++;
+        // calls 1,2 succeed; calls 3-6 are item 3 (initial + 3 retries); calls 7,8 are items 4,5
+        if (syncCallNum >= 3 && syncCallNum <= 6) {
+          return new Response(null, { status: 500 });
+        }
+        return new Response(null, { status: 200 });
+      });
+
+      const queue1 = new SubmissionQueue({ dbName, fetch: fetchRound1, delay: noDelay });
+      for (const sub of submissions) {
+        await queue1.enqueue(sub);
+      }
+
+      const result1 = await queue1.sync();
+      expect(result1.synced).toBe(4);
+      expect(result1.failed).toBe(1);
+
+      const status = await queue1.getStatus();
+      expect(status.pending).toBe(0);
+      expect(status.failed).toBe(1);
+
+      // Second sync: only pending items are synced (none left), failed stays
+      const fetchRound2 = mockFetch(() => new Response(null, { status: 200 }));
+      const queue2 = new SubmissionQueue({ dbName, fetch: fetchRound2, delay: noDelay });
+
+      const result2 = await queue2.sync();
+      expect(result2.synced).toBe(0);
+
+      const finalStatus = await queue2.getStatus();
+      expect(finalStatus.failed).toBe(1);
+    });
+  });
+
+  describe('retry with exponential backoff', () => {
+    it('should retry 3 times on 5xx errors with backoff then mark failed', async () => {
+      const dbName = uniqueDbName();
+      const delays: number[] = [];
+
+      const fetchFn = mockFetch(() => new Response(null, { status: 503 }));
+      const trackDelay = async (ms: number) => {
+        delays.push(ms);
+      };
+
+      const queue = new SubmissionQueue({ dbName, fetch: fetchFn, delay: trackDelay });
+      await queue.enqueue(makeSubmission());
+      const result = await queue.sync();
+
+      expect(result.failed).toBe(1);
+      expect(result.synced).toBe(0);
+      // 1 initial + 3 retries = 4 total calls
+      expect(fetchFn).toHaveBeenCalledTimes(4);
+      // Exponential backoff: 1000, 2000, 4000
+      expect(delays).toEqual([1000, 2000, 4000]);
+    });
+
+    it('should retry on network errors and succeed on 4th attempt', async () => {
+      const dbName = uniqueDbName();
+      let attempt = 0;
+
+      const fetchFn = mockFetch(() => {
+        attempt++;
+        if (attempt <= 3) throw new Error('Network failure');
+        return new Response(null, { status: 200 });
+      });
+
+      const queue = new SubmissionQueue({ dbName, fetch: fetchFn, delay: noDelay });
+      await queue.enqueue(makeSubmission());
+      const result = await queue.sync();
+
+      expect(result.synced).toBe(1);
+      expect(result.failed).toBe(0);
+    });
+  });
+
+  describe('event emitter', () => {
+    it('should emit events in correct order for successful sync', async () => {
+      const dbName = uniqueDbName();
+      const events: string[] = [];
+      const fetchFn = mockFetch(() => new Response(null, { status: 200 }));
+
+      const queue = new SubmissionQueue({ dbName, fetch: fetchFn, delay: noDelay });
+      queue.events.on('queued', () => events.push('queued'));
+      queue.events.on('syncing', () => events.push('syncing'));
+      queue.events.on('synced', () => events.push('synced'));
+
+      await queue.enqueue(makeSubmission());
+      await queue.sync();
+
+      expect(events).toEqual(['queued', 'syncing', 'synced']);
+    });
+
+    it('should allow unsubscribing from events', async () => {
+      const dbName = uniqueDbName();
+      const events: string[] = [];
+      const fetchFn = mockFetch(() => new Response(null, { status: 200 }));
+
+      const queue = new SubmissionQueue({ dbName, fetch: fetchFn, delay: noDelay });
+      const unsub = queue.events.on('queued', () => events.push('queued'));
+
+      await queue.enqueue(makeSubmission());
+      unsub();
+      await queue.enqueue(makeSubmission());
+
+      expect(events).toEqual(['queued']);
+    });
+  });
+});

--- a/sync-engine/src/event-emitter.ts
+++ b/sync-engine/src/event-emitter.ts
@@ -1,0 +1,29 @@
+import type { SyncEvent, SyncEventType, SyncEventListener } from './types.js';
+
+export class SyncEventEmitter {
+  private listeners = new Map<SyncEventType, Set<SyncEventListener>>();
+  private allListeners = new Set<SyncEventListener>();
+
+  on(type: SyncEventType, listener: SyncEventListener): () => void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+    return () => set!.delete(listener);
+  }
+
+  onAny(listener: SyncEventListener): () => void {
+    this.allListeners.add(listener);
+    return () => this.allListeners.delete(listener);
+  }
+
+  emit(event: SyncEvent): void {
+    const set = this.listeners.get(event.type);
+    if (set) {
+      for (const listener of set) listener(event);
+    }
+    for (const listener of this.allListeners) listener(event);
+  }
+}

--- a/sync-engine/src/index.ts
+++ b/sync-engine/src/index.ts
@@ -1,0 +1,15 @@
+export { SubmissionQueue } from './submission-queue.js';
+export type { SubmissionQueueOptions } from './submission-queue.js';
+export { SyncEventEmitter } from './event-emitter.js';
+export { QueueStore } from './store.js';
+export type {
+  Submission,
+  SyncResult,
+  QueueStatus,
+  QueueEntry,
+  QueueEntryStatus,
+  ConflictRecord,
+  SyncEvent,
+  SyncEventType,
+  SyncEventListener,
+} from './types.js';

--- a/sync-engine/src/store.ts
+++ b/sync-engine/src/store.ts
@@ -1,0 +1,84 @@
+import { openDB, type IDBPDatabase } from 'idb';
+import type { QueueEntry, QueueEntryStatus, Submission } from './types.js';
+
+const DB_NAME = 'fieldform-sync';
+const DB_VERSION = 1;
+const STORE_NAME = 'submissions';
+const META_STORE = 'meta';
+
+interface SyncDB {
+  submissions: {
+    key: number;
+    value: QueueEntry;
+    indexes: { 'by-status': QueueEntryStatus };
+  };
+  meta: {
+    key: string;
+    value: { key: string; value: string };
+  };
+}
+
+export class QueueStore {
+  private dbPromise: Promise<IDBPDatabase<SyncDB>>;
+
+  constructor(dbName = DB_NAME) {
+    this.dbPromise = openDB<SyncDB>(dbName, DB_VERSION, {
+      upgrade(db) {
+        const store = db.createObjectStore(STORE_NAME, {
+          keyPath: 'id',
+          autoIncrement: true,
+        });
+        store.createIndex('by-status', 'status');
+        db.createObjectStore(META_STORE, { keyPath: 'key' });
+      },
+    });
+  }
+
+  async add(submission: Submission): Promise<QueueEntry> {
+    const db = await this.dbPromise;
+    const entry: Omit<QueueEntry, 'id'> = {
+      submission,
+      status: 'pending',
+      retries: 0,
+      createdAt: new Date().toISOString(),
+    };
+    const id = await db.add(STORE_NAME, entry as QueueEntry);
+    return { ...entry, id } as QueueEntry;
+  }
+
+  async getPending(): Promise<QueueEntry[]> {
+    const db = await this.dbPromise;
+    return db.getAllFromIndex(STORE_NAME, 'by-status', 'pending');
+  }
+
+  async getFailed(): Promise<QueueEntry[]> {
+    const db = await this.dbPromise;
+    return db.getAllFromIndex(STORE_NAME, 'by-status', 'failed');
+  }
+
+  async update(entry: QueueEntry): Promise<void> {
+    const db = await this.dbPromise;
+    await db.put(STORE_NAME, entry);
+  }
+
+  async remove(id: number): Promise<void> {
+    const db = await this.dbPromise;
+    await db.delete(STORE_NAME, id);
+  }
+
+  async getLastSyncAt(): Promise<string | null> {
+    const db = await this.dbPromise;
+    const record = await db.get(META_STORE, 'lastSyncAt');
+    return record?.value ?? null;
+  }
+
+  async setLastSyncAt(value: string): Promise<void> {
+    const db = await this.dbPromise;
+    await db.put(META_STORE, { key: 'lastSyncAt', value });
+  }
+
+  async count(status: QueueEntryStatus): Promise<number> {
+    const db = await this.dbPromise;
+    return db.countFromIndex(STORE_NAME, 'by-status', status);
+  }
+}

--- a/sync-engine/src/submission-queue.ts
+++ b/sync-engine/src/submission-queue.ts
@@ -1,0 +1,193 @@
+import type {
+  Submission,
+  SyncResult,
+  QueueStatus,
+  ConflictRecord,
+  QueueEntry,
+} from './types.js';
+import { QueueStore } from './store.js';
+import { SyncEventEmitter } from './event-emitter.js';
+
+const MAX_RETRIES = 3;
+const BACKOFF_BASE_MS = 1000;
+
+export interface SubmissionQueueOptions {
+  apiBase?: string;
+  dbName?: string;
+  fetch?: typeof globalThis.fetch;
+  /** Override the delay function (useful for testing). Receives milliseconds. */
+  delay?: (ms: number) => Promise<void>;
+}
+
+export class SubmissionQueue {
+  private store: QueueStore;
+  private emitter = new SyncEventEmitter();
+  private apiBase: string;
+  private fetchFn: typeof globalThis.fetch;
+  private delayFn: (ms: number) => Promise<void>;
+
+  constructor(options: SubmissionQueueOptions = {}) {
+    this.apiBase = options.apiBase ?? '';
+    this.store = new QueueStore(options.dbName);
+    this.fetchFn = options.fetch ?? globalThis.fetch.bind(globalThis);
+    this.delayFn =
+      options.delay ??
+      ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  get events(): SyncEventEmitter {
+    return this.emitter;
+  }
+
+  async enqueue(submission: Submission): Promise<void> {
+    await this.store.add(submission);
+    this.emitter.emit({ type: 'queued', submission });
+  }
+
+  async sync(): Promise<SyncResult> {
+    const entries = await this.store.getPending();
+    const result: SyncResult = {
+      synced: 0,
+      failed: 0,
+      conflicts: [],
+      errors: [],
+    };
+
+    for (const entry of entries) {
+      await this.processEntry(entry, result);
+    }
+
+    return result;
+  }
+
+  async getStatus(): Promise<QueueStatus> {
+    const [pending, failed, lastSyncAt] = await Promise.all([
+      this.store.count('pending'),
+      this.store.count('failed'),
+      this.store.getLastSyncAt(),
+    ]);
+    return { pending, failed, lastSyncAt };
+  }
+
+  private async processEntry(
+    entry: QueueEntry,
+    result: SyncResult
+  ): Promise<void> {
+    const { submission } = entry;
+    this.emitter.emit({ type: 'syncing', submission });
+
+    const outcome = await this.postWithRetry(submission);
+
+    if (outcome.ok) {
+      await this.store.remove(entry.id);
+      const now = new Date().toISOString();
+      await this.store.setLastSyncAt(now);
+      result.synced++;
+      this.emitter.emit({ type: 'synced', submission });
+      return;
+    }
+
+    if (outcome.conflict) {
+      const conflictResult = await this.resolveConflict(submission);
+      if (conflictResult.ok) {
+        await this.store.remove(entry.id);
+        const now = new Date().toISOString();
+        await this.store.setLastSyncAt(now);
+        result.synced++;
+        const record: ConflictRecord = {
+          instanceId: submission.instanceId,
+          resolution: 'last-write-wins',
+          mergeLog: `Conflict on ${submission.instanceId}: local version overwrote server at ${now}`,
+        };
+        result.conflicts.push(record);
+        this.emitter.emit({ type: 'conflict', record });
+        this.emitter.emit({ type: 'synced', submission });
+        return;
+      }
+    }
+
+    entry.status = 'failed';
+    await this.store.update(entry);
+    result.failed++;
+    const errorMsg = outcome.error ?? 'Unknown error';
+    result.errors.push(`${submission.instanceId}: ${errorMsg}`);
+    this.emitter.emit({ type: 'failed', submission, error: errorMsg });
+  }
+
+  private async postWithRetry(
+    submission: Submission
+  ): Promise<{ ok: boolean; conflict: boolean; error?: string }> {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const response = await this.fetchFn(
+          `${this.apiBase}/api/submissions`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(submission),
+          }
+        );
+
+        if (response.ok) {
+          return { ok: true, conflict: false };
+        }
+
+        if (response.status === 409) {
+          return { ok: false, conflict: true };
+        }
+
+        if (response.status >= 500) {
+          if (attempt < MAX_RETRIES) {
+            await this.delayFn(BACKOFF_BASE_MS * Math.pow(2, attempt));
+            continue;
+          }
+          return {
+            ok: false,
+            conflict: false,
+            error: `Server error ${response.status} after ${MAX_RETRIES + 1} attempts`,
+          };
+        }
+
+        return {
+          ok: false,
+          conflict: false,
+          error: `HTTP ${response.status}`,
+        };
+      } catch (err) {
+        if (attempt < MAX_RETRIES) {
+          await this.delayFn(BACKOFF_BASE_MS * Math.pow(2, attempt));
+          continue;
+        }
+        return {
+          ok: false,
+          conflict: false,
+          error: `Network error after ${MAX_RETRIES + 1} attempts: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    }
+
+    return { ok: false, conflict: false, error: 'Exhausted retries' };
+  }
+
+  private async resolveConflict(
+    submission: Submission
+  ): Promise<{ ok: boolean }> {
+    try {
+      const response = await this.fetchFn(
+        `${this.apiBase}/api/submissions`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Conflict-Resolution': 'overwrite',
+          },
+          body: JSON.stringify(submission),
+        }
+      );
+      return { ok: response.ok };
+    } catch {
+      return { ok: false };
+    }
+  }
+
+}

--- a/sync-engine/src/types.ts
+++ b/sync-engine/src/types.ts
@@ -1,0 +1,46 @@
+export interface Submission {
+  instanceId: string;
+  formId: string;
+  data: Record<string, unknown>;
+  submittedAt: string;
+}
+
+export interface ConflictRecord {
+  instanceId: string;
+  resolution: 'last-write-wins';
+  mergeLog: string;
+}
+
+export interface SyncResult {
+  synced: number;
+  failed: number;
+  conflicts: ConflictRecord[];
+  errors: string[];
+}
+
+export interface QueueStatus {
+  pending: number;
+  failed: number;
+  lastSyncAt: string | null;
+}
+
+export type QueueEntryStatus = 'pending' | 'failed';
+
+export interface QueueEntry {
+  id: number;
+  submission: Submission;
+  status: QueueEntryStatus;
+  retries: number;
+  createdAt: string;
+}
+
+export type SyncEvent =
+  | { type: 'queued'; submission: Submission }
+  | { type: 'syncing'; submission: Submission }
+  | { type: 'synced'; submission: Submission }
+  | { type: 'conflict'; record: ConflictRecord }
+  | { type: 'failed'; submission: Submission; error: string };
+
+export type SyncEventType = SyncEvent['type'];
+
+export type SyncEventListener = (event: SyncEvent) => void;

--- a/sync-engine/tsconfig.json
+++ b/sync-engine/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}

--- a/sync-engine/vitest.config.ts
+++ b/sync-engine/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    setupFiles: ['./src/__tests__/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a new `sync-engine/` TypeScript module implementing an offline-first submission queue backed by IndexedDB (`idb` library)
- Queues form submissions locally and syncs in FIFO order with 409 conflict detection (last-write-wins resolution via `X-Conflict-Resolution: overwrite` header)
- Includes exponential backoff retry (1s, 2s, 4s) for 5xx/network errors, and an event emitter (`queued`, `syncing`, `synced`, `conflict`, `failed`) for UI integration

## Test plan
- [x] Queue persistence across simulated page reloads (new instance, same IndexedDB)
- [x] Conflict detection on 409 and last-write-wins resolution
- [x] Failed conflict resolution falls back to marking entry as failed
- [x] Partial sync recovery (items 1-2 succeed, item 3 fails, items 4-5 succeed, item 3 tracked as failed)
- [x] Exponential backoff timing verified (1000ms, 2000ms, 4000ms)
- [x] Network error retry with success on final attempt
- [x] Event emitter ordering and unsubscribe
- [x] All 9 tests pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)