### PR TITLE
fix: update Carto basemap tile URLs to HTTPS

### DIFF
--- a/mapbox/src/main/java/org/odk/collect/mapbox/Configurations.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/Configurations.kt
@@ -68,11 +68,11 @@ object Configurations {
             styleOptions = mapOf(
                 "positron" to StyleOption(
                     name = R.string.carto_map_style_positron,
-                    BasemapUri.Raster("http://1.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png")
+                    BasemapUri.Raster("https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png")
                 ),
                 "dark_matter" to StyleOption(
                     name = R.string.carto_map_style_dark_matter,
-                    BasemapUri.Raster("http://1.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png")
+                    BasemapUri.Raster("https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png")
                 )
             )
         ),

--- a/mapbox/src/test/java/org/odk/collect/mapbox/ConfigurationsTest.kt
+++ b/mapbox/src/test/java/org/odk/collect/mapbox/ConfigurationsTest.kt
@@ -1,0 +1,22 @@
+package org.odk.collect.mapbox
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.startsWith
+import org.junit.Test
+import org.odk.collect.settings.keys.ProjectKeys
+
+class ConfigurationsTest {
+    @Test
+    fun cartoStyleUrisUseHttps() {
+        val cartoStyleOptions = Configurations.all[ProjectKeys.BASEMAP_SOURCE_CARTO]!!.styleOptions
+
+        val positronUri = cartoStyleOptions["positron"]!!.uri.value
+        val darkMatterUri = cartoStyleOptions["dark_matter"]!!.uri.value
+
+        assertThat(positronUri, startsWith("https://"))
+        assertThat(darkMatterUri, startsWith("https://"))
+        assertThat(positronUri, equalTo("https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"))
+        assertThat(darkMatterUri, equalTo("https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"))
+    }
+}


### PR DESCRIPTION
Closes #7250

#### Why is this the best possible solution? Were any other approaches considered?

Carto serves the `positron` (`light_all`) and `dark_matter` (`dark_all`) raster basemap styles over HTTPS at the same paths, so switching the two tile URLs from `http://` to `https://` is a drop-in fix with no behavioral change. The subdomain form `https://a.basemaps.cartocdn.com/...` matches Carto's documented basemap endpoints. These were the only two cleartext Carto tile URLs in the codebase.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Carto basemap tiles (positron / dark_matter) now load over HTTPS instead of cleartext HTTP. The tiles themselves are unchanged; only the transport scheme differs. Regression risk is limited to those two Carto styles - if the HTTPS host or path were wrong the basemaps would fail to load, which the added unit test guards against.

#### Do we need any specific form for testing your changes? If so, please attach one.

No special form needed. Switch a project's basemap source to Carto (positron or dark_matter) and confirm tiles load.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators (N/A - no new strings)
- [x] added any new strings with date formatting to `DateFormatsTest` (N/A - no new strings)
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html). (N/A - no external code or assets)
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines) (N/A - no new UI elements)
