### PR TITLE
Fix geopoint reverting to input when rotating

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/DaggerSetup.kt
+++ b/geo/src/main/java/org/odk/collect/geo/DaggerSetup.kt
@@ -11,8 +11,8 @@ import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.geopoint.GeoPointActivity
 import org.odk.collect.geo.geopoint.GeoPointDialogFragment
 import org.odk.collect.geo.geopoint.GeoPointMapFragment
-import org.odk.collect.geo.geopoint.GeoPointViewModelFactory
-import org.odk.collect.geo.geopoint.LocationTrackerGeoPointViewModel
+import org.odk.collect.geo.geopoint.FindLocationViewModelFactory
+import org.odk.collect.geo.geopoint.LocationTrackerFindLocationViewModel
 import org.odk.collect.geo.geopoly.GeoPolyFragment
 import org.odk.collect.geo.selection.SelectionMapFragment
 import org.odk.collect.location.LocationClient
@@ -94,13 +94,13 @@ open class GeoDependencyModule {
     }
 
     @Provides
-    internal open fun providesGeoPointViewModelFactory(application: Application): GeoPointViewModelFactory {
-        return object : GeoPointViewModelFactory {
+    internal open fun providesGeoPointViewModelFactory(application: Application): FindLocationViewModelFactory {
+        return object : FindLocationViewModelFactory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 val componentProvider = application as GeoDependencyComponentProvider
                 val component = componentProvider.geoDependencyComponent
-                return LocationTrackerGeoPointViewModel(
+                return LocationTrackerFindLocationViewModel(
                     component.locationTracker,
                     component.satelliteInfoClient,
                     System::currentTimeMillis,

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/FindLocationViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/FindLocationViewModel.kt
@@ -13,7 +13,7 @@ import org.odk.collect.location.satellites.SatelliteInfoClient
 import org.odk.collect.location.tracker.LocationTracker
 import org.odk.collect.location.tracker.getCurrentLocation
 
-internal abstract class GeoPointViewModel : ViewModel() {
+internal abstract class FindLocationViewModel : ViewModel() {
 
     abstract val accuracyThreshold: Float
 
@@ -31,12 +31,12 @@ internal abstract class GeoPointViewModel : ViewModel() {
     abstract fun forceLocation()
 }
 
-internal class LocationTrackerGeoPointViewModel(
+internal class LocationTrackerFindLocationViewModel(
     private val locationTracker: LocationTracker,
     private val satelliteInfoClient: SatelliteInfoClient,
     private val clock: () -> Long,
     scheduler: Scheduler
-) : GeoPointViewModel() {
+) : FindLocationViewModel() {
 
     private val startTime = clock()
     private val repeat = scheduler.repeat(
@@ -112,4 +112,4 @@ internal class LocationTrackerGeoPointViewModel(
     }
 }
 
-internal interface GeoPointViewModelFactory : ViewModelProvider.Factory
+internal interface FindLocationViewModelFactory : ViewModelProvider.Factory

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointActivity.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointActivity.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 class GeoPointActivity : LocalizedActivity(), GeoPointDialogFragment.Listener {
 
     @Inject
-    internal lateinit var geoPointViewModelFactory: GeoPointViewModelFactory
+    internal lateinit var findLocationViewModelFactory: FindLocationViewModelFactory
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -21,7 +21,7 @@ class GeoPointActivity : LocalizedActivity(), GeoPointDialogFragment.Listener {
         (application as GeoDependencyComponentProvider).geoDependencyComponent.inject(this)
 
         val viewModel =
-            ViewModelProvider(this, geoPointViewModelFactory).get(GeoPointViewModel::class.java)
+            ViewModelProvider(this, findLocationViewModelFactory).get(FindLocationViewModel::class.java)
 
         viewModel.acceptedLocation.observe(this) {
             if (it != null) {

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointDialogFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointDialogFragment.kt
@@ -19,12 +19,12 @@ import javax.inject.Inject
 class GeoPointDialogFragment : DialogFragment() {
 
     @Inject
-    internal lateinit var geoPointViewModelFactory: GeoPointViewModelFactory
+    internal lateinit var findLocationViewModelFactory: FindLocationViewModelFactory
 
     var listener: Listener? = null
 
     lateinit var binding: GeopointDialogBinding
-    private lateinit var viewModel: GeoPointViewModel
+    private lateinit var viewModel: FindLocationViewModel
 
     private val onBackPressedCallback: OnBackPressedCallback =
         object : OnBackPressedCallback(true) {
@@ -44,8 +44,8 @@ class GeoPointDialogFragment : DialogFragment() {
         viewModel =
             ViewModelProvider(
                 requireActivity(),
-                geoPointViewModelFactory
-            ).get(GeoPointViewModel::class.java)
+                findLocationViewModelFactory
+            ).get(FindLocationViewModel::class.java)
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -55,10 +55,10 @@ import org.odk.collect.webpage.WebPageService
 import javax.inject.Inject
 
 class GeoPointMapFragment(
-    val inputPoint: MapPoint?,
-    val draggable: Boolean,
-    val readOnly: Boolean,
-    val retainMockAccuracy: Boolean,
+    val inputPoint: MapPoint? = null,
+    val draggable: Boolean = true,
+    val readOnly: Boolean = false,
+    val retainMockAccuracy: Boolean = false,
     val mappableData: MappableData? = null
 ) : Fragment() {
 
@@ -110,7 +110,7 @@ class GeoPointMapFragment(
     /**
      * While true, the point cannot be moved by dragging or long-pressing.
      */
-    private var isPointLocked = false
+    private var isPointLocked = inputPoint != null
 
     private val currentLocationDelegate = CurrentLocationDelegate()
     private val mappableItemsDelegate = MappableItemsDelegate(background = true, clickable = false)

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -199,8 +199,6 @@ class GeoPointMapFragment(
 
         if (setClear || (readOnly && featureId == -1)) {
             result = ""
-        } else if (isDragged || readOnly) {
-            result = formatResult(map!!.getMarkerPoint(featureId)!!)
         } else {
             val geoPoint = geoPointViewModel.geoPoint.value
             if (geoPoint != null) {
@@ -342,7 +340,6 @@ class GeoPointMapFragment(
             isDragged = true
             captureLocation = true
             setClear = false
-            map!!.setCenter(map!!.getMarkerPoint(featureId), true)
             geoPointViewModel.place(map!!.getMarkerPoint(featureId)!!)
         }
     }

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -271,7 +271,11 @@ class GeoPointMapFragment(
             clearButton!!.isEnabled = false
         }
 
-        if (inputPoint != null) {
+        if (previousState != null) {
+            restoreFromInstanceState(previousState!!)
+        }
+
+        if (inputPoint != null && !setClear) {
             // If the point is initially set, the "place marker"
             // button, dragging, and long-pressing are all initially disabled.
             // To enable them, the user must clear the marker and add a new one.
@@ -284,10 +288,6 @@ class GeoPointMapFragment(
             locationStatus!!.visibility = View.GONE
             zoomButton!!.isEnabled = true
             zoomToMarker(false)
-        }
-
-        if (previousState != null) {
-            restoreFromInstanceState(previousState!!)
         }
 
         map!!.showCurrentLocation(

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -271,6 +271,10 @@ class GeoPointMapFragment(
             restoreFromInstanceState(previousState!!)
         }
 
+        if (inputPoint != null && !map!!.hasCenter()) {
+            map!!.setCenter(inputPoint, animate = true)
+        }
+
         map!!.showCurrentLocation(
             locationTracker,
             currentLocationDelegate,
@@ -395,8 +399,6 @@ class GeoPointMapFragment(
 
         captureLocation = true
         setClear = false
-
-        map?.setCenter(point, animate = true)
     }
 
     companion object {

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -421,6 +421,8 @@ class GeoPointMapFragment(
 
         captureLocation = true
         setClear = false
+
+        map?.setCenter(point, animate = true)
     }
 
     companion object {

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -89,8 +89,6 @@ class GeoPointMapFragment(
 
     private var placeMarkerButton: ImageButton? = null
 
-    private var isDragged = false
-
     private var zoomButton: ImageButton? = null
     private var clearButton: ImageButton? = null
 
@@ -182,7 +180,6 @@ class GeoPointMapFragment(
         }
 
         // Flags
-        state.putBoolean(IS_DRAGGED_KEY, isDragged)
         state.putBoolean(CAPTURE_LOCATION_KEY, captureLocation)
         state.putBoolean(SET_CLEAR_KEY, setClear)
         state.putBoolean(IS_POINT_LOCKED_KEY, isPointLocked)
@@ -292,7 +289,6 @@ class GeoPointMapFragment(
     }
 
     private fun restoreFromInstanceState(state: Bundle) {
-        isDragged = state.getBoolean(IS_DRAGGED_KEY, false)
         captureLocation = state.getBoolean(CAPTURE_LOCATION_KEY, false)
         setClear = state.getBoolean(SET_CLEAR_KEY, false)
         isPointLocked = state.getBoolean(IS_POINT_LOCKED_KEY, false)
@@ -337,7 +333,6 @@ class GeoPointMapFragment(
 
     private fun onDragEnd(draggedFeatureId: Int) {
         if (draggedFeatureId == featureId) {
-            isDragged = true
             captureLocation = true
             setClear = false
             geoPointViewModel.place(map!!.getMarkerPoint(featureId)!!)
@@ -348,7 +343,6 @@ class GeoPointMapFragment(
         if (draggable && !readOnly && !isPointLocked) {
             geoPointViewModel.place(point)
             enableZoomButton()
-            isDragged = true
         }
     }
 
@@ -368,7 +362,6 @@ class GeoPointMapFragment(
         placeMarkerButton!!.isEnabled = true
 
         isPointLocked = false
-        isDragged = false
         captureLocation = false
         setClear = true
     }
@@ -407,7 +400,6 @@ class GeoPointMapFragment(
     }
 
     companion object {
-        const val IS_DRAGGED_KEY: String = "is_dragged"
         const val CAPTURE_LOCATION_KEY: String = "capture_location"
         const val SET_CLEAR_KEY: String = "set_clear"
         const val IS_POINT_LOCKED_KEY: String = "is_point_locked"

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -359,6 +359,7 @@ class GeoPointMapFragment(
             captureLocation = true
             setClear = false
             map!!.setCenter(map!!.getMarkerPoint(featureId), true)
+            geoPointViewModel.place(map!!.getMarkerPoint(featureId)!!)
         }
     }
 

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -24,7 +24,9 @@ import androidx.core.graphics.toColorInt
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
-import org.odk.collect.androidshared.system.getParcelableCompat
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewmodel.viewModelFactory
 import org.odk.collect.androidshared.ui.DialogFragmentUtils.showIfNotShowing
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.async.Scheduler
@@ -36,7 +38,6 @@ import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.R
 import org.odk.collect.geo.geopoint.LocationAccuracy.Improving
 import org.odk.collect.geo.items.MappableData
-import org.odk.collect.geo.items.MappableItem
 import org.odk.collect.geo.items.MappableItemsDelegate
 import org.odk.collect.location.tracker.LocationTracker
 import org.odk.collect.location.tracker.getCurrentLocation
@@ -86,7 +87,6 @@ class GeoPointMapFragment(
 
     private var locationStatus: AccuracyStatusView? = null
 
-    private var location: MapPoint? = null
     private var placeMarkerButton: ImageButton? = null
 
     private var isDragged = false
@@ -114,6 +114,14 @@ class GeoPointMapFragment(
 
     private val currentLocationDelegate = CurrentLocationDelegate()
     private val mappableItemsDelegate = MappableItemsDelegate(background = true, clickable = false)
+
+    private val geoPointViewModel: GeoPointViewModel by viewModels {
+        viewModelFactory {
+            addInitializer(GeoPointViewModel::class) {
+                GeoPointViewModel(inputPoint)
+            }
+        }
+    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -179,8 +187,6 @@ class GeoPointMapFragment(
             return
         }
 
-        state.putParcelable(POINT_KEY, map!!.getMarkerPoint(featureId))
-
         // Flags
         state.putBoolean(IS_DRAGGED_KEY, isDragged)
         state.putBoolean(CAPTURE_LOCATION_KEY, captureLocation)
@@ -202,8 +208,11 @@ class GeoPointMapFragment(
             result = ""
         } else if (isDragged || readOnly || hasInputPoint) {
             result = formatResult(map!!.getMarkerPoint(featureId)!!)
-        } else if (location != null) {
-            result = formatResult(location!!)
+        } else {
+            val geoPoint = geoPointViewModel.geoPoint.value
+            if (geoPoint != null) {
+                result = formatResult(geoPoint)
+            }
         }
 
         if (result != null) {
@@ -232,7 +241,7 @@ class GeoPointMapFragment(
             val currentLocation = locationTracker.getCurrentLocation()
             if (currentLocation != null) {
                 val mapPoint = currentLocation.toMapPoint()
-                placeMarker(mapPoint)
+                geoPointViewModel.place(mapPoint)
                 zoomToMarker(true)
             }
         }
@@ -275,21 +284,6 @@ class GeoPointMapFragment(
             restoreFromInstanceState(previousState!!)
         }
 
-        if (inputPoint != null && !setClear) {
-            // If the point is initially set, the "place marker"
-            // button, dragging, and long-pressing are all initially disabled.
-            // To enable them, the user must clear the marker and add a new one.
-            isPointLocked = true
-            placeMarker(inputPoint)
-            placeMarkerButton!!.isEnabled = false
-
-            captureLocation = true
-            hasInputPoint = true
-            locationStatus!!.visibility = View.GONE
-            zoomButton!!.isEnabled = true
-            zoomToMarker(false)
-        }
-
         map!!.showCurrentLocation(
             locationTracker,
             currentLocationDelegate,
@@ -301,6 +295,10 @@ class GeoPointMapFragment(
         if (mappableData != null) {
             (map as MapFragment).showData(mappableData, mappableItemsDelegate)
         }
+
+        geoPointViewModel.geoPoint.asLiveData().observe(viewLifecycleOwner) {
+            updateMarker(it)
+        }
     }
 
     private fun restoreFromInstanceState(state: Bundle) {
@@ -309,12 +307,6 @@ class GeoPointMapFragment(
         setClear = state.getBoolean(SET_CLEAR_KEY, false)
         hasInputPoint = state.getBoolean(HAS_INPUT_POINT_KEY, false)
         isPointLocked = state.getBoolean(IS_POINT_LOCKED_KEY, false)
-
-        // Restore the marker and dialog after the flags, because they use some of them.
-        val point = state.getParcelableCompat<MapPoint>(POINT_KEY)
-        if (point != null) {
-            placeMarker(point)
-        }
 
         // Restore the flags again, because placeMarker() and clear() modify some of them.
         isDragged = state.getBoolean(IS_DRAGGED_KEY, false)
@@ -339,7 +331,7 @@ class GeoPointMapFragment(
             enableZoomButton()
 
             if (!captureLocation && !setClear) {
-                placeMarker(point)
+                geoPointViewModel.place(point)
                 placeMarkerButton!!.isEnabled = true
             }
 
@@ -372,7 +364,7 @@ class GeoPointMapFragment(
 
     private fun onLongPress(point: MapPoint) {
         if (draggable && !readOnly && !isPointLocked) {
-            placeMarker(point)
+            geoPointViewModel.place(point)
             enableZoomButton()
             isDragged = true
         }
@@ -389,8 +381,7 @@ class GeoPointMapFragment(
     }
 
     private fun clear() {
-        map!!.clearFeatures(listOf(featureId))
-        featureId = -1
+        geoPointViewModel.clear()
         clearButton!!.isEnabled = false
         placeMarkerButton!!.isEnabled = true
 
@@ -400,14 +391,13 @@ class GeoPointMapFragment(
         setClear = true
     }
 
-    /**
-     * Places the marker and enables the button to remove it.
-     */
-    private fun placeMarker(point: MapPoint) {
-        this.location = point
-
+    private fun updateMarker(point: MapPoint?) {
         if (featureId != -1) {
             map!!.clearFeatures(listOf(featureId))
+        }
+
+        if (point == null) {
+            return
         }
 
         val iconDescription = MarkerIconDescription.DrawableResource(
@@ -423,16 +413,16 @@ class GeoPointMapFragment(
                 iconDescription
             )
         )
+
         if (!readOnly) {
             clearButton!!.isEnabled = true
         }
+
         captureLocation = true
         setClear = false
     }
 
     companion object {
-        const val POINT_KEY: String = "point"
-
         const val IS_DRAGGED_KEY: String = "is_dragged"
         const val CAPTURE_LOCATION_KEY: String = "capture_location"
         const val SET_CLEAR_KEY: String = "set_clear"

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -101,12 +101,6 @@ class GeoPointMapFragment(
      * no new marker has been placed.
      */
     private var setClear = false
-
-    /**
-     * True if the current point was not via interacting with the UI
-     */
-    private var hasInputPoint = false
-
     /**
      * While true, the point cannot be moved by dragging or long-pressing.
      */
@@ -191,7 +185,6 @@ class GeoPointMapFragment(
         state.putBoolean(IS_DRAGGED_KEY, isDragged)
         state.putBoolean(CAPTURE_LOCATION_KEY, captureLocation)
         state.putBoolean(SET_CLEAR_KEY, setClear)
-        state.putBoolean(HAS_INPUT_POINT_KEY, hasInputPoint)
         state.putBoolean(IS_POINT_LOCKED_KEY, isPointLocked)
 
         // UI state
@@ -206,7 +199,7 @@ class GeoPointMapFragment(
 
         if (setClear || (readOnly && featureId == -1)) {
             result = ""
-        } else if (isDragged || readOnly || hasInputPoint) {
+        } else if (isDragged || readOnly) {
             result = formatResult(map!!.getMarkerPoint(featureId)!!)
         } else {
             val geoPoint = geoPointViewModel.geoPoint.value
@@ -266,7 +259,6 @@ class GeoPointMapFragment(
         clearButton!!.setOnClickListener {
             clear()
             locationStatus!!.visibility = View.VISIBLE
-            hasInputPoint = false
         }
 
         if (!draggable) {
@@ -305,14 +297,12 @@ class GeoPointMapFragment(
         isDragged = state.getBoolean(IS_DRAGGED_KEY, false)
         captureLocation = state.getBoolean(CAPTURE_LOCATION_KEY, false)
         setClear = state.getBoolean(SET_CLEAR_KEY, false)
-        hasInputPoint = state.getBoolean(HAS_INPUT_POINT_KEY, false)
         isPointLocked = state.getBoolean(IS_POINT_LOCKED_KEY, false)
 
         // Restore the flags again, because placeMarker() and clear() modify some of them.
         isDragged = state.getBoolean(IS_DRAGGED_KEY, false)
         captureLocation = state.getBoolean(CAPTURE_LOCATION_KEY, false)
         setClear = state.getBoolean(SET_CLEAR_KEY, false)
-        hasInputPoint = state.getBoolean(HAS_INPUT_POINT_KEY, false)
         isPointLocked = state.getBoolean(IS_POINT_LOCKED_KEY, false)
 
         placeMarkerButton!!.isEnabled = state.getBoolean(PLACE_MARKER_BUTTON_ENABLED_KEY, false)
@@ -429,7 +419,6 @@ class GeoPointMapFragment(
         const val IS_DRAGGED_KEY: String = "is_dragged"
         const val CAPTURE_LOCATION_KEY: String = "capture_location"
         const val SET_CLEAR_KEY: String = "set_clear"
-        const val HAS_INPUT_POINT_KEY: String = "has_input_point"
         const val IS_POINT_LOCKED_KEY: String = "is_point_locked"
 
         const val PLACE_MARKER_BUTTON_ENABLED_KEY: String = "place_marker_button_enabled"

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -22,6 +22,7 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import androidx.core.graphics.toColorInt
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.viewModels
@@ -91,8 +92,6 @@ class GeoPointMapFragment(
 
     private var zoomButton: ImageButton? = null
     private var clearButton: ImageButton? = null
-
-    private var captureLocation = false
 
     /**
      * True if a tap on the clear button removed an existing marker and
@@ -165,6 +164,10 @@ class GeoPointMapFragment(
         if (mappableData != null) {
             showItemLoading(mappableData)
         }
+
+        geoPointViewModel.isInputPoint.asLiveData().observe(viewLifecycleOwner) {
+            locationStatus!!.isVisible = !it
+        }
     }
 
     override fun onSaveInstanceState(state: Bundle) {
@@ -180,7 +183,6 @@ class GeoPointMapFragment(
         }
 
         // Flags
-        state.putBoolean(CAPTURE_LOCATION_KEY, captureLocation)
         state.putBoolean(SET_CLEAR_KEY, setClear)
         state.putBoolean(IS_POINT_LOCKED_KEY, isPointLocked)
 
@@ -188,7 +190,6 @@ class GeoPointMapFragment(
         state.putBoolean(PLACE_MARKER_BUTTON_ENABLED_KEY, placeMarkerButton!!.isEnabled)
         state.putBoolean(ZOOM_BUTTON_ENABLED_KEY, zoomButton!!.isEnabled)
         state.putBoolean(CLEAR_BUTTON_ENABLED_KEY, clearButton!!.isEnabled)
-        state.putInt(LOCATION_STATUS_VISIBILITY_KEY, locationStatus!!.visibility)
     }
 
     private fun returnLocation() {
@@ -253,7 +254,6 @@ class GeoPointMapFragment(
         clearButton!!.isEnabled = false
         clearButton!!.setOnClickListener {
             clear()
-            locationStatus!!.visibility = View.VISIBLE
         }
 
         if (!draggable) {
@@ -263,7 +263,6 @@ class GeoPointMapFragment(
         }
 
         if (readOnly) {
-            captureLocation = true
             clearButton!!.isEnabled = false
         }
 
@@ -293,15 +292,12 @@ class GeoPointMapFragment(
     }
 
     private fun restoreFromInstanceState(state: Bundle) {
-        captureLocation = state.getBoolean(CAPTURE_LOCATION_KEY, false)
         setClear = state.getBoolean(SET_CLEAR_KEY, false)
         isPointLocked = state.getBoolean(IS_POINT_LOCKED_KEY, false)
 
         placeMarkerButton!!.isEnabled = state.getBoolean(PLACE_MARKER_BUTTON_ENABLED_KEY, false)
         zoomButton!!.isEnabled = state.getBoolean(ZOOM_BUTTON_ENABLED_KEY, false)
         clearButton!!.isEnabled = state.getBoolean(CLEAR_BUTTON_ENABLED_KEY, false)
-
-        locationStatus!!.visibility = state.getInt(LOCATION_STATUS_VISIBILITY_KEY, View.GONE)
     }
 
     private fun onLocationChanged(point: MapPoint?) {
@@ -312,7 +308,7 @@ class GeoPointMapFragment(
         if (point != null) {
             enableZoomButton()
 
-            if (!captureLocation && !setClear) {
+            if (!geoPointViewModel.hasGeoPoint() && !setClear) {
                 geoPointViewModel.place(point)
                 placeMarkerButton!!.isEnabled = true
             }
@@ -337,7 +333,6 @@ class GeoPointMapFragment(
 
     private fun onDragEnd(draggedFeatureId: Int) {
         if (draggedFeatureId == featureId) {
-            captureLocation = true
             setClear = false
             geoPointViewModel.place(map!!.getMarkerPoint(featureId)!!)
         }
@@ -362,7 +357,6 @@ class GeoPointMapFragment(
         placeMarkerButton!!.isEnabled = true
 
         isPointLocked = false
-        captureLocation = false
         setClear = true
     }
 
@@ -393,19 +387,16 @@ class GeoPointMapFragment(
             clearButton!!.isEnabled = true
         }
 
-        captureLocation = true
         setClear = false
     }
 
     companion object {
-        const val CAPTURE_LOCATION_KEY: String = "capture_location"
         const val SET_CLEAR_KEY: String = "set_clear"
         const val IS_POINT_LOCKED_KEY: String = "is_point_locked"
 
         const val PLACE_MARKER_BUTTON_ENABLED_KEY: String = "place_marker_button_enabled"
         const val ZOOM_BUTTON_ENABLED_KEY: String = "zoom_button_enabled"
         const val CLEAR_BUTTON_ENABLED_KEY: String = "clear_button_enabled"
-        const val LOCATION_STATUS_VISIBILITY_KEY: String = "location_status_visibility"
 
         const val MARKER_COLOR: String = "#52C268"
         const val REQUEST_GEOPOINT: String = "geopoint"

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -230,7 +230,7 @@ class GeoPointMapFragment(
             if (currentLocation != null) {
                 val mapPoint = currentLocation.toMapPoint()
                 geoPointViewModel.place(mapPoint)
-                zoomToMarker(true)
+                map!!.zoomToPoint(map!!.getMarkerPoint(featureId), true)
             }
         }
 
@@ -354,10 +354,6 @@ class GeoPointMapFragment(
         if (zoomButton != null) {
             zoomButton!!.isEnabled = true
         }
-    }
-
-    private fun zoomToMarker(animate: Boolean) {
-        map!!.zoomToPoint(map!!.getMarkerPoint(featureId), animate)
     }
 
     private fun clear() {

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointMapFragment.kt
@@ -299,12 +299,6 @@ class GeoPointMapFragment(
         setClear = state.getBoolean(SET_CLEAR_KEY, false)
         isPointLocked = state.getBoolean(IS_POINT_LOCKED_KEY, false)
 
-        // Restore the flags again, because placeMarker() and clear() modify some of them.
-        isDragged = state.getBoolean(IS_DRAGGED_KEY, false)
-        captureLocation = state.getBoolean(CAPTURE_LOCATION_KEY, false)
-        setClear = state.getBoolean(SET_CLEAR_KEY, false)
-        isPointLocked = state.getBoolean(IS_POINT_LOCKED_KEY, false)
-
         placeMarkerButton!!.isEnabled = state.getBoolean(PLACE_MARKER_BUTTON_ENABLED_KEY, false)
         zoomButton!!.isEnabled = state.getBoolean(ZOOM_BUTTON_ENABLED_KEY, false)
         clearButton!!.isEnabled = state.getBoolean(CLEAR_BUTTON_ENABLED_KEY, false)

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointViewModel.kt
@@ -1,0 +1,20 @@
+package org.odk.collect.geo.geopoint
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.odk.collect.maps.MapPoint
+
+class GeoPointViewModel(inputPoint: MapPoint?) : ViewModel() {
+
+    private val _geopoint = MutableStateFlow(inputPoint)
+    val geoPoint: StateFlow<MapPoint?> = _geopoint
+
+    fun place(point: MapPoint) {
+        _geopoint.value = point
+    }
+
+    fun clear() {
+        _geopoint.value = null
+    }
+}

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointViewModel.kt
@@ -1,20 +1,30 @@
 package org.odk.collect.geo.geopoint
 
+import androidx.compose.runtime.MutableState
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import org.odk.collect.maps.MapPoint
 
 class GeoPointViewModel(inputPoint: MapPoint?) : ViewModel() {
 
+    private val _isInputPoint = MutableStateFlow(inputPoint != null)
+    val isInputPoint = _isInputPoint.asStateFlow()
+
     private val _geoPoint = MutableStateFlow(inputPoint)
-    val geoPoint: StateFlow<MapPoint?> = _geoPoint
+    val geoPoint = _geoPoint.asStateFlow()
 
     fun place(point: MapPoint) {
         _geoPoint.value = point
     }
 
+    fun hasGeoPoint(): Boolean {
+        return _geoPoint.value != null
+    }
+
     fun clear() {
         _geoPoint.value = null
+        _isInputPoint.value = false
     }
 }

--- a/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointViewModel.kt
+++ b/geo/src/main/java/org/odk/collect/geo/geopoint/GeoPointViewModel.kt
@@ -7,14 +7,14 @@ import org.odk.collect.maps.MapPoint
 
 class GeoPointViewModel(inputPoint: MapPoint?) : ViewModel() {
 
-    private val _geopoint = MutableStateFlow(inputPoint)
-    val geoPoint: StateFlow<MapPoint?> = _geopoint
+    private val _geoPoint = MutableStateFlow(inputPoint)
+    val geoPoint: StateFlow<MapPoint?> = _geoPoint
 
     fun place(point: MapPoint) {
-        _geopoint.value = point
+        _geoPoint.value = point
     }
 
     fun clear() {
-        _geopoint.value = null
+        _geoPoint.value = null
     }
 }

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointActivityTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointActivityTest.kt
@@ -32,7 +32,7 @@ import org.odk.collect.testshared.FakeScheduler
 class GeoPointActivityTest {
 
     private val locationLiveData: MutableLiveData<Location?> = MutableLiveData(null)
-    private val viewModel = mock<GeoPointViewModel> {
+    private val viewModel = mock<FindLocationViewModel> {
         on { acceptedLocation } doReturn locationLiveData
         on { currentAccuracy } doReturn MutableLiveData(null)
         on { timeElapsed } doReturn MutableNonNullLiveData(0)
@@ -53,7 +53,7 @@ class GeoPointActivityTest {
                 override fun providesScheduler() = scheduler
 
                 override fun providesGeoPointViewModelFactory(application: Application) =
-                    object : GeoPointViewModelFactory {
+                    object : FindLocationViewModelFactory {
                         @Suppress("UNCHECKED_CAST")
                         override fun <T : ViewModel> create(modelClass: Class<T>): T {
                             return viewModel as T

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointDialogFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointDialogFragmentTest.kt
@@ -41,7 +41,7 @@ class GeoPointDialogFragmentTest {
     private val currentAccuracyLiveData: MutableLiveData<LocationAccuracy?> = MutableLiveData(null)
     private val timeElapsedLiveData: MutableNonNullLiveData<Long> = MutableNonNullLiveData(0)
     private val satellitesLiveData = MutableNonNullLiveData(0)
-    private val viewModel = mock<GeoPointViewModel> {
+    private val viewModel = mock<FindLocationViewModel> {
         on { currentAccuracy } doReturn currentAccuracyLiveData
         on { timeElapsed } doReturn timeElapsedLiveData
         on { satellites } doReturn satellitesLiveData
@@ -56,7 +56,7 @@ class GeoPointDialogFragmentTest {
             .application(application)
             .geoDependencyModule(object : GeoDependencyModule() {
                 override fun providesGeoPointViewModelFactory(application: Application) =
-                    object : GeoPointViewModelFactory {
+                    object : FindLocationViewModelFactory {
                         @Suppress("UNCHECKED_CAST")
                         override fun <T : ViewModel> create(modelClass: Class<T>): T {
                             return viewModel as T

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -245,6 +245,15 @@ class GeoPointMapFragmentTest {
     }
 
     @Test
+    fun `enables place marker button when input point marker cleared`() {
+        launcherRule.launchInContainer { GeoPointMapFragment(MapPoint(1.0, 2.0)) }
+
+        EspressoAssertions.assertDisabled(withContentDescription(string.record_geopoint))
+        EspressoInteractions.clickOn(withContentDescription(string.clear))
+        EspressoAssertions.assertEnabled(withContentDescription(string.record_geopoint))
+    }
+
+    @Test
     fun `shows items from mappable data`() {
         val mappableData = FakeMappableData(
             listOf(

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -221,6 +221,23 @@ class GeoPointMapFragmentTest {
     }
 
     @Test
+    fun `clicking clear when input provided clears marker after recreation`() {
+        val scenario = launcherRule.launchInContainer {
+            GeoPointMapFragment(MapPoint(0.0, 0.0), false, false, false)
+        }
+
+        val location = Location(2.0, 2.0, accuracy = 5.2f)
+        locationTracker.currentLocation = location
+
+        EspressoInteractions.clickOn(withContentDescription(string.clear))
+        assertThat(map.getMarkers().size, equalTo(1))
+        assertThat(map, showsCurrentLocation(location.toMapPoint()))
+
+        scenario.recreate()
+        assertThat(map.getMarkers().size, equalTo(1))
+    }
+
+    @Test
     fun `enables place marker button when existing location cleared`() {
         val inputPoint = MapPoint(1.0, 2.0)
         launcherRule.launchInContainer {

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -66,18 +66,14 @@ class GeoPointMapFragmentTest {
 
     @Test
     fun `displays please wait message when location not set`() {
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, false)
-        }
+        launcherRule.launchInContainer { GeoPointMapFragment() }
 
         EspressoAssertions.assertVisible(withText(string.please_wait_long))
     }
 
     @Test
     fun `displays status message when location set`() {
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, false)
-        }
+        launcherRule.launchInContainer { GeoPointMapFragment() }
 
         locationTracker.currentLocation = Location(1.0, 2.0, 3.0, 4.0f)
         EspressoAssertions.assertVisible(withText("Accuracy: 4 m"))
@@ -85,9 +81,7 @@ class GeoPointMapFragmentTest {
 
     @Test
     fun `returns point from first location fix`() {
-        val scenario = launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, false)
-        }
+        val scenario = launcherRule.launchInContainer { GeoPointMapFragment() }
 
         val resultListener = FragmentResultRecorder()
         scenario.setFragmentResultListener(GeoPointMapFragment.REQUEST_GEOPOINT, resultListener)
@@ -123,9 +117,7 @@ class GeoPointMapFragmentTest {
 
     @Test
     fun `clicking add marker moves marker to the current location`() {
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, false)
-        }
+        launcherRule.launchInContainer { GeoPointMapFragment() }
 
         locationTracker.currentLocation = Location(1.0, 2.0, 3.0, 4.0f)
         val secondLocation = Location(5.0, 6.0, 7.0, 8.0f)
@@ -142,21 +134,18 @@ class GeoPointMapFragmentTest {
     @Test
     fun `shows marker when input point provided`() {
         val inputPoint = MapPoint(1.0, 2.0)
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(inputPoint, false, false, false)
-        }
+        launcherRule.launchInContainer { GeoPointMapFragment(inputPoint) }
 
         val markers = map.getMarkers()
         assertThat(markers.size, equalTo(1))
         assertThat(markers[0].point.latitude, equalTo(1.0))
         assertThat(markers[0].point.longitude, equalTo(2.0))
+        assertThat(markers[0].isDraggable, equalTo(false))
     }
 
     @Test
     fun `passing retain mock accuracy extra updates location tracker`() {
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, true)
-        }
+        launcherRule.launchInContainer { GeoPointMapFragment(retainMockAccuracy = true) }
 
         assertThat(locationTracker.retainMockAccuracy, equalTo(true))
 
@@ -170,7 +159,7 @@ class GeoPointMapFragmentTest {
     @Test
     fun `recreating the fragment with the layers dialog displayed does not crash the app`() {
         val scenario =
-            launcherRule.launchInContainer { GeoPointMapFragment(null, false, false, false) }
+            launcherRule.launchInContainer { GeoPointMapFragment() }
 
         onView(withId(R.id.layer_menu)).perform(click())
 
@@ -179,9 +168,7 @@ class GeoPointMapFragmentTest {
 
     @Test
     fun `clicking zoom zooms to the current location`() {
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, false)
-        }
+        launcherRule.launchInContainer { GeoPointMapFragment() }
 
         locationTracker.currentLocation = Location(5.0, 5.0)
         locationTracker.currentLocation = Location(6.0, 6.0)
@@ -192,9 +179,7 @@ class GeoPointMapFragmentTest {
 
     @Test
     fun `shows current location`() {
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, false)
-        }
+        launcherRule.launchInContainer { GeoPointMapFragment() }
 
         val firstLocation = Location(2.0, 2.0, accuracy = 5.2f)
         locationTracker.currentLocation = firstLocation
@@ -208,9 +193,7 @@ class GeoPointMapFragmentTest {
 
     @Test
     fun `clicking clear clears marker`() {
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, false)
-        }
+        launcherRule.launchInContainer { GeoPointMapFragment() }
 
         val location = Location(2.0, 2.0, accuracy = 5.2f)
         locationTracker.currentLocation = location
@@ -222,9 +205,7 @@ class GeoPointMapFragmentTest {
 
     @Test
     fun `clicking clear when input provided clears marker after recreation`() {
-        val scenario = launcherRule.launchInContainer {
-            GeoPointMapFragment(MapPoint(0.0, 0.0), false, false, false)
-        }
+        val scenario = launcherRule.launchInContainer { GeoPointMapFragment(MapPoint(0.0, 0.0)) }
 
         val location = Location(2.0, 2.0, accuracy = 5.2f)
         locationTracker.currentLocation = location
@@ -247,10 +228,7 @@ class GeoPointMapFragmentTest {
             )
         )
 
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, false, mappableData)
-        }
-
+        launcherRule.launchInContainer { GeoPointMapFragment(mappableData = mappableData) }
         assertThat(map, showsMappableData(mappableData, background = true, clickable = false))
     }
 
@@ -259,27 +237,26 @@ class GeoPointMapFragmentTest {
         val mappableData = FakeMappableData(emptyList())
         mappableData.isLoading = false
 
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(null, false, false, false, mappableData)
-        }.onFragment {
-            val dialogClass = MaterialProgressDialogFragment::class.java
-            assertThat(
-                getFragmentByClass(it.childFragmentManager, dialogClass),
-                nullValue()
-            )
+        launcherRule.launchInContainer { GeoPointMapFragment(mappableData = mappableData) }
+            .onFragment {
+                val dialogClass = MaterialProgressDialogFragment::class.java
+                assertThat(
+                    getFragmentByClass(it.childFragmentManager, dialogClass),
+                    nullValue()
+                )
 
-            mappableData.isLoading = true
-            assertThat(
-                getFragmentByClass(it.childFragmentManager, dialogClass),
-                notNullValue()
-            )
+                mappableData.isLoading = true
+                assertThat(
+                    getFragmentByClass(it.childFragmentManager, dialogClass),
+                    notNullValue()
+                )
 
-            mappableData.isLoading = false
-            assertThat(
-                getFragmentByClass(it.childFragmentManager, dialogClass),
-                nullValue()
-            )
-        }
+                mappableData.isLoading = false
+                assertThat(
+                    getFragmentByClass(it.childFragmentManager, dialogClass),
+                    nullValue()
+                )
+            }
     }
 
     private fun overrideDependencies(mapFragment: MapFragment) {

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -229,7 +229,7 @@ class GeoPointMapFragmentTest {
     }
 
     @Test
-    fun `clicking clear when input provided clears marker after recreation`() {
+    fun `clicking clear when input point provided keeps marker cleared after recreation`() {
         val scenario = launcherRule.launchInContainer { GeoPointMapFragment(MapPoint(0.0, 0.0)) }
 
         val location = Location(2.0, 2.0, accuracy = 5.2f)

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -182,6 +182,17 @@ class GeoPointMapFragmentTest {
     }
 
     @Test
+    fun `does not show accuracy status when there is an input point`() {
+        launcherRule.launchInContainer { GeoPointMapFragment(MapPoint(0.0, 0.0)) }
+
+        locationTracker.currentLocation = Location(1.0, 2.0, 3.0, 4.0f)
+        EspressoAssertions.assertNotVisible(withText("Accuracy: 4 m"))
+
+        EspressoInteractions.clickOn(withContentDescription(string.clear))
+        EspressoAssertions.assertVisible(withText("Accuracy: 4 m"))
+    }
+
+    @Test
     fun `passing retain mock accuracy extra updates location tracker`() {
         launcherRule.launchInContainer { GeoPointMapFragment(retainMockAccuracy = true) }
 

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -305,6 +305,17 @@ class GeoPointMapFragmentTest {
             }
     }
 
+    @Test
+    fun `recreating retains center when there is a point`() {
+        val inputPoint = MapPoint(-1.0, -1.0)
+        val scenario = launcherRule.launchInContainer { GeoPointMapFragment(inputPoint) }
+
+        val center = MapPoint(5.0, 5.0)
+        map.setCenter(center)
+        scenario.recreate()
+        assertThat(map.getCenter(), equalTo(center))
+    }
+
     private fun overrideDependencies(mapFragment: MapFragment) {
         val application = ApplicationProvider.getApplicationContext<RobolectricApplication>()
         application.geoDependencyComponent = DaggerGeoDependencyComponent.builder()

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -133,7 +133,10 @@ class GeoPointMapFragmentTest {
 
     @Test
     fun `can drag marker after adding one`() {
-        launcherRule.launchInContainer { GeoPointMapFragment() }
+        val scenario = launcherRule.launchInContainer { GeoPointMapFragment() }
+
+        val resultListener = FragmentResultRecorder()
+        scenario.setFragmentResultListener(GeoPointMapFragment.REQUEST_GEOPOINT, resultListener)
 
         val location = Location(1.0, 2.0, 3.0, 4.0f)
         locationTracker.currentLocation = location
@@ -143,6 +146,14 @@ class GeoPointMapFragmentTest {
         val destination = MapPoint(2.0, 3.0)
         map.dragMarker(1, destination)
         assertThat(map.getMarkers()[1].point, equalTo(destination))
+
+        EspressoInteractions.clickOn(withContentDescription(string.save))
+        val result = resultListener.getAll().last()
+        assertThat(result.first, equalTo(GeoPointMapFragment.REQUEST_GEOPOINT))
+        assertThat(
+            result.second.getString(GeoPointMapFragment.RESULT_GEOPOINT),
+            equalTo("2.0 3.0 0.0 0.0")
+        )
     }
 
     @Test

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -116,7 +116,7 @@ class GeoPointMapFragmentTest {
     }
 
     @Test
-    fun `clicking add marker moves marker to the current location`() {
+    fun `clicking add marker moves marker to the current location and centers on it`() {
         launcherRule.launchInContainer { GeoPointMapFragment() }
 
         locationTracker.currentLocation = Location(1.0, 2.0, 3.0, 4.0f)
@@ -129,6 +129,8 @@ class GeoPointMapFragmentTest {
             .filter { it.iconDescription != CurrentLocationDelegate.ICON_DESCRIPTION }
         assertThat(markers.size, equalTo(1))
         assertThat(markers[0].point, equalTo(secondLocation.toMapPoint()))
+
+        assertThat(map.getCenter(), equalTo(secondLocation.toMapPoint()))
     }
 
     @Test

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -132,6 +132,20 @@ class GeoPointMapFragmentTest {
     }
 
     @Test
+    fun `can drag marker after adding one`() {
+        launcherRule.launchInContainer { GeoPointMapFragment() }
+
+        val location = Location(1.0, 2.0, 3.0, 4.0f)
+        locationTracker.currentLocation = location
+        EspressoInteractions.clickOn(withContentDescription(string.record_geopoint))
+        assertThat(map.getMarkers().size, equalTo(2))
+
+        val destination = MapPoint(2.0, 3.0)
+        map.dragMarker(1, destination)
+        assertThat(map.getMarkers()[1].point, equalTo(destination))
+    }
+
+    @Test
     fun `shows marker when input point provided`() {
         val inputPoint = MapPoint(1.0, 2.0)
         launcherRule.launchInContainer { GeoPointMapFragment(inputPoint) }

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -146,7 +146,7 @@ class GeoPointMapFragmentTest {
     }
 
     @Test
-    fun `shows marker when input point provided`() {
+    fun `shows marker and centers on it when input point provided`() {
         val inputPoint = MapPoint(1.0, 2.0)
         launcherRule.launchInContainer { GeoPointMapFragment(inputPoint) }
 
@@ -154,6 +154,17 @@ class GeoPointMapFragmentTest {
         assertThat(markers.size, equalTo(1))
         assertThat(markers[0].point.latitude, equalTo(1.0))
         assertThat(markers[0].point.longitude, equalTo(2.0))
+
+        assertThat(map.getCenter(), equalTo(inputPoint))
+    }
+
+    @Test
+    fun `does not allow editing input point`() {
+        val inputPoint = MapPoint(1.0, 2.0)
+        launcherRule.launchInContainer { GeoPointMapFragment(inputPoint) }
+
+        val markers = map.getMarkers()
+        assertThat(markers.size, equalTo(1))
         assertThat(markers[0].isDraggable, equalTo(false))
     }
 

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -1,7 +1,6 @@
 package org.odk.collect.geo.geopoint
 
 import android.app.Application
-import androidx.activity.OnBackPressedDispatcher
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -26,7 +25,6 @@ import org.odk.collect.geo.DaggerGeoDependencyComponent
 import org.odk.collect.geo.GeoDependencyModule
 import org.odk.collect.geo.GeoUtils.toMapPoint
 import org.odk.collect.geo.R
-import org.odk.collect.geo.geopoly.GeoPolyFragment
 import org.odk.collect.geo.support.FakeLocationTracker
 import org.odk.collect.geo.support.FakeMapFragment
 import org.odk.collect.geo.support.FakeMappableData
@@ -51,7 +49,6 @@ import org.odk.collect.testshared.EspressoInteractions
 import org.odk.collect.testshared.FragmentResultRecorder
 import org.odk.collect.testshared.RobolectricHelpers.getFragmentByClass
 import org.odk.collect.webpage.WebPageService
-import org.robolectric.Shadows
 
 @RunWith(AndroidJUnit4::class)
 class GeoPointMapFragmentTest {
@@ -62,14 +59,8 @@ class GeoPointMapFragmentTest {
     @get:Rule
     val launcherRule = FragmentScenarioLauncherRule()
 
-    private val application = ApplicationProvider.getApplicationContext<Application>()
-
     @Before
     fun setUp() {
-        val shadowApplication =
-            Shadows.shadowOf(application)
-        shadowApplication.grantPermissions("android.permission.ACCESS_FINE_LOCATION")
-        shadowApplication.grantPermissions("android.permission.ACCESS_COARSE_LOCATION")
         overrideDependencies(map)
     }
 

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -222,6 +222,7 @@ class GeoPointMapFragmentTest {
 
         val location = Location(2.0, 2.0, accuracy = 5.2f)
         locationTracker.currentLocation = location
+        assertThat(map.getMarkers().size, equalTo(2))
 
         EspressoInteractions.clickOn(withContentDescription(string.clear))
         assertThat(map.getMarkers().size, equalTo(1))

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/GeoPointMapFragmentTest.kt
@@ -238,18 +238,6 @@ class GeoPointMapFragmentTest {
     }
 
     @Test
-    fun `enables place marker button when existing location cleared`() {
-        val inputPoint = MapPoint(1.0, 2.0)
-        launcherRule.launchInContainer {
-            GeoPointMapFragment(inputPoint, false, false, false)
-        }
-
-        EspressoAssertions.assertDisabled(withContentDescription(string.record_geopoint))
-        EspressoInteractions.clickOn(withContentDescription(string.clear))
-        EspressoAssertions.assertEnabled(withContentDescription(string.record_geopoint))
-    }
-
-    @Test
     fun `shows items from mappable data`() {
         val mappableData = FakeMappableData(
             listOf(

--- a/geo/src/test/java/org/odk/collect/geo/geopoint/LocationTrackerFindLocationViewModelTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/geopoint/LocationTrackerFindLocationViewModelTest.kt
@@ -17,7 +17,7 @@ import org.odk.collect.location.satellites.SatelliteInfoClient
 import org.odk.collect.location.tracker.LocationTracker
 import org.odk.collect.testshared.FakeScheduler
 
-class LocationTrackerGeoPointViewModelTest {
+class LocationTrackerFindLocationViewModelTest {
 
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -302,5 +302,5 @@ class LocationTrackerGeoPointViewModelTest {
     }
 
     private fun createViewModel(clock: () -> Long = { 0 }) =
-        LocationTrackerGeoPointViewModel(locationTracker, satelliteInfoClient, clock, scheduler)
+        LocationTrackerFindLocationViewModel(locationTracker, satelliteInfoClient, clock, scheduler)
 }

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -278,4 +278,10 @@ class FakeMapFragment(private val ready: Boolean = false) : Fragment(), MapFragm
         polyLines[featureId] = polyLines[featureId]!!.copy(points = new)
         dragListener?.onFeature(featureId)
     }
+
+    fun dragMarker(index: Int, destination: MapPoint) {
+        val featureId = featureIds[index]
+        markers[featureId] = markers[featureId]!!.copy(point = destination)
+        dragListener?.onFeature(featureId)
+    }
 }

--- a/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
+++ b/google-maps/src/main/java/org/odk/collect/googlemaps/GoogleMapFragment.java
@@ -357,7 +357,10 @@ public class GoogleMapFragment extends MapViewModelMapFragment implements
     @Override
     public void clearFeatures(@NotNull List<@NotNull Integer> ids) {
         for (Integer id : ids) {
-            features.remove(id).dispose();
+            MapFeature removedFeature = features.remove(id);
+            if (removedFeature != null) {
+                removedFeature.dispose();
+            }
         }
     }
 

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MarkerFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MarkerFeature.kt
@@ -67,6 +67,10 @@ class MarkerFeature(
         override fun onAnnotationDragFinished(annotation: com.mapbox.maps.plugin.annotation.Annotation<*>) {
             onAnnotationDrag(annotation)
             if (annotation.id == pointAnnotation.id && featureDragEndListener != null) {
+                /**
+                 * Prevents listener from accidentally interfering with features while Mapbox
+                 * performs updates which can cause a `ConcurrentModificationException`
+                 */
                 Handler(Looper.getMainLooper()).post {
                     featureDragEndListener.onFeature(featureId)
                 }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MarkerFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MarkerFeature.kt
@@ -1,6 +1,8 @@
 package org.odk.collect.mapbox
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationDragListener
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
@@ -65,7 +67,9 @@ class MarkerFeature(
         override fun onAnnotationDragFinished(annotation: com.mapbox.maps.plugin.annotation.Annotation<*>) {
             onAnnotationDrag(annotation)
             if (annotation.id == pointAnnotation.id && featureDragEndListener != null) {
-                featureDragEndListener.onFeature(featureId)
+                Handler(Looper.getMainLooper()).post {
+                    featureDragEndListener.onFeature(featureId)
+                }
             }
         }
     }

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.kt
@@ -43,7 +43,7 @@ interface MapFragment {
      * Centers the map view on the given point, leaving zoom level unchanged,
      * possibly with animation.
      */
-    fun setCenter(center: MapPoint?, animate: Boolean)
+    fun setCenter(center: MapPoint?, animate: Boolean = false)
 
     /**
      * Centers the map view on the current location, zooming in to the last zoom level set by the


### PR DESCRIPTION
Closes #7325 

#### Why is this the best possible solution? Were any other approaches considered?

The main change here is to introduce a ViewModel to hold the UI's "point" state so that it doesn't end up having to deal with the spaghetti that results from using the Fragment's saved instance state. There's definitely more refactoring that could happen here, but that's a rabbit hole that feels like a low priority right now given how much time we've already given to improving the geopoint flow.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This changes how state is retained when entering a geopoint. This is an area that has only had tests written after the fact rather than during implementation, so there's a high risk that things can break when changing still (until we backfill enough coverage).

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
