### PR TITLE
Improve reporting for file path check failures

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/PathUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/PathUtils.kt
@@ -13,10 +13,19 @@ object PathUtils {
 
         val absoluteFile = File(absoluteFilePath)
         return try {
-            if (absoluteFile.sanitizedCanonicalPath().startsWith(File(dirPath).sanitizedCanonicalPath())) {
+            val canonicalFilePath = absoluteFile.sanitizedCanonicalPath()
+            val canonicalDirPath = File(dirPath).sanitizedCanonicalPath()
+
+            if (canonicalFilePath.startsWith(canonicalDirPath)) {
                 absoluteFilePath
             } else {
-                throw SecurityException("Contact support@getodk.org. Attempt to access file outside of Collect directory: $absoluteFilePath")
+                throw SecurityException(
+                    "Contact support@getodk.org. Attempt to access file outside of Collect directory: $absoluteFilePath\n" +
+                        "dirPath: $dirPath\n" +
+                        "filePath: $filePath\n" +
+                        "canonicalFilePath: $canonicalFilePath\n" +
+                        "canonicalDirPath: $canonicalDirPath\n"
+                )
             }
         } catch (e: IOException) {
             Timber.e(

--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/PathUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/PathUtils.kt
@@ -27,14 +27,14 @@ object PathUtils {
                         "canonicalDirPath: $canonicalDirPath\n"
                 )
             }
-        } catch (e: IOException) {
-            Timber.e(
-                "Failed attempt to access canonicalPath:\n" +
-                    "dirPath: $dirPath\n" +
-                    "filePath: $filePath\n" +
-                    "absoluteFilePath: $absoluteFilePath\n" +
-                    "absoluteFilePath exists: ${absoluteFile.exists()}\n"
-            )
+        } catch (_: IOException) {
+            val message = "Failed attempt to access canonicalPath:\n" +
+                "dirPath: $dirPath\n" +
+                "filePath: $filePath\n" +
+                "absoluteFilePath: $absoluteFilePath\n" +
+                "absoluteFilePath exists: ${absoluteFile.exists()}\n"
+
+            Timber.e(Error(message))
             absoluteFilePath
         }
     }


### PR DESCRIPTION
#### Why is this the best possible solution? Were any other approaches considered?
This just improves the logging so we can see what `sanitizedCanonicalPath() `actually returned for the file and for the directory, and how the two don't match. Right now the message only prints `absoluteFilePath` and it always looks correct, so the reports tell us nothing about why the check failed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
