### PR TITLE
Select current server URL when Server URL configuration dialog opens

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
@@ -64,6 +64,11 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment {
 
         serverUrlPreference.setOnPreferenceChangeListener(createChangeListener());
         serverUrlPreference.setSummary(serverUrlPreference.getText());
+        serverUrlPreference.setOnBindEditTextListener(editText -> {
+    if (editText.getText() != null) {
+        editText.selectAll();
+    }
+});
 
         usernamePreference.setOnPreferenceChangeListener(createChangeListener());
         usernamePreference.setSummary(usernamePreference.getText());


### PR DESCRIPTION
Closes #4574

### Why is this the best possible solution? Were any other approaches considered?

This change uses `setOnBindEditTextListener` to select the existing server URL when the dialog is opened. It is a small, localized change that affects only the Server URL preference.

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users can immediately replace the existing server URL without manually selecting the text first. The change only affects the Server URL preference dialog.

### Do we need any specific form for testing your changes? If so, please attach one.

- Project builds successfully using `assembleDebug`.
- I was not able to manually verify the UI behavior on an Android device or emulator.

### Does this change require updates to documentation?

No.