### PR TITLE
Don't initialize Google Maps in the background

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
@@ -1,8 +1,9 @@
 package org.odk.collect.android.application.initialization
 
 import android.content.Context
-import android.os.Handler
+import androidx.fragment.app.FragmentActivity
 import com.google.android.gms.maps.MapView
+import org.odk.collect.android.application.MapboxClassInstanceCreator
 import org.odk.collect.android.geo.MapConfiguratorProvider
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys
@@ -16,9 +17,24 @@ class MapsInitializer @Inject constructor(
 
     fun initialize() {
         resetToAvailableFramework()
+        initializeFrameworks()
+    }
 
-        if (!FRAMEWORKS_INITIALIZED) {
-            initializeFrameworks()
+    fun initializeUIComponents(activity: FragmentActivity, fragmentContainer: Int) {
+        if (!UI_COMPONENTS_INITIALIZED) {
+            MapView(activity).onCreate(null)
+
+            if (MapboxClassInstanceCreator.isMapboxAvailable()) {
+                activity.supportFragmentManager
+                    .beginTransaction()
+                    .add(
+                        fragmentContainer,
+                        MapboxClassInstanceCreator.createMapBoxInitializationFragment()
+                    )
+                    .commit()
+            }
+
+            UI_COMPONENTS_INITIALIZED = true
         }
     }
 
@@ -54,6 +70,6 @@ class MapsInitializer @Inject constructor(
     }
 
     companion object {
-        private var FRAMEWORKS_INITIALIZED = false
+        private var UI_COMPONENTS_INITIALIZED = false
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
@@ -22,7 +22,9 @@ class MapsInitializer @Inject constructor(
 
     fun initializeUIComponents(activity: FragmentActivity, fragmentContainer: Int) {
         if (!UI_COMPONENTS_INITIALIZED) {
-            MapView(activity.application).onCreate(null)
+            val mapView = MapView(activity.application)
+            mapView.onCreate(null)
+            mapView.onDestroy()
 
             if (MapboxClassInstanceCreator.isMapboxAvailable()) {
                 activity.supportFragmentManager

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
@@ -46,11 +46,6 @@ class MapsInitializer @Inject constructor(
                     com.google.android.gms.maps.MapsInitializer.Renderer.LEGACY -> Timber.d("The legacy version of Google Maps renderer is used.")
                 }
             }
-            val handler = Handler(context.mainLooper)
-            handler.post {
-                // This has to happen on the main thread but we might call `initialize` from tests
-                MapView(context).onCreate(null)
-            }
         } catch (ignore: Exception) {
             // ignored
         } catch (ignore: Error) {

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
@@ -2,6 +2,8 @@ package org.odk.collect.android.application.initialization
 
 import android.content.Context
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.google.android.gms.maps.MapView
 import org.odk.collect.android.application.MapboxClassInstanceCreator
 import org.odk.collect.android.geo.MapConfiguratorProvider
@@ -24,7 +26,11 @@ class MapsInitializer @Inject constructor(
         if (!UI_COMPONENTS_INITIALIZED) {
             val mapView = MapView(activity.application)
             mapView.onCreate(null)
-            mapView.onDestroy()
+            activity.lifecycle.addObserver(object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    mapView.onDestroy()
+                }
+            })
 
             if (MapboxClassInstanceCreator.isMapboxAvailable()) {
                 activity.supportFragmentManager

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/MapsInitializer.kt
@@ -22,7 +22,7 @@ class MapsInitializer @Inject constructor(
 
     fun initializeUIComponents(activity: FragmentActivity, fragmentContainer: Int) {
         if (!UI_COMPONENTS_INITIALIZED) {
-            MapView(activity).onCreate(null)
+            MapView(activity.application).onCreate(null)
 
             if (MapboxClassInstanceCreator.isMapboxAvailable()) {
                 activity.supportFragmentManager

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -7,11 +7,13 @@ import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
 import androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.gms.maps.MapView
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.ActivityUtils
 import org.odk.collect.android.activities.CrashHandlerActivity
 import org.odk.collect.android.activities.FirstLaunchActivity
 import org.odk.collect.android.application.CollectComposeThemeProvider
+import org.odk.collect.android.application.MapboxClassInstanceCreator
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.projects.ProjectSettingsDialog
 import org.odk.collect.android.utilities.ThemeUtils
@@ -96,6 +98,8 @@ class MainMenuActivity : LocalizedActivity(), CollectComposeThemeProvider {
             super.onCreate(savedInstanceState)
             setView(R.layout.main_menu_activity, false)
             lifecycle.addObserver(mdmConfigObserver)
+
+            initMapFrameworks()
         }
     }
 
@@ -110,5 +114,19 @@ class MainMenuActivity : LocalizedActivity(), CollectComposeThemeProvider {
         } else {
             setTheme(R.style.Theme_Collect)
         }
+    }
+
+    private fun initMapFrameworks() {
+        if (MapboxClassInstanceCreator.isMapboxAvailable()) {
+            supportFragmentManager
+                .beginTransaction()
+                .add(
+                    R.id.map_box_initialization_fragment,
+                    MapboxClassInstanceCreator.createMapBoxInitializationFragment()
+                )
+                .commit()
+        }
+
+        MapView(this).onCreate(null)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -14,6 +14,7 @@ import org.odk.collect.android.activities.CrashHandlerActivity
 import org.odk.collect.android.activities.FirstLaunchActivity
 import org.odk.collect.android.application.CollectComposeThemeProvider
 import org.odk.collect.android.application.MapboxClassInstanceCreator
+import org.odk.collect.android.application.initialization.MapsInitializer
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.projects.ProjectSettingsDialog
 import org.odk.collect.android.utilities.ThemeUtils
@@ -44,6 +45,9 @@ class MainMenuActivity : LocalizedActivity(), CollectComposeThemeProvider {
 
     @Inject
     lateinit var webPageService: WebPageService
+
+    @Inject
+    lateinit var mapsInitializer: MapsInitializer
 
     private lateinit var currentProjectViewModel: CurrentProjectViewModel
 
@@ -99,7 +103,7 @@ class MainMenuActivity : LocalizedActivity(), CollectComposeThemeProvider {
             setView(R.layout.main_menu_activity, false)
             lifecycle.addObserver(mdmConfigObserver)
 
-            initMapFrameworks()
+            mapsInitializer.initializeUIComponents(this, R.id.map_box_initialization_fragment)
         }
     }
 
@@ -114,19 +118,5 @@ class MainMenuActivity : LocalizedActivity(), CollectComposeThemeProvider {
         } else {
             setTheme(R.style.Theme_Collect)
         }
-    }
-
-    private fun initMapFrameworks() {
-        if (MapboxClassInstanceCreator.isMapboxAvailable()) {
-            supportFragmentManager
-                .beginTransaction()
-                .add(
-                    R.id.map_box_initialization_fragment,
-                    MapboxClassInstanceCreator.createMapBoxInitializationFragment()
-                )
-                .commit()
-        }
-
-        MapView(this).onCreate(null)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
@@ -15,11 +15,9 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import com.google.android.gms.maps.MapView
 import org.odk.collect.android.activities.DeleteFormsActivity
 import org.odk.collect.android.activities.FormDownloadListActivity
 import org.odk.collect.android.activities.InstanceChooserList
-import org.odk.collect.android.application.MapboxClassInstanceCreator
 import org.odk.collect.android.databinding.MainMenuBinding
 import org.odk.collect.android.formentry.FormOpeningMode
 import org.odk.collect.android.formlists.blankformlist.BlankFormListActivity
@@ -120,8 +118,6 @@ class MainMenuFragment(
                 binding.googleDriveDeprecationBanner.root.visibility = View.GONE
             }
         }
-
-        initMapFrameworks()
     }
 
     override fun onResume() {
@@ -163,20 +159,6 @@ class MainMenuFragment(
     private fun initToolbar(binding: MainMenuBinding) {
         val toolbar = binding.root.findViewById<Toolbar>(org.odk.collect.androidshared.R.id.toolbar)
         (requireActivity() as AppCompatActivity).setSupportActionBar(toolbar)
-    }
-
-    private fun initMapFrameworks() {
-        if (MapboxClassInstanceCreator.isMapboxAvailable()) {
-            childFragmentManager
-                .beginTransaction()
-                .add(
-                    org.odk.collect.android.R.id.map_box_initialization_fragment,
-                    MapboxClassInstanceCreator.createMapBoxInitializationFragment()!!
-                )
-                .commit()
-        }
-
-        MapView(requireContext()).onCreate(null)
     }
 
     private fun initButtons(binding: MainMenuBinding) {

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuFragment.kt
@@ -15,6 +15,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.gms.maps.MapView
 import org.odk.collect.android.activities.DeleteFormsActivity
 import org.odk.collect.android.activities.FormDownloadListActivity
 import org.odk.collect.android.activities.InstanceChooserList
@@ -77,7 +78,6 @@ class MainMenuFragment(
 
         val binding = MainMenuBinding.bind(view)
         initToolbar(binding)
-        initMapbox()
         initButtons(binding)
         initAppName(binding)
 
@@ -120,6 +120,8 @@ class MainMenuFragment(
                 binding.googleDriveDeprecationBanner.root.visibility = View.GONE
             }
         }
+
+        initMapFrameworks()
     }
 
     override fun onResume() {
@@ -163,7 +165,7 @@ class MainMenuFragment(
         (requireActivity() as AppCompatActivity).setSupportActionBar(toolbar)
     }
 
-    private fun initMapbox() {
+    private fun initMapFrameworks() {
         if (MapboxClassInstanceCreator.isMapboxAvailable()) {
             childFragmentManager
                 .beginTransaction()
@@ -173,6 +175,8 @@ class MainMenuFragment(
                 )
                 .commit()
         }
+
+        MapView(requireContext()).onCreate(null)
     }
 
     private fun initButtons(binding: MainMenuBinding) {

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -19,14 +19,6 @@
             android:paddingBottom="@dimen/margin_standard"
             app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.fragment.app.FragmentContainerView
-                android:id="@+id/map_box_initialization_fragment"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
             <include
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -36,7 +28,7 @@
                 android:layout_marginHorizontal="@dimen/margin_standard"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/map_box_initialization_fragment" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <org.odk.collect.android.mainmenu.StartNewFormButton
                 android:id="@+id/enter_data"

--- a/collect_app/src/main/res/layout/main_menu_activity.xml
+++ b/collect_app/src/main/res/layout/main_menu_activity.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/map_box_initialization_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"


### PR DESCRIPTION
Addresses [this ANR](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/5fe02b1a31bc3076bca7ab7dcfb3524b).
Closes #7316

#### Why is this the best possible solution? Were any other approaches considered?

There's probably more to improve here, but for the moment, this just ensures that Google Maps initialization only runs when the app is in the foreground so that we don't run into background ANRs.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We just need to check that offline tiles are still available while offline as long as the app has been started up (with a project) online.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
