### PR TITLE
Don't crash when annotate background image can't be decoded

### DIFF
--- a/draw/src/main/java/org/odk/collect/draw/DrawView.kt
+++ b/draw/src/main/java/org/odk/collect/draw/DrawView.kt
@@ -183,12 +183,20 @@ class DrawView(context: Context, attrs: AttributeSet?) : View(context, attrs) {
 
     private fun resetImage(width: Int, height: Int) {
         val backgroundBitmapFile = File(imagePath)
-        if (backgroundBitmapFile.exists()) {
+        val loadedBitmap = if (backgroundBitmapFile.exists()) {
             val options = BitmapFactory.Options()
             options.inSampleSize = backgroundBitmapFile.calculateSampleSize(4096)
+            ImageFileUtils.getBitmap(backgroundBitmapFile.absolutePath, options)
+                ?.copy(Bitmap.Config.ARGB_8888, true)
+        } else {
+            null
+        }
 
-            bitmap = ImageFileUtils.getBitmap(backgroundBitmapFile.absolutePath, options)!!
-                .copy(Bitmap.Config.ARGB_8888, true)
+        // Treat a missing or undecodable background the same: blank canvas.
+        // Some camera/device images (or corrupt files) fail BitmapFactory.decodeFile
+        // and previously crashed via !! on a null decode result.
+        if (loadedBitmap != null) {
+            bitmap = loadedBitmap
             canvas = Canvas(bitmap)
         } else {
             bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)

--- a/draw/src/test/java/org/odk/collect/draw/DrawActivityTest.kt
+++ b/draw/src/test/java/org/odk/collect/draw/DrawActivityTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.notNullValue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -140,5 +141,30 @@ internal class DrawActivityTest {
         val savedImage = BitmapFactory.decodeFile(imagePath)
         assertThat(savedImage.width, equalTo(50))
         assertThat(savedImage.height, equalTo(3000))
+    }
+
+    @Test
+    @Config(qualifiers = "w400dp-h700dp-mdpi")
+    fun `does not crash when annotating an image that cannot be decoded`() {
+        val invalidImageFile = TempFiles.createTempFile(".jpg")
+        invalidImageFile.writeText("not an image")
+
+        val intent = Intent(getApplicationContext(), DrawActivity::class.java).apply {
+            putExtra(DrawActivity.SCREEN_ORIENTATION, 1)
+            putExtra(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE)
+            putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(invalidImageFile))
+        }
+        val scenario = launcherRule.launchForResult<DrawActivity>(intent)
+
+        assertThat(scenario.isFinishing, equalTo(false))
+
+        Espresso.pressBack()
+        EspressoInteractions.clickOn(withText(R.string.keep_changes), isDialog())
+        scheduler.flush()
+
+        assertThat(scenario.isFinishing, equalTo(true))
+        assertThat(scenario.result.resultCode, equalTo(Activity.RESULT_OK))
+        val savedImage = BitmapFactory.decodeFile(imagePath)
+        assertThat(savedImage, notNullValue())
     }
 }


### PR DESCRIPTION
Closes #7319

#### Why is this the best possible solution? Were any other approaches considered?

`DrawView.resetImage` loaded a background file and asserted a non-null bitmap with `!!`. When `BitmapFactory.decodeFile` returns null (corrupt file, some camera images, etc.), that assertion crashed the annotate screen.

The simplest fix matches the existing "no background file" path: if the file is missing **or** cannot be decoded into a mutable bitmap, use a blank white canvas. Alternatives considered:

- Showing an error dialog and finishing the activity — more disruptive for a recovery path the user can still draw on.
- Retrying decode with different options — `ImageFileUtils.getBitmap` already retries on OOM; a null result means the image truly cannot be decoded.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

- **Intentional:** Annotate/draw no longer crashes when the background image cannot be decoded; the user gets a blank canvas instead.
- **Regression risk:** Low. Valid images still take the same decode + copy path. Only the null-decode case changes (previously crashed).

#### Do we need any specific form for testing your changes? If so, please attach one.

No form required. Manual path: annotate question with a corrupt image file as the answer, open markup — should open without crash.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [ ] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)

Notes: Ran `./gradlew :draw:testDebugUnitTest --tests org.odk.collect.draw.DrawActivityTest` successfully (includes new regression test for undecodable background). No new strings/UI. Full `connectedAndroidTest` not run in this environment.