### PR TITLE
Merge Fix NPE in MediaLoadingTask when no widget is waiting for binary data [7321] to v2026.3.x

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -22,6 +22,8 @@ import java.lang.ref.WeakReference;
 
 import javax.inject.Inject;
 
+import timber.log.Timber;
+
 public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
 
     private final File instanceFile;
@@ -54,6 +56,7 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             // This can happen if that state was lost before the result came back (e.g. the activity/view
             // was recreated in the meantime), in which case there is nothing to attach the file to.
             if (questionWidget == null) {
+                Timber.e(new Error("MediaLoadingTask: no widget waiting for binary data - media file cannot be attached"));
                 return null;
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -47,10 +47,6 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
     @Override
     protected File doInBackground(Uri... uris) {
         if (instanceFile != null) {
-            String extension = ContentUriHelper.getFileExtensionFromUri(uris[0]);
-
-            File newFile = FileUtils.createDestinationMediaFile(instanceFile.getParent(), extension);
-            FileUtils.saveAnswerFileFromUri(uris[0], newFile, Collect.getInstance());
             QuestionWidget questionWidget = formFillingActivity.get().getWidgetWaitingForBinaryData();
 
             // getWidgetWaitingForBinaryData() returns null when no widget on it is registered
@@ -60,6 +56,11 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             if (questionWidget == null) {
                 return null;
             }
+
+            String extension = ContentUriHelper.getFileExtensionFromUri(uris[0]);
+
+            File newFile = FileUtils.createDestinationMediaFile(instanceFile.getParent(), extension);
+            FileUtils.saveAnswerFileFromUri(uris[0], newFile, Collect.getInstance());
 
             // apply image conversion if the question is an image question
             if (questionWidget.getFormEntryPrompt().getControlType() == Constants.CONTROL_IMAGE_CHOOSE) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -53,6 +53,14 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             FileUtils.saveAnswerFileFromUri(uris[0], newFile, Collect.getInstance());
             QuestionWidget questionWidget = formFillingActivity.get().getWidgetWaitingForBinaryData();
 
+            // getWidgetWaitingForBinaryData() returns null when no widget on it is registered
+            // in the waitingForDataRegistry as waiting for data.
+            // This can happen if that state was lost before the result came back (e.g. the activity/view
+            // was recreated in the meantime), in which case there is nothing to attach the file to.
+            if (questionWidget == null) {
+                return null;
+            }
+
             // apply image conversion if the question is an image question
             if (questionWidget.getFormEntryPrompt().getControlType() == Constants.CONTROL_IMAGE_CHOOSE) {
                 String imageSizeMode = settingsProvider.getUnprotectedSettings().getString(KEY_IMAGE_SIZE);


### PR DESCRIPTION
- **Merge pull request #7321 from grzesiek2010/COLLECT-7321**