### PR TITLE
Synchronize mutations to DB connections

### DIFF
--- a/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
+++ b/db/src/main/java/org/odk/collect/db/sqlite/DatabaseConnection.kt
@@ -109,27 +109,31 @@ open class DatabaseConnection @JvmOverloads constructor(
 
         @JvmStatic
         fun cleanUp() {
-            val openHelpersToClear = mutableListOf<String>()
+            synchronized(openHelpers) {
+                val openHelpersToClear = mutableListOf<String>()
 
-            openHelpers.forEach { (databasePath, openHelper) ->
-                if (!File(databasePath).exists()) {
-                    openHelper.close()
-                    openHelpersToClear.add(databasePath)
+                openHelpers.forEach { (databasePath, openHelper) ->
+                    if (!File(databasePath).exists()) {
+                        openHelper.close()
+                        openHelpersToClear.add(databasePath)
+                    }
                 }
-            }
 
-            openHelpersToClear.forEach {
-                openHelpers.remove(it)
+                openHelpersToClear.forEach {
+                    openHelpers.remove(it)
+                }
             }
         }
 
         @JvmStatic
         fun closeAll() {
-            openHelpers.forEach { (_, openHelper) -> openHelper.close() }
-            openHelpers.clear()
+            synchronized(openHelpers) {
+                openHelpers.forEach { (_, openHelper) -> openHelper.close() }
+                openHelpers.clear()
 
-            toClose.forEach(SQLiteOpenHelper::close)
-            toClose.clear()
+                toClose.forEach(SQLiteOpenHelper::close)
+                toClose.clear()
+            }
         }
     }
 }


### PR DESCRIPTION
Potentially address [this crash report](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/22f9636325db2d273a8b4b5400e8b357).

#### Why is this the best possible solution? Were any other approaches considered?

It definitely seemed like we shouldn't allow multiple threads to access `cleanUp` or `closeAll` so whether this is a fix for the crash or not, I think it's a good change.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to play around with changing and deleting projects as that's the only time we destroy database connections in the app.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
