### PR TITLE
Honor clickable for Markers in Google Maps

### DIFF
--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -535,8 +535,9 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
     @Nullable
     private MarkerFeature getFeature(Marker marker) {
         for (int featureId : features.keySet()) {
-            if (features.get(featureId).ownsMarker(marker)) {
-                return (MarkerFeature) features.get(featureId);
+            MapFeature mapFeature = features.get(featureId);
+            if (mapFeature instanceof MarkerFeature && mapFeature.ownsMarker(marker)) {
+                return (MarkerFeature) mapFeature;
             }
         }
 

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -714,10 +714,10 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
 
         public boolean isClickable() {
             MarkerIconDescription iconDescription = markerDescription.getIconDescription();
-            if (iconDescription instanceof MarkerIconDescription.TracePoint) {
-                return false;
-            } else {
+            if (iconDescription instanceof MarkerIconDescription.DrawableResource) {
                 return ((MarkerIconDescription.DrawableResource) iconDescription).getClickable();
+            } else {
+                return false;
             }
         }
 

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -405,6 +405,8 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
             } else {
                 onMapClick(marker.getPosition());
             }
+        } else {
+            onMapClick(marker.getPosition());
         }
 
         return true;  // consume the event (no default zoom and popup behaviour)

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -80,6 +80,7 @@ import java.util.stream.StreamSupport;
 
 import javax.inject.Inject;
 
+import kotlin.Pair;
 import timber.log.Timber;
 
 public class GoogleMapFragment extends MapViewModelMapFragment implements
@@ -396,10 +397,11 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
 
     @Override
     public boolean onMarkerClick(Marker marker) {
-        MarkerFeature markerFeature = getFeature(marker);
+        Pair<Integer, MarkerFeature> markerFeature = getFeature(marker);
+
         if (markerFeature != null) {
-            if (featureClickListener != null && markerFeature.isClickable()) {
-                featureClickListener.onFeature(getFeatureId(marker));
+            if (featureClickListener != null && markerFeature.getSecond().isClickable()) {
+                featureClickListener.onFeature(markerFeature.getFirst());
             } else {
                 onMapClick(marker.getPosition());
             }
@@ -533,11 +535,11 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
     }
 
     @Nullable
-    private MarkerFeature getFeature(Marker marker) {
+    private Pair<Integer, MarkerFeature> getFeature(Marker marker) {
         for (int featureId : features.keySet()) {
             MapFeature mapFeature = features.get(featureId);
             if (mapFeature instanceof MarkerFeature && mapFeature.ownsMarker(marker)) {
-                return (MarkerFeature) mapFeature;
+                return new Pair<>(featureId, (MarkerFeature) mapFeature);
             }
         }
 

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -396,25 +396,29 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
 
     @Override
     public boolean onMarkerClick(Marker marker) {
-        if (featureClickListener != null) { // FormMapActivity
-            featureClickListener.onFeature(findFeature(marker));
-        } else { // GeoWidget
-            onMapClick(marker.getPosition());
+        MarkerFeature markerFeature = getFeature(marker);
+        if (markerFeature != null) {
+            if (featureClickListener != null && markerFeature.isClickable()) {
+                featureClickListener.onFeature(getFeatureId(marker));
+            } else {
+                onMapClick(marker.getPosition());
+            }
         }
+
         return true;  // consume the event (no default zoom and popup behaviour)
     }
 
     @Override
     public void onPolylineClick(Polyline polyline) {
         if (featureClickListener != null) {
-            featureClickListener.onFeature(findFeature(polyline));
+            featureClickListener.onFeature(getFeatureId(polyline));
         }
     }
 
     @Override
     public void onPolygonClick(@NonNull Polygon polygon) {
         if (featureClickListener != null) {
-            featureClickListener.onFeature(findFeature(polygon));
+            featureClickListener.onFeature(getFeatureId(polygon));
         }
     }
 
@@ -423,7 +427,7 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
         // When dragging starts, GoogleMap makes the marker jump up to move it
         // out from under the user's finger; whenever a marker moves, we have
         // to update its corresponding feature.
-        updateFeature(findFeature(marker));
+        updateFeature(getFeatureId(marker));
     }
 
     @Override
@@ -432,12 +436,12 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
         // obtained from a GPS reading, so the altitude and standard deviation
         // fields are no longer meaningful; reset them to zero.
         marker.setSnippet("0;0");
-        updateFeature(findFeature(marker));
+        updateFeature(getFeatureId(marker));
     }
 
     @Override
     public void onMarkerDragEnd(Marker marker) {
-        int featureId = findFeature(marker);
+        int featureId = getFeatureId(marker);
         updateFeature(featureId);
         if (dragEndListener != null && featureId != -1) {
             dragEndListener.onFeature(featureId);
@@ -528,22 +532,34 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
         }
     }
 
+    @Nullable
+    private MarkerFeature getFeature(Marker marker) {
+        for (int featureId : features.keySet()) {
+            if (features.get(featureId).ownsMarker(marker)) {
+                return (MarkerFeature) features.get(featureId);
+            }
+        }
+
+        return null;
+    }
+
     /**
-     * Finds the feature to which the given marker belongs.
+     * Finds the feature ID to which the given marker belongs.
      */
-    private int findFeature(Marker marker) {
+    private int getFeatureId(Marker marker) {
         for (int featureId : features.keySet()) {
             if (features.get(featureId).ownsMarker(marker)) {
                 return featureId;
             }
         }
-        return -1;  // not found
+
+        return -1;
     }
 
     /**
      * Finds the feature to which the given polyline belongs.
      */
-    private int findFeature(Polyline polyline) {
+    private int getFeatureId(Polyline polyline) {
         for (int featureId : features.keySet()) {
             if (features.get(featureId).ownsPolyline(polyline)) {
                 return featureId;
@@ -552,7 +568,7 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
         return -1;  // not found
     }
 
-    private int findFeature(Polygon polygon) {
+    private int getFeatureId(Polygon polygon) {
         for (int featureId : features.keySet()) {
             if (features.get(featureId).ownsPolygon(polygon)) {
                 return featureId;
@@ -682,16 +698,27 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
     }
 
     private static class MarkerFeature implements MapFeature {
+        private final MarkerDescription markerDescription;
         private Marker marker;
         private final Context context;
 
         MarkerFeature(Context context, MarkerDescription markerDescription, GoogleMap map) {
             this.context = context;
-            marker = createMarker(context, markerDescription, map);
+            this.markerDescription = markerDescription;
+            marker = createMarker(context, this.markerDescription, map);
         }
 
         public void setIcon(MarkerIconDescription markerIconDescription) {
             marker.setIcon(getBitmapDescriptor(context, markerIconDescription));
+        }
+
+        public boolean isClickable() {
+            MarkerIconDescription iconDescription = markerDescription.getIconDescription();
+            if (iconDescription instanceof MarkerIconDescription.TracePoint) {
+                return false;
+            } else {
+                return ((MarkerIconDescription.DrawableResource) iconDescription).getClickable();
+            }
         }
 
         public MapPoint getPoint() {


### PR DESCRIPTION
Closes #7313

#### Why is this the best possible solution? Were any other approaches considered?

Google Maps doesn't offer a way to make markers non-clickable so we need to determine whether we should call the feature listener or the map click listener when a marker click occurs here. That does mean that trying to add a point or a line/shape vertex by clicking on a marker will always add the new feature at exactly the same location: that could be considered feature.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue! As mentioned above, clicking on a marker will always count as a click on the **exact** point of the marker which means that new features being added via clicks will snap to it.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
