### PR TITLE
Add GIF support to Coil ImageLoader

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -350,6 +350,7 @@ dependencies {
     implementation(libs.androidXComposeMaterialIcons)
     implementation(libs.androidXComposePreview)
     implementation(libs.coil)
+    implementation(libs.coil.gif)
 
     testImplementation project(':forms-test')
 

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.kt
@@ -1,13 +1,8 @@
 package org.odk.collect.android.application.initialization
 
 import android.app.Application
-import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.startup.AppInitializer
-import coil3.ImageLoader
-import coil3.SingletonImageLoader
-import coil3.gif.AnimatedImageDecoder
-import coil3.gif.GifDecoder
 import net.danlew.android.joda.JodaTimeInitializer
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.BuildConfig
@@ -61,6 +56,7 @@ class ApplicationInitializer(
         ).initialize()
         mapsInitializer.initialize()
         JavaRosaInitializer(propertyManager, projectsDataService, entitiesRepositoryProvider).initialize()
+        CoilInitializer().initialize()
     }
 
     private fun initializeFrameworks() {
@@ -68,21 +64,6 @@ class ApplicationInitializer(
         initializeLogging()
         AppInitializer.getInstance(context).initializeComponent(JodaTimeInitializer::class.java)
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
-        initializeImageLoader()
-    }
-
-    private fun initializeImageLoader() {
-        SingletonImageLoader.setSafe { context ->
-            ImageLoader.Builder(context)
-                .components {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        add(AnimatedImageDecoder.Factory())
-                    } else {
-                        add(GifDecoder.Factory())
-                    }
-                }
-                .build()
-        }
     }
 
     private fun initializeLocale() {

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.kt
@@ -1,8 +1,13 @@
 package org.odk.collect.android.application.initialization
 
 import android.app.Application
+import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.startup.AppInitializer
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.gif.AnimatedImageDecoder
+import coil3.gif.GifDecoder
 import net.danlew.android.joda.JodaTimeInitializer
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.BuildConfig
@@ -63,6 +68,21 @@ class ApplicationInitializer(
         initializeLogging()
         AppInitializer.getInstance(context).initializeComponent(JodaTimeInitializer::class.java)
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
+        initializeImageLoader()
+    }
+
+    private fun initializeImageLoader() {
+        SingletonImageLoader.setSafe { context ->
+            ImageLoader.Builder(context)
+                .components {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        add(AnimatedImageDecoder.Factory())
+                    } else {
+                        add(GifDecoder.Factory())
+                    }
+                }
+                .build()
+        }
     }
 
     private fun initializeLocale() {

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/CoilInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/CoilInitializer.kt
@@ -1,0 +1,24 @@
+package org.odk.collect.android.application.initialization
+
+import android.os.Build
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.gif.AnimatedImageDecoder
+import coil3.gif.GifDecoder
+
+class CoilInitializer {
+
+    fun initialize() {
+        SingletonImageLoader.setSafe { context ->
+            ImageLoader.Builder(context)
+                .components {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        add(AnimatedImageDecoder.Factory())
+                    } else {
+                        add(GifDecoder.Factory())
+                    }
+                }
+                .build()
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,6 +101,7 @@ jsoup = { group = "org.jsoup", name = "jsoup", version = "1.22.1" }
 mlkit-barcodescanning = { group = "com.google.android.gms", name = "play-services-mlkit-barcode-scanning", version = "18.3.1" }
 runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
 coil = { group = "io.coil-kt.coil3", name = "coil-compose", version = "3.4.0" }
+coil-gif = { group = "io.coil-kt.coil3", name = "coil-gif", version = "3.4.0" }
 
 # Test dependencies
 junit = { group = "junit", name = "junit", version = "4.13.2" }


### PR DESCRIPTION
Closes #7281 

#### Why is this the best possible solution? Were any other approaches considered?
Coil does not include a GIF decoder by default. If we want GIF support, we need to add it explicitly.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Animated GIFs now play correctly again in the image widget, restoring the pre-migration behavior.
The fix is simple: it does not change how other image types are displayed and only re-enables GIF playback, so it should be safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
