### PR TITLE
Fix flaky FormMapTest

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.kt
@@ -79,7 +79,7 @@ class FormMapTest {
                     1
                 )
             )
-            .selectForm(mapFragment, 0)
+            .selectForm(mapFragment, LATITUDE, LONGITUDE)
             .clickEditSavedForm("Single geopoint")
             .clickOnQuestion("Name")
             .assertText("Foo")
@@ -87,8 +87,8 @@ class FormMapTest {
 
     private fun stubGeopointIntent() {
         val location = Location("gps")
-        location.latitude = 125.1
-        location.longitude = 10.1
+        location.latitude = LATITUDE
+        location.longitude = LONGITUDE
         location.altitude = 5.0
 
         val intent = getReturnIntent(GeoUtils.formatLocationResultString(location))
@@ -101,5 +101,7 @@ class FormMapTest {
     companion object {
         private const val SINGLE_GEOPOINT_FORM = "single-geopoint.xml"
         private const val NO_GEOPOINT_FORM = "basic.xml"
+        private const val LATITUDE = 125.1
+        private const val LONGITUDE = 10.1
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.kt
@@ -56,7 +56,9 @@ class FormMapTest {
 
     @Test
     fun fillingBlankForm_addsInstanceToMap() {
-        stubGeopointIntent()
+        val latitude = 125.1
+        val longitude = 10.1
+        stubGeopointIntent(latitude, longitude)
 
         rule.startAtMainMenu()
             .copyForm(SINGLE_GEOPOINT_FORM)
@@ -79,16 +81,16 @@ class FormMapTest {
                     1
                 )
             )
-            .selectForm(mapFragment, LATITUDE, LONGITUDE)
+            .selectForm(mapFragment, latitude, longitude)
             .clickEditSavedForm("Single geopoint")
             .clickOnQuestion("Name")
             .assertText("Foo")
     }
 
-    private fun stubGeopointIntent() {
+    private fun stubGeopointIntent(latitude: Double, longitude: Double) {
         val location = Location("gps")
-        location.latitude = LATITUDE
-        location.longitude = LONGITUDE
+        location.latitude = latitude
+        location.longitude = longitude
         location.altitude = 5.0
 
         val intent = getReturnIntent(GeoUtils.formatLocationResultString(location))
@@ -101,7 +103,5 @@ class FormMapTest {
     companion object {
         private const val SINGLE_GEOPOINT_FORM = "single-geopoint.xml"
         private const val NO_GEOPOINT_FORM = "basic.xml"
-        private const val LATITUDE = 125.1
-        private const val LONGITUDE = 10.1
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -14,7 +14,7 @@ import org.odk.collect.maps.traces.PolygonDescription
 class FakeClickableMapFragment : Fragment(), MapFragment {
 
     private var idCounter = 1
-    private val featureIds = mutableListOf<Int>()
+    private val markers = mutableMapOf<Int, MarkerDescription>()
     private var featureClickListener: MapFragment.FeatureListener? = null
 
     override fun init(
@@ -52,8 +52,8 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
     }
 
     override fun addMarkers(markers: List<MarkerDescription>): List<Int> {
-        return markers.map {
-            idCounter++.also { id -> featureIds.add(id) }
+        return markers.map { marker ->
+            idCounter++.also { id -> this.markers[id] = marker }
         }
     }
 
@@ -89,11 +89,11 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
     }
 
     override fun clearFeatures() {
-        featureIds.clear()
+        markers.clear()
     }
 
     override fun clearFeatures(ids: List<Int>) {
-        featureIds.removeAll(ids)
+        markers.keys.removeAll(ids.toSet())
     }
 
     override fun setClickListener(listener: MapFragment.PointListener?) {}
@@ -110,11 +110,15 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         return false
     }
 
-    fun clickOnFeature(index: Int) {
+    fun clickOnFeatureAt(latitude: Double, longitude: Double) {
+        val featureId = markers.entries.single {
+            it.value.point.latitude == latitude && it.value.point.longitude == longitude
+        }.key
+
         var done = false
 
         Handler(Looper.getMainLooper()).post {
-            featureClickListener!!.onFeature(featureIds[index])
+            featureClickListener!!.onFeature(featureId)
             done = true
         }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormMapPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormMapPage.java
@@ -25,8 +25,8 @@ public class FormMapPage extends Page<FormMapPage> {
         return new FormEntryPage(formName).assertOnPage();
     }
 
-    public FormMapPage selectForm(FakeClickableMapFragment mapFragment, int index) {
-        mapFragment.clickOnFeature(index);
+    public FormMapPage selectForm(FakeClickableMapFragment mapFragment, double latitude, double longitude) {
+        mapFragment.clickOnFeatureAt(latitude, longitude);
         WaitFor.waitFor((Callable<Object>) () -> {
             return assertText(org.odk.collect.strings.R.string.edit_data);
         });


### PR DESCRIPTION
Fixes: https://console.firebase.google.com/project/api-project-322300403941/testlab/histories/bh.f6f8331e5ae6e371/matrices/7429327717566411084

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that the test picked a map feature by index. The fake map fragment keeps every marker in one flat list, so depending on the order they were added the first one was sometimes the form's marker and sometimes the current location marker that `CurrentLocationDelegate` adds once the device gets a location fix.
Now the fake keeps every marker, like a real map, and the test asks for the one at the coordinates it saved. An index can't address a specific marker, a point can. Filtering the location marker out instead would work too, but I find the current fix more reliable.                                                                                                                                                                                                                                                                                                                                                                                        
Ran the single test 50 times on Test Lab: 0 failures with this change, ~10 out of 50 without it.  

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
