### PR TITLE
Scroll to focused question only after view is laid out

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredAndConstraintQuestionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RequiredAndConstraintQuestionTest.kt
@@ -95,6 +95,21 @@ class RequiredAndConstraintQuestionTest {
     }
 
     @Test
+    // The required question we scroll to is intentionally NOT a text question. A text question
+    // contains an EditText that requests focus, and that requestFocus makes the framework
+    // automatically scroll it into view - which would mask a broken scroll and let this test pass
+    // even when the scrolling is broken. A non-text question (here select_one) has no such
+    // focusable input, so it actually verifies that we scroll to the question ourselves.
+    fun validatingFormByPressingValidateInOptionsMenu_scrollsToTheQuestionWithError_whenItIsAtTheEndOfALongFieldList() {
+        rule.startAtMainMenu()
+            .copyForm("longListOfQuestionsWithRequiredOneAtTheEnd.xml")
+            .startBlankForm("longListOfQuestionsWithRequiredOneAtTheEnd")
+            .clickOptionsIcon()
+            .clickOnString(R.string.validate, FormEntryPage("longListOfQuestionsWithRequiredOneAtTheEnd"))
+            .assertQuestion("Question 10", true)
+    }
+
+    @Test
     fun validatingFormByPressingValidateInOptionsMenuOnFormEndScreen_displaysSuccessMessage() {
         rule.startAtMainMenu()
             .copyForm("required_question_with_custom_error_message.xml")

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -579,14 +579,27 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
 
     public void focusToTopOf(@Nullable QuestionWidget qw) {
         if (qw != null && widgets.contains(qw)) {
-            // This can be called synchronously just after the view has been added (before it has
-            // been laid out), in which case qw.getTop() would still be 0 and we'd scroll to the
-            // top instead of to the widget. Defer the scroll so it runs once layout has happened.
-            post(() -> {
-                findViewById(R.id.odk_view_container).scrollTo(0, qw.getTop());
-                qw.setFocus(getContext());
-            });
+            // focusToTopOf can be called synchronously just after the view has been added (before
+            // it has been laid out), in which case qw.getTop() would still be 0 and we'd scroll to
+            // the top instead of to the widget. Wait for an actual layout pass so getTop() is valid.
+            if (qw.isLaidOut() && !qw.isLayoutRequested()) {
+                scrollAndFocus(qw);
+            } else {
+                qw.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+                    @Override
+                    public void onLayoutChange(View v, int left, int top, int right, int bottom,
+                                               int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                        v.removeOnLayoutChangeListener(this);
+                        scrollAndFocus(qw);
+                    }
+                });
+            }
         }
+    }
+
+    private void scrollAndFocus(QuestionWidget qw) {
+        findViewById(R.id.odk_view_container).scrollTo(0, qw.getTop());
+        qw.setFocus(getContext());
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -579,8 +579,13 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
 
     public void focusToTopOf(@Nullable QuestionWidget qw) {
         if (qw != null && widgets.contains(qw)) {
-            findViewById(R.id.odk_view_container).scrollTo(0, qw.getTop());
-            qw.setFocus(getContext());
+            // This can be called synchronously just after the view has been added (before it has
+            // been laid out), in which case qw.getTop() would still be 0 and we'd scroll to the
+            // top instead of to the widget. Defer the scroll so it runs once layout has happened.
+            post(() -> {
+                findViewById(R.id.odk_view_container).scrollTo(0, qw.getTop());
+                qw.setFocus(getContext());
+            });
         }
     }
 

--- a/test-forms/src/main/resources/forms/longListOfQuestionsWithRequiredOneAtTheEnd.xml
+++ b/test-forms/src/main/resources/forms/longListOfQuestionsWithRequiredOneAtTheEnd.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>longListOfQuestionsWithRequiredOneAtTheEnd</h:title>
+        <model>
+            <instance>
+                <data id="longListOfQuestionsWithRequiredOneAtTheEnd">
+                    <group>
+                        <text1/>
+                        <text2/>
+                        <text3/>
+                        <text4/>
+                        <text5/>
+                        <text6/>
+                        <text7/>
+                        <text8/>
+                        <text9/>
+                        <text10/>
+                    </group>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/group/text1" type="string"/>
+            <bind nodeset="/data/group/text2" type="string"/>
+            <bind nodeset="/data/group/text3" type="string"/>
+            <bind nodeset="/data/group/text4" type="string"/>
+            <bind nodeset="/data/group/text5" type="string"/>
+            <bind nodeset="/data/group/text6" type="string"/>
+            <bind nodeset="/data/group/text7" type="string"/>
+            <bind nodeset="/data/group/text8" type="string"/>
+            <bind nodeset="/data/group/text9" type="string"/>
+            <bind nodeset="/data/group/text10" required="true()" type="string"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group appearance="field-list" ref="/data/group">
+            <input ref="/data/group/text1">
+                <label>Question 1</label>
+            </input>
+            <input ref="/data/group/text2">
+                <label>Question 2</label>
+            </input>
+            <input ref="/data/group/text3">
+                <label>Question 3</label>
+            </input>
+            <input ref="/data/group/text4">
+                <label>Question 4</label>
+            </input>
+            <input ref="/data/group/text5">
+                <label>Question 5</label>
+            </input>
+            <input ref="/data/group/text6">
+                <label>Question 6</label>
+            </input>
+            <input ref="/data/group/text7">
+                <label>Question 7</label>
+            </input>
+            <input ref="/data/group/text8">
+                <label>Question 8</label>
+            </input>
+            <input ref="/data/group/text9">
+                <label>Question 9</label>
+            </input>
+            <select1 ref="/data/group/text10">
+                <label>Question 10</label>
+                <item>
+                    <label>Option A</label>
+                    <value>a</value>
+                </item>
+                <item>
+                    <label>Option B</label>
+                    <value>b</value>
+                </item>
+            </select1>
+        </group>
+    </h:body>
+</h:html>

--- a/test-shared/src/main/java/org/odk/collect/testshared/EspressoAssertions.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/EspressoAssertions.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import org.hamcrest.CoreMatchers.not
@@ -42,7 +43,7 @@ object EspressoAssertions {
             onView(withSibling)
         }
 
-        onView.check(matches(not(doesNotExist())))
+        onView.check(matches(isDisplayed()))
     }
 
     fun assertEnabled(


### PR DESCRIPTION
Closes #7252 
Closes #7258 

#### Why is this the best possible solution? Were any other approaches considered?
`focusToTopOf` is called right after the view has been added but before it has been laid out. At that point `qw.getTop()` is still 0, so the scroll jumped to the top of the form instead of to the  
focused question. Wrapping the scroll/focus in `post(...)` defers it until the current layout pass has completed, so `getTop()` returns the widget's real position.   

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's worth testing all scenarios where the user should be taken to a question with an error- for example, when validating a form with constraint or required-field violations, or when finalizing a form that contains errors. I'm not suggesting that the screen navigation itself is at risk in these cases, but rather the automatic scrolling to the relevant question.
  
#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
