### PR TITLE
Retry on accidental long press

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
@@ -5,6 +5,7 @@ import androidx.test.espresso.PerformException
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import org.odk.collect.testshared.EspressoInteractions
 import timber.log.Timber
 
 class RetryOnDeviceErrorRule : TestRule {
@@ -25,6 +26,9 @@ class RetryOnDeviceErrorRule : TestRule {
                     } else if (e::class.simpleName == "RootViewWithoutFocusException") {
                         Timber.w("RetryOnDeviceErrorRule: Retrying due to RootViewWithoutFocusException!")
                         Timber.e(e)
+                        base.evaluate()
+                    } else if (e is EspressoInteractions.LongPressInsteadOfClickException) {
+                        Timber.w("LongPressInsteadOfClickException: Retrying due to accidental long press!")
                         base.evaluate()
                     } else {
                         throw e

--- a/test-shared/src/main/java/org/odk/collect/testshared/EspressoInteractions.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/EspressoInteractions.kt
@@ -68,7 +68,7 @@ object EspressoInteractions {
         closeSoftKeyboard()
     }
 
-    class ExceptionRollbackAction : ViewAction {
+    private class ExceptionRollbackAction : ViewAction {
         override fun getConstraints(): Matcher<View> {
             return object : TypeSafeMatcher<View>() {
                 override fun matchesSafely(view: View): Boolean {

--- a/test-shared/src/main/java/org/odk/collect/testshared/EspressoInteractions.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/EspressoInteractions.kt
@@ -4,10 +4,15 @@ import android.view.View
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Root
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.scrollTo
+import org.hamcrest.Description
 import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+import org.odk.collect.testshared.EspressoInteractions.clickOn
 import org.odk.collect.testshared.WaitFor.tryAgainOnFail
 
 object EspressoInteractions {
@@ -31,7 +36,7 @@ object EspressoInteractions {
          * Click on the view again in an attempt to clear any long press UI if a long press might
          * have occurred. More discussion of this issue can be found at https://stackoverflow.com/questions/32330671/android-espresso-performs-longclick-instead-of-click.
          */
-        val clickAction = click(click())
+        val clickAction = click(ExceptionRollbackAction())
 
         try {
             onView.perform(clickAction)
@@ -46,7 +51,7 @@ object EspressoInteractions {
      *
      * This can be useful in cases where [clickOn] itself appears to succeed, but the test fails
      * because the click never actually occurs (most likely due to some flakiness in
-     * [androidx.test.espresso.action.ViewActions.click]).
+     * [click]).
      */
     fun clickOn(view: Matcher<View>, root: Matcher<Root>? = null, assertion: () -> Unit) {
         tryAgainOnFail {
@@ -63,4 +68,31 @@ object EspressoInteractions {
         onView(view).perform(ViewActions.replaceText(text))
         closeSoftKeyboard()
     }
+
+    class ExceptionRollbackAction : ViewAction {
+        override fun getConstraints(): Matcher<View> {
+            return object : TypeSafeMatcher<View>() {
+                override fun matchesSafely(view: View): Boolean {
+                    return true
+                }
+
+                override fun describeTo(description: Description) {
+
+                }
+            }
+        }
+
+        override fun getDescription(): String? {
+            return null
+        }
+
+        override fun perform(
+            uiController: UiController?,
+            view: View?
+        ) {
+            throw LongPressInsteadOfClickException()
+        }
+    }
+
+    class LongPressInsteadOfClickException : Exception()
 }

--- a/test-shared/src/main/java/org/odk/collect/testshared/EspressoInteractions.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/EspressoInteractions.kt
@@ -33,8 +33,7 @@ object EspressoInteractions {
         }
 
         /**
-         * Click on the view again in an attempt to clear any long press UI if a long press might
-         * have occurred. More discussion of this issue can be found at https://stackoverflow.com/questions/32330671/android-espresso-performs-longclick-instead-of-click.
+         * Click on item and throw exception if Espresso detects a long press.
          */
         val clickAction = click(ExceptionRollbackAction())
 


### PR DESCRIPTION
This forces a test full retry when Espresso detects an accidental long press to hopefully alleviate failures due to it.