### PR TITLE
Use correct method for starting foreground services

### DIFF
--- a/async/src/main/java/org/odk/collect/async/services/ForegroundServiceTaskSpecRunner.kt
+++ b/async/src/main/java/org/odk/collect/async/services/ForegroundServiceTaskSpecRunner.kt
@@ -40,7 +40,7 @@ class ForegroundServiceTaskSpecRunner(private val application: Application) : Ta
             it.putExtra(EXTRA_INPUT_DATA, HashMap(inputData))
         }
 
-        application.startService(intent)
+        application.startForegroundService(intent)
     }
 }
 

--- a/audio-recorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ForegroundServiceAudioRecorder.kt
+++ b/audio-recorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ForegroundServiceAudioRecorder.kt
@@ -33,7 +33,7 @@ internal class ForegroundServiceAudioRecorder internal constructor(private val a
     }
 
     override fun start(sessionId: Serializable, output: Output) {
-        application.startService(
+        application.startForegroundService(
             Intent(application, AudioRecorderService::class.java).apply {
                 action = ACTION_START
                 putExtra(EXTRA_SESSION_ID, sessionId)

--- a/location/src/main/java/org/odk/collect/location/tracker/ForegroundServiceLocationTracker.kt
+++ b/location/src/main/java/org/odk/collect/location/tracker/ForegroundServiceLocationTracker.kt
@@ -36,7 +36,7 @@ class ForegroundServiceLocationTracker(private val application: Application) : L
             }
         }
 
-        application.startService(intent)
+        application.startForegroundService(intent)
     }
 
     override fun stop() {


### PR DESCRIPTION
Potentially helps with https://github.com/getodk/collect/issues/7332

#### Why is this the best possible solution? Were any other approaches considered?

This brings our foreground service handling up to date with the [latest best practices](https://developer.android.com/develop/background-work/services/fgs/launch). Whether this actually lowers/prevents problems with foreground services starting in the background or not will need to be proved in the wild, but I wouldn't be surprised if it did. That, and it's a good change to inline with our new minimum API level (`startForegroundServices` is an API 26 method).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This shouldn't change anything. The areas to test are parts of the app that record location, background audio recording (as part of audit) and manually syncing forms.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
