### PR TITLE
Don't allow crash reports on tampered APKs

### DIFF
--- a/analytics/src/main/java/org/odk/collect/analytics/BlockableFirebaseAnalytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/BlockableFirebaseAnalytics.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 
-class BlockableFirebaseAnalytics(application: Application) : Analytics {
+class BlockableFirebaseAnalytics(application: Application, private val crashReports: Boolean) : Analytics {
     private val firebaseAnalytics = FirebaseAnalytics.getInstance(application)
     private val crashlytics = FirebaseCrashlytics.getInstance()
 
@@ -29,7 +29,9 @@ class BlockableFirebaseAnalytics(application: Application) : Analytics {
 
     override fun setAnalyticsCollectionEnabled(isAnalyticsEnabled: Boolean) {
         firebaseAnalytics.setAnalyticsCollectionEnabled(isAnalyticsEnabled)
-        crashlytics.setCrashlyticsCollectionEnabled(isAnalyticsEnabled)
+        if (!crashReports) {
+            crashlytics.isCrashlyticsCollectionEnabled = isAnalyticsEnabled
+        }
     }
 
     override fun setUserProperty(name: String, value: String) {

--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
@@ -1,0 +1,28 @@
+package org.odk.collect.androidshared.system
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import java.security.MessageDigest
+
+object TamperDetector {
+
+    @JvmStatic
+    fun isTampered(context: Context, expectedSignature: String): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val packageInfo = context.packageManager.getPackageInfo(
+                context.packageName,
+                PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong())
+            )
+            val signatures = packageInfo.signingInfo?.signingCertificateHistory
+
+            return signatures?.none { sig ->
+                val bytes = sig.toByteArray()
+                val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+                digest.joinToString(":") { "%02x".format(it).uppercase() } == expectedSignature
+            } ?: false
+        } else {
+            return false
+        }
+    }
+}

--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
@@ -9,19 +9,23 @@ object TamperDetector {
 
     @JvmStatic
     fun isTampered(context: Context, expectedSignature: String): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && expectedSignature.isNotBlank()) {
-            val packageInfo = context.packageManager.getPackageInfo(
-                context.packageName,
-                PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong())
-            )
-            val signatures = packageInfo.signingInfo?.signingCertificateHistory
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && expectedSignature.isNotBlank()) {
+                val packageInfo = context.packageManager.getPackageInfo(
+                    context.packageName,
+                    PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong())
+                )
+                val signatures = packageInfo.signingInfo?.signingCertificateHistory
 
-            return signatures?.none { sig ->
-                val bytes = sig.toByteArray()
-                val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
-                digest.joinToString(":") { "%02x".format(it).uppercase() } == expectedSignature
-            } ?: false
-        } else {
+                return signatures?.none { sig ->
+                    val bytes = sig.toByteArray()
+                    val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+                    digest.joinToString(":") { "%02x".format(it).uppercase() } == expectedSignature
+                } ?: false
+            } else {
+                return false
+            }
+        } catch (_: Throwable) {
             return false
         }
     }

--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
@@ -9,7 +9,7 @@ object TamperDetector {
 
     @JvmStatic
     fun isTampered(context: Context, expectedSignature: String): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && expectedSignature.isNotBlank()) {
             val packageInfo = context.packageManager.getPackageInfo(
                 context.packageName,
                 PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong())

--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
@@ -21,7 +21,7 @@ object TamperDetector {
                     val bytes = sig.toByteArray()
                     val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
                     digest.joinToString(":") { "%02X".format(it) } == expectedSignature
-                } ?: false
+                } ?: true
             } else {
                 return false
             }

--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/TamperDetector.kt
@@ -20,7 +20,7 @@ object TamperDetector {
                 return signatures?.none { sig ->
                     val bytes = sig.toByteArray()
                     val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
-                    digest.joinToString(":") { "%02x".format(it).uppercase() } == expectedSignature
+                    digest.joinToString(":") { "%02X".format(it) } == expectedSignature
                 } ?: false
             } else {
                 return false

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -154,6 +154,7 @@ android {
             buildConfigField("String", "ENTITIES_FILTER_SEARCH_PROJECT_URL", "\"$entitiesFilterSearchProjectUrl\"")
             buildConfigField("String", "THOUSAND_MEDIA_FILE_PROJECT_URL", "\"$thousandMediaFileProjectUrl\"")
             buildConfigField("String", "THOUSAND_MEDIA_FILE_ENTITY_LIST_PROJECT_URL", "\"$thousandMediaFileEntityListProjectUrl\"")
+            buildConfigField("String", "SIGNATURE", "\"\"")
         }
     }
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -118,6 +118,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             resValue("string", "mapbox_access_token", mapboxAccessToken)
+            buildConfigField("String", "SIGNATURE", "\"\"")
         }
 
         // Release build for the official ODK Collect app
@@ -130,6 +131,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             resValue("string", "mapbox_access_token", mapboxAccessToken)
+            buildConfigField("String", "SIGNATURE", "\"\"")
 
             matchingFallbacks = ['release'] // So other modules use release build type for this
         }
@@ -142,6 +144,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             resValue("string", "mapbox_access_token", mapboxAccessToken)
+            buildConfigField("String", "SIGNATURE", "\"\"")
 
             matchingFallbacks = ['release'] // So other modules use release build type for this
         }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -131,7 +131,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             resValue("string", "mapbox_access_token", mapboxAccessToken)
-            buildConfigField("String", "SIGNATURE", "\"\"")
+            buildConfigField("String", "SIGNATURE", "\"DC:D4:B9:4B:1E:0C:3D:96:69:22:3D:45:CD:C0:E2:F0:CC:6D:ED:12:A7:E6:EF:AB:49:BA:36:B3:D1:D4:8D:D8\"")
 
             matchingFallbacks = ['release'] // So other modules use release build type for this
         }

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/AnalyticsInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/AnalyticsInitializer.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.application.initialization
 
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.version.VersionInformation
+import org.odk.collect.androidshared.system.TamperDetector
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys
 

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
@@ -2,8 +2,10 @@ package org.odk.collect.android.application.initialization
 
 import android.content.Context
 import org.odk.collect.analytics.Analytics
+import org.odk.collect.android.BuildConfig
 import org.odk.collect.android.instancemanagement.send.autosend.shouldFormBeSentAutomatically
 import org.odk.collect.android.preferences.Defaults
+import org.odk.collect.androidshared.system.TamperDetector
 import org.odk.collect.async.Scheduler
 import org.odk.collect.forms.FormsRepository
 import org.odk.collect.forms.instances.Instance
@@ -42,6 +44,11 @@ class UserPropertiesInitializer(
             analytics.setUserProperty(
                 "HasUnsentAutosendForms",
                 projects.any { hasUnsentAutoSendForms(it) }.toString()
+            )
+
+            analytics.setUserProperty(
+                "UsingTamperedAPK",
+                TamperDetector.isTampered(context, BuildConfig.SIGNATURE).toString()
             )
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -95,6 +95,7 @@ import org.odk.collect.androidshared.system.BroadcastReceiverRegister;
 import org.odk.collect.androidshared.system.BroadcastReceiverRegisterImpl;
 import org.odk.collect.androidshared.system.IntentLauncher;
 import org.odk.collect.androidshared.system.IntentLauncherImpl;
+import org.odk.collect.androidshared.system.TamperDetector;
 import org.odk.collect.androidshared.utils.ScreenUtils;
 import org.odk.collect.androidshared.utils.SettingsUniqueIdGenerator;
 import org.odk.collect.androidshared.utils.UniqueIdGenerator;
@@ -203,7 +204,8 @@ public class AppDependencyModule {
     @Singleton
     public Analytics providesAnalytics(Application application) {
         try {
-            return new BlockableFirebaseAnalytics(application);
+            boolean isTampered = TamperDetector.isTampered(application, BuildConfig.SIGNATURE);
+            return new BlockableFirebaseAnalytics(application, !isTampered);
         } catch (IllegalStateException e) {
             // Couldn't setup Firebase so use no-op instance
             return new NoopAnalytics();


### PR DESCRIPTION
We discussed doing this to prevent tampered APK/runtimes causing noise in our crash reports.

#### Why is this the best possible solution? Were any other approaches considered?

Detection only works for Android 13+ - it didn't seem worth putting extra effort in to get this working across all devices. As well as disabling crash reporting, I've also added a user property so that we can get a sense of how many installations this affects.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Other than properly signed release builds, crash reporting should still work as normal. @lognaturel will need to do a manually signed `release` build to check crash reporting still works (it can be simulated in experimental settings).

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
