### PR TITLE
Make sure connection isn't reset while another transaction runs against it

### DIFF
--- a/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/SynchronizedDatabaseConnection.kt
@@ -41,7 +41,12 @@ class SynchronizedDatabaseConnection(
     fun resetTransaction(
         body: SQLiteDatabase.() -> Unit
     ) {
-        transaction(body)
-        databaseConnection.reset()
+        withConnection {
+            writableDatabase.transaction {
+                body()
+            }
+
+            reset()
+        }
     }
 }


### PR DESCRIPTION
As the title suggests, it was possible for a `transaction` or `withConnection` to be using a connection while it was reset because the `reset` call happened outside a `synchronized` block. This could be the cause for occasional crash reports we get around transactions executing on closed connections.