### PR TITLE
Add reference geometry support to geopoint

### DIFF
--- a/androidtest/src/main/java/org/odk/collect/androidtest/TestDispatcherProvider.kt
+++ b/androidtest/src/main/java/org/odk/collect/androidtest/TestDispatcherProvider.kt
@@ -1,13 +1,17 @@
 package org.odk.collect.androidtest
 
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import org.odk.collect.async.DispatcherProvider
 
 class TestDispatcherProvider : DispatcherProvider {
-    override val foreground = StandardTestDispatcher()
-    override val background = StandardTestDispatcher()
+    private val testScope = TestScope()
+    private val scheduler = testScope.testScheduler
 
-    fun runBackground() {
-        background.scheduler.advanceUntilIdle()
+    override val foreground = StandardTestDispatcher(scheduler = scheduler)
+    override val background = StandardTestDispatcher(scheduler = scheduler)
+
+    fun flush() {
+        scheduler.advanceUntilIdle()
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -170,11 +170,11 @@ import org.odk.collect.android.widgets.datetime.DateTimeWidget;
 import org.odk.collect.android.widgets.datetime.pickers.CustomDatePickerDialog;
 import org.odk.collect.android.widgets.datetime.pickers.CustomTimePickerDialog;
 import org.odk.collect.android.widgets.geo.GeoPointMapDialogFragment;
+import org.odk.collect.android.widgets.geo.GeoPolyDialogFragment;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.items.SelectOneFromMapDialogFragment;
 import org.odk.collect.android.widgets.utilities.ExternalAppRecordingRequester;
 import org.odk.collect.android.widgets.utilities.FormControllerWaitingForDataRegistry;
-import org.odk.collect.android.widgets.geo.GeoPolyDialogFragment;
 import org.odk.collect.android.widgets.utilities.InternalRecordingRequester;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 import org.odk.collect.androidshared.system.IntentLauncher;
@@ -456,7 +456,7 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
                 .forClass(BackgroundAudioPermissionDialogFragment.class, () -> new BackgroundAudioPermissionDialogFragment(viewModelFactory))
                 .forClass(SelectOneFromMapDialogFragment.class, () -> new SelectOneFromMapDialogFragment(viewModelFactory))
                 .forClass(GeoPolyDialogFragment.class, () -> new GeoPolyDialogFragment(viewModelFactory, scheduler))
-                .forClass(GeoPointMapDialogFragment.class, () -> new GeoPointMapDialogFragment(viewModelFactory))
+                .forClass(GeoPointMapDialogFragment.class, () -> new GeoPointMapDialogFragment(viewModelFactory, scheduler))
                 .forClass(RangePickerDialogFragment.class, () -> new RangePickerDialogFragment(viewModelFactory))
                 .build());
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -185,6 +185,7 @@ import org.odk.collect.androidshared.ui.DialogUtils;
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder;
 import org.odk.collect.androidshared.ui.SnackbarUtils;
 import org.odk.collect.androidshared.ui.ToastUtils;
+import org.odk.collect.async.DefaultDispatcherProvider;
 import org.odk.collect.async.Scheduler;
 import org.odk.collect.audioclips.AudioPlayer;
 import org.odk.collect.audioclips.AudioPlayerFactory;
@@ -449,14 +450,15 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
                 projectDependencyModuleFactory
         );
 
+        DefaultDispatcherProvider dispatcherProvider = new DefaultDispatcherProvider();
         this.getSupportFragmentManager().setFragmentFactory(new FragmentFactoryBuilder()
                 .forClass(AudioRecordingControllerFragment.class, () -> new AudioRecordingControllerFragment(viewModelFactory))
                 .forClass(SaveFormProgressDialogFragment.class, () -> new SaveFormProgressDialogFragment(viewModelFactory))
                 .forClass(DeleteRepeatDialogFragment.class, () -> new DeleteRepeatDialogFragment(viewModelFactory))
                 .forClass(BackgroundAudioPermissionDialogFragment.class, () -> new BackgroundAudioPermissionDialogFragment(viewModelFactory))
                 .forClass(SelectOneFromMapDialogFragment.class, () -> new SelectOneFromMapDialogFragment(viewModelFactory))
-                .forClass(GeoPolyDialogFragment.class, () -> new GeoPolyDialogFragment(viewModelFactory, scheduler))
-                .forClass(GeoPointMapDialogFragment.class, () -> new GeoPointMapDialogFragment(viewModelFactory, scheduler))
+                .forClass(GeoPolyDialogFragment.class, () -> new GeoPolyDialogFragment(viewModelFactory, dispatcherProvider))
+                .forClass(GeoPointMapDialogFragment.class, () -> new GeoPointMapDialogFragment(viewModelFactory, dispatcherProvider))
                 .forClass(RangePickerDialogFragment.class, () -> new RangePickerDialogFragment(viewModelFactory))
                 .build());
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/geo/GeoPointMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/geo/GeoPointMapDialogFragment.kt
@@ -1,6 +1,8 @@
 package org.odk.collect.android.widgets.geo
 
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.viewModelFactory
 import org.javarosa.core.model.data.GeoPointData
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.utilities.Appearances
@@ -8,12 +10,14 @@ import org.odk.collect.android.utilities.FormEntryPromptUtils
 import org.odk.collect.android.widgets.interfaces.SelectChoiceLoader
 import org.odk.collect.android.widgets.utilities.BindAttributes
 import org.odk.collect.android.widgets.utilities.WidgetAnswerDialogFragment
+import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.GeoUtils.parseGeometryPoint
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.geopoint.GeoPointMapFragment
 
 class GeoPointMapDialogFragment(
-    viewModelFactory: ViewModelProvider.Factory
+    viewModelFactory: ViewModelProvider.Factory,
+    private val scheduler: Scheduler
 ) :
     WidgetAnswerDialogFragment<GeoPointMapFragment>(
         GeoPointMapFragment::class,
@@ -47,12 +51,21 @@ class GeoPointMapDialogFragment(
             else -> throw IllegalArgumentException()
         }
 
+        val referenceGeometryMappableData by viewModels<ReferenceGeometryMappableData> {
+            viewModelFactory {
+                addInitializer(ReferenceGeometryMappableData::class) {
+                    ReferenceGeometryMappableData(scheduler, prompt, selectChoiceLoader)
+                }
+            }
+        }
+
         val draggable = Appearances.hasAppearance(prompt, Appearances.PLACEMENT_MAP)
         return GeoPointMapFragment(
             inputPoint,
             draggable,
             prompt.isReadOnly,
-            retainMockAccuracy
+            retainMockAccuracy,
+            referenceGeometryMappableData
         )
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/geo/GeoPointMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/geo/GeoPointMapDialogFragment.kt
@@ -10,14 +10,14 @@ import org.odk.collect.android.utilities.FormEntryPromptUtils
 import org.odk.collect.android.widgets.interfaces.SelectChoiceLoader
 import org.odk.collect.android.widgets.utilities.BindAttributes
 import org.odk.collect.android.widgets.utilities.WidgetAnswerDialogFragment
-import org.odk.collect.async.Scheduler
+import org.odk.collect.async.DispatcherProvider
 import org.odk.collect.geo.GeoUtils.parseGeometryPoint
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.geopoint.GeoPointMapFragment
 
 class GeoPointMapDialogFragment(
     viewModelFactory: ViewModelProvider.Factory,
-    private val scheduler: Scheduler
+    private val dispatcherProvider: DispatcherProvider
 ) :
     WidgetAnswerDialogFragment<GeoPointMapFragment>(
         GeoPointMapFragment::class,
@@ -54,7 +54,7 @@ class GeoPointMapDialogFragment(
         val referenceGeometryMappableData by viewModels<ReferenceGeometryMappableData> {
             viewModelFactory {
                 addInitializer(ReferenceGeometryMappableData::class) {
-                    ReferenceGeometryMappableData(scheduler, prompt, selectChoiceLoader)
+                    ReferenceGeometryMappableData(dispatcherProvider, prompt, selectChoiceLoader)
                 }
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/geo/GeoPolyDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/geo/GeoPolyDialogFragment.kt
@@ -17,13 +17,13 @@ import org.odk.collect.android.widgets.utilities.AdditionalAttributes
 import org.odk.collect.android.widgets.utilities.BindAttributes
 import org.odk.collect.android.widgets.utilities.WidgetAnswerDialogFragment
 import org.odk.collect.androidshared.ui.DisplayString
-import org.odk.collect.async.Scheduler
+import org.odk.collect.async.DispatcherProvider
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.geopoly.GeoPolyFragment
 
 class GeoPolyDialogFragment(
     viewModelFactory: ViewModelProvider.Factory,
-    private val scheduler: Scheduler
+    private val dispatcherProvider: DispatcherProvider
 ) :
     WidgetAnswerDialogFragment<GeoPolyFragment>(
         GeoPolyFragment::class,
@@ -76,7 +76,7 @@ class GeoPolyDialogFragment(
         val referenceGeometryMappableData by viewModels<ReferenceGeometryMappableData> {
             viewModelFactory {
                 addInitializer(ReferenceGeometryMappableData::class) {
-                    ReferenceGeometryMappableData(scheduler, prompt, selectChoiceLoader)
+                    ReferenceGeometryMappableData(dispatcherProvider, prompt, selectChoiceLoader)
                 }
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/geo/ReferenceGeometryMappableData.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/geo/ReferenceGeometryMappableData.kt
@@ -3,27 +3,33 @@ package org.odk.collect.android.widgets.geo
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.widgets.interfaces.SelectChoiceLoader
 import org.odk.collect.android.widgets.items.MappableItemsParser
-import org.odk.collect.androidshared.async.TrackableWorker
+import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidshared.livedata.NonNullLiveData
-import org.odk.collect.async.Scheduler
+import org.odk.collect.async.DispatcherProvider
 import org.odk.collect.geo.items.MappableData
 import org.odk.collect.geo.items.MappableItem
 
 class ReferenceGeometryMappableData(
-    scheduler: Scheduler,
+    dispatcherProvider: DispatcherProvider,
     prompt: FormEntryPrompt,
     private val selectChoiceLoader: SelectChoiceLoader,
 ) : ViewModel(), MappableData {
 
-    private val trackableWorker = TrackableWorker(scheduler)
+    private val isLoading = MutableNonNullLiveData(false)
     private val items = MutableLiveData<List<MappableItem>>(emptyList())
 
     init {
-        trackableWorker.immediate(
-            background = {
+
+        viewModelScope.launch(dispatcherProvider.foreground) {
+            isLoading.value = true
+
+            val mappableItems = withContext(dispatcherProvider.background) {
                 val selectChoices = selectChoiceLoader.loadSelectChoices(prompt)
                 val options = MappableItemsParser.Options(color = ITEM_COLOR)
                 MappableItemsParser.parseChoices(
@@ -31,11 +37,11 @@ class ReferenceGeometryMappableData(
                     options,
                     prompt::getSelectChoiceText
                 )
-            },
-            foreground = {
-                items.value = it
             }
-        )
+
+            items.value = mappableItems
+            isLoading.value = false
+        }
     }
 
     override fun getMappableItems(): LiveData<List<MappableItem>> {
@@ -43,7 +49,7 @@ class ReferenceGeometryMappableData(
     }
 
     override fun isLoading(): NonNullLiveData<Boolean> {
-        return trackableWorker.isWorking
+        return isLoading
     }
 
     companion object {

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/send/InstanceUploadViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/send/InstanceUploadViewModelTest.kt
@@ -123,7 +123,7 @@ class InstanceUploadViewModelTest {
             "Waiting"
         )
         viewModel.upload(listOf(instance1.dbId, instance2.dbId))
-        dispatcherProvider.runBackground()
+        dispatcherProvider.flush()
 
         assertThat(submittedInstances.containsAll(listOf(instance1.dbId)), equalTo(true))
         assertThat(instancesRepository.get(instance1.dbId)!!.deletedDate, notNullValue())

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPointMapDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPointMapDialogFragmentTest.kt
@@ -7,11 +7,13 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
 import org.javarosa.core.model.data.GeoPointData
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.odk.collect.android.formentry.FormEntryViewModel
@@ -19,11 +21,19 @@ import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.MockFormEntryPromptBuilder
 import org.odk.collect.android.utilities.Appearances
 import org.odk.collect.android.widgets.geo.GeoPointMapDialogFragment
+import org.odk.collect.android.widgets.geo.ReferenceGeometryMappableData
+import org.odk.collect.android.widgets.items.GeoSelectChoiceElements
+import org.odk.collect.android.widgets.support.FormElementFixtures.selectChoice
+import org.odk.collect.android.widgets.support.FormElementFixtures.treeElement
 import org.odk.collect.android.widgets.utilities.WidgetAnswerDialogFragment.Companion.ARG_FORM_INDEX
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.geopoint.GeoPointMapFragment
+import org.odk.collect.geo.items.MappableItem
+import org.odk.collect.maps.MapPoint
+import org.odk.collect.testshared.FakeScheduler
+import org.odk.collect.testshared.getOrAwaitValue
 
 @RunWith(AndroidJUnit4::class)
 class GeoPointMapDialogFragmentTest {
@@ -31,7 +41,10 @@ class GeoPointMapDialogFragmentTest {
     private var prompt = MockFormEntryPromptBuilder().build()
     private val formEntryViewModel = mock<FormEntryViewModel> {
         on { getQuestionPrompt(prompt.index) } doReturn prompt
+        on { loadSelectChoices(prompt) } doAnswer { prompt.selectChoices }
     }
+
+    private val scheduler = FakeScheduler()
 
     private val viewModelFactory = object : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
@@ -47,7 +60,7 @@ class GeoPointMapDialogFragmentTest {
         FragmentScenarioLauncherRule(
             FragmentFactoryBuilder()
                 .forClass(GeoPointMapDialogFragment::class) {
-                    GeoPointMapDialogFragment(viewModelFactory)
+                    GeoPointMapDialogFragment(viewModelFactory, scheduler)
                 }.build()
         )
 
@@ -110,6 +123,84 @@ class GeoPointMapDialogFragmentTest {
             bundleOf(ARG_FORM_INDEX to prompt.index)
         ) {
             assertThat(it.readOnly, equalTo(true))
+        }
+    }
+
+    @Test
+    fun `configures GeoPointMapFragment with MappableData`() {
+        val selectChoices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(
+                            GeoSelectChoiceElements.GEOMETRY,
+                            "12.0 -1.0 305 0"
+                        )
+                    )
+                )
+            ),
+            selectChoice(
+                value = "b",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(
+                            GeoSelectChoiceElements.GEOMETRY,
+                            "12.0 -1.0 3 4; 12.1 -1.0 3 4"
+                        )
+                    )
+                )
+            ),
+            selectChoice(
+                value = "c",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(
+                            GeoSelectChoiceElements.GEOMETRY,
+                            "12.0 -1.0 3 4; 12.1 -1.0 3 4; 12.0 -1.0 3 4"
+                        )
+                    )
+                )
+            )
+        )
+
+        prompt = MockFormEntryPromptBuilder(prompt)
+            .withSelectChoices(selectChoices)
+            .build()
+
+        launcherRule.launchAndAssertOnChild<GeoPointMapFragment>(
+            GeoPointMapDialogFragment::class,
+            bundleOf(ARG_FORM_INDEX to prompt.index)
+        ) {
+            scheduler.flush()
+            assertThat(it.mappableData, notNullValue())
+            val mappableItems = it.mappableData!!.getMappableItems().getOrAwaitValue()
+            assertThat(mappableItems.size, equalTo(3))
+
+            val point = mappableItems[0] as MappableItem.Point
+            assertThat(point.point, equalTo(MapPoint(12.0, -1.0, 305.0)))
+            assertThat(point.color, equalTo(ReferenceGeometryMappableData.ITEM_COLOR))
+
+            val line = mappableItems[1] as MappableItem.Line
+            assertThat(
+                line.points,
+                equalTo(listOf(MapPoint(12.0, -1.0, 3.0, 4.0), MapPoint(12.1, -1.0, 3.0, 4.0)))
+            )
+            assertThat(line.strokeColor, equalTo(ReferenceGeometryMappableData.ITEM_COLOR))
+
+            val polygon = mappableItems[2] as MappableItem.Polygon
+            assertThat(
+                polygon.points,
+                equalTo(
+                    listOf(
+                        MapPoint(12.0, -1.0, 3.0, 4.0),
+                        MapPoint(12.1, -1.0, 3.0, 4.0),
+                        MapPoint(12.0, -1.0, 3.0, 4.0)
+                    )
+                )
+            )
+            assertThat(polygon.strokeColor, equalTo(ReferenceGeometryMappableData.ITEM_COLOR))
+            assertThat(polygon.fillColor, equalTo(ReferenceGeometryMappableData.ITEM_COLOR))
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPointMapDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPointMapDialogFragmentTest.kt
@@ -27,6 +27,7 @@ import org.odk.collect.android.widgets.support.FormElementFixtures.selectChoice
 import org.odk.collect.android.widgets.support.FormElementFixtures.treeElement
 import org.odk.collect.android.widgets.utilities.WidgetAnswerDialogFragment.Companion.ARG_FORM_INDEX
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
+import org.odk.collect.androidtest.TestDispatcherProvider
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.geopoint.GeoPointMapFragment
@@ -44,7 +45,7 @@ class GeoPointMapDialogFragmentTest {
         on { loadSelectChoices(prompt) } doAnswer { prompt.selectChoices }
     }
 
-    private val scheduler = FakeScheduler()
+    private val dispatcherProvider = TestDispatcherProvider()
 
     private val viewModelFactory = object : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
@@ -60,7 +61,7 @@ class GeoPointMapDialogFragmentTest {
         FragmentScenarioLauncherRule(
             FragmentFactoryBuilder()
                 .forClass(GeoPointMapDialogFragment::class) {
-                    GeoPointMapDialogFragment(viewModelFactory, scheduler)
+                    GeoPointMapDialogFragment(viewModelFactory, dispatcherProvider)
                 }.build()
         )
 
@@ -172,7 +173,7 @@ class GeoPointMapDialogFragmentTest {
             GeoPointMapDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
         ) {
-            scheduler.flush()
+            dispatcherProvider.flush()
             assertThat(it.mappableData, notNullValue())
             val mappableItems = it.mappableData!!.getMappableItems().getOrAwaitValue()
             assertThat(mappableItems.size, equalTo(3))

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoPolyDialogFragmentTest.kt
@@ -41,6 +41,7 @@ import org.odk.collect.android.widgets.utilities.WidgetAnswerDialogFragment.Comp
 import org.odk.collect.android.widgets.viewmodels.QuestionViewModel
 import org.odk.collect.androidshared.ui.DisplayString
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
+import org.odk.collect.androidtest.TestDispatcherProvider
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.geo.geopoly.GeoPolyFragment
 import org.odk.collect.geo.geopoly.GeoPolyFragment.OutputMode
@@ -74,14 +75,14 @@ class GeoPolyDialogFragmentTest {
         }
     }
 
-    private val scheduler = FakeScheduler()
+    private val dispatcherProvider = TestDispatcherProvider()
 
     @get:Rule
     val launcherRule =
         FragmentScenarioLauncherRule(
             FragmentFactoryBuilder()
                 .forClass(GeoPolyDialogFragment::class) {
-                    GeoPolyDialogFragment(viewModelFactory, scheduler)
+                    GeoPolyDialogFragment(viewModelFactory, dispatcherProvider)
                 }.build()
         )
 
@@ -611,7 +612,7 @@ class GeoPolyDialogFragmentTest {
             GeoPolyDialogFragment::class,
             bundleOf(ARG_FORM_INDEX to prompt.index)
         ) {
-            scheduler.flush()
+            dispatcherProvider.flush()
             assertThat(it.mappableData, notNullValue())
             val mappableItems = it.mappableData!!.getMappableItems().getOrAwaitValue()
             assertThat(mappableItems!!.size, equalTo(3))

--- a/geo/src/main/java/org/odk/collect/geo/GeoUtils.kt
+++ b/geo/src/main/java/org/odk/collect/geo/GeoUtils.kt
@@ -143,7 +143,7 @@ object GeoUtils {
 
     fun Fragment.showItemLoading(mappableData: MappableData) {
         MaterialProgressDialogFragment.showOn(
-            this,
+            viewLifecycleOwner,
             mappableData.isLoading(),
             childFragmentManager
         ) {

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -30,9 +30,13 @@ import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.GeoDependencyComponentProvider
 import org.odk.collect.geo.GeoUtils.showCurrentLocation
+import org.odk.collect.geo.GeoUtils.showData
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.R
 import org.odk.collect.geo.geopoint.LocationAccuracy.Improving
+import org.odk.collect.geo.items.MappableData
+import org.odk.collect.geo.items.MappableItem
+import org.odk.collect.geo.items.MappableItemsDelegate
 import org.odk.collect.location.tracker.LocationTracker
 import org.odk.collect.location.tracker.getCurrentLocation
 import org.odk.collect.maps.MapFragment
@@ -53,6 +57,7 @@ class GeoPointMapFragment(
     val draggable: Boolean,
     val readOnly: Boolean,
     val retainMockAccuracy: Boolean,
+    val mappableData: MappableData? = null
 ) : Fragment() {
 
     @Inject
@@ -107,6 +112,7 @@ class GeoPointMapFragment(
     private var isPointLocked = false
 
     private val currentLocationDelegate = CurrentLocationDelegate()
+    private val mappableItemsDelegate = MappableItemsDelegate(background = true, clickable = false)
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -285,6 +291,10 @@ class GeoPointMapFragment(
             retainMockAccuracy
         ) { mapPoint: MapPoint? ->
             onLocationChanged(mapPoint)
+        }
+
+        if (mappableData != null) {
+            (map as MapFragment).showData(mappableData, mappableItemsDelegate)
         }
     }
 

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -31,6 +31,7 @@ import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.GeoDependencyComponentProvider
 import org.odk.collect.geo.GeoUtils.showCurrentLocation
 import org.odk.collect.geo.GeoUtils.showData
+import org.odk.collect.geo.GeoUtils.showItemLoading
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.R
 import org.odk.collect.geo.geopoint.LocationAccuracy.Improving
@@ -160,6 +161,10 @@ class GeoPointMapFragment(
             { newMapFragment: MapFragment -> this.initMap(newMapFragment) },
             { cancel() }
         )
+
+        if (mappableData != null) {
+            showItemLoading(mappableData)
+        }
     }
 
     override fun onSaveInstanceState(state: Bundle) {

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyFragment.kt
@@ -145,10 +145,6 @@ class GeoPolyFragment @JvmOverloads constructor(
         viewModel.points.asLiveData().observe(this) {
             setChangeResult(it)
         }
-
-        if (mappableData != null) {
-            showItemLoading(mappableData)
-        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -173,6 +169,10 @@ class GeoPolyFragment @JvmOverloads constructor(
 
         viewModel.fixedAlerts.showSnackbar(viewLifecycleOwner, view) {
             SnackbarUtils.SnackbarDetails(getString(string.error_fixed))
+        }
+
+        if (mappableData != null) {
+            showItemLoading(mappableData)
         }
     }
 

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -127,8 +127,6 @@ class SelectionMapFragment(
             ToastUtils.showLongToast(org.odk.collect.strings.R.string.not_granted_permission)
             requireActivity().finish()
         }
-
-        showItemLoading(selectionMapData)
     }
 
     override fun onCreateView(
@@ -158,6 +156,7 @@ class SelectionMapFragment(
         }
 
         setUpSummarySheet(binding)
+        showItemLoading(selectionMapData)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.geo.geopoint
 
 import android.app.Application
+import androidx.activity.OnBackPressedDispatcher
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -11,6 +12,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -23,6 +26,7 @@ import org.odk.collect.geo.DaggerGeoDependencyComponent
 import org.odk.collect.geo.GeoDependencyModule
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.R
+import org.odk.collect.geo.geopoly.GeoPolyFragment
 import org.odk.collect.geo.support.FakeLocationTracker
 import org.odk.collect.geo.support.FakeMapFragment
 import org.odk.collect.geo.support.FakeMappableData
@@ -38,12 +42,14 @@ import org.odk.collect.maps.MapFragmentFactory
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.circles.CurrentLocationDelegate
 import org.odk.collect.maps.layers.ReferenceLayerRepository
+import org.odk.collect.material.MaterialProgressDialogFragment
 import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.strings.R.string
 import org.odk.collect.testshared.EspressoAssertions
 import org.odk.collect.testshared.EspressoInteractions
 import org.odk.collect.testshared.FragmentResultRecorder
+import org.odk.collect.testshared.RobolectricHelpers.getFragmentByClass
 import org.odk.collect.webpage.WebPageService
 import org.robolectric.Shadows
 
@@ -250,6 +256,34 @@ class GeoPointMapFragmentTest {
         }
 
         assertThat(map, showsMappableData(mappableData, background = true, clickable = false))
+    }
+
+    @Test
+    fun `shows progress while loading mappable items`() {
+        val mappableData = FakeMappableData(emptyList())
+        mappableData.isLoading = false
+
+        launcherRule.launchInContainer {
+            GeoPointMapFragment(null, false, false, false, mappableData)
+        }.onFragment {
+            val dialogClass = MaterialProgressDialogFragment::class.java
+            assertThat(
+                getFragmentByClass(it.childFragmentManager, dialogClass),
+                nullValue()
+            )
+
+            mappableData.isLoading = true
+            assertThat(
+                getFragmentByClass(it.childFragmentManager, dialogClass),
+                notNullValue()
+            )
+
+            mappableData.isLoading = false
+            assertThat(
+                getFragmentByClass(it.childFragmentManager, dialogClass),
+                nullValue()
+            )
+        }
     }
 
     private fun overrideDependencies(mapFragment: MapFragment) {

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -25,8 +25,11 @@ import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.R
 import org.odk.collect.geo.support.FakeLocationTracker
 import org.odk.collect.geo.support.FakeMapFragment
+import org.odk.collect.geo.support.FakeMappableData
 import org.odk.collect.geo.support.MapFragmentAssertions.hasZoomedToCurrentLocation
 import org.odk.collect.geo.support.MapFragmentAssertions.showsCurrentLocation
+import org.odk.collect.geo.support.MapFragmentAssertions.showsMappableData
+import org.odk.collect.geo.support.MappableItemsFixtures
 import org.odk.collect.geo.support.RobolectricApplication
 import org.odk.collect.location.Location
 import org.odk.collect.location.tracker.LocationTracker
@@ -230,6 +233,23 @@ class GeoPointMapFragmentTest {
         EspressoAssertions.assertDisabled(withContentDescription(string.record_geopoint))
         EspressoInteractions.clickOn(withContentDescription(string.clear))
         EspressoAssertions.assertEnabled(withContentDescription(string.record_geopoint))
+    }
+
+    @Test
+    fun `shows items from mappable data`() {
+        val mappableData = FakeMappableData(
+            listOf(
+                MappableItemsFixtures.point(),
+                MappableItemsFixtures.actionMappableLine(),
+                MappableItemsFixtures.actionMappablePolygon()
+            )
+        )
+
+        launcherRule.launchInContainer {
+            GeoPointMapFragment(null, false, false, false, mappableData)
+        }
+
+        assertThat(map, showsMappableData(mappableData, background = true, clickable = false))
     }
 
     private fun overrideDependencies(mapFragment: MapFragment) {

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyFragmentTest.kt
@@ -47,6 +47,7 @@ import org.odk.collect.geo.items.MappableItem
 import org.odk.collect.geo.support.AccuracyStatusViewMatcher.Companion.hasAccuracy
 import org.odk.collect.geo.support.FakeLocationTracker
 import org.odk.collect.geo.support.FakeMapFragment
+import org.odk.collect.geo.support.FakeMappableData
 import org.odk.collect.geo.support.MapFragmentAssertions.hasZoomedToCurrentLocation
 import org.odk.collect.geo.support.MapFragmentAssertions.showsCurrentLocation
 import org.odk.collect.geo.support.MapFragmentAssertions.showsMappableData
@@ -1147,20 +1148,3 @@ class GeoPolyFragmentTest {
 
 private val DEFAULT_RECORDING_INTERVAL =
     INTERVAL_OPTIONS[GeoPolyFragment.DEFAULT_INTERVAL_INDEX].toLong() * 1000
-
-private class FakeMappableData(items: List<MappableItem>) : MappableData {
-
-    private val _items = MutableLiveData(items)
-    private val _isLoading = MutableNonNullLiveData(false)
-    var isLoading
-        get() = _isLoading.value
-        set(value) { _isLoading.value = value }
-
-    override fun getMappableItems(): LiveData<List<MappableItem>> {
-        return _items
-    }
-
-    override fun isLoading(): NonNullLiveData<Boolean> {
-        return _isLoading
-    }
-}

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMappableData.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMappableData.kt
@@ -1,0 +1,25 @@
+package org.odk.collect.geo.support
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
+import org.odk.collect.androidshared.livedata.NonNullLiveData
+import org.odk.collect.geo.items.MappableData
+import org.odk.collect.geo.items.MappableItem
+
+class FakeMappableData(items: List<MappableItem>) : MappableData {
+
+    private val _items = MutableLiveData(items)
+    private val _isLoading = MutableNonNullLiveData(false)
+    var isLoading
+        get() = _isLoading.value
+        set(value) { _isLoading.value = value }
+
+    override fun getMappableItems(): LiveData<List<MappableItem>> {
+        return _items
+    }
+
+    override fun isLoading(): NonNullLiveData<Boolean> {
+        return _isLoading
+    }
+}


### PR DESCRIPTION
Closes #7118
Closes #7202 

#### Why is this the best possible solution? Were any other approaches considered?

This just emulates the approach we took to add reference geometry to geopoly questions, so there shouldn't be anything controversial here. The one additional change I made is to remove the deprecated use of `Scheduler` for immediate async work.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just adds the reference geometry feature to geopoint (with `maps`/`placement-map` appearances) questions! No map code has changed, so this can be tested on any one of the basemap source settings.


As I've noted above, I think styling should also be supported for existing geometry across all three question types. This was likely true for `geotrace`/`geoshape` already, but we haven't tested it yet.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
