### PR TITLE
Fix missing basemap attribution in geopoint map

### DIFF
--- a/geo/src/main/res/layout-land/geopoint_layout.xml
+++ b/geo/src/main/res/layout-land/geopoint_layout.xml
@@ -17,7 +17,8 @@
         android:id="@+id/map_container"
         android:name="org.odk.collect.maps.MapFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/status_section" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/geo/src/main/res/layout/geopoint_layout.xml
+++ b/geo/src/main/res/layout/geopoint_layout.xml
@@ -17,7 +17,8 @@
         android:id="@+id/map_container"
         android:name="org.odk.collect.maps.MapFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/status_section" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton


### PR DESCRIPTION
Closes #5390 

#### Why is this the best possible solution? Were any other approaches considered?
The map container used wrap_content with only a top constraint, so the map extended past the screen bottom and the SDK-rendered attribution fell off-screen.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users now see the basemap attribution at the bottom of the Geopoint map. Layout-only change, so the only risk is map sizing on that screen - a quick visual check of the Geopoint map (attribution visible, map fills the area) in portrait and landscape covers it. 

#### Do we need any specific form for testing your changes? If so, please attach one.
The `All question types` form, which is available on the demo server.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
