### PR TITLE
Keep org.xmlpull.v1 classes to stop R8 breaking form downloads

### DIFF
--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -9,6 +9,7 @@
 -dontwarn java.beans.**
 
 -keep class org.kxml2.** { *; }
+-keep class org.xmlpull.v1.** { *; }
 -keep class com.google.android.gms.oss.licenses.** { *; }
 -keep class org.odk.collect.android.logic.actions.**
 -keep class android.support.v7.widget.** { *; }


### PR DESCRIPTION
Closes #7257 

#### Why is this the best possible solution? Were any other approaches considered?
We keep `org.xmlpull.v1.**` so R8 stops optimizing/removing these classes and emitting bytecode that breaks at runtime.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
