### PR TITLE
Fix max-pixels compression not applying to `ImageWidget`

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ImageCompressionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ImageCompressionTest.kt
@@ -1,0 +1,113 @@
+package org.odk.collect.android.feature.formentry
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.provider.MediaStore
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import org.hamcrest.Matcher
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.odk.collect.android.storage.StoragePathProvider
+import org.odk.collect.android.support.StorageUtils
+import org.odk.collect.android.support.rules.FormEntryActivityTestRule
+import org.odk.collect.android.support.rules.TestRuleChain.chain
+import org.odk.collect.androidtest.RecordedIntentsRule
+import org.odk.collect.draw.DrawActivity
+import org.odk.collect.testshared.WaitFor.waitFor
+import org.odk.collect.strings.R.string
+import org.odk.collect.testshared.AssertionFramework
+import java.io.File
+import java.io.FileOutputStream
+
+class ImageCompressionTest {
+    private val rule = FormEntryActivityTestRule()
+
+    @get:Rule
+    var chain: RuleChain = chain()
+        .around(RecordedIntentsRule())
+        .around(rule)
+
+    @Test
+    fun imageWidget_scalesCapturedImageDownToMaxPixels() {
+        rule
+            .setUpProjectAndCopyForm("image-compression.xml")
+            .fillNewForm("image-compression.xml", "image-compression")
+            .also {
+                stubCaptureReturningImage(hasAction(MediaStore.ACTION_IMAGE_CAPTURE))
+            }.clickOnString(string.capture_image, AssertionFramework.COMPOSE)
+
+        assertSavedImageWasScaledDownToMaxPixels()
+    }
+
+    @Test
+    fun annotateWidget_scalesCapturedImageDownToMaxPixels() {
+        rule
+            .setUpProjectAndCopyForm("image-compression.xml")
+            .fillNewForm("image-compression.xml", "image-compression")
+            .swipeToNextQuestion("Annotate")
+            .also {
+                stubCaptureReturningImage(hasAction(MediaStore.ACTION_IMAGE_CAPTURE))
+            }.clickOnString(string.capture_image)
+
+        assertSavedImageWasScaledDownToMaxPixels()
+    }
+
+    @Test
+    fun drawWidget_scalesCapturedImageDownToMaxPixels() {
+        rule
+            .setUpProjectAndCopyForm("image-compression.xml")
+            .fillNewForm("image-compression.xml", "image-compression")
+            .swipeToNextQuestion("Annotate")
+            .swipeToNextQuestion("Draw")
+            .also {
+                stubCaptureReturningImage(hasComponent(DrawActivity::class.java.name))
+            }.clickOnString(string.draw_image)
+
+        assertSavedImageWasScaledDownToMaxPixels()
+    }
+
+    @Test
+    fun signatureWidget_scalesCapturedImageDownToMaxPixels() {
+        rule
+            .setUpProjectAndCopyForm("image-compression.xml")
+            .fillNewForm("image-compression.xml", "image-compression")
+            .swipeToNextQuestion("Annotate")
+            .swipeToNextQuestion("Draw")
+            .swipeToNextQuestion("Signature")
+            .also {
+                stubCaptureReturningImage(hasComponent(DrawActivity::class.java.name))
+            }.clickOnString(string.sign_button)
+
+        assertSavedImageWasScaledDownToMaxPixels()
+    }
+
+    private fun stubCaptureReturningImage(captureIntent: Matcher<Intent>) {
+        // Long edge (2000) is twice the form's max image size, so it should be scaled down to 1000.
+        val bitmap = Bitmap.createBitmap(2000, 1000, Bitmap.Config.ARGB_8888)
+        val tmpImage = File(StoragePathProvider().getTmpImageFilePath())
+        FileOutputStream(tmpImage).use { bitmap.compress(Bitmap.CompressFormat.JPEG, 90, it) }
+
+        Intents.intending(captureIntent).respondWith(
+            Instrumentation.ActivityResult(Activity.RESULT_OK, null)
+        )
+    }
+
+    private fun assertSavedImageWasScaledDownToMaxPixels() {
+        waitFor {
+            val instanceDir = File(StorageUtils.getInstancesDirPath()).listFiles()!!.single()
+            val image = instanceDir.listFiles()!!.single { it.extension.equals("jpg", ignoreCase = true) }
+
+            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeFile(image.absolutePath, options)
+            assertThat(maxOf(options.outWidth, options.outHeight), equalTo(1000))
+        }
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ImageCompressionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ImageCompressionTest.kt
@@ -16,77 +16,106 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.odk.collect.android.storage.StoragePathProvider
-import org.odk.collect.android.support.StorageUtils
-import org.odk.collect.android.support.rules.FormEntryActivityTestRule
+import org.odk.collect.android.support.TestDependencies
+import org.odk.collect.android.support.pages.SendFinalizedFormPage
+import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 import org.odk.collect.androidtest.RecordedIntentsRule
 import org.odk.collect.draw.DrawActivity
-import org.odk.collect.testshared.WaitFor.waitFor
 import org.odk.collect.strings.R.string
 import org.odk.collect.testshared.AssertionFramework
 import java.io.File
 import java.io.FileOutputStream
 
 class ImageCompressionTest {
-    private val rule = FormEntryActivityTestRule()
+    private val testDependencies = TestDependencies()
+    private val rule = CollectTestRule(useDemoProject = false)
 
     @get:Rule
-    var chain: RuleChain = chain()
+    val chain: RuleChain = chain(testDependencies)
         .around(RecordedIntentsRule())
         .around(rule)
 
     @Test
     fun imageWidget_scalesCapturedImageDownToMaxPixels() {
-        rule
-            .setUpProjectAndCopyForm("image-compression.xml")
-            .fillNewForm("image-compression.xml", "image-compression")
+        rule.withProject(testDependencies.server, "image-compression.xml")
+            .startBlankForm("image-compression")
             .also {
                 stubCaptureReturningImage(hasAction(MediaStore.ACTION_IMAGE_CAPTURE), 2000)
-            }.clickOnString(string.capture_image, AssertionFramework.COMPOSE)
+            }
+            .clickOnString(string.capture_image, AssertionFramework.COMPOSE)
+            .clickGoToArrow()
+            .clickGoToEnd()
+            .clickFinalize()
+            .clickSendFinalizedForm(1)
+            .clickSelectAll()
+            .clickSendSelected()
+            .clickOK(SendFinalizedFormPage())
 
-        assertSavedImageWasScaledTo(1000)
+        assertSubmittedImageWasScaledTo(1000)
     }
 
     @Test
     fun annotateWidget_scalesCapturedImageDownToMaxPixels() {
-        rule
-            .setUpProjectAndCopyForm("image-compression.xml")
-            .fillNewForm("image-compression.xml", "image-compression")
+        rule.withProject(testDependencies.server, "image-compression.xml")
+            .startBlankForm("image-compression")
             .swipeToNextQuestion("Annotate")
             .also {
                 stubCaptureReturningImage(hasAction(MediaStore.ACTION_IMAGE_CAPTURE), 2000)
-            }.clickOnString(string.capture_image)
+            }
+            .clickOnString(string.capture_image)
+            .clickGoToArrow()
+            .clickGoToEnd()
+            .clickFinalize()
+            .clickSendFinalizedForm(1)
+            .clickSelectAll()
+            .clickSendSelected()
+            .clickOK(SendFinalizedFormPage())
 
-        assertSavedImageWasScaledTo(1000)
+        assertSubmittedImageWasScaledTo(1000)
     }
 
     @Test
     fun drawWidget_scalesCapturedImageDownToMaxPixels() {
-        rule
-            .setUpProjectAndCopyForm("image-compression.xml")
-            .fillNewForm("image-compression.xml", "image-compression")
+        rule.withProject(testDependencies.server, "image-compression.xml")
+            .startBlankForm("image-compression")
             .swipeToNextQuestion("Annotate")
             .swipeToNextQuestion("Draw")
             .also {
                 stubCaptureReturningImage(hasComponent(DrawActivity::class.java.name), 2000)
-            }.clickOnString(string.draw_image)
+            }
+            .clickOnString(string.draw_image)
+            .clickGoToArrow()
+            .clickGoToEnd()
+            .clickFinalize()
+            .clickSendFinalizedForm(1)
+            .clickSelectAll()
+            .clickSendSelected()
+            .clickOK(SendFinalizedFormPage())
 
-        assertSavedImageWasScaledTo(1000)
+        assertSubmittedImageWasScaledTo(1000)
     }
 
     @Test
     fun signatureWidget_scalesCapturedImageDownToMaxPixels() {
-        rule
-            .setUpProjectAndCopyForm("image-compression.xml")
-            .fillNewForm("image-compression.xml", "image-compression")
+        rule.withProject(testDependencies.server, "image-compression.xml")
+            .startBlankForm("image-compression")
             .swipeToNextQuestion("Annotate")
             .swipeToNextQuestion("Draw")
             .swipeToNextQuestion("Signature")
             .also {
                 stubCaptureReturningImage(hasComponent(DrawActivity::class.java.name), 2000)
-            }.clickOnString(string.sign_button)
+            }
+            .clickOnString(string.sign_button)
+            .clickGoToArrow()
+            .clickGoToEnd()
+            .clickFinalize()
+            .clickSendFinalizedForm(1)
+            .clickSelectAll()
+            .clickSendSelected()
+            .clickOK(SendFinalizedFormPage())
 
-        assertSavedImageWasScaledTo(1000)
+        assertSubmittedImageWasScaledTo(1000)
     }
 
     private fun stubCaptureReturningImage(captureIntent: Matcher<Intent>, longEdge: Int) {
@@ -99,14 +128,13 @@ class ImageCompressionTest {
         )
     }
 
-    private fun assertSavedImageWasScaledTo(longEdge: Int) {
-        waitFor {
-            val instanceDir = File(StorageUtils.getInstancesDirPath()).listFiles()!!.single()
-            val image = instanceDir.listFiles()!!.single { it.extension.equals("jpg", ignoreCase = true) }
-
-            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-            BitmapFactory.decodeFile(image.absolutePath, options)
-            assertThat(maxOf(options.outWidth, options.outHeight), equalTo(longEdge))
+    private fun assertSubmittedImageWasScaledTo(longEdge: Int) {
+        val image = testDependencies.server.submittedMediaFiles.single {
+            it.extension.equals("jpg", ignoreCase = true)
         }
+
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(image.absolutePath, options)
+        assertThat(maxOf(options.outWidth, options.outHeight), equalTo(longEdge))
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ImageCompressionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ImageCompressionTest.kt
@@ -41,10 +41,10 @@ class ImageCompressionTest {
             .setUpProjectAndCopyForm("image-compression.xml")
             .fillNewForm("image-compression.xml", "image-compression")
             .also {
-                stubCaptureReturningImage(hasAction(MediaStore.ACTION_IMAGE_CAPTURE))
+                stubCaptureReturningImage(hasAction(MediaStore.ACTION_IMAGE_CAPTURE), 2000)
             }.clickOnString(string.capture_image, AssertionFramework.COMPOSE)
 
-        assertSavedImageWasScaledDownToMaxPixels()
+        assertSavedImageWasScaledTo(1000)
     }
 
     @Test
@@ -54,10 +54,10 @@ class ImageCompressionTest {
             .fillNewForm("image-compression.xml", "image-compression")
             .swipeToNextQuestion("Annotate")
             .also {
-                stubCaptureReturningImage(hasAction(MediaStore.ACTION_IMAGE_CAPTURE))
+                stubCaptureReturningImage(hasAction(MediaStore.ACTION_IMAGE_CAPTURE), 2000)
             }.clickOnString(string.capture_image)
 
-        assertSavedImageWasScaledDownToMaxPixels()
+        assertSavedImageWasScaledTo(1000)
     }
 
     @Test
@@ -68,10 +68,10 @@ class ImageCompressionTest {
             .swipeToNextQuestion("Annotate")
             .swipeToNextQuestion("Draw")
             .also {
-                stubCaptureReturningImage(hasComponent(DrawActivity::class.java.name))
+                stubCaptureReturningImage(hasComponent(DrawActivity::class.java.name), 2000)
             }.clickOnString(string.draw_image)
 
-        assertSavedImageWasScaledDownToMaxPixels()
+        assertSavedImageWasScaledTo(1000)
     }
 
     @Test
@@ -83,15 +83,14 @@ class ImageCompressionTest {
             .swipeToNextQuestion("Draw")
             .swipeToNextQuestion("Signature")
             .also {
-                stubCaptureReturningImage(hasComponent(DrawActivity::class.java.name))
+                stubCaptureReturningImage(hasComponent(DrawActivity::class.java.name), 2000)
             }.clickOnString(string.sign_button)
 
-        assertSavedImageWasScaledDownToMaxPixels()
+        assertSavedImageWasScaledTo(1000)
     }
 
-    private fun stubCaptureReturningImage(captureIntent: Matcher<Intent>) {
-        // Long edge (2000) is twice the form's max image size, so it should be scaled down to 1000.
-        val bitmap = Bitmap.createBitmap(2000, 1000, Bitmap.Config.ARGB_8888)
+    private fun stubCaptureReturningImage(captureIntent: Matcher<Intent>, longEdge: Int) {
+        val bitmap = Bitmap.createBitmap(longEdge, longEdge / 2, Bitmap.Config.ARGB_8888)
         val tmpImage = File(StoragePathProvider().getTmpImageFilePath())
         FileOutputStream(tmpImage).use { bitmap.compress(Bitmap.CompressFormat.JPEG, 90, it) }
 
@@ -100,14 +99,14 @@ class ImageCompressionTest {
         )
     }
 
-    private fun assertSavedImageWasScaledDownToMaxPixels() {
+    private fun assertSavedImageWasScaledTo(longEdge: Int) {
         waitFor {
             val instanceDir = File(StorageUtils.getInstancesDirPath()).listFiles()!!.single()
             val image = instanceDir.listFiles()!!.single { it.extension.equals("jpg", ignoreCase = true) }
 
             val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
             BitmapFactory.decodeFile(image.absolutePath, options)
-            assertThat(maxOf(options.outWidth, options.outHeight), equalTo(1000))
+            assertThat(maxOf(options.outWidth, options.outHeight), equalTo(longEdge))
         }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.kt
@@ -34,6 +34,7 @@ class StubOpenRosaServer : OpenRosaHttpInterface {
      * A list of submitted forms, maintained in the original order of submission, with the oldest forms appearing first.
      */
     private val submittedForms: MutableList<File> = mutableListOf()
+    private val submittedAttachments: MutableList<File> = mutableListOf()
     private val deletedEntities: MutableList<String> = mutableListOf()
     private var includeIntegrityUrl = false
 
@@ -43,6 +44,9 @@ class StubOpenRosaServer : OpenRosaHttpInterface {
 
     val submissions: List<File>
         get() = submittedForms
+
+    val submittedMediaFiles: List<File>
+        get() = submittedAttachments
 
     var accesses = 0
         private set
@@ -135,6 +139,7 @@ class StubOpenRosaServer : OpenRosaHttpInterface {
             return HttpPostResult("", 401, "")
         } else if (uri.path == OpenRosaConstants.SUBMISSION) {
             submittedForms.add(submissionFile)
+            submittedAttachments.addAll(fileList)
             return HttpPostResult("", 201, "")
         } else {
             return HttpPostResult("", 404, "")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -309,8 +309,9 @@ abstract class Page<T : Page<T>> {
         return destination
     }
 
-    fun clickOnString(stringID: Int): T {
-        clickOnText(getTranslatedString(stringID))
+    @JvmOverloads
+    fun clickOnString(stringID: Int, assertionFramework: AssertionFramework = AssertionFramework.ESPRESSO): T {
+        clickOnText(getTranslatedString(stringID), assertionFramework)
         return this as T
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -5,15 +5,14 @@ import static org.odk.collect.settings.keys.ProjectKeys.KEY_IMAGE_SIZE;
 import android.net.Uri;
 import android.os.AsyncTask;
 
+import org.javarosa.core.model.Constants;
 import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.utilities.ContentUriHelper;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.ImageCompressionController;
-import org.odk.collect.android.widgets.BaseImageWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
-import org.odk.collect.android.widgets.image.ImageWidget;
 import org.odk.collect.androidshared.ui.DialogFragmentUtils;
 import org.odk.collect.settings.SettingsProvider;
 
@@ -52,8 +51,8 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             FileUtils.saveAnswerFileFromUri(uris[0], newFile, Collect.getInstance());
             QuestionWidget questionWidget = formFillingActivity.get().getWidgetWaitingForBinaryData();
 
-            // apply image conversion if the widget is an image widget
-            if (questionWidget instanceof BaseImageWidget || questionWidget instanceof ImageWidget) {
+            // apply image conversion if the question is an image question
+            if (questionWidget.getFormEntryPrompt().getControlType() == Constants.CONTROL_IMAGE_CHOOSE) {
                 String imageSizeMode = settingsProvider.getUnprotectedSettings().getString(KEY_IMAGE_SIZE);
                 imageCompressionController.execute(newFile.getPath(), questionWidget.getFormEntryPrompt(), formFillingActivity.get(), imageSizeMode);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.ImageCompressionController;
 import org.odk.collect.android.widgets.BaseImageWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
+import org.odk.collect.android.widgets.image.ImageWidget;
 import org.odk.collect.androidshared.ui.DialogFragmentUtils;
 import org.odk.collect.settings.SettingsProvider;
 
@@ -52,7 +53,7 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             QuestionWidget questionWidget = formFillingActivity.get().getWidgetWaitingForBinaryData();
 
             // apply image conversion if the widget is an image widget
-            if (questionWidget instanceof BaseImageWidget) {
+            if (questionWidget instanceof BaseImageWidget || questionWidget instanceof ImageWidget) {
                 String imageSizeMode = settingsProvider.getUnprotectedSettings().getString(KEY_IMAGE_SIZE);
                 imageCompressionController.execute(newFile.getPath(), questionWidget, formFillingActivity.get(), imageSizeMode);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -55,7 +55,7 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             // apply image conversion if the widget is an image widget
             if (questionWidget instanceof BaseImageWidget || questionWidget instanceof ImageWidget) {
                 String imageSizeMode = settingsProvider.getUnprotectedSettings().getString(KEY_IMAGE_SIZE);
-                imageCompressionController.execute(newFile.getPath(), questionWidget, formFillingActivity.get(), imageSizeMode);
+                imageCompressionController.execute(newFile.getPath(), questionWidget.getFormEntryPrompt(), formFillingActivity.get(), imageSizeMode);
             }
             return newFile;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -2,6 +2,7 @@ package org.odk.collect.android.tasks;
 
 import static org.odk.collect.settings.keys.ProjectKeys.KEY_IMAGE_SIZE;
 
+import android.annotation.SuppressLint;
 import android.net.Uri;
 import android.os.AsyncTask;
 
@@ -42,6 +43,7 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
         DaggerUtils.getComponent(this.formFillingActivity.get()).inject(this);
     }
 
+    @SuppressLint("WrongThread")
     @Override
     protected File doInBackground(Uri... uris) {
         if (instanceFile != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ImageCompressionController.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ImageCompressionController.kt
@@ -1,20 +1,20 @@
 package org.odk.collect.android.utilities
 
 import android.content.Context
+import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.R
-import org.odk.collect.android.widgets.QuestionWidget
 import org.odk.collect.androidshared.bitmap.ImageCompressor
 import timber.log.Timber
 
 class ImageCompressionController(private val imageCompressor: ImageCompressor) {
     fun execute(
         imagePath: String,
-        questionWidget: QuestionWidget,
+        prompt: FormEntryPrompt,
         context: Context,
         imageSizeMode: String
     ) {
         var maxPixels: Int?
-        maxPixels = getMaxPixelsFromFormIfDefined(questionWidget)
+        maxPixels = getMaxPixelsFromFormIfDefined(prompt)
         if (maxPixels == null) {
             maxPixels = getMaxPixelsFromSettings(context, imageSizeMode)
         }
@@ -23,8 +23,8 @@ class ImageCompressionController(private val imageCompressor: ImageCompressor) {
         }
     }
 
-    private fun getMaxPixelsFromFormIfDefined(questionWidget: QuestionWidget): Int? {
-        for (bindAttribute in questionWidget.formEntryPrompt.bindAttributes) {
+    private fun getMaxPixelsFromFormIfDefined(prompt: FormEntryPrompt): Int? {
+        for (bindAttribute in prompt.bindAttributes) {
             if ("max-pixels" == bindAttribute.name && ApplicationConstants.Namespaces.XML_OPENROSA_NAMESPACE == bindAttribute.namespace) {
                 try {
                     return bindAttribute.attributeValue?.toInt()

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ImageCompressionControllerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ImageCompressionControllerTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import org.odk.collect.android.widgets.QuestionWidget
 import org.odk.collect.androidshared.bitmap.ImageCompressor
 
 @RunWith(AndroidJUnit4::class)
@@ -19,9 +18,6 @@ class ImageCompressionControllerTest {
 
     private val context = ApplicationProvider.getApplicationContext<Application>()
     private val formEntryPrompt = mock<FormEntryPrompt>()
-    private val questionWidget = mock<QuestionWidget>().also {
-        whenever(it.formEntryPrompt).thenReturn(formEntryPrompt)
-    }
     private val treeElement = mock<TreeElement>().also {
         whenever(it.attributeValue).thenReturn("123")
         whenever(it.name).thenReturn("max-pixels")
@@ -34,7 +30,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is not specified on a form level and expected image size in setting is 'original_image_size', image compression should not be triggered`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(emptyList())
 
-        imageCompressionController.execute("/path", questionWidget, context, "original_image_size")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "original_image_size")
 
         verifyNoInteractions(imageCompressor)
     }
@@ -43,7 +39,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is not specified on a form level and expected image size in setting is 'very_small', image compression should be triggered for 640px`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(emptyList())
 
-        imageCompressionController.execute("/path", questionWidget, context, "very_small")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "very_small")
 
         verify(imageCompressor).execute("/path", 640)
     }
@@ -52,7 +48,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is not specified on a form level and expected image size in setting is 'small', image compression should be triggered for 1024px`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(emptyList())
 
-        imageCompressionController.execute("/path", questionWidget, context, "small")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "small")
 
         verify(imageCompressor).execute("/path", 1024)
     }
@@ -61,7 +57,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is not specified on a form level and expected image size in setting is 'medium', image compression should be triggered for 2048px`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(emptyList())
 
-        imageCompressionController.execute("/path", questionWidget, context, "medium")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "medium")
 
         verify(imageCompressor).execute("/path", 2048)
     }
@@ -70,7 +66,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is not specified on a form level and expected image size in setting is 'large', image compression should be triggered for 3072px`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(emptyList())
 
-        imageCompressionController.execute("/path", questionWidget, context, "large")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "large")
 
         verify(imageCompressor).execute("/path", 3072)
     }
@@ -79,7 +75,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is specified on a form level and expected image size in setting is 'original_image_size', image compression should be triggered for value stored in 'max-pixels'`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "original_image_size")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "original_image_size")
 
         verify(imageCompressor).execute("/path", 123)
     }
@@ -88,7 +84,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is specified on a form level and expected image size in setting is 'very_small', image compression should be triggered and the value stored in for value stored in 'max-pixels' should take precedence`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "very_small")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "very_small")
 
         verify(imageCompressor).execute("/path", 123)
     }
@@ -97,7 +93,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is specified on a form level and expected image size in setting is 'small', image compression should be triggered and the value stored in for value stored in 'max-pixels' should take precedence`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "small")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "small")
 
         verify(imageCompressor).execute("/path", 123)
     }
@@ -106,7 +102,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is specified on a form level and expected image size in setting is 'medium', image compression should be triggered and the value stored in for value stored in 'max-pixels' should take precedence`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "medium")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "medium")
 
         verify(imageCompressor).execute("/path", 123)
     }
@@ -115,7 +111,7 @@ class ImageCompressionControllerTest {
     fun `when 'max-pixels' is specified on a form level and expected image size in setting is 'large', image compression should be triggered and the value stored in for value stored in 'max-pixels' should take precedence`() {
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "large")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "large")
 
         verify(imageCompressor).execute("/path", 123)
     }
@@ -125,7 +121,7 @@ class ImageCompressionControllerTest {
         whenever(treeElement.attributeValue).thenReturn("123.5")
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "original_image_size")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "original_image_size")
 
         verifyNoInteractions(imageCompressor)
     }
@@ -135,7 +131,7 @@ class ImageCompressionControllerTest {
         whenever(treeElement.attributeValue).thenReturn("123.5")
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "very_small")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "very_small")
 
         verify(imageCompressor).execute("/path", 640)
     }
@@ -145,7 +141,7 @@ class ImageCompressionControllerTest {
         whenever(treeElement.attributeValue).thenReturn("123.5")
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "small")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "small")
 
         verify(imageCompressor).execute("/path", 1024)
     }
@@ -155,7 +151,7 @@ class ImageCompressionControllerTest {
         whenever(treeElement.attributeValue).thenReturn("123.5")
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "medium")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "medium")
 
         verify(imageCompressor).execute("/path", 2048)
     }
@@ -165,7 +161,7 @@ class ImageCompressionControllerTest {
         whenever(treeElement.attributeValue).thenReturn("123.5")
         whenever(formEntryPrompt.bindAttributes).thenReturn(listOf(treeElement))
 
-        imageCompressionController.execute("/path", questionWidget, context, "large")
+        imageCompressionController.execute("/path", formEntryPrompt, context, "large")
 
         verify(imageCompressor).execute("/path", 3072)
     }

--- a/test-forms/src/main/resources/forms/image-compression.xml
+++ b/test-forms/src/main/resources/forms/image-compression.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<h:html
+    xmlns="http://www.w3.org/2002/xforms"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:odk="http://www.opendatakit.org/xforms">
+    <h:head>
+        <h:title>image-compression</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="image-compression">
+                    <image/>
+                    <annotate/>
+                    <draw/>
+                    <signature/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/image" type="binary" orx:max-pixels="1000"/>
+            <bind nodeset="/data/annotate" type="binary" orx:max-pixels="1000"/>
+            <bind nodeset="/data/draw" type="binary" orx:max-pixels="1000"/>
+            <bind nodeset="/data/signature" type="binary" orx:max-pixels="1000"/>
+            <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
+        </model>
+    </h:head>
+    <h:body>
+        <upload mediatype="image/*" ref="/data/image">
+            <label>Image</label>
+        </upload>
+        <upload appearance="annotate" mediatype="image/*" ref="/data/annotate">
+            <label>Annotate</label>
+        </upload>
+        <upload appearance="draw" mediatype="image/*" ref="/data/draw">
+            <label>Draw</label>
+        </upload>
+        <upload appearance="signature" mediatype="image/*" ref="/data/signature">
+            <label>Signature</label>
+        </upload>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #7277 

#### Why is this the best possible solution? Were any other approaches considered?
We recently refactored `ImageWidget` and detached it from the old hierarchy (it previously extended `BaseImageWidget`). As a result, we now need to explicitly handle it in `MediaLoadingTask`, where we determine whether image compression should be triggered.

This is probably not the ideal architecture (although it has been working this way for a long time), as `MediaLoadingTask` is responsible for more than just image loading. A better long-term solution would be to move the compression logic into the image widgets themselves. However, that would require a larger refactoring, and with the release just around the corner, this doesn't seem like the right time for such a change.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The fix is tiny and carries virtually no risk. A simple check to verify that compression works for basic image widgets is sufficient.

#### Do we need any specific form for testing your changes? If so, please attach one.
There's a form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
