### PR TITLE
Fix memory config for test_app

### DIFF
--- a/.circleci/gradle-test-app.properties
+++ b/.circleci/gradle-test-app.properties
@@ -1,8 +1,7 @@
 # Gradle config for "Large" Circle CI resource (https://circleci.com/pricing/price-list/)
 
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-Xmx2g
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-Xmx1024m
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=4
-test.heap.max=4g
-
+test.heap.max=2g


### PR DESCRIPTION
This is a fix for: https://app.circleci.com/pipelines/github/getodk/collect/10319/workflows/2cd38e20-d00f-4e2a-bb62-2f7e31897681/jobs/60551

#### Why is this the best possible solution? Were any other approaches considered?
`test_app` fails with `Gradle build daemon disappeared unexpectedly`. There is no `OutOfMemoryError` anywhere in the log, no stack trace, and the daemon log just stops mid-stream, which means the process was killed from outside, probably the kernel OOM killer, not a JVM running out of heap. 
I realized that the large Docker resource class that we use has [8GB RAM](https://circleci.com/pricing/price-list/), and that this job runs three JVMs at the same time - the Gradle daemon, the Kotlin compile daemon, and the test worker. Their heap ceilings were 4g + 2g + 4g, so the config allowed 10GB of heap in an 8GB container. 
In practice, that meant the job could exceed the container at any point where the JVMs actually grew into those ceilings, and the kernel would then kill the Gradle daemon.

The fix is to lower those ceilings so the total stays under 8GB. That is also what CircleCI's own support article for this error recommends - either upgrade the resource class or reduce org.gradle.jvmargs see: https://support.circleci.com/hc/en-us/articles/14008245308827-How-to-limit-RAM-usage-for-Android

These ceilings were raised in #7194 to fix real failures, but in the wrong way as far as I can tell. And if lowering them does cause problems, we can handle them properly - maybe by switching to `xlarge`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There is no need to test anything here.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
