### PR TITLE
Fix crash when an inaccessible file is used as an answer

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/UriExt.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/UriExt.kt
@@ -16,8 +16,8 @@ fun Uri.copyToFile(context: Context, dest: File) {
                 inputStream.copyTo(outputStream)
             }
         }
-    } catch (e: Exception) {
-        // ignore
+    } catch (_: Exception) {
+        dest.delete()
     }
 }
 

--- a/androidshared/src/test/java/org/odk/collect/androidshared/system/UriExtTest.kt
+++ b/androidshared/src/test/java/org/odk/collect/androidshared/system/UriExtTest.kt
@@ -1,6 +1,8 @@
 package org.odk.collect.androidshared.system
 
 import android.app.Application
+import android.content.ContentResolver
+import android.content.Context
 import android.net.Uri
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
@@ -9,22 +11,73 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.odk.collect.shared.TempFiles
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
 
 @RunWith(AndroidJUnit4::class)
 class UriExtTest {
     private val context = ApplicationProvider.getApplicationContext<Application>()
 
     @Test
-    fun `copyToFile copies the source file to the target file`() {
-        val sourceFile = TempFiles.createTempFile().also {
-            it.writeText("blah")
-        }
-        val sourceFileUri = sourceFile.toUri()
-        val targetFile = TempFiles.createTempFile()
+    fun `copyToFile creates the target file with the contents of the uri`() {
+        val uri = Uri.parse("content://media/external/downloads/64711")
+        val targetFile = File(TempFiles.createTempDir(), "target")
+        val context = contextWhereOpeningUri(uri) { ByteArrayInputStream("blah".toByteArray()) }
 
-        sourceFileUri.copyToFile(context, targetFile)
-        assertThat(targetFile.readText(), equalTo(sourceFile.readText()))
+        uri.copyToFile(context, targetFile)
+
+        assertThat(targetFile.readText(), equalTo("blah"))
+    }
+
+    @Test
+    fun `copyToFile creates no file when the uri cannot be opened`() {
+        val uri = Uri.parse("content://media/external/downloads/64711")
+        val targetFile = File(TempFiles.createTempDir(), "target")
+        val context = contextWhereOpeningUri(uri) {
+            throw IllegalStateException("Only owner is able to interact with pending media")
+        }
+
+        uri.copyToFile(context, targetFile)
+
+        assertThat(targetFile.exists(), equalTo(false))
+    }
+
+    @Test
+    fun `copyToFile creates no file when there is nothing to read`() {
+        val uri = Uri.parse("content://media/external/downloads/64711")
+        val targetFile = File(TempFiles.createTempDir(), "target")
+        val context = contextWhereOpeningUri(uri) { null }
+
+        uri.copyToFile(context, targetFile)
+
+        assertThat(targetFile.exists(), equalTo(false))
+    }
+
+    @Test
+    fun `copyToFile leaves no partial file when reading fails part way through`() {
+        val uri = Uri.parse("content://media/external/downloads/64711")
+        val targetFile = File(TempFiles.createTempDir(), "target")
+        val context = contextWhereOpeningUri(uri) {
+            object : ByteArrayInputStream("blah".toByteArray()) {
+                override fun read(b: ByteArray, off: Int, len: Int): Int {
+                    return if (available() > 0) {
+                        super.read(b, off, len)
+                    } else {
+                        throw IOException("connection lost")
+                    }
+                }
+            }
+        }
+
+        uri.copyToFile(context, targetFile)
+
+        assertThat(targetFile.exists(), equalTo(false))
     }
 
     @Test
@@ -73,5 +126,13 @@ class UriExtTest {
         val result = uri.addQueryParam("id", "123")
 
         assertThat(result.toString(), equalTo("https://example.com/path/subpath?id=123"))
+    }
+
+    private fun contextWhereOpeningUri(uri: Uri, open: () -> InputStream?): Context {
+        val contentResolver = mock<ContentResolver> {
+            on { openInputStream(uri) } doAnswer { open() }
+        }
+
+        return mock<Context> { on { getContentResolver() } doReturn contentResolver }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -83,6 +83,7 @@ import org.odk.collect.android.widgets.utilities.RecordingRequesterProvider;
 import org.odk.collect.android.widgets.utilities.StringRequesterImpl;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 import org.odk.collect.androidshared.system.IntentLauncher;
+import org.odk.collect.androidshared.system.UriExtKt;
 import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeMaterialButton;
 import org.odk.collect.audioclips.PlaybackFailedException;
@@ -643,7 +644,7 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
                                         public void granted() {
                                             File destFile = FileUtils.createDestinationMediaFile(formController.getInstanceFile().getParent(), ContentUriHelper.getFileExtensionFromUri(uri));
                                             //TODO might be better to use QuestionMediaManager in the future
-                                            FileUtils.saveAnswerFileFromUri(uri, destFile, getContext());
+                                            UriExtKt.copyToFile(uri, getContext(), destFile);
                                             ((WidgetDataReceiver) questionWidget).setData(destFile);
 
                                             questionWidget.showAnswerContainer();

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -14,6 +14,7 @@ import org.odk.collect.android.utilities.ContentUriHelper;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.ImageCompressionController;
 import org.odk.collect.android.widgets.QuestionWidget;
+import org.odk.collect.androidshared.system.UriExtKt;
 import org.odk.collect.androidshared.ui.DialogFragmentUtils;
 import org.odk.collect.settings.SettingsProvider;
 
@@ -63,7 +64,7 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             String extension = ContentUriHelper.getFileExtensionFromUri(uris[0]);
 
             File newFile = FileUtils.createDestinationMediaFile(instanceFile.getParent(), extension);
-            FileUtils.saveAnswerFileFromUri(uris[0], newFile, Collect.getInstance());
+            UriExtKt.copyToFile(uris[0], Collect.getInstance(), newFile);
 
             // apply image conversion if the question is an image question
             if (questionWidget.getFormEntryPrompt().getControlType() == Constants.CONTROL_IMAGE_CHOOSE) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -65,15 +65,6 @@ public final class FileUtils {
     private FileUtils() {
     }
 
-    public static void saveAnswerFileFromUri(Uri uri, File destFile, Context context) {
-        try (InputStream fileInputStream = context.getContentResolver().openInputStream(uri);
-             OutputStream fileOutputStream = new FileOutputStream(destFile)) {
-            IOUtils.copy(fileInputStream, fileOutputStream);
-        } catch (IOException e) {
-            Timber.e(e);
-        }
-    }
-
     public static File createDestinationMediaFile(String fileLocation, String fileExtension) {
         return new File(fileLocation
                 + File.separator


### PR DESCRIPTION
Closes #7301 

#### Why is this the best possible solution? Were any other approaches considered?
The root cause was that `FileUtils.saveAnswerFileFromUri` only caught `IOException`, so anything else (here, an `IllegalStateException` from MediaStore’s pending-media guard) killed the app.
The method was also a duplicate of `Uri.copyToFile` in `androidshared`. Instead of patching the duplicate, I deleted it and moved all call sites to the shared extension.
`copyToFile` catches `Exception` and now also deletes the destination file if the copy fails, preventing a truncated or empty file from being left behind and subsequently attached as the answer.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Picking a file that can't be read no longer crashes Collect and interrupts form filling — the question is just left unanswered, and any previous answer for it is cleared, since the user was replacing it anyway. A failed copy also no longer leaves a truncated or empty file on disk.
The copy path is shared by the image, audio, video and file widgets through MediaLoadingTask, so all of those are affected, but this is a swap to an equivalent helper and the successful-copy path is unchanged.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
