### PR TITLE
Prevent issues recreating `ChangeReasonPromptDialogFragment`

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -460,6 +460,7 @@ public class FormFillingActivity extends LocalizedActivity implements CollectCom
                 .forClass(GeoPolyDialogFragment.class, () -> new GeoPolyDialogFragment(viewModelFactory, dispatcherProvider))
                 .forClass(GeoPointMapDialogFragment.class, () -> new GeoPointMapDialogFragment(viewModelFactory, dispatcherProvider))
                 .forClass(RangePickerDialogFragment.class, () -> new RangePickerDialogFragment(viewModelFactory))
+                .forClass(ChangesReasonPromptDialogFragment.class, () -> new ChangesReasonPromptDialogFragment(viewModelFactory))
                 .build());
 
         getSupportFragmentManager().setFragmentResultListener(REQUEST_DELETE_REPEAT, this, (requestKey, result) -> deleteGroup());

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -20,7 +20,18 @@ import org.odk.collect.material.MaterialFullScreenDialogFragment;
 
 public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogFragment {
 
+    private final ViewModelProvider.Factory viewModelFactory;
     private FormSaveViewModel viewModel;
+
+    public ChangesReasonPromptDialogFragment(ViewModelProvider.Factory viewModelFactory) {
+        this.viewModelFactory = viewModelFactory;
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        viewModel = new ViewModelProvider(requireActivity(), viewModelFactory).get(FormSaveViewModel.class);
+    }
 
     @Nullable
     @Override
@@ -63,12 +74,6 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
         });
 
         reasonField.requestFocus();
-    }
-
-    @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
-        viewModel = new ViewModelProvider(requireActivity()).get(FormSaveViewModel.class);
     }
 
     @Override


### PR DESCRIPTION
A quick fix for https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/00a1d811635f54e98748176e6c83d1d4