### PR TITLE
Fix flaky FormMapTest

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.kt
@@ -79,7 +79,7 @@ class FormMapTest {
                     1
                 )
             )
-            .selectForm(mapFragment, 1)
+            .selectForm(mapFragment, 0)
             .clickEditSavedForm("Single geopoint")
             .clickOnQuestion("Name")
             .assertText("Foo")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -14,6 +14,7 @@ import org.odk.collect.maps.traces.PolygonDescription
 class FakeClickableMapFragment : Fragment(), MapFragment {
 
     private var idCounter = 1
+    private val featureIds = mutableListOf<Int>()
     private var featureClickListener: MapFragment.FeatureListener? = null
 
     override fun init(
@@ -53,7 +54,7 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
 
     override fun addMarkers(markers: List<MarkerDescription>): List<Int> {
         return markers.map {
-            idCounter++
+            idCounter++.also { id -> featureIds.add(id) }
         }
     }
 
@@ -89,8 +90,13 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         return mutableListOf()
     }
 
-    override fun clearFeatures() {}
-    override fun clearFeatures(ids: List<Int>) {}
+    override fun clearFeatures() {
+        featureIds.clear()
+    }
+
+    override fun clearFeatures(ids: List<Int>) {
+        featureIds.removeAll(ids)
+    }
 
     override fun setClickListener(listener: MapFragment.PointListener?) {}
 
@@ -106,11 +112,11 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         return false
     }
 
-    fun clickOnFeature(featureId: Int) {
+    fun clickOnFeature(index: Int) {
         var done = false
 
         Handler(Looper.getMainLooper()).post {
-            featureClickListener!!.onFeature(featureId)
+            featureClickListener!!.onFeature(featureIds[index])
             done = true
         }
 


### PR DESCRIPTION
Closes #7312 

#### Why is this the best possible solution? Were any other approaches considered?
The flaky failure came from `FakeClickableMapFragment`: it never reset its monotonic `idCounter`, `clearFeatures` was a no-op, and `clickOnFeature` accepted a raw feature id. Every re-render (`MappableItemsDelegate.updateFeatures()` → `clearFeatures` + `addMarkers`) incremented the counter, so when the features were redrawn more than once before the click (non-deterministically, due to extra `onResume`/`load()` cycles), the single feature received id `2` instead of `1`. As a result, `clickOnFeature(1)` no longer matched anything, the summary sheet never opened, and the test timed out.

The fix tracks feature ids in a list that is properly cleared by `clearFeatures` and changes `clickOnFeature` to select a feature by index rather than by id. This ensures it always targets the currently visible feature, regardless of how many times the map has been redrawn. It also aligns `FakeClickableMapFragment` with the already proven index-based `FakeMapFragment` implementation in the geo module.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
