### PR TITLE
Stop blocking the addition of new points when constraint fails

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyViewModel.kt
@@ -62,11 +62,9 @@ class GeoPolyViewModel(
     private var recording: Cancellable? = null
 
     fun add(point: MapPoint) {
-        if (invalidMessage.value == null) {
-            val points = _points.value
-            if (points.isEmpty() || point != points.last()) {
-                _points.value = points + point
-            }
+        val points = _points.value
+        if (points.isEmpty() || point != points.last()) {
+            _points.value = points + point
         }
     }
 

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -620,7 +620,7 @@ class GeoPolyFragmentTest {
     }
 
     @Test
-    fun whenInvalidMessageIsNotNull_pointsCannotBeAddedByClicking() {
+    fun whenInvalidMessageIsNotNull_pointsCanBeAddedByClicking() {
         val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
@@ -633,7 +633,7 @@ class GeoPolyFragmentTest {
 
         invalidMessage.value = DisplayString.Raw("Blah")
         mapFragment.click(MapPoint(0.0, 0.0))
-        assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(0))
+        assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(1))
     }
 
     @Test
@@ -654,7 +654,7 @@ class GeoPolyFragmentTest {
     }
 
     @Test
-    fun whenInvalidMessageIsNotNull_automaticRecordingStops() {
+    fun whenInvalidMessageIsNotNull_automaticRecordingDoesNotStop() {
         val invalidMessage = MutableLiveData<DisplayString?>(null)
         fragmentLauncherRule.launchInContainer {
             GeoPolyFragment(
@@ -668,7 +668,7 @@ class GeoPolyFragmentTest {
         invalidMessage.value = DisplayString.Raw("Blah")
         locationTracker.currentLocation = Location(1.0, 1.0, 1.0, 1f)
         scheduler.runForeground(0)
-        assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(0))
+        assertThat(mapFragment.getPolyLines()[0].points.size, equalTo(1))
     }
 
     @Test


### PR DESCRIPTION
Closes #7191 

#### Why is this the best possible solution? Were any other approaches considered?
The decision to unblock adding new points is a result of our internal discussions. There is nothing worth discussing regarding implementation changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We should not block adding new points when a geoshape/trace is invalid. We should still display errors and highlight the geotrace/geoshape in red, and block saving, but allow the user to fix the issue by adding new points.
There is no need to test every map engine, we can focus on one. 

#### Do we need any specific form for testing your changes? If so, please attach one.
I used: [geo.xlsx](https://github.com/user-attachments/files/27198820/geo.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
