### PR TITLE
Wait for snackbar before closing

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -599,7 +599,10 @@ abstract class Page<T : Page<T>> {
     }
 
     fun closeSnackbar(): T {
-        EspressoInteractions.clickOn(withContentDescription(org.odk.collect.strings.R.string.close_snackbar))
+        waitFor {
+            EspressoInteractions.clickOn(withContentDescription(org.odk.collect.strings.R.string.close_snackbar))
+        }
+
         return this as T
     }
 


### PR DESCRIPTION
We've seen a few flakey runs related to this assertion, and it makes sense that the snackbar should be waited for due to animation times (which aren't always disable-able).