### PR TITLE
Fix updating Snackbar position

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
@@ -9,6 +9,7 @@ import androidx.annotation.LayoutRes
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import com.google.android.material.snackbar.Snackbar
@@ -49,12 +50,21 @@ object EdgeToEdge {
         }
     }
 
-    @JvmStatic
-    fun Snackbar.applyBottomInsets() {
+    fun Snackbar.applyBottomInsets(anchorView: View?) {
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
-            view.translationY = -windowInsets.keyboardSafeOffset().toFloat()
+            view.post {
+                val anchorOffset = if (anchorView != null && anchorView.isVisible) {
+                    val lp = anchorView.layoutParams as? ViewGroup.MarginLayoutParams
+                    anchorView.height + (lp?.bottomMargin ?: 0)
+                } else {
+                    0
+                }
+
+                view.translationY  = -maxOf(windowInsets.keyboardSafeOffset(), anchorOffset).toFloat()
+            }
             windowInsets
         }
+
         ViewCompat.requestApplyInsets(view)
     }
 

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
@@ -52,7 +52,7 @@ object EdgeToEdge {
 
     fun Snackbar.applyBottomInsets(anchorView: View?) {
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
-            view.post {
+            view.post { // wait for anchorView to reposition before reading its offset
                 val anchorOffset = if (anchorView != null && anchorView.isVisible) {
                     val layoutParams = anchorView.layoutParams as? ViewGroup.MarginLayoutParams
                     anchorView.height + (layoutParams?.bottomMargin ?: 0)

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/EdgeToEdge.kt
@@ -54,8 +54,8 @@ object EdgeToEdge {
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
             view.post {
                 val anchorOffset = if (anchorView != null && anchorView.isVisible) {
-                    val lp = anchorView.layoutParams as? ViewGroup.MarginLayoutParams
-                    anchorView.height + (lp?.bottomMargin ?: 0)
+                    val layoutParams = anchorView.layoutParams as? ViewGroup.MarginLayoutParams
+                    anchorView.height + (layoutParams?.bottomMargin ?: 0)
                 } else {
                     0
                 }

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/SnackbarUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/SnackbarUtils.kt
@@ -102,10 +102,6 @@ object SnackbarUtils {
             view.findViewById<TextView>(R.id.snackbar_text)
         textView.isSingleLine = false
 
-        if (anchorView?.visibility != View.GONE) {
-            this.anchorView = anchorView
-        }
-
         if (displayDismissButton) {
             view.findViewById<Button>(R.id.snackbar_action).let {
                 val dismissButton = ImageView(view.context).apply {
@@ -134,7 +130,7 @@ object SnackbarUtils {
             }
         }
 
-        applyBottomInsets()
+        applyBottomInsets(anchorView)
     }.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
         override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
             super.onDismissed(transientBottomBar, event)

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/FormHierarchyFragment.java
@@ -304,7 +304,7 @@ public class FormHierarchyFragment extends Fragment {
                     view,
                     getString(org.odk.collect.strings.R.string.finalized_form_edit_started),
                     SnackbarUtils.DURATION_LONG,
-                    null,
+                    view.findViewById(R.id.buttonholder),
                     null,
                     true
             );


### PR DESCRIPTION
Closes #7197
Closes #7201

#### Why is this the best possible solution? Were any other approaches considered?
The issue was related to displaying snackbars above an anchor view. Previously, we set the anchor view in `SnackbarUtils` when creating a snackbar, and then adjusted its position separately to support edge-to-edge layouts. These two approaches conflicted with each other. I removed the anchor view assignment from `SnackbarUtils` and improved the position calculation so that it now accounts not only for system bars and the keyboard, but also for a provided anchor view.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should fix the snackbar position across different states/cases. Please test various snackbars to ensure everything works correctly.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
