### PR TITLE
Fix external app parameters not resolving relative references

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalAppsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalAppsUtils.java
@@ -27,12 +27,9 @@ import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.model.xform.XPathReference;
-import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.expr.XPathFuncExpr;
-import org.javarosa.xpath.expr.XPathPathExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.ExternalParamsException;
@@ -138,15 +135,7 @@ public final class ExternalAppsUtils {
             return text.endsWith("'") ? text.substring(1, text.length() - 1) : text.substring(1);
         }
 
-        FormDef formDef = formController.getFormDef();
-        FormInstance formInstance = formDef.getInstance();
-        EvaluationContext evaluationContext = new EvaluationContext(formDef.getEvaluationContext(), reference);
-        if (text.startsWith("/")) {
-            // treat this is an xpath
-            XPathPathExpr pathExpr = XPathReference.getPathExpr(text);
-            XPathNodeset xpathNodeset = pathExpr.eval(formInstance, evaluationContext);
-            return XPathFuncExpr.unpack(xpathNodeset);
-        } else if (text.equals("instanceProviderID()")) {
+        if (text.equals("instanceProviderID()")) {
             // instanceProviderID returns -1 if the current instance has not been saved to disk already
             String path = formController.getInstanceFile().getAbsolutePath();
 
@@ -157,11 +146,15 @@ public final class ExternalAppsUtils {
             }
 
             return instanceProviderID;
-        } else {
-            // treat this as a function
-            XPathExpression xpathExpression = XPathParseTool.parseXPath(text);
-            return xpathExpression.eval(formInstance, evaluationContext);
         }
+
+        // treat this as an xpath expression (absolute path, relative path or function)
+        FormDef formDef = formController.getFormDef();
+        FormInstance formInstance = formDef.getInstance();
+        EvaluationContext evaluationContext = new EvaluationContext(formDef.getEvaluationContext(), reference);
+        XPathExpression xpathExpression = XPathParseTool.parseXPath(text);
+        Object evalResult = xpathExpression.eval(formInstance, evaluationContext);
+        return XPathFuncExpr.unpack(evalResult);
     }
 
     public static StringData asStringData(Object value) {

--- a/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/ExternalAppsUtilsTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/dynamicpreload/ExternalAppsUtilsTest.kt
@@ -1,0 +1,103 @@
+package org.odk.collect.android.dynamicpreload
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.javarosa.test.BindBuilderXFormsElement.bind
+import org.javarosa.test.Scenario
+import org.javarosa.test.XFormsElement.body
+import org.javarosa.test.XFormsElement.head
+import org.javarosa.test.XFormsElement.html
+import org.javarosa.test.XFormsElement.input
+import org.javarosa.test.XFormsElement.mainInstance
+import org.javarosa.test.XFormsElement.model
+import org.javarosa.test.XFormsElement.repeat
+import org.javarosa.test.XFormsElement.t
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.odk.collect.android.javarosawrapper.FormController
+
+@RunWith(AndroidJUnit4::class)
+class ExternalAppsUtilsTest {
+    private val scenario = Scenario.init(
+        html(
+            head(
+                model(
+                    mainInstance(
+                        t(
+                            "data id=\"form\"",
+                            t("label"),
+                            t(
+                                "rep",
+                                t("name")
+                            )
+                        )
+                    ),
+                    bind("/data/label").type("string"),
+                    bind("/data/rep/name").type("string")
+                )
+            ),
+            body(
+                input("/data/label"),
+                repeat(
+                    "/data/rep",
+                    input("/data/rep/name")
+                )
+            )
+        )
+    ).apply {
+        answer("/data/label", "foo")
+        answer("/data/rep[1]/name", "bar")
+    }
+
+    private val formController = mock<FormController> {
+        on { getFormDef() } doReturn scenario.formDef
+    }
+
+    @Test
+    fun `#getValueRepresentedBy resolves a relative reference inside a repeat against the current repeat instance`() {
+        val reference = Scenario.getRef("/data/rep[1]/name")
+
+        val result = ExternalAppsUtils.getValueRepresentedBy("../name", reference, formController)
+
+        assertThat(result, equalTo("bar"))
+    }
+
+    @Test
+    fun `#getValueRepresentedBy resolves a relative reference outside a repeat`() {
+        val reference = Scenario.getRef("/data/label")
+
+        val result = ExternalAppsUtils.getValueRepresentedBy("../label", reference, formController)
+
+        assertThat(result, equalTo("foo"))
+    }
+
+    @Test
+    fun `#getValueRepresentedBy resolves an absolute reference`() {
+        val reference = Scenario.getRef("/data/rep[1]/name")
+
+        val result = ExternalAppsUtils.getValueRepresentedBy("/data/label", reference, formController)
+
+        assertThat(result, equalTo("foo"))
+    }
+
+    @Test
+    fun `#getValueRepresentedBy evaluates a function`() {
+        val reference = Scenario.getRef("/data/rep[1]/name")
+
+        val result = ExternalAppsUtils.getValueRepresentedBy("true()", reference, formController)
+
+        assertThat(result, equalTo(true))
+    }
+
+    @Test
+    fun `#getValueRepresentedBy returns a constant as is`() {
+        val reference = Scenario.getRef("/data/rep[1]/name")
+
+        val result = ExternalAppsUtils.getValueRepresentedBy("'hello'", reference, formController)
+
+        assertThat(result, equalTo("hello"))
+    }
+}


### PR DESCRIPTION
Closes #4580

#### Why is this the best possible solution? Were any other approaches considered?
 All three inputs - absolute paths, relative paths and functions are just XPath, but the old code special-cased them into separate branches and only unpacked the function branch's result, so relative references (`../name`) never resolved. Instead of adding yet another branch, this collapses everything into one path: parse → evaluate against the current node's context → unpack. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Relative references in external app parameters (e.g. `../name` inside a repeat) now resolve to the correct value instead of failing. Absolute paths, functions, instanceProviderID(), and literal/constant values are unchanged.   
Populating data for external apps is at risk here, so please test all the forms you have that launch external apps and pass data to them.

#### Do we need any specific form for testing your changes? If so, please attach one.
As said above, any form that launches external apps and passes data to them.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
