### PR TITLE
Remove optimization that obscures `NullPointerException` stacktraces

### DIFF
--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -39,4 +39,4 @@
 -keepattributes SourceFile,LineNumberTable
 
 # Prevent optimizations and the obscure NullPointerException crashes
--optimizations !convertchecknotnull
+-processkotlinnullchecks keep

--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -37,3 +37,6 @@
 
 # Keep line numbers for Crashlytics https://stackoverflow.com/questions/38529304/android-crashlytics-sending-incorrect-line-number
 -keepattributes SourceFile,LineNumberTable
+
+# Prevent optimizations and the obscure NullPointerException crashes
+-optimizations !convertchecknotnull


### PR DESCRIPTION
This should prevent us from seeing the `Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference` crash so we get a better sense of why a crash happens.