### PR TITLE
Use consistent image answer view in summary and widget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetAnswer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetAnswer.kt
@@ -1,20 +1,14 @@
 package org.odk.collect.android.widgets
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.unit.dp
 import org.javarosa.core.model.Constants
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.widgets.image.ImageWidgetAnswer
@@ -57,19 +51,7 @@ fun WidgetAnswer(
                     )
                 }
             }
-            Constants.CONTROL_IMAGE_CHOOSE -> ImageWidgetAnswer(
-                if (compact) {
-                    modifier
-                        .height(200.dp)
-                        .wrapContentWidth(Alignment.Start)
-                } else {
-                    modifier.fillMaxWidth()
-                },
-                answer,
-                if (compact) ContentScale.Fit else ContentScale.FillWidth,
-                mediaWidgetAnswerViewModel,
-                onLongClick
-            )
+            Constants.CONTROL_IMAGE_CHOOSE -> ImageWidgetAnswer(modifier, answer, mediaWidgetAnswerViewModel, onLongClick)
             Constants.CONTROL_VIDEO_CAPTURE -> VideoWidgetAnswer(modifier, answer, mediaWidgetAnswerViewModel, onLongClick)
             Constants.CONTROL_FILE_CAPTURE -> {
                 val context = LocalContext.current

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/image/ImageWidgetAnswer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/image/ImageWidgetAnswer.kt
@@ -1,6 +1,8 @@
 package org.odk.collect.android.widgets.image
 
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -8,11 +10,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import org.odk.collect.android.widgets.MediaWidgetAnswerViewModel
 import org.odk.collect.androidshared.system.ContextExt.getActivity
@@ -22,7 +26,6 @@ import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard
 fun ImageWidgetAnswer(
     modifier: Modifier,
     answer: String,
-    contentScale: ContentScale,
     mediaWidgetAnswerViewModel: MediaWidgetAnswerViewModel,
     onLongClick: () -> Unit
 ) {
@@ -41,10 +44,12 @@ fun ImageWidgetAnswer(
         } else {
             AsyncImage(
                 model = it,
-                contentScale = contentScale,
+                contentScale = ContentScale.Fit,
                 contentDescription = null,
                 onError = { isError = true },
                 modifier = modifier
+                    .height(200.dp)
+                    .wrapContentWidth(Alignment.Start)
                     .clip(MaterialTheme.shapes.large)
                     .combinedClickable(
                         onClick = {

--- a/collect_app/src/main/res/layout/annotate_widget.xml
+++ b/collect_app/src/main/res/layout/annotate_widget.xml
@@ -53,15 +53,18 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/annotate_button" />
 
-    <ImageView
+    <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/image"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_height="200dp"
         android:layout_marginTop="@dimen/margin_small"
         android:tag="ImageView"
         android:adjustViewBounds="true"
+        app:shapeAppearance="?attr/shapeAppearanceLargeComponent"
+        app:layout_constrainedWidth="true"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintTop_toBottomOf="@id/error_message"
         tools:src="@drawable/notes"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/draw_widget.xml
+++ b/collect_app/src/main/res/layout/draw_widget.xml
@@ -27,15 +27,18 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/draw_button" />
 
-    <ImageView
+    <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/image"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_height="200dp"
         android:layout_marginTop="@dimen/margin_small"
         android:tag="ImageView"
         android:adjustViewBounds="true"
+        app:shapeAppearance="?attr/shapeAppearanceLargeComponent"
+        app:layout_constrainedWidth="true"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintTop_toBottomOf="@id/error_message"
         tools:src="@drawable/notes"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/signature_widget.xml
+++ b/collect_app/src/main/res/layout/signature_widget.xml
@@ -27,15 +27,18 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/sign_button" />
 
-    <ImageView
+    <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/image"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_height="200dp"
         android:layout_marginTop="@dimen/margin_small"
         android:tag="ImageView"
         android:adjustViewBounds="true"
+        app:shapeAppearance="?attr/shapeAppearanceLargeComponent"
+        app:layout_constrainedWidth="true"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintTop_toBottomOf="@id/error_message"
         tools:src="@drawable/notes"/>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?
We discussed that it's better to maintain consistency in how image and video answers are displayed across different types of questions, as well as between widgets and the hierarchy view.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should display images and videos consistently across different question types, regardless of whether they are shown in the hierarchy view or inline within widgets. Please verify that the behavior is consistent and that no regressions have been introduced. There is no need to test opening media files, as the only change is the display size of images.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with different image questions, like the `All question types` form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
