### PR TITLE
Downscale huge images in DrawView to avoid running out of memory

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/FileExt.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/FileExt.kt
@@ -2,10 +2,30 @@ package org.odk.collect.androidshared.utils
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.media.MediaMetadataRetriever
 import androidx.core.net.toUri
 import timber.log.Timber
 import java.io.File
+
+/**
+ * Calculates the [BitmapFactory.Options.inSampleSize] to use when decoding this image file so
+ * that neither dimension of the decoded bitmap exceeds [maxDimension]. Only the image bounds
+ * are read here, so no bitmap is allocated. Because [BitmapFactory.Options.inSampleSize] is a
+ * power of 2, the decoded bitmap can end up smaller than [maxDimension] (an image just over
+ * the limit will be halved), but it is never larger.
+ */
+fun File.calculateInSampleSize(maxDimension: Int): Int {
+    val options = BitmapFactory.Options()
+    options.inJustDecodeBounds = true
+    BitmapFactory.decodeFile(absolutePath, options)
+
+    var inSampleSize = 1
+    while (options.outWidth / inSampleSize > maxDimension || options.outHeight / inSampleSize > maxDimension) {
+        inSampleSize *= 2
+    }
+    return inSampleSize
+}
 
 fun File.getVideoThumbnail(context: Context): Bitmap? {
     val retriever = MediaMetadataRetriever()

--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/FileExt.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/FileExt.kt
@@ -13,7 +13,7 @@ import java.io.File
  * that neither dimension of the decoded bitmap exceeds [maxDimension]. Only the image bounds
  * are read here, so no bitmap is allocated.
  */
-fun File.calculateInSampleSize(maxDimension: Int): Int {
+fun File.calculateSampleSize(maxDimension: Int): Int {
     val options = BitmapFactory.Options()
     options.inJustDecodeBounds = true
     BitmapFactory.decodeFile(absolutePath, options)

--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/FileExt.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/FileExt.kt
@@ -11,9 +11,7 @@ import java.io.File
 /**
  * Calculates the [BitmapFactory.Options.inSampleSize] to use when decoding this image file so
  * that neither dimension of the decoded bitmap exceeds [maxDimension]. Only the image bounds
- * are read here, so no bitmap is allocated. Because [BitmapFactory.Options.inSampleSize] is a
- * power of 2, the decoded bitmap can end up smaller than [maxDimension] (an image just over
- * the limit will be halved), but it is never larger.
+ * are read here, so no bitmap is allocated.
  */
 fun File.calculateInSampleSize(maxDimension: Int): Int {
     val options = BitmapFactory.Options()

--- a/androidshared/src/test/java/org/odk/collect/androidshared/utils/FileExtTest.kt
+++ b/androidshared/src/test/java/org/odk/collect/androidshared/utils/FileExtTest.kt
@@ -1,0 +1,44 @@
+package org.odk.collect.androidshared.utils
+
+import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class FileExtTest {
+    @Test
+    fun `calculateInSampleSize returns 1 when both dimensions are within the limit`() {
+        assertThat(imageFile(80, 40).calculateInSampleSize(100), equalTo(1))
+    }
+
+    @Test
+    fun `calculateInSampleSize returns 1 when both dimensions are exactly the limit`() {
+        assertThat(imageFile(100, 100).calculateInSampleSize(100), equalTo(1))
+    }
+
+    @Test
+    fun `calculateInSampleSize returns the smallest power of 2 that brings the image within the limit`() {
+        // 500 / 4 = 125 still exceeds the limit, 500 / 8 = 62 does not
+        assertThat(imageFile(500, 375).calculateInSampleSize(100), equalTo(8))
+        assertThat(imageFile(375, 500).calculateInSampleSize(100), equalTo(8))
+    }
+
+    @Test
+    fun `calculateInSampleSize does not downsample when a dimension sits exactly on the limit`() {
+        // 200 / 2 = 100 is within the limit, so it stops there rather than halving again
+        assertThat(imageFile(200, 200).calculateInSampleSize(100), equalTo(2))
+    }
+
+    private fun imageFile(width: Int, height: Int): File {
+        val file = File.createTempFile("image", ".png")
+        file.deleteOnExit()
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        FileOutputStream(file).use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        return file
+    }
+}

--- a/androidshared/src/test/java/org/odk/collect/androidshared/utils/FileExtTest.kt
+++ b/androidshared/src/test/java/org/odk/collect/androidshared/utils/FileExtTest.kt
@@ -12,26 +12,26 @@ import java.io.FileOutputStream
 @RunWith(AndroidJUnit4::class)
 class FileExtTest {
     @Test
-    fun `calculateInSampleSize returns 1 when both dimensions are within the limit`() {
-        assertThat(imageFile(80, 40).calculateInSampleSize(100), equalTo(1))
+    fun `calculateSampleSize returns 1 when both dimensions are within the limit`() {
+        assertThat(imageFile(80, 40).calculateSampleSize(100), equalTo(1))
     }
 
     @Test
-    fun `calculateInSampleSize returns 1 when both dimensions are exactly the limit`() {
-        assertThat(imageFile(100, 100).calculateInSampleSize(100), equalTo(1))
+    fun `calculateSampleSize returns 1 when both dimensions are exactly the limit`() {
+        assertThat(imageFile(100, 100).calculateSampleSize(100), equalTo(1))
     }
 
     @Test
-    fun `calculateInSampleSize returns the smallest power of 2 that brings the image within the limit`() {
+    fun `calculateSampleSize returns the smallest power of 2 that brings the image within the limit`() {
         // 500 / 4 = 125 still exceeds the limit, 500 / 8 = 62 does not
-        assertThat(imageFile(500, 375).calculateInSampleSize(100), equalTo(8))
-        assertThat(imageFile(375, 500).calculateInSampleSize(100), equalTo(8))
+        assertThat(imageFile(500, 375).calculateSampleSize(100), equalTo(8))
+        assertThat(imageFile(375, 500).calculateSampleSize(100), equalTo(8))
     }
 
     @Test
-    fun `calculateInSampleSize does not downsample when a dimension sits exactly on the limit`() {
+    fun `calculateSampleSize does not downsample when a dimension sits exactly on the limit`() {
         // 200 / 2 = 100 is within the limit, so it stops there rather than halving again
-        assertThat(imageFile(200, 200).calculateInSampleSize(100), equalTo(2))
+        assertThat(imageFile(200, 200).calculateSampleSize(100), equalTo(2))
     }
 
     private fun imageFile(width: Int, height: Int): File {

--- a/draw/src/main/java/org/odk/collect/draw/DrawView.kt
+++ b/draw/src/main/java/org/odk/collect/draw/DrawView.kt
@@ -26,6 +26,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import org.odk.collect.androidshared.bitmap.ImageFileUtils
+import org.odk.collect.androidshared.utils.calculateInSampleSize
 import java.io.File
 import javax.inject.Inject
 import androidx.core.graphics.withTranslation
@@ -183,7 +184,10 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
     private fun resetImage(width: Int, height: Int) {
         val backgroundBitmapFile = File(imagePath)
         if (backgroundBitmapFile.exists()) {
-            bitmap = ImageFileUtils.getBitmap(backgroundBitmapFile.absolutePath, BitmapFactory.Options())!!
+            val options = BitmapFactory.Options()
+            options.inSampleSize = backgroundBitmapFile.calculateInSampleSize(4096)
+
+            bitmap = ImageFileUtils.getBitmap(backgroundBitmapFile.absolutePath, options)!!
                 .copy(Bitmap.Config.ARGB_8888, true)
             canvas = Canvas(bitmap)
         } else {

--- a/draw/src/main/java/org/odk/collect/draw/DrawView.kt
+++ b/draw/src/main/java/org/odk/collect/draw/DrawView.kt
@@ -26,7 +26,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import org.odk.collect.androidshared.bitmap.ImageFileUtils
-import org.odk.collect.androidshared.utils.calculateInSampleSize
+import org.odk.collect.androidshared.utils.calculateSampleSize
 import java.io.File
 import javax.inject.Inject
 import androidx.core.graphics.withTranslation
@@ -185,7 +185,7 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
         val backgroundBitmapFile = File(imagePath)
         if (backgroundBitmapFile.exists()) {
             val options = BitmapFactory.Options()
-            options.inSampleSize = backgroundBitmapFile.calculateInSampleSize(4096)
+            options.inSampleSize = backgroundBitmapFile.calculateSampleSize(4096)
 
             bitmap = ImageFileUtils.getBitmap(backgroundBitmapFile.absolutePath, options)!!
                 .copy(Bitmap.Config.ARGB_8888, true)

--- a/draw/src/test/java/org/odk/collect/draw/DrawActivityTest.kt
+++ b/draw/src/test/java/org/odk/collect/draw/DrawActivityTest.kt
@@ -118,4 +118,27 @@ internal class DrawActivityTest {
         assertThat(savedImage.width, equalTo(originalImage.width))
         assertThat(savedImage.height, equalTo(originalImage.height))
     }
+
+    @Test
+    @Config(qualifiers = "w400dp-h700dp-mdpi")
+    fun `saved image is downscaled when annotating an image that is too big to keep in memory`() {
+        val originalImage = Bitmap.createBitmap(100, 6000, Bitmap.Config.ARGB_8888)
+        val originalImageFile = TempFiles.createTempFile(".png")
+        ImageFileUtils.saveBitmapToFile(originalImage, originalImageFile.absolutePath)
+
+        val intent = Intent(getApplicationContext(), DrawActivity::class.java).apply {
+            putExtra(DrawActivity.SCREEN_ORIENTATION, 1)
+            putExtra(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE)
+            putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(originalImageFile))
+        }
+        launcherRule.launch<DrawActivity>(intent)
+
+        Espresso.pressBack()
+        EspressoInteractions.clickOn(withText(R.string.keep_changes), isDialog())
+        scheduler.flush()
+
+        val savedImage = BitmapFactory.decodeFile(imagePath)
+        assertThat(savedImage.width, equalTo(50))
+        assertThat(savedImage.height, equalTo(3000))
+    }
 }


### PR DESCRIPTION
Closes #7296

#### Why is this the best possible solution? Were any other approaches considered?
Loading huge images at full resolution can allocate a very large bitmap, which crashes the app.
Instead, we subsample oversized images during decoding, so the full-size bitmap is never allocated.
I chose **4096 px** as the maximum image dimension limit to ensure that even lower-end devices can handle the image safely without crashing. This value should still be higher than the resolution of typical photos, so most images will not be resized and will keep their original resolution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Images that don't exceed 4096px on the long edge are not affected and keep their original resolution when annotating. Bigger images are scaled down below that limit instead of crashing the app or rendering blank.

#### Do we need any specific form for testing your changes? If so, please attach one.
The `All question types` form is fine.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
