### PR TITLE
Fix handling validation results

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredAndConstraintQuestionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredAndConstraintQuestionTest.kt
@@ -95,6 +95,19 @@ class RequiredAndConstraintQuestionTest {
     }
 
     @Test
+    fun validatingFormByPressingValidateInOptionsMenuOnFormEndScreen_displaysSuccessMessage() {
+        rule.startAtMainMenu()
+            .copyForm("required_question_with_custom_error_message.xml")
+            .startBlankForm("required_question_with_custom_error_message")
+            .answerQuestion("* Required question", "blah")
+            .swipeToEndScreen()
+            .clickOptionsIcon()
+            .clickOnString(R.string.validate)
+            .assertText(R.string.success_form_validation)
+            .assertTextDoesNotExist("Custom message")
+    }
+
+    @Test
     fun emptyRequiredQuestion_isNotSavedToAuditLogOnMovingForward() {
         rule.startAtMainMenu()
             .copyForm("required_question_with_custom_error_message.xml")

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -649,13 +649,16 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
         });
     }
 
-    private void handleValidationResult(ODKView view, ValidationResult validationResult) {
+    private void handleValidationResult(ValidationResult validationResult) {
         if (validationResult instanceof FailedValidationResult failedValidationResult) {
             String errorMessage = failedValidationResult.getCustomErrorMessage();
             if (errorMessage == null) {
                 errorMessage = getString(failedValidationResult.getDefaultErrorMessage());
             }
-            view.setErrorForQuestionWithIndex(failedValidationResult.getIndex(), errorMessage);
+            ODKView view = getCurrentViewIfODKView();
+            if (view != null) {
+                view.setErrorForQuestionWithIndex(failedValidationResult.getIndex(), errorMessage);
+            }
             swipeHandler.setBeenSwiped(false);
         } else if (validationResult instanceof SuccessValidationResult) {
             SnackbarUtils.showSnackbar(
@@ -1839,16 +1842,19 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
     private int animationCompletionSet;
 
     private void afterAllAnimations() {
-        ODKView view = getCurrentViewIfODKView();
-        if (view != null) {
-            CurrentFormIndex index = formEntryViewModel.getCurrentIndex().getValue();
-            ValidationResult validationResult = index.getValidationResult();
-            if (validationResult != null) {
-                handleValidationResult(view, validationResult);
-            } else if (index.getQuestionIndex() != null) {
-                view.focusToTopOf(index.getQuestionIndex());
-            } else {
-                view.setFocus(this);
+        CurrentFormIndex index = formEntryViewModel.getCurrentIndex().getValue();
+        ValidationResult validationResult = index.getValidationResult();
+
+        if (validationResult != null) {
+            handleValidationResult(validationResult);
+        } else {
+            ODKView view = getCurrentViewIfODKView();
+            if (view != null) {
+                if (index.getQuestionIndex() != null) {
+                    view.focusToTopOf(index.getQuestionIndex());
+                } else {
+                    view.setFocus(this);
+                }
             }
         }
 


### PR DESCRIPTION
Closes #7183 

#### Why is this the best possible solution? Were any other approaches considered?
Handling validation results was broken because it first checked whether the current view was an ODK view before attempting to display the result. However, at the end of the form, the view is no longer an ODK view.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Here, the risk is limited to handling validation results within a form, so please verify that there is no regression. That should be sufficient.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
