### PR TITLE
Fix NPE in MediaLoadingTask when no widget is waiting for binary data

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -22,6 +22,8 @@ import java.lang.ref.WeakReference;
 
 import javax.inject.Inject;
 
+import timber.log.Timber;
+
 public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
 
     private final File instanceFile;
@@ -54,6 +56,7 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             // This can happen if that state was lost before the result came back (e.g. the activity/view
             // was recreated in the meantime), in which case there is nothing to attach the file to.
             if (questionWidget == null) {
+                Timber.e(new Error("MediaLoadingTask: no widget waiting for binary data - media file cannot be attached"));
                 return null;
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -47,10 +47,6 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
     @Override
     protected File doInBackground(Uri... uris) {
         if (instanceFile != null) {
-            String extension = ContentUriHelper.getFileExtensionFromUri(uris[0]);
-
-            File newFile = FileUtils.createDestinationMediaFile(instanceFile.getParent(), extension);
-            FileUtils.saveAnswerFileFromUri(uris[0], newFile, Collect.getInstance());
             QuestionWidget questionWidget = formFillingActivity.get().getWidgetWaitingForBinaryData();
 
             // getWidgetWaitingForBinaryData() returns null when no widget on it is registered
@@ -60,6 +56,11 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             if (questionWidget == null) {
                 return null;
             }
+
+            String extension = ContentUriHelper.getFileExtensionFromUri(uris[0]);
+
+            File newFile = FileUtils.createDestinationMediaFile(instanceFile.getParent(), extension);
+            FileUtils.saveAnswerFileFromUri(uris[0], newFile, Collect.getInstance());
 
             // apply image conversion if the question is an image question
             if (questionWidget.getFormEntryPrompt().getControlType() == Constants.CONTROL_IMAGE_CHOOSE) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -53,6 +53,14 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             FileUtils.saveAnswerFileFromUri(uris[0], newFile, Collect.getInstance());
             QuestionWidget questionWidget = formFillingActivity.get().getWidgetWaitingForBinaryData();
 
+            // getWidgetWaitingForBinaryData() returns null when no widget on it is registered
+            // in the waitingForDataRegistry as waiting for data.
+            // This can happen if that state was lost before the result came back (e.g. the activity/view
+            // was recreated in the meantime), in which case there is nothing to attach the file to.
+            if (questionWidget == null) {
+                return null;
+            }
+
             // apply image conversion if the question is an image question
             if (questionWidget.getFormEntryPrompt().getControlType() == Constants.CONTROL_IMAGE_CHOOSE) {
                 String imageSizeMode = settingsProvider.getUnprotectedSettings().getString(KEY_IMAGE_SIZE);


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?
It doesn't fix the actual problem, which is attempting to save a media file when there is no question waiting for it. This can happen, for example, after a process death. However, it at least restores the previous behavior: instead of crashing, the app simply ignores the media file.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
