### PR TITLE
Don't fallback to default colors when choice has blank style

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/MappableItemsParser.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/MappableItemsParser.kt
@@ -19,8 +19,8 @@ object MappableItemsParser {
 
     fun parseChoices(
         choices: List<SelectChoice>,
-        options: Options,
-        translator: (SelectChoice) -> String
+        options: Options = Options(),
+        translator: (SelectChoice) -> String = { it.value }
     ): List<MappableItem> {
         return choices.mapIndexedNotNull { index, selectChoice ->
             val geometry = selectChoice.getChild(GEOMETRY)
@@ -52,34 +52,35 @@ object MappableItemsParser {
                                 point = points[0],
                                 smallIcon = if (markerSymbol.isNullOrBlank()) R.drawable.ic_map_marker_with_hole_small else R.drawable.ic_map_marker_small,
                                 largeIcon = if (markerSymbol.isNullOrBlank()) R.drawable.ic_map_marker_with_hole_big else R.drawable.ic_map_marker_big,
-                                color = markerColor ?: options.color,
+                                color = if (!markerColor.isNullOrBlank()) markerColor else options.color,
                                 symbol = markerSymbol,
                                 action = options.action
                             )
-                        } else if (points.first() != points.last()) {
-                            MappableItem.Line(
-                                index.toLong(),
-                                translator(selectChoice),
-                                properties,
-                                points = points,
-                                strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
-                                strokeColor = getPropertyValue(selectChoice, STROKE)
-                                    ?: options.color,
-                                action = options.action
-                            )
                         } else {
-                            MappableItem.Polygon(
-                                index.toLong(),
-                                translator(selectChoice),
-                                properties,
-                                points = points,
-                                strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
-                                strokeColor = getPropertyValue(selectChoice, STROKE)
-                                    ?: options.color,
-                                fillColor = getPropertyValue(selectChoice, FILL)
-                                    ?: options.color,
-                                action = options.action
-                            )
+                            val strokeColor = getPropertyValue(selectChoice, STROKE)
+                            if (points.first() != points.last()) {
+                                MappableItem.Line(
+                                    index.toLong(),
+                                    translator(selectChoice),
+                                    properties,
+                                    points = points,
+                                    strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
+                                    strokeColor = if (!strokeColor.isNullOrBlank()) strokeColor else options.color,
+                                    action = options.action
+                                )
+                            } else {
+                                val fillColor = getPropertyValue(selectChoice, FILL)
+                                MappableItem.Polygon(
+                                    index.toLong(),
+                                    translator(selectChoice),
+                                    properties,
+                                    points = points,
+                                    strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
+                                    strokeColor = if (!strokeColor.isNullOrBlank()) strokeColor else options.color,
+                                    fillColor = if (!fillColor.isNullOrBlank()) fillColor else options.color,
+                                    action = options.action
+                                )
+                            }
                         }
                     } else {
                         null

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/MappableItemsParser.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/MappableItemsParser.kt
@@ -44,7 +44,7 @@ object MappableItemsParser {
                             parsePoint(selectChoice, index, translator, properties, points, options)
                         } else {
                             if (points.first() != points.last()) {
-                                parsePolygon(
+                                parseLine(
                                     selectChoice,
                                     index,
                                     translator,
@@ -53,7 +53,7 @@ object MappableItemsParser {
                                     options
                                 )
                             } else {
-                                parseLine(
+                                parsePolygon(
                                     selectChoice,
                                     index,
                                     translator,
@@ -75,7 +75,7 @@ object MappableItemsParser {
         }
     }
 
-    private fun parseLine(
+    private fun parsePolygon(
         selectChoice: SelectChoice,
         index: Int,
         translator: (SelectChoice) -> String,
@@ -97,7 +97,7 @@ object MappableItemsParser {
         )
     }
 
-    private fun parsePolygon(
+    private fun parseLine(
         selectChoice: SelectChoice,
         index: Int,
         translator: (SelectChoice) -> String,

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/MappableItemsParser.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/MappableItemsParser.kt
@@ -14,6 +14,7 @@ import org.odk.collect.geo.geopoly.GeoPolyUtils.parseGeometry
 import org.odk.collect.geo.items.IconifiedText
 import org.odk.collect.geo.items.MappableItem
 import org.odk.collect.icons.R
+import org.odk.collect.maps.MapPoint
 
 object MappableItemsParser {
 
@@ -40,45 +41,25 @@ object MappableItemsParser {
                         }
 
                         if (points.size == 1) {
-                            val markerColor =
-                                getPropertyValue(selectChoice, MARKER_COLOR)
-                            val markerSymbol =
-                                getPropertyValue(selectChoice, MARKER_SYMBOL)
-
-                            MappableItem.Point(
-                                index.toLong(),
-                                translator(selectChoice),
-                                properties,
-                                point = points[0],
-                                smallIcon = if (markerSymbol.isNullOrBlank()) R.drawable.ic_map_marker_with_hole_small else R.drawable.ic_map_marker_small,
-                                largeIcon = if (markerSymbol.isNullOrBlank()) R.drawable.ic_map_marker_with_hole_big else R.drawable.ic_map_marker_big,
-                                color = if (!markerColor.isNullOrBlank()) markerColor else options.color,
-                                symbol = markerSymbol,
-                                action = options.action
-                            )
+                            parsePoint(selectChoice, index, translator, properties, points, options)
                         } else {
-                            val strokeColor = getPropertyValue(selectChoice, STROKE)
                             if (points.first() != points.last()) {
-                                MappableItem.Line(
-                                    index.toLong(),
-                                    translator(selectChoice),
+                                parsePolygon(
+                                    selectChoice,
+                                    index,
+                                    translator,
                                     properties,
-                                    points = points,
-                                    strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
-                                    strokeColor = if (!strokeColor.isNullOrBlank()) strokeColor else options.color,
-                                    action = options.action
+                                    points,
+                                    options
                                 )
                             } else {
-                                val fillColor = getPropertyValue(selectChoice, FILL)
-                                MappableItem.Polygon(
-                                    index.toLong(),
-                                    translator(selectChoice),
+                                parseLine(
+                                    selectChoice,
+                                    index,
+                                    translator,
                                     properties,
-                                    points = points,
-                                    strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
-                                    strokeColor = if (!strokeColor.isNullOrBlank()) strokeColor else options.color,
-                                    fillColor = if (!fillColor.isNullOrBlank()) fillColor else options.color,
-                                    action = options.action
+                                    points,
+                                    options
                                 )
                             }
                         }
@@ -92,6 +73,74 @@ object MappableItemsParser {
                 null
             }
         }
+    }
+
+    private fun parseLine(
+        selectChoice: SelectChoice,
+        index: Int,
+        translator: (SelectChoice) -> String,
+        properties: List<IconifiedText>,
+        points: List<MapPoint>,
+        options: Options
+    ): MappableItem.Polygon {
+        val strokeColor = getPropertyValue(selectChoice, STROKE)
+        val fillColor = getPropertyValue(selectChoice, FILL)
+        return MappableItem.Polygon(
+            index.toLong(),
+            translator(selectChoice),
+            properties,
+            points = points,
+            strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
+            strokeColor = if (!strokeColor.isNullOrBlank()) strokeColor else options.color,
+            fillColor = if (!fillColor.isNullOrBlank()) fillColor else options.color,
+            action = options.action
+        )
+    }
+
+    private fun parsePolygon(
+        selectChoice: SelectChoice,
+        index: Int,
+        translator: (SelectChoice) -> String,
+        properties: List<IconifiedText>,
+        points: List<MapPoint>,
+        options: Options
+    ): MappableItem.Line {
+        val strokeColor = getPropertyValue(selectChoice, STROKE)
+        return MappableItem.Line(
+            index.toLong(),
+            translator(selectChoice),
+            properties,
+            points = points,
+            strokeWidth = getPropertyValue(selectChoice, STROKE_WIDTH),
+            strokeColor = if (!strokeColor.isNullOrBlank()) strokeColor else options.color,
+            action = options.action
+        )
+    }
+
+    private fun parsePoint(
+        selectChoice: SelectChoice,
+        index: Int,
+        translator: (SelectChoice) -> String,
+        properties: List<IconifiedText>,
+        points: List<MapPoint>,
+        options: Options
+    ): MappableItem.Point {
+        val markerColor =
+            getPropertyValue(selectChoice, MARKER_COLOR)
+        val markerSymbol =
+            getPropertyValue(selectChoice, MARKER_SYMBOL)
+
+        return MappableItem.Point(
+            index.toLong(),
+            translator(selectChoice),
+            properties,
+            point = points[0],
+            smallIcon = if (markerSymbol.isNullOrBlank()) R.drawable.ic_map_marker_with_hole_small else R.drawable.ic_map_marker_small,
+            largeIcon = if (markerSymbol.isNullOrBlank()) R.drawable.ic_map_marker_with_hole_big else R.drawable.ic_map_marker_big,
+            color = if (!markerColor.isNullOrBlank()) markerColor else options.color,
+            symbol = markerSymbol,
+            action = options.action
+        )
     }
 
     private fun getPropertyValue(selectChoice: SelectChoice, propertyName: String): String? {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/MappableItemsParserTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/MappableItemsParserTest.kt
@@ -1,0 +1,95 @@
+package org.odk.collect.android.widgets.items
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.odk.collect.android.widgets.support.FormElementFixtures.selectChoice
+import org.odk.collect.android.widgets.support.FormElementFixtures.treeElement
+import org.odk.collect.geo.items.MappableItem
+
+class MappableItemsParserTest {
+
+    @Test
+    fun `uses Options color when point marker color is blank`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(GeoSelectChoiceElements.GEOMETRY, "1.0 -1.0 0 0"),
+                        treeElement(GeoSelectChoiceElements.MARKER_COLOR, "")
+                    )
+                )
+            )
+        )
+
+        val mappableItems = MappableItemsParser.parseChoices(
+            choices,
+            MappableItemsParser.Options(color = "#ffffff")
+        )
+        assertThat((mappableItems[0] as MappableItem.Point).color, equalTo("#ffffff"))
+    }
+
+    @Test
+    fun `uses Options color when line stroke is blank`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(GeoSelectChoiceElements.GEOMETRY, "1.0 -1.0 0 0;2.0 -2.0 0 0"),
+                        treeElement(GeoSelectChoiceElements.STROKE, "")
+                    )
+                )
+            )
+        )
+
+        val mappableItems = MappableItemsParser.parseChoices(
+            choices,
+            MappableItemsParser.Options(color = "#ffffff")
+        )
+        assertThat((mappableItems[0] as MappableItem.Line).strokeColor, equalTo("#ffffff"))
+    }
+
+    @Test
+    fun `uses Options color when polygon stroke is blank`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(GeoSelectChoiceElements.GEOMETRY, "1.0 -1.0 0 0;1.0 -1.0 0 0"),
+                        treeElement(GeoSelectChoiceElements.STROKE, "")
+                    )
+                )
+            )
+        )
+
+        val mappableItems = MappableItemsParser.parseChoices(
+            choices,
+            MappableItemsParser.Options(color = "#ffffff")
+        )
+        assertThat((mappableItems[0] as MappableItem.Polygon).strokeColor, equalTo("#ffffff"))
+    }
+
+    @Test
+    fun `uses Options color when polygon fill is blank`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(
+                        treeElement(GeoSelectChoiceElements.GEOMETRY, "1.0 -1.0 0 0;1.0 -1.0 0 0"),
+                        treeElement(GeoSelectChoiceElements.FILL, "")
+                    )
+                )
+            )
+        )
+
+        val mappableItems = MappableItemsParser.parseChoices(
+            choices,
+            MappableItemsParser.Options(color = "#ffffff")
+        )
+        assertThat((mappableItems[0] as MappableItem.Polygon).fillColor, equalTo("#ffffff"))
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/getodk/collect/pull/7265#issuecomment-4788565994

#### Why is this the best possible solution? Were any other approaches considered?

I've just made sure we always use the `Options` color unless we a choice has a non-blank value for the relevant color properties.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just need to check that the issue is fixed! Only the logic that picks the colors for points, lines and shapes has been touched.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
