### PR TITLE
Resume interrupted submission uploads from the last uploaded chunk

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/send/InstanceUploadProgressTracker.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/send/InstanceUploadProgressTracker.kt
@@ -1,0 +1,115 @@
+package org.odk.collect.android.instancemanagement.send
+
+import org.odk.collect.openrosa.http.SubmissionUploadProgressTracker
+import org.odk.collect.shared.strings.Md5.getMd5Hash
+import timber.log.Timber
+import java.io.File
+
+/**
+ * File-backed [SubmissionUploadProgressTracker] that lets an interrupted submission resume from the
+ * last chunk the server accepted instead of restarting from the first one.
+ *
+ * Progress is stored in a hidden `.upload_progress` file inside the instance directory. It is hidden
+ * so that [OpenRosaServerInstanceUploader]'s own directory listing (which skips dot-files) never
+ * uploads it. The file records two things:
+ *  1. a [computeUploadFingerprint] of the whole upload (submission XML + every attachment), and
+ *  2. the index of the last chunk the server accepted.
+ *
+ * When [start] is called, if the stored fingerprint matches the current upload the tracker resumes
+ * from `lastChunk + 1`; otherwise (the upload content changed, or there is no stored progress) it
+ * starts from the first chunk and (re)writes the fingerprint.
+ *
+ * Resuming relies on the server retaining the previously uploaded chunks of an unfinished submission
+ * — the OpenRosa `*isIncomplete*` contract keeps the submission open until a chunk without that flag
+ * is received. If the server discards partial submissions, resuming is still safe because every
+ * chunk re-sends the submission XML (identifying the submission) and the server merges attachments
+ * by name; the worst case is that a discarded earlier chunk is missing, which the fingerprint check
+ * cannot detect. Progress is therefore best-effort and only ever skips re-uploading data.
+ */
+class InstanceUploadProgressTracker(instanceDir: File) : SubmissionUploadProgressTracker {
+
+    private val progressFile = File(instanceDir, PROGRESS_FILE_NAME)
+    private var fingerprint: String = ""
+    private var resumeFromChunkIndex: Int = 0
+
+    /**
+     * Loads any stored progress for [uploadFingerprint] and decides where the upload should resume.
+     * Must be called before the upload starts.
+     */
+    fun start(uploadFingerprint: String) {
+        fingerprint = uploadFingerprint
+
+        val stored = read()
+        resumeFromChunkIndex = if (stored != null && stored.fingerprint == uploadFingerprint) {
+            // Same upload as last time: continue from the chunk after the last one that succeeded.
+            stored.lastChunk + 1
+        } else {
+            // No progress, or the upload content changed since last time: start over.
+            write(uploadFingerprint, NO_CHUNK_UPLOADED)
+            0
+        }
+    }
+
+    override fun getResumeFromChunkIndex(): Int = resumeFromChunkIndex
+
+    override fun onChunkUploaded(chunkIndex: Int) {
+        write(fingerprint, chunkIndex)
+    }
+
+    /** Removes stored progress. Call once the whole submission has been accepted. */
+    fun clear() {
+        progressFile.delete()
+    }
+
+    private fun read(): StoredProgress? {
+        if (!progressFile.exists()) {
+            return null
+        }
+
+        return try {
+            val lines = progressFile.readLines()
+            val storedFingerprint = lines.getOrNull(0)
+            val lastChunk = lines.getOrNull(1)?.toIntOrNull()
+            if (storedFingerprint.isNullOrEmpty() || lastChunk == null) {
+                null
+            } else {
+                StoredProgress(storedFingerprint, lastChunk)
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Could not read upload progress; the upload will restart from the first chunk")
+            null
+        }
+    }
+
+    private fun write(fingerprint: String, lastChunk: Int) {
+        try {
+            progressFile.writeText("$fingerprint\n$lastChunk")
+        } catch (e: Exception) {
+            // Progress tracking is best-effort: a failed write just means the next retry restarts.
+            Timber.w(e, "Could not persist upload progress")
+        }
+    }
+
+    private data class StoredProgress(val fingerprint: String, val lastChunk: Int)
+
+    companion object {
+        const val PROGRESS_FILE_NAME = ".upload_progress"
+        private const val NO_CHUNK_UPLOADED = -1
+
+        /**
+         * Fingerprint of the whole upload: the MD5 of a manifest built from each file's name and its
+         * own MD5 (the submission XML first, then the attachments in the exact order they will be
+         * uploaded). Any change to the set, order or content of the uploaded files changes the
+         * fingerprint, which invalidates resume progress and forces a restart from the first chunk.
+         */
+        @JvmStatic
+        fun computeUploadFingerprint(submissionFile: File, orderedFiles: List<File>): String {
+            val manifest = StringBuilder()
+            manifest.append(submissionFile.name).append(':').append(submissionFile.getMd5Hash()).append('\n')
+            for (file in orderedFiles) {
+                manifest.append(file.name).append(':').append(file.getMd5Hash()).append('\n')
+            }
+            return manifest.toString().getMd5Hash() ?: ""
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/send/OpenRosaServerInstanceUploader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/send/OpenRosaServerInstanceUploader.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.android.instancemanagement.send
 
 import android.net.Uri
+import androidx.annotation.VisibleForTesting
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.analytics.AnalyticsEvents
 import org.odk.collect.android.application.Collect
@@ -161,9 +162,19 @@ class OpenRosaServerInstanceUploader(
             throw FormUploadException("${FAIL}instance XML file does not exist!")
         }
 
+        val instanceDir = instanceFile.parentFile
+            ?: throw FormUploadException("Error reading files to upload")
+
         val files = getFilesInParentDirectory(instanceFile, submissionFile)
             // TODO: when can this happen? It used to cause the whole submission attempt to fail. Should it?
             ?: throw FormUploadException("Error reading files to upload")
+
+        // Resume an interrupted chunked upload from the last chunk the server accepted, as long as the
+        // upload's content is unchanged since the previous attempt (see InstanceUploadProgressTracker).
+        val progressTracker = InstanceUploadProgressTracker(instanceDir)
+        progressTracker.start(
+            InstanceUploadProgressTracker.computeUploadFingerprint(submissionFile, files)
+        )
 
         val messageParser = ResponseMessageParser()
 
@@ -174,7 +185,8 @@ class OpenRosaServerInstanceUploader(
                 files,
                 uri,
                 webCredentialsUtils.getCredentials(uri),
-                contentLength
+                contentLength,
+                progressTracker
             )
 
             val responseCode = postResult.responseCode
@@ -203,6 +215,7 @@ class OpenRosaServerInstanceUploader(
         }
 
         markSubmissionComplete(instance, instancesRepository)
+        progressTracker.clear()
         logOverrideURL(referrer, overrideURL)
 
         return if (messageParser.isValid) {
@@ -212,7 +225,8 @@ class OpenRosaServerInstanceUploader(
         }
     }
 
-    private fun getFilesInParentDirectory(instanceFile: File, submissionFile: File): List<File>? {
+    @VisibleForTesting
+    internal fun getFilesInParentDirectory(instanceFile: File, submissionFile: File): List<File>? {
         val files = mutableListOf<File>()
 
         // find all files in parent directory
@@ -230,7 +244,10 @@ class OpenRosaServerInstanceUploader(
             files.add(file)
         }
 
-        return files
+        // Sort by name so the upload order — and therefore the chunk boundaries — is deterministic and
+        // reproducible across retries (a prerequisite for resuming a chunked upload). File.listFiles()
+        // itself returns files in no guaranteed order.
+        return files.sortedBy { it.name }
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/send/InstanceUploadProgressTrackerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/send/InstanceUploadProgressTrackerTest.kt
@@ -1,0 +1,103 @@
+package org.odk.collect.android.instancemanagement.send
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class InstanceUploadProgressTrackerTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun `a fresh upload starts from the first chunk and stores progress`() {
+        val dir = tempFolder.newFolder()
+        val tracker = InstanceUploadProgressTracker(dir)
+
+        tracker.start("fingerprint-1")
+
+        assertThat(tracker.getResumeFromChunkIndex(), equalTo(0))
+        assertThat(File(dir, InstanceUploadProgressTracker.PROGRESS_FILE_NAME).exists(), equalTo(true))
+    }
+
+    @Test
+    fun `the same fingerprint resumes from the chunk after the last uploaded one`() {
+        val dir = tempFolder.newFolder()
+        InstanceUploadProgressTracker(dir).apply {
+            start("fingerprint-1")
+            onChunkUploaded(0)
+            onChunkUploaded(1)
+        }
+
+        val resumed = InstanceUploadProgressTracker(dir)
+        resumed.start("fingerprint-1")
+
+        assertThat(resumed.getResumeFromChunkIndex(), equalTo(2))
+    }
+
+    @Test
+    fun `a different fingerprint restarts from the first chunk and resets stored progress`() {
+        val dir = tempFolder.newFolder()
+        InstanceUploadProgressTracker(dir).apply {
+            start("fingerprint-1")
+            onChunkUploaded(3)
+        }
+
+        val changed = InstanceUploadProgressTracker(dir)
+        changed.start("fingerprint-2")
+        assertThat(changed.getResumeFromChunkIndex(), equalTo(0))
+
+        // Stored progress now belongs to the new fingerprint: a further retry with fingerprint-2
+        // resumes from the start (nothing uploaded for it yet), not from fingerprint-1's chunk 3.
+        val retry = InstanceUploadProgressTracker(dir)
+        retry.start("fingerprint-2")
+        assertThat(retry.getResumeFromChunkIndex(), equalTo(0))
+    }
+
+    @Test
+    fun `clearing progress makes the next upload start from the first chunk`() {
+        val dir = tempFolder.newFolder()
+        InstanceUploadProgressTracker(dir).apply {
+            start("fingerprint-1")
+            onChunkUploaded(2)
+            clear()
+        }
+
+        assertThat(File(dir, InstanceUploadProgressTracker.PROGRESS_FILE_NAME).exists(), equalTo(false))
+
+        val next = InstanceUploadProgressTracker(dir)
+        next.start("fingerprint-1")
+        assertThat(next.getResumeFromChunkIndex(), equalTo(0))
+    }
+
+    @Test
+    fun `the fingerprint is stable for the same files and changes when a file's content changes`() {
+        val submission = tempFolder.newFile().apply { writeText("<x/>") }
+        val a = tempFolder.newFile().apply { writeText("AAA") }
+        val b = tempFolder.newFile().apply { writeText("BBB") }
+
+        val fingerprint = InstanceUploadProgressTracker.computeUploadFingerprint(submission, listOf(a, b))
+        val recomputed = InstanceUploadProgressTracker.computeUploadFingerprint(submission, listOf(a, b))
+        assertThat(recomputed, equalTo(fingerprint))
+
+        a.writeText("AAAA")
+        val afterContentChange = InstanceUploadProgressTracker.computeUploadFingerprint(submission, listOf(a, b))
+        assertThat(afterContentChange, not(equalTo(fingerprint)))
+    }
+
+    @Test
+    fun `the fingerprint changes when the set of files changes`() {
+        val submission = tempFolder.newFile().apply { writeText("<x/>") }
+        val a = tempFolder.newFile().apply { writeText("AAA") }
+        val b = tempFolder.newFile().apply { writeText("BBB") }
+
+        val withOne = InstanceUploadProgressTracker.computeUploadFingerprint(submission, listOf(a))
+        val withTwo = InstanceUploadProgressTracker.computeUploadFingerprint(submission, listOf(a, b))
+
+        assertThat(withTwo, not(equalTo(withOne)))
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/send/OpenRosaServerInstanceUploaderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/send/OpenRosaServerInstanceUploaderTest.kt
@@ -1,0 +1,41 @@
+package org.odk.collect.android.instancemanagement.send
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.mock
+import java.io.File
+
+class OpenRosaServerInstanceUploaderTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    /**
+     * The attachment list must be deterministically ordered so the chunk boundaries are reproducible
+     * across upload attempts (which is what makes resuming a chunked upload safe). This also confirms
+     * the hidden `.upload_progress` resume file is not treated as an attachment (so it is never
+     * uploaded), alongside the existing instance/submission XML exclusions.
+     */
+    @Test
+    fun `getFilesInParentDirectory returns attachments sorted by name, ignoring hidden and xml files`() {
+        val instanceDir = tempFolder.newFolder()
+        val instanceFile = File(instanceDir, "instance.xml").apply { writeText("<x/>") }
+        val submissionFile = File(instanceDir, "submission.xml").apply { writeText("<x/>") }
+
+        // created in a deliberately non-sorted order
+        File(instanceDir, "3.jpg").writeText("c")
+        File(instanceDir, "1.jpg").writeText("a")
+        File(instanceDir, "2.jpg").writeText("b")
+        File(instanceDir, InstanceUploadProgressTracker.PROGRESS_FILE_NAME).writeText("progress")
+        File(instanceDir, ".other").writeText("hidden")
+
+        val uploader = OpenRosaServerInstanceUploader(mock(), mock())
+
+        val files = uploader.getFilesInParentDirectory(instanceFile, submissionFile)!!
+
+        assertThat(files.map { it.name }, equalTo(listOf("1.jpg", "2.jpg", "3.jpg")))
+    }
+}

--- a/open-rosa/src/main/java/org/odk/collect/openrosa/http/OpenRosaHttpInterface.java
+++ b/open-rosa/src/main/java/org/odk/collect/openrosa/http/OpenRosaHttpInterface.java
@@ -66,6 +66,28 @@ public interface OpenRosaHttpInterface {
                                             @NonNull HttpCredentialsInterface credentials,
                                             @NonNull long contentLength) throws Exception;
 
+    /**
+     * Uploads a submission that may be split into several chunks, resuming from the chunk indicated
+     * by {@code progressTracker} and reporting each accepted chunk back to it so that a later retry
+     * can continue where this attempt stopped.
+     *
+     * <p>Implementations that do not support resumable uploads may ignore the tracker; the default
+     * simply delegates to the non-resumable overload (upload the whole submission from the start).
+     *
+     * @param progressTracker tracks and resumes chunk progress, or {@code null} to always upload
+     *                        from the first chunk
+     * @throws IOException can be thrown if files do not exist
+     */
+    @NonNull
+    default HttpPostResult uploadSubmissionAndFiles(@NonNull File submissionFile,
+                                                    @NonNull List<File> fileList,
+                                                    @NonNull URI uri,
+                                                    @NonNull HttpCredentialsInterface credentials,
+                                                    @NonNull long contentLength,
+                                                    @Nullable SubmissionUploadProgressTracker progressTracker) throws Exception {
+        return uploadSubmissionAndFiles(submissionFile, fileList, uri, credentials, contentLength);
+    }
+
     interface FileToContentTypeMapper {
 
         @NonNull

--- a/open-rosa/src/main/java/org/odk/collect/openrosa/http/SubmissionChunker.kt
+++ b/open-rosa/src/main/java/org/odk/collect/openrosa/http/SubmissionChunker.kt
@@ -1,0 +1,75 @@
+package org.odk.collect.openrosa.http
+
+import java.io.File
+
+/**
+ * Splits a submission (the submission XML plus its media attachments) into the same chunks that
+ * `OpenRosaHttpInterface#uploadSubmissionAndFiles` posts to an OpenRosa server. A new chunk is
+ * started whenever adding the next attachment would push the chunk over 100 attachments or over the
+ * server's max content length. Because every chunk re-sends the submission XML, the XML's length is
+ * counted against every chunk's byte budget.
+ *
+ * The partition is a *pure function* of the (ordered) file list and the files' sizes, so for a given
+ * ordered file list it is fully deterministic and reproducible across upload attempts. That
+ * determinism is what makes it safe to resume an interrupted upload from a specific chunk index: as
+ * long as the file list is ordered deterministically (see the caller) and unchanged, the chunk at
+ * index `i` contains exactly the same attachments on every attempt.
+ */
+class SubmissionChunker(
+    private val submissionFileLength: Long,
+    private val fileList: List<File>,
+    private val contentLength: Long
+) {
+
+    /**
+     * @return the ordered list of chunks. Always contains at least one chunk (a submission with no
+     * attachments is a single XML-only chunk).
+     */
+    fun chunk(): List<Chunk> {
+        val chunks = mutableListOf<Chunk>()
+
+        var first = true
+        var fileIndex = 0
+        while (fileIndex < fileList.size || first) {
+            val chunkStart = fileIndex
+            first = false
+            var byteCount = submissionFileLength
+            var incomplete = false
+
+            while (fileIndex < fileList.size) {
+                byteCount += fileList[fileIndex].length()
+
+                // we've added at least one attachment to the request...
+                if (fileIndex + 1 < fileList.size) {
+                    if (fileIndex - chunkStart + 1 > MAX_FILES_PER_CHUNK ||
+                        byteCount + fileList[fileIndex + 1].length() > contentLength
+                    ) {
+                        // the next file would exceed the threshold, so this chunk is incomplete...
+                        incomplete = true
+                        fileIndex++ // advance over the last attachment added
+                        break
+                    }
+                }
+                fileIndex++
+            }
+
+            chunks.add(Chunk(chunkStart, fileIndex, incomplete))
+        }
+
+        return chunks
+    }
+
+    /**
+     * A contiguous range of attachments `[startIndex, endIndex)` uploaded in a single POST.
+     * [isIncomplete] is true when more chunks follow this one (the `*isIncomplete*` flag is sent).
+     */
+    class Chunk(
+        val startIndex: Int,
+        val endIndex: Int,
+        val isIncomplete: Boolean
+    )
+
+    private companion object {
+        const val MAX_FILES_PER_CHUNK = 100
+    }
+}

--- a/open-rosa/src/main/java/org/odk/collect/openrosa/http/SubmissionUploadProgressTracker.kt
+++ b/open-rosa/src/main/java/org/odk/collect/openrosa/http/SubmissionUploadProgressTracker.kt
@@ -1,0 +1,27 @@
+package org.odk.collect.openrosa.http
+
+/**
+ * Tracks the progress of a chunked submission upload so that an interrupted upload can resume from
+ * the last chunk the server accepted instead of restarting from the first one.
+ *
+ * Chunk indexes are only stable across attempts when the file list is ordered deterministically (see
+ * [SubmissionChunker]) and its content is unchanged. The implementation is responsible for
+ * invalidating stored progress — by returning `0` from [getResumeFromChunkIndex] — whenever the
+ * upload's content changes, so that a changed upload restarts from the beginning.
+ */
+interface SubmissionUploadProgressTracker {
+
+    /**
+     * @return the index of the first chunk that still needs to be uploaded; `0` starts from the
+     * beginning. A value greater than the number of chunks is clamped by the uploader to the final
+     * chunk so that the finalizing request is always re-sent.
+     */
+    fun getResumeFromChunkIndex(): Int
+
+    /**
+     * Called after a chunk has been accepted by the server (HTTP 201/202).
+     *
+     * @param chunkIndex the zero-based index of the chunk that was just uploaded
+     */
+    fun onChunkUploaded(chunkIndex: Int)
+}

--- a/open-rosa/src/main/java/org/odk/collect/openrosa/http/okhttp/OkHttpConnection.java
+++ b/open-rosa/src/main/java/org/odk/collect/openrosa/http/okhttp/OkHttpConnection.java
@@ -11,6 +11,8 @@ import org.odk.collect.openrosa.http.HttpGetResult;
 import org.odk.collect.openrosa.http.HttpHeadResult;
 import org.odk.collect.openrosa.http.HttpPostResult;
 import org.odk.collect.openrosa.http.OpenRosaHttpInterface;
+import org.odk.collect.openrosa.http.SubmissionChunker;
+import org.odk.collect.openrosa.http.SubmissionUploadProgressTracker;
 import org.odk.collect.shared.strings.Md5;
 
 import java.io.ByteArrayInputStream;
@@ -138,15 +140,28 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
     @NonNull
     @Override
     public HttpPostResult uploadSubmissionAndFiles(@NonNull File submissionFile, @NonNull List<File> fileList, @NonNull URI uri, @Nullable HttpCredentialsInterface credentials, @NonNull long contentLength) throws Exception {
-        HttpPostResult postResult = null;
+        return uploadSubmissionAndFiles(submissionFile, fileList, uri, credentials, contentLength, null);
+    }
 
-        boolean first = true;
-        int fileIndex = 0;
-        int lastFileIndex;
-        while (fileIndex < fileList.size() || first) {
-            lastFileIndex = fileIndex;
-            first = false;
-            long byteCount = 0L;
+    @NonNull
+    @Override
+    public HttpPostResult uploadSubmissionAndFiles(@NonNull File submissionFile, @NonNull List<File> fileList, @NonNull URI uri, @Nullable HttpCredentialsInterface credentials, @NonNull long contentLength, @Nullable SubmissionUploadProgressTracker progressTracker) throws Exception {
+        List<SubmissionChunker.Chunk> chunks = new SubmissionChunker(submissionFile.length(), fileList, contentLength).chunk();
+
+        // Resume from the last chunk the server accepted (if the tracker says so). A resume index
+        // beyond the last chunk is clamped so we always re-send the final, submission-finalizing
+        // chunk. A null tracker always starts from the first chunk.
+        int startChunk = 0;
+        if (progressTracker != null) {
+            startChunk = Math.max(0, Math.min(progressTracker.getResumeFromChunkIndex(), chunks.size() - 1));
+        }
+        if (startChunk > 0) {
+            Timber.i("Resuming submission upload from chunk %d of %d", startChunk, chunks.size());
+        }
+
+        HttpPostResult postResult = null;
+        for (int chunkIndex = startChunk; chunkIndex < chunks.size(); chunkIndex++) {
+            SubmissionChunker.Chunk chunk = chunks.get(chunkIndex);
 
             RequestBody requestBody = RequestBody.create(MediaType.parse(HTTP_CONTENT_TYPE_TEXT_XML), submissionFile);
 
@@ -155,9 +170,8 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
                     .addPart(MultipartBody.Part.createFormData("xml_submission_file", submissionFile.getName(), requestBody));
 
             Timber.i("added xml_submission_file: %s", submissionFile.getName());
-            byteCount += submissionFile.length();
 
-            for (; fileIndex < fileList.size(); fileIndex++) {
+            for (int fileIndex = chunk.getStartIndex(); fileIndex < chunk.getEndIndex(); fileIndex++) {
                 File file = fileList.get(fileIndex);
 
                 String contentType = fileToContentTypeMapper.map(file.getName());
@@ -165,20 +179,13 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
                 RequestBody fileRequestBody = RequestBody.create(MediaType.parse(contentType), file);
                 multipartBuilder.addPart(MultipartBody.Part.createFormData(file.getName(), file.getName(), fileRequestBody));
 
-                byteCount += file.length();
                 Timber.i("added file of type '%s' %s", contentType, file.getName());
+            }
 
-                // we've added at least one attachment to the request...
-                if (fileIndex + 1 < fileList.size()) {
-                    if ((fileIndex - lastFileIndex + 1 > 100) || (byteCount + fileList.get(fileIndex + 1).length()
-                            > contentLength)) {
-                        // the next file would exceed the 10MB threshold...
-                        Timber.i("Extremely long post is being split into multiple posts");
-                        multipartBuilder.addPart(MultipartBody.Part.createFormData("*isIncomplete*", "yes"));
-                        ++fileIndex; // advance over the last attachment added...
-                        break;
-                    }
-                }
+            if (chunk.isIncomplete()) {
+                // more chunks follow this one, so the server must keep the submission open...
+                Timber.i("Extremely long post is being split into multiple posts");
+                multipartBuilder.addPart(MultipartBody.Part.createFormData("*isIncomplete*", "yes"));
             }
 
             MultipartBody multipartBody = multipartBuilder.build();
@@ -186,9 +193,14 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
 
             if (postResult.getResponseCode() != HttpURLConnection.HTTP_CREATED &&
                     postResult.getResponseCode() != HttpURLConnection.HTTP_ACCEPTED) {
+                // this chunk was not accepted: stop and do not record it as uploaded so the next
+                // retry re-attempts from here...
                 return postResult;
             }
 
+            if (progressTracker != null) {
+                progressTracker.onChunkUploaded(chunkIndex);
+            }
         }
 
         return postResult;

--- a/open-rosa/src/test/java/org/odk/collect/openrosa/http/SubmissionChunkerTest.kt
+++ b/open-rosa/src/test/java/org/odk/collect/openrosa/http/SubmissionChunkerTest.kt
@@ -1,0 +1,74 @@
+package org.odk.collect.openrosa.http
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class SubmissionChunkerTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun `chunks with no attachments into a single complete chunk`() {
+        val chunks = SubmissionChunker(10, emptyList(), 100).chunk()
+
+        assertThat(chunks, hasSize(1))
+        assertThat(describe(chunks), equalTo(listOf("0-0-complete")))
+    }
+
+    @Test
+    fun `chunks everything into a single complete chunk when it all fits in one request`() {
+        val files = listOf(file(10), file(10), file(10))
+
+        val chunks = SubmissionChunker(10, files, 10_000).chunk()
+
+        assertThat(describe(chunks), equalTo(listOf("0-3-complete")))
+    }
+
+    @Test
+    fun `splits when the content length would be exceeded and marks all but the last chunk incomplete`() {
+        // xml = 0 bytes; three 100-byte files; budget 250: files 0+1 fit (200), file 2 would push to
+        // 300 > 250 so it starts a second chunk.
+        val files = listOf(file(100), file(100), file(100))
+
+        val chunks = SubmissionChunker(0, files, 250).chunk()
+
+        assertThat(describe(chunks), equalTo(listOf("0-2-incomplete", "2-3-complete")))
+    }
+
+    @Test
+    fun `counts the submission xml length toward every chunk's budget`() {
+        // The two 100-byte files (200) would fit in a 250 budget on their own, but the 100-byte xml
+        // is re-sent in every chunk, so only one file fits per chunk.
+        val files = listOf(file(100), file(100))
+
+        val chunks = SubmissionChunker(100, files, 250).chunk()
+
+        assertThat(describe(chunks), equalTo(listOf("0-1-incomplete", "1-2-complete")))
+    }
+
+    @Test
+    fun `produces the same chunks for the same input`() {
+        val files = listOf(file(100), file(90), file(100), file(70), file(100))
+
+        val first = describe(SubmissionChunker(50, files, 250).chunk())
+        val second = describe(SubmissionChunker(50, files, 250).chunk())
+
+        assertThat(second, equalTo(first))
+    }
+
+    private fun file(length: Int): File {
+        return tempFolder.newFile().apply { writeBytes(ByteArray(length)) }
+    }
+
+    private fun describe(chunks: List<SubmissionChunker.Chunk>): List<String> {
+        return chunks.map {
+            "${it.startIndex}-${it.endIndex}-${if (it.isIncomplete) "incomplete" else "complete"}"
+        }
+    }
+}

--- a/open-rosa/src/test/java/org/odk/collect/openrosa/http/okhttp/OkHttpConnectionResumableUploadTest.java
+++ b/open-rosa/src/test/java/org/odk/collect/openrosa/http/okhttp/OkHttpConnectionResumableUploadTest.java
@@ -1,0 +1,157 @@
+package org.odk.collect.openrosa.http.okhttp;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.odk.collect.openrosa.http.HttpPostResult;
+import org.odk.collect.openrosa.http.OpenRosaHttpInterface;
+import org.odk.collect.openrosa.http.SubmissionUploadProgressTracker;
+import org.odk.collect.openrosa.support.MockWebServerRule;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+/**
+ * Covers resuming a chunked upload: with every attachment forced into its own chunk (contentLength
+ * 0), the tracker controls which chunk the upload starts from and is told about each chunk the
+ * server accepts.
+ */
+public class OkHttpConnectionResumableUploadTest {
+
+    @Rule
+    public MockWebServerRule mockWebServerRule = new MockWebServerRule();
+
+    private MockWebServer mockWebServer;
+    private OpenRosaHttpInterface subject;
+
+    @Before
+    public void setup() throws Exception {
+        subject = new OkHttpConnection(null, fileName -> "application/octet-stream", "Test Agent");
+        mockWebServer = mockWebServerRule.start();
+    }
+
+    @Test
+    public void resumingFromAChunk_skipsAlreadyUploadedChunks_andReportsProgress() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(201));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(201));
+
+        URI uri = mockWebServer.url("/submission").uri();
+        RecordingTracker tracker = new RecordingTracker(1); // resume from the 2nd chunk
+
+        subject.uploadSubmissionAndFiles(
+                createTempFile("<x/>"),
+                asList(createTempFile("AAA"), createTempFile("BBB"), createTempFile("CCC")),
+                uri, null, 0, tracker
+        );
+
+        // Only chunks 1 and 2 are posted; chunk 0 is treated as already uploaded and skipped.
+        assertThat(mockWebServer.getRequestCount(), equalTo(2));
+        assertThat(tracker.uploaded, contains(1, 2));
+
+        // The first request actually sent is chunk 1 ("BBB"), and chunk 0 ("AAA") is never sent.
+        String firstBody = mockWebServer.takeRequest().getBody().readUtf8();
+        assertThat(firstBody, containsString("BBB"));
+        assertThat(firstBody, not(containsString("AAA")));
+        // Every chunk, including a resumed one, carries the submission XML (as in the original upload).
+        assertThat(firstBody, containsString("xml_submission_file"));
+    }
+
+    @Test
+    public void resumingBeyondTheLastChunk_reSendsOnlyTheFinalChunk() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(201));
+
+        URI uri = mockWebServer.url("/submission").uri();
+        RecordingTracker tracker = new RecordingTracker(99); // past the end -> clamp to the final chunk
+
+        subject.uploadSubmissionAndFiles(
+                createTempFile("<x/>"),
+                asList(createTempFile("AAA"), createTempFile("BBB"), createTempFile("CCC")),
+                uri, null, 0, tracker
+        );
+
+        assertThat(mockWebServer.getRequestCount(), equalTo(1));
+        assertThat(tracker.uploaded, contains(2));
+        assertThat(mockWebServer.takeRequest().getBody().readUtf8(), containsString("CCC"));
+    }
+
+    @Test
+    public void resumingFromZero_uploadsEveryChunk_andRecordsEachOne() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(201));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(201));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(201));
+
+        URI uri = mockWebServer.url("/submission").uri();
+        RecordingTracker tracker = new RecordingTracker(0);
+
+        subject.uploadSubmissionAndFiles(
+                createTempFile("<x/>"),
+                asList(createTempFile("AAA"), createTempFile("BBB"), createTempFile("CCC")),
+                uri, null, 0, tracker
+        );
+
+        assertThat(mockWebServer.getRequestCount(), equalTo(3));
+        assertThat(tracker.uploaded, contains(0, 1, 2));
+    }
+
+    @Test
+    public void whenAChunkFails_stopsAndDoesNotRecordThatChunkAsUploaded() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(201)); // chunk 0 accepted
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500)); // chunk 1 fails
+
+        URI uri = mockWebServer.url("/submission").uri();
+        RecordingTracker tracker = new RecordingTracker(0);
+
+        HttpPostResult result = subject.uploadSubmissionAndFiles(
+                createTempFile("<x/>"),
+                asList(createTempFile("AAA"), createTempFile("BBB"), createTempFile("CCC")),
+                uri, null, 0, tracker
+        );
+
+        assertThat(result.getResponseCode(), equalTo(500));
+        assertThat(mockWebServer.getRequestCount(), equalTo(2)); // chunk 2 was never attempted
+        assertThat(tracker.uploaded, contains(0)); // only chunk 0 recorded; the failed chunk 1 is not
+    }
+
+    private File createTempFile(String content) throws Exception {
+        File temp = File.createTempFile("tempfile", ".tmp");
+        temp.deleteOnExit();
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(temp))) {
+            bw.write(content);
+        }
+        return temp;
+    }
+
+    private static class RecordingTracker implements SubmissionUploadProgressTracker {
+
+        private final int resumeFrom;
+        private final List<Integer> uploaded = new ArrayList<>();
+
+        RecordingTracker(int resumeFrom) {
+            this.resumeFrom = resumeFrom;
+        }
+
+        @Override
+        public int getResumeFromChunkIndex() {
+            return resumeFrom;
+        }
+
+        @Override
+        public void onChunkUploaded(int chunkIndex) {
+            uploaded.add(chunkIndex);
+        }
+    }
+}


### PR DESCRIPTION
We used ODK Collect a couple of years ago in rural Tanzania as part of the ARTEMIS project, where we collected farm data along with close to 100 high-res images. Sending such a submission is already hard there, and today's upload behavior makes it harder: there is no chunk-level progress, so whenever an upload fails, which happens often on an unreliable link, the entire submission is re-uploaded from the beginning on the next attempt. The device re-sends images the server has already received, wasting scarce bandwidth and time. A large submission may never finish uploading at all, leaving collected media stranded on the device, reducing storage space and potentially creating incomplete instances on the server.

Under the hood, a large submission is split into several POST requests, but nothing records which chunks already succeeded: each retry re-lists the instance folder (in unspecified File.listFiles() order) and re-chunks from the first chunk, so the split can even differ from one attempt to the next.

Two changes let retries continue where they left off:

- Deterministic chunks: attachments are sorted by name, and the chunk boundaries are computed by a pure SubmissionChunker, so a given submission produces the same chunks on every attempt.

- Resume: a hidden .upload_progress file in the instance directory records an MD5 fingerprint of the whole upload (submission XML + attachments) and the index of the last chunk the server accepted. A matching fingerprint resumes at the next chunk; a differing one (the content changed) restarts from the first chunk.

Resuming relies on the server retaining an unfinished submission's earlier chunks (the OpenRosa *isIncomplete* contract).

Adds SubmissionChunker and SubmissionUploadProgressTracker (open-rosa) and InstanceUploadProgressTracker (collect_app), with unit tests for the chunker, the resume/fingerprint logic, and the resumable upload path.

Note: AI was used during diagnosis, design, implementation, and QA testing of the code. Carlos Quiros (cquiros@qlands.com) was involved in all stages.


<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/docs/CONTRIBUTING.md
-->

#### Why is this the best possible solution? Were any other approaches considered?
We tested and determined that ODK Collect cannot properly handle submissions with a high number of media files. We also tested and determined that if an upload fails, the new upload may not contain the same order of the media files. So the only possible solution is to make the upload deterministic and control which chunk gets uploaded.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We tested and determined that there are no regression risks. However, users may experience better uploads on remote locations.

#### Do we need any specific form for testing your changes? If so, please attach one.
QA tests are attached to the code

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No, this is an internal change.

#### Before submitting this PR, please make sure you have:
- [✔ ] added or modified tests for any new or changed behavior
- [ ✔] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [NA] added a comment above any new strings describing it for translators
- [NA] added any new strings with date formatting to `DateFormatsTest`
- [NA] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [NA] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
