### PR TITLE
Fix SelectionSummarySheet position for edge-to-edge

### DIFF
--- a/geo/src/main/res/layout/selection_map_layout.xml
+++ b/geo/src/main/res/layout/selection_map_layout.xml
@@ -105,6 +105,7 @@
         app:behavior_hideable="true"
         android:maxWidth="@null"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+        app:paddingBottomSystemWindowInsets="false"
         style="@style/Widget.Material3.BottomSheet"
         tools:visibility="gone" />
 


### PR DESCRIPTION
Closes #7222 

#### Why is this the best possible solution? Were any other approaches considered?
`BottomSheetBehavior` has its own internal logic to handle window insets (enabled by default). This resulted in "double padding": the activity-level margin pushed the layout up, and the BottomSheetBehavior pushed the sheet up again. By setting app:paddingBottomSystemWindowInsets="false", we disable the redundant internal handling, allowing the sheet to correctly align with the bottom of the container.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should simply restore the old behavior. We can focus on testing the bottom sheet used in maps, as it’s the only affected area.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is linked to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
