### PR TITLE
Fix crash when rotating the screen after switching map layer

### DIFF
--- a/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapViewModel.kt
@@ -74,9 +74,10 @@ class MapViewModel(
 
     fun getSettings(keys: Collection<String>): LiveData<Settings> {
         return MediatorLiveData<Settings>().apply {
+            value = unprotectedSettings
             addSource(lastSettingsKeyChange) {
-                if (it == null || keys.contains(it)) {
-                    this.value = unprotectedSettings
+                if (keys.contains(it)) {
+                    value = unprotectedSettings
                 }
             }
         }

--- a/maps/src/test/java/org/odk/collect/maps/MapViewModelTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/MapViewModelTest.kt
@@ -1,0 +1,67 @@
+package org.odk.collect.maps
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.maps.layers.InMemReferenceLayerRepository
+import org.odk.collect.settings.keys.ProjectKeys
+import org.odk.collect.shared.settings.InMemSettings
+import org.odk.collect.shared.settings.Settings
+
+@RunWith(AndroidJUnit4::class)
+class MapViewModelTest {
+
+    private val unprotectedSettings = InMemSettings()
+    private val metaSettings = InMemSettings()
+    private val referenceLayerRepository = InMemReferenceLayerRepository()
+
+    private val viewModel = MapViewModel(unprotectedSettings, metaSettings, referenceLayerRepository)
+
+    @Test
+    fun `getSettings delivers current settings on subscription`() {
+        var observed: Settings? = null
+        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).observeForever {
+            observed = it
+        }
+
+        assertThat(observed, equalTo(unprotectedSettings))
+    }
+
+    @Test
+    fun `getSettings delivers current settings on subscription even after a different key changed`() {
+        viewModel.onSettingChanged(ProjectKeys.KEY_REFERENCE_LAYER)
+
+        var observed: Settings? = null
+        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).observeForever {
+            observed = it
+        }
+
+        assertThat(observed, equalTo(unprotectedSettings))
+    }
+
+    @Test
+    fun `getSettings re-delivers settings when a requested key changes`() {
+        var deliveries = 0
+        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).observeForever {
+            deliveries++
+        }
+
+        viewModel.onSettingChanged(ProjectKeys.KEY_MAPBOX_MAP_STYLE)
+
+        assertThat(deliveries, equalTo(2))
+    }
+
+    @Test
+    fun `getSettings does not re-deliver settings when an unrelated key changes`() {
+        var deliveries = 0
+        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).observeForever {
+            deliveries++
+        }
+
+        viewModel.onSettingChanged(ProjectKeys.KEY_REFERENCE_LAYER)
+
+        assertThat(deliveries, equalTo(1))
+    }
+}

--- a/maps/src/test/java/org/odk/collect/maps/MapViewModelTest.kt
+++ b/maps/src/test/java/org/odk/collect/maps/MapViewModelTest.kt
@@ -5,10 +5,11 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.odk.collect.androidtest.getOrAwaitValue
+import org.odk.collect.androidtest.recordValues
 import org.odk.collect.maps.layers.InMemReferenceLayerRepository
 import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.shared.settings.InMemSettings
-import org.odk.collect.shared.settings.Settings
 
 @RunWith(AndroidJUnit4::class)
 class MapViewModelTest {
@@ -21,10 +22,7 @@ class MapViewModelTest {
 
     @Test
     fun `getSettings delivers current settings on subscription`() {
-        var observed: Settings? = null
-        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).observeForever {
-            observed = it
-        }
+        val observed = viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).getOrAwaitValue()
 
         assertThat(observed, equalTo(unprotectedSettings))
     }
@@ -33,35 +31,26 @@ class MapViewModelTest {
     fun `getSettings delivers current settings on subscription even after a different key changed`() {
         viewModel.onSettingChanged(ProjectKeys.KEY_REFERENCE_LAYER)
 
-        var observed: Settings? = null
-        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).observeForever {
-            observed = it
-        }
+        val observed = viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).getOrAwaitValue()
 
         assertThat(observed, equalTo(unprotectedSettings))
     }
 
     @Test
     fun `getSettings re-delivers settings when a requested key changes`() {
-        var deliveries = 0
-        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).observeForever {
-            deliveries++
+        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).recordValues { settings ->
+            viewModel.onSettingChanged(ProjectKeys.KEY_MAPBOX_MAP_STYLE)
+
+            assertThat(settings.size, equalTo(2))
         }
-
-        viewModel.onSettingChanged(ProjectKeys.KEY_MAPBOX_MAP_STYLE)
-
-        assertThat(deliveries, equalTo(2))
     }
 
     @Test
     fun `getSettings does not re-deliver settings when an unrelated key changes`() {
-        var deliveries = 0
-        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).observeForever {
-            deliveries++
+        viewModel.getSettings(setOf(ProjectKeys.KEY_MAPBOX_MAP_STYLE)).recordValues { settings ->
+            viewModel.onSettingChanged(ProjectKeys.KEY_REFERENCE_LAYER)
+
+            assertThat(settings.size, equalTo(1))
         }
-
-        viewModel.onSettingChanged(ProjectKeys.KEY_REFERENCE_LAYER)
-
-        assertThat(deliveries, equalTo(1))
     }
 }


### PR DESCRIPTION
Closes #7254 

#### Why is this the best possible solution? Were any other approaches considered?
The crash came from settings not being delivered to a fresh subscriber after a setting had already changed. Fixing it in `MapViewModel` so subscribers always receive the current settings on subscription addresses the root cause. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Switching the map layer and then rotating the screen no longer crashes the app. Maps should otherwise behave as before.                                                                                                                                                                                                                                                                                                                  Regression risk is limited to maps: worth checking that the map style and reference layer still update correctly when changed, and that switching layers and rotating work across the different map engines. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
