### PR TITLE
Fix crash when resetting instances with an undeletable edit

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstancesDataService.kt
@@ -205,11 +205,8 @@ class InstancesDataService(
                 val grouped = instancesRepository.all.groupBy { it.editOf ?: it.dbId }
                 grouped.values.forEach { group ->
                     group.sortedByDescending { it.editNumber }
-                        .forEach {
-                            if (it.isDeletable()) {
-                                instancesRepository.delete(it.dbId)
-                            }
-                        }
+                        .takeWhile { it.isDeletable() }
+                        .forEach { instancesRepository.delete(it.dbId) }
                 }
                 update(projectId)
                 true

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstancesDataServiceTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstancesDataServiceTest.kt
@@ -226,6 +226,34 @@ class InstancesDataServiceTest {
     }
 
     @Test
+    fun `#reset does not reset instances with an edit that can't be deleted before sending`() {
+        val formsRepository = projectDependencyModule.formsRepository
+        val form = formsRepository.save(FormFixtures.form())
+
+        val instancesRepository = projectDependencyModule.instancesRepository
+        val originalInstance = instancesRepository.save(
+            InstanceFixtures.instance(
+                form = form,
+                status = STATUS_SUBMITTED,
+                canDeleteBeforeSend = false
+            )
+        )
+        instancesRepository.save(
+            InstanceFixtures.instance(
+                form = form,
+                status = STATUS_COMPLETE,
+                canDeleteBeforeSend = false,
+                editOf = originalInstance.dbId,
+                editNumber = 1
+            )
+        )
+
+        instancesDataService.reset(projectDependencyModule.projectId)
+        val remainingInstances = instancesRepository.all
+        assertThat(remainingInstances.size, equalTo(2))
+    }
+
+    @Test
     fun `#update updates instances and counts`() {
         val instancesRepository = projectDependencyModule.instancesRepository
         instancesRepository.save(InstanceFixtures.instance(status = STATUS_COMPLETE))


### PR DESCRIPTION
Closes #7306 

#### Why is this the best possible solution? Were any other approaches considered?
When deleting instances, we group them by ID so that instances with edits are deleted from newest to oldest. The problem was that each instance was checked independently. In a group containing a sent original (deletable) and a finalized but unsent edit (not deletable - if the form uses entities), the original was deleted even though the edit still referenced it via `editOf`, triggering a foreign key constraint crash.
Now, within a group, we stop deleting as soon as we reach a non-deletable instance, so an original is never removed while a retained edit still points to it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We fixed a similar issue last year https://github.com/getodk/collect/issues/6716. This is almost exactly the smame but can be reproduced only with forms that use entities. If there is no crash anymore that means everything is fine as it's a small and safe fix.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any editable form with entities.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
