### PR TITLE
Fix ConcurrentModificationException when dragging points in Mapbox

### DIFF
--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -1,6 +1,8 @@
 package org.odk.collect.mapbox
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.mapbox.geojson.Point
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationDragListener
@@ -23,6 +25,8 @@ internal class DynamicPolyLineFeature(
     private val featureDragEndListener: MapFragment.FeatureListener?,
     private val lineDescription: LineDescription
 ) : LineFeature {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
     override val points: List<MapPoint>
         get() = _points.toList()
 
@@ -124,7 +128,9 @@ internal class DynamicPolyLineFeature(
             if (featureDragEndListener != null) {
                 for (pointAnnotation in pointAnnotations) {
                     if (annotation.id == pointAnnotation.id) {
-                        featureDragEndListener.onFeature(featureId)
+                        mainHandler.post {
+                            featureDragEndListener.onFeature(featureId)
+                        }
                         break
                     }
                 }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolyLineFeature.kt
@@ -128,6 +128,8 @@ internal class DynamicPolyLineFeature(
             if (featureDragEndListener != null) {
                 for (pointAnnotation in pointAnnotations) {
                     if (annotation.id == pointAnnotation.id) {
+                        // Deferred to avoid ConcurrentModificationException caused by Mapbox iterating over
+                        // its annotation list while this callback disposes and recreates annotations.
                         mainHandler.post {
                             featureDragEndListener.onFeature(featureId)
                         }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
@@ -1,6 +1,8 @@
 package org.odk.collect.mapbox
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.mapbox.geojson.Point
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationDragListener
@@ -27,6 +29,8 @@ internal class DynamicPolygonFeature(
     private val featureDragEndListener: MapFragment.FeatureListener?,
     private val polygonDescription: PolygonDescription
 ) : LineFeature {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
     override val points: List<MapPoint>
         get() = _points.toList()
 
@@ -147,7 +151,9 @@ internal class DynamicPolygonFeature(
             if (featureDragEndListener != null) {
                 for (pointAnnotation in pointAnnotations) {
                     if (annotation.id == pointAnnotation.id) {
-                        featureDragEndListener.onFeature(featureId)
+                        mainHandler.post {
+                            featureDragEndListener.onFeature(featureId)
+                        }
                         break
                     }
                 }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/DynamicPolygonFeature.kt
@@ -151,6 +151,8 @@ internal class DynamicPolygonFeature(
             if (featureDragEndListener != null) {
                 for (pointAnnotation in pointAnnotations) {
                     if (annotation.id == pointAnnotation.id) {
+                        // Deferred to avoid ConcurrentModificationException caused by Mapbox iterating over
+                        // its annotation list while this callback disposes and recreates annotations.
                         mainHandler.post {
                             featureDragEndListener.onFeature(featureId)
                         }


### PR DESCRIPTION
Closes #7185

#### Why is this the best possible solution? Were any other approaches considered?
When a point annotation is dragged and released, Mapbox invokes our `onAnnotationDragFinished()` callback before finishing its internal processing. We were calling `featureDragEndListener.onFeature()` synchronously inside that callback, which triggered a chain of events that caused the polyline feature to be disposed and recreated all before `onAnnotationDragFinished()` returned. This modified Mapbox's internal state while it was still being processed, resulting in a `ConcurrentModificationException`.

The fix defers the `onFeature()` call using `Handler(Looper.getMainLooper()).post {}`, so the feature update happens after Mapbox finishes processing the drag event.

A more optimal solution could be to update the polyline/polygon in place rather than disposing and recreating it entirely (maybe that would also fix this issue). However, the current pattern is shared across all three map engines, so changing it would require a broader refactor. Given that we are planning to migrate to `MapLibre` in the near future, this does not seem worth addressing at this point.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Only the code responsible for dragging points in geotrace/geoshape with Mapbox has been changed, so testing can be focused on this functionality only.

#### Do we need any specific form for testing your changes? If so, please attach one.
The `All question types` form is ok.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
