### PR TITLE
Fix choices hidden behind the keyboard in minimal selects

### DIFF
--- a/.circleci/gradle-test-app.properties
+++ b/.circleci/gradle-test-app.properties
@@ -1,8 +1,7 @@
 # Gradle config for "Large" Circle CI resource (https://circleci.com/pricing/price-list/)
 
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-Xmx2g
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-Xmx1024m
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=4
-test.heap.max=4g
-
+test.heap.max=2g

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialog.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.fragments.dialogs;
 
 import static org.odk.collect.android.injection.DaggerUtils.getComponent;
+import static org.odk.collect.androidshared.ui.EdgeToEdge.applyBottomInsets;
 
 import android.content.Context;
 import android.os.Bundle;
@@ -90,6 +91,7 @@ public abstract class SelectMinimalDialog extends MaterialFullScreenDialogFragme
 
         initRecyclerView();
         initToolbar();
+        applyBottomInsets(view);
     }
 
     @Override


### PR DESCRIPTION
Closes #7323 

#### Why is this the best possible solution? Were any other approaches considered?
I used the existing `EdgeToEdge.applyBottomInsets helper` - the same approach as in other places.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's an isolated change, so testing `select_one`/`select_multiple` with `autocomplete minimal` appearance should be sufficient. There shouldn't be any risk of affecting other screens.

#### Do we need any specific form for testing your changes? If so, please attach one.
The one attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
