### PR TITLE
Fix answers disappearing in the hierarchy view when scrolling

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/compose/RemeasureHostOnCompose.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/compose/RemeasureHostOnCompose.kt
@@ -1,0 +1,26 @@
+package org.odk.collect.androidshared.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
+
+/**
+ * Requests a layout pass on the host [android.view.View] after every composition.
+ *
+ * A [androidx.compose.ui.platform.ComposeView] reused from a RecyclerView pool can get measured to
+ * 0 height on rebind, so its row renders blank after scrolling. Wrapping the content in this
+ * Composable nudges a remeasure once composition completes, applying the real height.
+ *
+ * This function is `inline` so that the SideEffect remains part of the caller's
+ * composition. Without `inline`, Compose may skip this wrapper during recomposition,
+ * preventing the SideEffect from running.
+ */
+@Composable
+inline fun RemeasureHostOnCompose(content: @Composable () -> Unit) {
+    val hostView = LocalView.current
+    SideEffect {
+        hostView.requestLayout()
+    }
+
+    content()
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/HierarchyListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/HierarchyListItemView.kt
@@ -3,19 +3,16 @@ package org.odk.collect.android.formhierarchy
 import android.content.Context
 import android.view.LayoutInflater
 import android.widget.FrameLayout
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.platform.LocalView
 import com.google.android.material.textview.MaterialTextView
 import org.odk.collect.android.R
 import org.odk.collect.android.widgets.MediaWidgetAnswerViewModel
 import org.odk.collect.android.widgets.WidgetAnswer
-import org.odk.collect.androidshared.R.dimen
 import org.odk.collect.androidshared.ui.ComposeThemeProvider.Companion.setContextThemedContent
-import org.odk.collect.androidshared.ui.compose.marginSmall
 import org.odk.collect.androidshared.ui.compose.marginStandard
 
 class HierarchyListItemView(context: Context, layoutResId: Int) : FrameLayout(context) {
@@ -31,6 +28,15 @@ class HierarchyListItemView(context: Context, layoutResId: Int) : FrameLayout(co
         findViewById<MaterialTextView>(R.id.primary_text).text = item.primaryText
         if (item is HierarchyItem.Question) {
             findViewById<ComposeView>(R.id.answer_view).setContextThemedContent {
+                val currentView = LocalView.current
+
+                // A ComposeView reused from the RecyclerView pool gets measured to 0 height on
+                // rebind, so the row renders blank after scrolling. Nudge a remeasure after
+                // composition to apply the real height.
+                SideEffect {
+                    currentView.requestLayout()
+                }
+
                 WidgetAnswer(
                     modifier = Modifier.padding(top = marginStandard()),
                     prompt = item.formEntryPrompt,

--- a/collect_app/src/main/java/org/odk/collect/android/formhierarchy/HierarchyListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formhierarchy/HierarchyListItemView.kt
@@ -4,15 +4,14 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.compose.foundation.layout.padding
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalView
 import com.google.android.material.textview.MaterialTextView
 import org.odk.collect.android.R
 import org.odk.collect.android.widgets.MediaWidgetAnswerViewModel
 import org.odk.collect.android.widgets.WidgetAnswer
 import org.odk.collect.androidshared.ui.ComposeThemeProvider.Companion.setContextThemedContent
+import org.odk.collect.androidshared.ui.compose.RemeasureHostOnCompose
 import org.odk.collect.androidshared.ui.compose.marginStandard
 
 class HierarchyListItemView(context: Context, layoutResId: Int) : FrameLayout(context) {
@@ -28,23 +27,16 @@ class HierarchyListItemView(context: Context, layoutResId: Int) : FrameLayout(co
         findViewById<MaterialTextView>(R.id.primary_text).text = item.primaryText
         if (item is HierarchyItem.Question) {
             findViewById<ComposeView>(R.id.answer_view).setContextThemedContent {
-                val currentView = LocalView.current
-
-                // A ComposeView reused from the RecyclerView pool gets measured to 0 height on
-                // rebind, so the row renders blank after scrolling. Nudge a remeasure after
-                // composition to apply the real height.
-                SideEffect {
-                    currentView.requestLayout()
+                RemeasureHostOnCompose {
+                    WidgetAnswer(
+                        modifier = Modifier.padding(top = marginStandard()),
+                        prompt = item.formEntryPrompt,
+                        answer = item.secondaryText,
+                        compact = true,
+                        mediaWidgetAnswerViewModel = mediaWidgetAnswerViewModel,
+                        onClick = onCLick
+                    )
                 }
-
-                WidgetAnswer(
-                    modifier = Modifier.padding(top = marginStandard()),
-                    prompt = item.formEntryPrompt,
-                    answer = item.secondaryText,
-                    compact = true,
-                    mediaWidgetAnswerViewModel = mediaWidgetAnswerViewModel,
-                    onClick = onCLick
-                )
             }
         }
     }


### PR DESCRIPTION
Closes #7275

#### Why is this the best possible solution? Were any other approaches considered?
The problem was not specific to question types and was not limited to image questions, as suggested in the issue. It was a general issue affecting question answers rendered with Jetpack Compose while being hosted inside a RecyclerView, as we are currently in the process of gradually migrating our UI to Jetpack Compose.                                                                                                              
                                                                                                                                                                                                                           
I initially expected this setup to work out of the box, but it appears there are some issues with combining Compose-based views and RecyclerView in this way.                                                            
                                                                                                                                                                                                                           
As explained in the comment, the issue was caused by the answer components not being measured correctly: a `ComposeView` reused from the RecyclerView pool keeps a stale, collapsed (0-height) measurement and is never re-measured on rebind, so the row renders blank. Fresh views work because they go through a full measure/layout pass.                                              
                                                                                                                                                                                                                           
I considered other approaches such as 
1. Changing `ViewCompositionStrategy`
2. Calling `disposeComposition()` on recycle
3. Disabling recycling for these rows
4. Migrating RecyclerView to LazyColumn

1,2 The first two don't help (the problem is layout-related, not a composition lifecycle issue).
3 Disabling recycling would give up on view recycling entirely. 
4 Migrating to LazyColumn should help but that would require way more changes and would be riskier.

Forcing a remeasure after composition keeps recycling intact and is the least invasive fix.    

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Question answers in the form hierarchy view no longer disappear after scrolling through a long list. The change is limited to how answer rows in the hierarchy view are laid out, so the regression risk is confined to that screen - mainly the rendering and sizing of answer rows as they are scrolled and recycled.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with many questions, so that the list in the hierarchy is long.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
