### PR TITLE
Fix digest() crash on release builds

### DIFF
--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -21,6 +21,7 @@
 }
 -keep class org.javarosa.core.model.instance.geojson.GeojsonFeature { *; }
 -keep class org.javarosa.core.model.instance.geojson.GeojsonGeometry { *; }
+-keep class org.javarosa.xpath.expr.DigestAlgorithm { *; }
 
 # Make sure TaskSpecs are kept as they are instantiated via reflection
 -keep public class * implements org.odk.collect.async.TaskSpec { *; }


### PR DESCRIPTION
Closes #7304 

#### Why is this the best possible solution? Were any other approaches considered?
On release (minified) builds, R8 strips the `DigestAlgorithm` enum constants because `digest()` looks them up using `Enum.valueOf()` with a name computed at runtime, so R8 doesn't recognize them as being used. As a result, `valueOf()` throws an exception, and opening the form crashes with an "unsupported construct" error. A
`-keep` rule for the enum is the minimal fix needed to preserve the constants and restore the runtime lookup.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing the form linked in the issue should suffice. There might be other crashes like that one caused by R8, but it's not possible to identify them easily.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is linked in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
