### PR TITLE
Harden `ThreadSafeMediaPlayer`

### DIFF
--- a/audio-clips/src/main/java/org/odk/collect/audioclips/ThreadSafeMediaPlayerWrapper.kt
+++ b/audio-clips/src/main/java/org/odk/collect/audioclips/ThreadSafeMediaPlayerWrapper.kt
@@ -32,7 +32,11 @@ internal class ThreadSafeMediaPlayerWrapper(
                 mediaPlayer.setDataSource(uri)
                 mediaPlayer.prepare()
                 true
-            } catch (e: IOException) {
+            } catch (_: IOException) {
+                releaseMediaPlayerInstance()
+                false
+            } catch (_: IllegalStateException) {
+                releaseMediaPlayerInstance()
                 false
             }
         }
@@ -69,9 +73,13 @@ internal class ThreadSafeMediaPlayerWrapper(
 
     fun release() {
         synchronized(this) {
-            mediaPlayer?.release()
-            mediaPlayer = null
+            releaseMediaPlayerInstance()
         }
+    }
+
+    private fun releaseMediaPlayerInstance() {
+        mediaPlayer?.release()
+        mediaPlayer = null
     }
 
     private fun setupNewMediaPlayer(): MediaPlayer {

--- a/audio-clips/src/main/java/org/odk/collect/audioclips/ThreadSafeMediaPlayerWrapper.kt
+++ b/audio-clips/src/main/java/org/odk/collect/audioclips/ThreadSafeMediaPlayerWrapper.kt
@@ -68,7 +68,9 @@ internal class ThreadSafeMediaPlayerWrapper(
     }
 
     fun getPosition(): Int? {
-        return mediaPlayer?.currentPosition
+        synchronized(this) {
+            return mediaPlayer?.currentPosition
+        }
     }
 
     fun release() {


### PR DESCRIPTION
Address [this crash report](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/0165fafeb00d25f497f27695a48d998c)

#### Why is this the best possible solution? Were any other approaches considered?

It looks like it's still possible for `MediaPlayer#prepare` to throw an `IllegalStateException`. The approach taken here to minimize the impact of that is to treat that as a failed load (rather than a crash) and to "clean up" the `MediaPlayer` instance when errors occur - this prevents an instance in a bad state from being reused.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to check audio playback for questions, selects and in the audio question itself. We don't have a way to reproduce the crash: this change shouldn't affect behaviour.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
