### PR TITLE
Disable remove response for most tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/CatchFormDesignExceptionsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/CatchFormDesignExceptionsTest.kt
@@ -9,6 +9,7 @@ import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.OkDialog
 import org.odk.collect.android.support.rules.CollectTestRule
+import org.odk.collect.android.support.rules.EnableQuestionWidgetLongPressRule
 import org.odk.collect.android.support.rules.TestRuleChain
 
 @RunWith(AndroidJUnit4::class)
@@ -17,7 +18,9 @@ class CatchFormDesignExceptionsTest {
     private val rule = CollectTestRule()
 
     @get:Rule
-    val ruleChain: RuleChain = TestRuleChain.chain().around(rule)
+    val ruleChain: RuleChain = TestRuleChain.chain()
+        .around(EnableQuestionWidgetLongPressRule())
+        .around(rule)
 
     @Test // https://github.com/getodk/collect/issues/4750
     fun whenFormHasFatalErrors_explanationDialogShouldBeDisplayedAndSurviveActivityRecreationAndTheFormShouldBeClosedAfterClickingOK() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ContextMenuTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ContextMenuTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.rules.BlankFormTestRule;
+import org.odk.collect.android.support.rules.EnableQuestionWidgetLongPressRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 
 public class ContextMenuTest {
@@ -14,6 +15,7 @@ public class ContextMenuTest {
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()
+            .around(new EnableQuestionWidgetLongPressRule())
             .around(activityTestRule);
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.kt
@@ -16,6 +16,7 @@ import org.odk.collect.android.R
 import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.ProjectSettingsPage
+import org.odk.collect.android.support.rules.EnableQuestionWidgetLongPressRule
 import org.odk.collect.android.support.rules.FormEntryActivityTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 import org.odk.collect.androidtest.RecordedIntentsRule
@@ -29,6 +30,7 @@ class FieldListUpdateTest {
     @get:Rule
     var copyFormChain: RuleChain = chain()
         .around(RecordedIntentsRule())
+        .around(EnableQuestionWidgetLongPressRule())
         .around(rule)
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -112,7 +112,7 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         var done = false
 
         Handler(Looper.getMainLooper()).post {
-            featureClickListener?.onFeature(featureId)
+            featureClickListener!!.onFeature(featureId)
             done = true
         }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/EnableQuestionWidgetLongPressRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/EnableQuestionWidgetLongPressRule.kt
@@ -1,0 +1,14 @@
+package org.odk.collect.android.support.rules
+
+import org.junit.rules.ExternalResource
+import org.odk.collect.android.widgets.QuestionWidget
+
+class EnableQuestionWidgetLongPressRule : ExternalResource() {
+    override fun before() {
+        QuestionWidget.longPressClear = true
+    }
+
+    override fun after() {
+        QuestionWidget.longPressClear = false
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/EnableQuestionWidgetLongPressRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/EnableQuestionWidgetLongPressRule.kt
@@ -5,10 +5,10 @@ import org.odk.collect.android.widgets.QuestionWidget
 
 class EnableQuestionWidgetLongPressRule : ExternalResource() {
     override fun before() {
-        QuestionWidget.longPressClear = true
+        QuestionWidget.longPressMenuEnabled = true
     }
 
     override fun after() {
-        QuestionWidget.longPressClear = false
+        QuestionWidget.longPressMenuEnabled = false
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/ResetStateRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/ResetStateRule.kt
@@ -10,6 +10,7 @@ import org.odk.collect.android.injection.config.AppDependencyComponent
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.views.DecoratedBarcodeView
+import org.odk.collect.android.widgets.QuestionWidget
 import org.odk.collect.androidshared.ui.SnackbarUtils
 import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
@@ -36,6 +37,7 @@ private class ResetStateStatement(
     private fun setTestState() {
         MultiClickGuard.test = true
         DecoratedBarcodeView.test = true
+        QuestionWidget.longPressClear = false
         ToastUtils.alertStore.enabled = true
         SnackbarUtils.alertStore.enabled = true
         BottomSheetBehavior.DRAGGING_ENABLED = false

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/ResetStateRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/ResetStateRule.kt
@@ -37,7 +37,7 @@ private class ResetStateStatement(
     private fun setTestState() {
         MultiClickGuard.test = true
         DecoratedBarcodeView.test = true
-        QuestionWidget.longPressClear = false
+        QuestionWidget.longPressMenuEnabled = false
         ToastUtils.alertStore.enabled = true
         SnackbarUtils.alertStore.enabled = true
         BottomSheetBehavior.DRAGGING_ENABLED = false

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -68,6 +68,8 @@ import timber.log.Timber;
 
 public abstract class QuestionWidget extends FrameLayout implements Widget {
 
+    public static Boolean longPressClear = true;
+
     private final FormEntryPrompt formEntryPrompt;
     private final AudioVideoImageTextLabel audioVideoImageTextLabel;
     protected final QuestionDetails questionDetails;
@@ -133,7 +135,7 @@ public abstract class QuestionWidget extends FrameLayout implements Widget {
         errorLayout = findViewById(R.id.error_message_container);
         setupGuidanceTextAndLayout(helpTextLayout.findViewById(R.id.guidance_text_view), formEntryPrompt);
 
-        if (context instanceof Activity && !questionDetails.isReadOnly()) {
+        if (longPressClear && context instanceof Activity && !questionDetails.isReadOnly()) {
             registerToClearAnswerOnLongPress((Activity) context, this);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -68,7 +68,7 @@ import timber.log.Timber;
 
 public abstract class QuestionWidget extends FrameLayout implements Widget {
 
-    public static Boolean longPressClear = true;
+    public static Boolean longPressMenuEnabled = true;
 
     private final FormEntryPrompt formEntryPrompt;
     private final AudioVideoImageTextLabel audioVideoImageTextLabel;
@@ -135,7 +135,7 @@ public abstract class QuestionWidget extends FrameLayout implements Widget {
         errorLayout = findViewById(R.id.error_message_container);
         setupGuidanceTextAndLayout(helpTextLayout.findViewById(R.id.guidance_text_view), formEntryPrompt);
 
-        if (longPressClear && context instanceof Activity && !questionDetails.isReadOnly()) {
+        if (longPressMenuEnabled && context instanceof Activity && !questionDetails.isReadOnly()) {
             registerToClearAnswerOnLongPress((Activity) context, this);
         }
 


### PR DESCRIPTION
This disables the long press context menu for widgets in tests other than the ones that interact with it. This menu causes a lot of flakes due to the [accidental long press problem in Espresso](https://stackoverflow.com/questions/32330671/android-espresso-performs-longclick-instead-of-click). @lognaturel and I have discussed potentially moving the menu away from a long press as a general UX change in the future, so this just works around the problem for now.