### PR TITLE
Don't crash if dialog is shown after an Activity is closed

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/DialogFragmentUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/DialogFragmentUtils.kt
@@ -61,6 +61,9 @@ object DialogFragmentUtils {
                 fragmentManager.executePendingTransactions()
             } catch (e: IllegalStateException) {
                 Timber.w(e)
+            } catch (e: android.view.WindowManager.BadTokenException) {
+                // Catch dialogs getting shown after an Activity has been closed
+                Timber.w(e)
             }
         }
     }


### PR DESCRIPTION
Seeing a few crash reports around this.