### PR TITLE
Keep DrawView bitmap at original image resolution

### DIFF
--- a/draw/src/main/java/org/odk/collect/draw/DrawView.kt
+++ b/draw/src/main/java/org/odk/collect/draw/DrawView.kt
@@ -17,6 +17,7 @@ package org.odk.collect.draw
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
@@ -27,6 +28,7 @@ import android.view.View
 import org.odk.collect.androidshared.bitmap.ImageFileUtils
 import java.io.File
 import javax.inject.Inject
+import androidx.core.graphics.withTranslation
 
 class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
 
@@ -50,7 +52,6 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
 
     private var canvas = Canvas()
     private var currentPath = Path()
-    private var offscreenPath = Path()
     private var valueX = 0f
     private var valueY = 0f
 
@@ -60,13 +61,16 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
     val bitmapWidth: Int
         get() = bitmap.width
 
+    private val displayScale: Float
+        get() = minOf(width.toFloat() / bitmap.width, height.toFloat() / bitmap.height)
+
     // Centered horizontally
-    private val bitmapLeft: Int
-        get() = (width - bitmap.width) / 2
+    private val displayLeft: Float
+        get() = (width - bitmap.width * displayScale) / 2f
 
     // Centered vertically
-    private val bitmapTop: Int
-        get() = (height - bitmap.height) / 2
+    private val displayTop: Float
+        get() = (height - bitmap.height * displayScale) / 2f
 
     private var isSignature = false
 
@@ -79,7 +83,12 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
     }
 
     override fun onDraw(canvas: Canvas) {
-        drawOnCanvas(canvas, bitmapLeft.toFloat(), bitmapTop.toFloat())
+        canvas.drawColor(0xFFAAAAAA.toInt())
+        canvas.withTranslation(displayLeft, displayTop) {
+            scale(displayScale, displayScale)
+            drawBitmap(bitmap, 0f, 0f, Paint(Paint.DITHER_FLAG))
+            drawPath(currentPath, paint)
+        }
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
@@ -123,22 +132,23 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
         canvas.drawPath(currentPath, paint)
     }
 
+    private fun toBitmapX(x: Float) = (x - displayLeft) / displayScale
+    private fun toBitmapY(y: Float) = (y - displayTop) / displayScale
+
     private fun touchStart(x: Float, y: Float) {
+        paint.strokeWidth = 10f / displayScale
         currentPath.reset()
-        currentPath.moveTo(x, y)
-        offscreenPath.reset()
-        offscreenPath.moveTo(x - bitmapLeft, y - bitmapTop)
+        currentPath.moveTo(toBitmapX(x), toBitmapY(y))
         valueX = x
         valueY = y
     }
 
     private fun touchMove(x: Float, y: Float) {
-        currentPath.quadTo(valueX, valueY, (x + valueX) / 2, (y + valueY) / 2)
-        offscreenPath.quadTo(
-            valueX - bitmapLeft,
-            valueY - bitmapTop,
-            (x + valueX) / 2 - bitmapLeft,
-            (y + valueY) / 2 - bitmapTop
+        currentPath.quadTo(
+            toBitmapX(valueX),
+            toBitmapY(valueY),
+            toBitmapX((x + valueX) / 2),
+            toBitmapY((y + valueY) / 2)
         )
         valueX = x
         valueY = y
@@ -146,13 +156,12 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
 
     private fun touchUp() {
         if (currentPath.isEmpty) {
-            canvas.drawPoint(valueX, valueY, paint)
+            canvas.drawPoint(toBitmapX(valueX), toBitmapY(valueY), paint)
         } else {
-            currentPath.lineTo(valueX, valueY)
-            offscreenPath.lineTo(valueX - bitmapLeft, valueY - bitmapTop)
+            currentPath.lineTo(toBitmapX(valueX), toBitmapY(valueY))
 
             // commit the path to our offscreen
-            canvas.drawPath(offscreenPath, paint)
+            canvas.drawPath(currentPath, paint)
         }
         // kill this so we don't double draw
         currentPath.reset()
@@ -174,7 +183,7 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
     private fun resetImage(width: Int, height: Int) {
         val backgroundBitmapFile = File(imagePath)
         if (backgroundBitmapFile.exists()) {
-            bitmap = ImageFileUtils.getBitmapScaledToDisplay(backgroundBitmapFile, height, width, true)!!
+            bitmap = ImageFileUtils.getBitmap(backgroundBitmapFile.absolutePath, BitmapFactory.Options())!!
                 .copy(Bitmap.Config.ARGB_8888, true)
             canvas = Canvas(bitmap)
         } else {

--- a/draw/src/test/java/org/odk/collect/draw/DrawActivityTest.kt
+++ b/draw/src/test/java/org/odk/collect/draw/DrawActivityTest.kt
@@ -2,6 +2,9 @@ package org.odk.collect.draw
 
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -13,6 +16,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.odk.collect.androidshared.bitmap.ImageFileUtils
 import org.odk.collect.androidtest.ActivityScenarioExtensions.isFinishing
 import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.async.Scheduler
@@ -31,6 +36,7 @@ internal class DrawActivityTest {
 
     private val application: RobolectricApplication by lazy { getApplicationContext() }
     private val scheduler = FakeScheduler()
+    private val imagePath = TempFiles.createTempFile().absolutePath
 
     @Before
     fun setup() {
@@ -45,7 +51,7 @@ internal class DrawActivityTest {
                 }
 
                 override fun providesImagePath(): String {
-                    return TempFiles.createTempFile().absolutePath
+                    return imagePath
                 }
             }
         )
@@ -88,5 +94,28 @@ internal class DrawActivityTest {
         scheduler.flush()
         assertThat(scenario.isFinishing, equalTo(true))
         assertThat(scenario.result.resultCode, equalTo(Activity.RESULT_OK))
+    }
+
+    @Test
+    @Config(qualifiers = "w400dp-h700dp-mdpi")
+    fun `saved image keeps the original image resolution when annotating`() {
+        val originalImage = Bitmap.createBitmap(800, 1400, Bitmap.Config.ARGB_8888)
+        val originalImageFile = TempFiles.createTempFile(".png")
+        ImageFileUtils.saveBitmapToFile(originalImage, originalImageFile.absolutePath)
+
+        val intent = Intent(getApplicationContext(), DrawActivity::class.java).apply {
+            putExtra(DrawActivity.SCREEN_ORIENTATION, 1)
+            putExtra(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE)
+            putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(originalImageFile))
+        }
+        launcherRule.launch<DrawActivity>(intent)
+
+        Espresso.pressBack()
+        EspressoInteractions.clickOn(withText(R.string.keep_changes), isDialog())
+        scheduler.flush()
+
+        val savedImage = BitmapFactory.decodeFile(imagePath)
+        assertThat(savedImage.width, equalTo(originalImage.width))
+        assertThat(savedImage.height, equalTo(originalImage.height))
     }
 }


### PR DESCRIPTION
Closes #7293 

#### Why is this the best possible solution? Were any other approaches considered?
`DrawView` has always rasterized the image into a bitmap sized to the view, and the result was saved at that bitmap's size. As a result, annotating always reduced the resolution to roughly the screen size.
It got significantly worse with the Android 16 (targetSdk 36) transition. On large screens, the system no longer honors our orientation lock, so on tablets held in the "wrong" orientation, the drawing screen gets letterboxed into a small window. The image was then downscaled to that window (for example, **2400×1800 → 1118×838**).

This fix removes the root cause rather than the symptom. The working bitmap now always stays at the original image resolution, while the view only renders a scaled preview and maps touch events into bitmap coordinates. As a result, the saved image resolution no longer depends on the window size, orientation, or letterboxing.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
**Intentional changes:**
* Annotated images are now saved at the original image resolution instead of being scaled to the view size, regardless of device orientation, letterboxing, or window size.
* Small images are no longer upscaled to the screen size when saved. The output preserves the original image dimensions.
* Saved files may be noticeably larger, since the output is no longer limited to the screen resolution.

**Regression risks:**
* **Memory:** The full-resolution bitmap is now kept in memory for the entire drawing session, so peak memory usage is higher for very large images (for example, photos taken without a maximum pixel limit).
* **Rendering and touch mapping:** The preview is rendered as a scaled version of the original bitmap, and touch coordinates are mapped to bitmap coordinates. Any bugs in this mapping could result in misplaced strokes or incorrect stroke thickness.
* **Drawing and signature widgets:** Widgets without a background image are unaffected. Their bitmap is still created at the view size, so their behavior remains unchanged.

#### Do we need any specific form for testing your changes? If so, please attach one.
The `All question types` form is fine.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
