### PR TITLE
Don't use foreground service when binding `LocationTracker` to UI lifecycle

### DIFF
--- a/geo/src/test/java/org/odk/collect/geo/support/FakeLocationTracker.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeLocationTracker.kt
@@ -27,7 +27,11 @@ class FakeLocationTracker : LocationTracker {
         return _currentLocation
     }
 
-    override fun start(retainMockAccuracy: Boolean, updateInterval: Long?) {
+    override fun start(
+        retainMockAccuracy: Boolean,
+        updateInterval: Long?,
+        notification: Boolean
+    ) {
         this.retainMockAccuracy = retainMockAccuracy
 
         isStarted = true

--- a/location/src/main/java/org/odk/collect/location/tracker/ForegroundServiceLocationTracker.kt
+++ b/location/src/main/java/org/odk/collect/location/tracker/ForegroundServiceLocationTracker.kt
@@ -28,15 +28,20 @@ class ForegroundServiceLocationTracker(private val application: Application) : L
         return application.getState().getFlow(LOCATION_KEY, null)
     }
 
-    override fun start(retainMockAccuracy: Boolean, updateInterval: Long?) {
+    override fun start(retainMockAccuracy: Boolean, updateInterval: Long?, notification: Boolean) {
         val intent = Intent(application, LocationTrackerService::class.java).also { intent ->
             intent.putExtra(LocationTrackerService.EXTRA_RETAIN_MOCK_ACCURACY, retainMockAccuracy)
+            intent.putExtra(LocationTrackerService.EXTRA_NOTIFICATION, notification)
             updateInterval?.let {
                 intent.putExtra(LocationTrackerService.EXTRA_UPDATE_INTERVAL, it)
             }
         }
 
-        application.startForegroundService(intent)
+        if (notification) {
+            application.startForegroundService(intent)
+        } else {
+            application.startService(intent)
+        }
     }
 
     override fun stop() {
@@ -57,12 +62,6 @@ class LocationTrackerService : Service(), LocationClient.LocationClientListener 
         super.onCreate()
         val provider = applicationContext as LocationDependencyComponentProvider
         provider.locationDependencyComponent.inject(this)
-
-        setupNotificationChannel()
-        startForeground(
-            uniqueIdGenerator.getInt(NOTIFICATION_IDENTIFIER),
-            createNotification()
-        )
     }
 
     override fun onBind(intent: Intent?): IBinder? {
@@ -70,6 +69,14 @@ class LocationTrackerService : Service(), LocationClient.LocationClientListener 
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.getBooleanExtra(EXTRA_NOTIFICATION, true) ?: true) {
+            setupNotificationChannel()
+            startForeground(
+                uniqueIdGenerator.getInt(NOTIFICATION_IDENTIFIER),
+                createNotification()
+            )
+        }
+
         locationClient.setRetainMockAccuracy(
             intent?.getBooleanExtra(
                 EXTRA_RETAIN_MOCK_ACCURACY,
@@ -120,7 +127,12 @@ class LocationTrackerService : Service(), LocationClient.LocationClientListener 
     }
 
     private fun createNotificationIntent() =
-        PendingIntent.getActivity(this, 0, Intent(this, ReturnToAppActivity::class.java), PendingIntent.FLAG_IMMUTABLE)
+        PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, ReturnToAppActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE
+        )
 
     private fun setupNotificationChannel() {
         val notificationChannel = NotificationChannel(
@@ -137,6 +149,7 @@ class LocationTrackerService : Service(), LocationClient.LocationClientListener 
     companion object {
         const val EXTRA_RETAIN_MOCK_ACCURACY = "retain_mock_accuracy"
         const val EXTRA_UPDATE_INTERVAL = "update_interval"
+        const val EXTRA_NOTIFICATION = "notification"
 
         private const val NOTIFICATION_IDENTIFIER = "location_tracking"
         private const val NOTIFICATION_CHANNEL = "location_tracking"

--- a/location/src/main/java/org/odk/collect/location/tracker/ForegroundServiceLocationTracker.kt
+++ b/location/src/main/java/org/odk/collect/location/tracker/ForegroundServiceLocationTracker.kt
@@ -57,6 +57,12 @@ class LocationTrackerService : Service(), LocationClient.LocationClientListener 
         super.onCreate()
         val provider = applicationContext as LocationDependencyComponentProvider
         provider.locationDependencyComponent.inject(this)
+
+        setupNotificationChannel()
+        startForeground(
+            uniqueIdGenerator.getInt(NOTIFICATION_IDENTIFIER),
+            createNotification()
+        )
     }
 
     override fun onBind(intent: Intent?): IBinder? {
@@ -64,12 +70,6 @@ class LocationTrackerService : Service(), LocationClient.LocationClientListener 
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        setupNotificationChannel()
-        startForeground(
-            uniqueIdGenerator.getInt(NOTIFICATION_IDENTIFIER),
-            createNotification()
-        )
-
         locationClient.setRetainMockAccuracy(
             intent?.getBooleanExtra(
                 EXTRA_RETAIN_MOCK_ACCURACY,

--- a/location/src/main/java/org/odk/collect/location/tracker/LocationTracker.kt
+++ b/location/src/main/java/org/odk/collect/location/tracker/LocationTracker.kt
@@ -19,7 +19,12 @@ interface LocationTracker {
     /**
      * @param updateInterval requested (not guaranteed) interval for location updates
      */
-    fun start(retainMockAccuracy: Boolean, updateInterval: Long? = null)
+    fun start(
+        retainMockAccuracy: Boolean,
+        updateInterval: Long? = null,
+        notification: Boolean = true
+    )
+
     fun start(retainMockAccuracy: Boolean) = start(retainMockAccuracy, null)
     fun start(updateInterval: Long?) = start(false, updateInterval)
     fun start() = start(false, null)
@@ -34,10 +39,17 @@ fun LocationTracker.getCurrentLocation(): Location? {
     return this.getLocation().value
 }
 
-fun LocationTracker.bindToLifecycle(lifecycleOwner: LifecycleOwner, retainMockAccuracy: Boolean = false) {
+fun LocationTracker.bindToLifecycle(
+    lifecycleOwner: LifecycleOwner,
+    retainMockAccuracy: Boolean = false
+) {
     lifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
         override fun onResume(owner: LifecycleOwner) {
-            start(retainMockAccuracy)
+            start(
+                retainMockAccuracy = retainMockAccuracy,
+                updateInterval = null,
+                notification = false
+            )
         }
 
         override fun onPause(owner: LifecycleOwner) {

--- a/location/src/test/java/org/odk/collect/location/tracker/ForegroundServiceLocationTrackerTest.kt
+++ b/location/src/test/java/org/odk/collect/location/tracker/ForegroundServiceLocationTrackerTest.kt
@@ -92,6 +92,18 @@ class ForegroundServiceLocationTrackerTest : LocationTrackerTest() {
         assertThat(locationClient.getRetainMockAccuracy(), equalTo(true))
         assertThat(locationClient.getUpdateInterval(), equalTo(2000L))
     }
+
+    @Test
+    fun start_whenNotificationIsFalse_doesNotStartServiceInForeground() {
+        locationTracker.start(
+            retainMockAccuracy = false,
+            updateInterval = null,
+            notification = false
+        )
+        runBackground()
+
+        assertThat(RobolectricHelpers.getForegroundServiceNotifications(), equalTo(emptyList()))
+    }
 }
 
 private class FakeLocationClient : LocationClient {

--- a/location/src/test/java/org/odk/collect/location/tracker/ForegroundServiceLocationTrackerTest.kt
+++ b/location/src/test/java/org/odk/collect/location/tracker/ForegroundServiceLocationTrackerTest.kt
@@ -10,6 +10,12 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.odk.collect.location.Location
 import org.odk.collect.location.LocationClient
 import org.odk.collect.location.LocationClient.LocationClientListener
@@ -94,15 +100,37 @@ class ForegroundServiceLocationTrackerTest : LocationTrackerTest() {
     }
 
     @Test
+    fun start_whenNotificationIsTrue_startsServiceInForeground() {
+        val application = mock<Application>()
+        val locationTracker = ForegroundServiceLocationTracker(application)
+
+        locationTracker.start(
+            retainMockAccuracy = false,
+            updateInterval = null,
+            notification = true
+        )
+
+        verify(application, never()).startService(any())
+        verify(application).startForegroundService(
+            argWhere { it.getBooleanExtra(LocationTrackerService.EXTRA_NOTIFICATION, false) }
+        )
+    }
+
+    @Test
     fun start_whenNotificationIsFalse_doesNotStartServiceInForeground() {
+        val application = mock<Application>()
+        val locationTracker = ForegroundServiceLocationTracker(application)
+
         locationTracker.start(
             retainMockAccuracy = false,
             updateInterval = null,
             notification = false
         )
-        runBackground()
 
-        assertThat(RobolectricHelpers.getForegroundServiceNotifications(), equalTo(emptyList()))
+        verify(application, never()).startForegroundService(any())
+        verify(application).startService(
+            argWhere { !it.getBooleanExtra(LocationTrackerService.EXTRA_NOTIFICATION, false) }
+        )
     }
 }
 

--- a/location/src/test/java/org/odk/collect/location/tracker/LocationTrackerServiceTest.kt
+++ b/location/src/test/java/org/odk/collect/location/tracker/LocationTrackerServiceTest.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.location.tracker
 
+import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -13,9 +14,19 @@ import org.odk.collect.servicetest.ServiceScenario
 class LocationTrackerServiceTest {
 
     @Test
-    fun onStartCommand_startsServiceInForeground() {
+    fun startsServiceInForeground() {
         val service = ServiceScenario.launch(LocationTrackerService::class.java)
         assertThat(service.getForegroundNotification(), notNullValue())
+    }
+
+    @Test
+    fun whenNotificationIsFalse_doesNotStartServiceInForeground() {
+        val service = ServiceScenario.launch(
+            LocationTrackerService::class.java,
+            Intent().also { it.putExtra(LocationTrackerService.EXTRA_NOTIFICATION, false) }
+        )
+
+        assertThat(service.getForegroundNotification(), equalTo(null))
     }
 
     @Test

--- a/test-shared/src/main/java/org/odk/collect/testshared/RobolectricHelpers.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/RobolectricHelpers.kt
@@ -16,6 +16,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import org.odk.collect.servicetest.NotificationDetails
 import org.odk.collect.servicetest.ServiceScenario
 import org.odk.collect.servicetest.ServiceScenario.Companion.launch
 import org.robolectric.Robolectric
@@ -102,6 +103,10 @@ object RobolectricHelpers {
 
     fun clearServices() {
         services.clear()
+    }
+
+    fun getForegroundServiceNotifications(): List<NotificationDetails> {
+        return services.mapNotNull { it.value.getForegroundNotification() }
     }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Closes https://github.com/getodk/collect/issues/7369

#### Why is this the best possible solution? Were any other approaches considered?

We shouldn't need to use a foreground service when we're stopping/starting `LocationTracker` on UI `onPause`/`onResume`. This means we can just use a normal service and avoid problems with a stop happening to a foreground service before `startForeground` is called.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This only affects UI that tracks location and the only places behaviour should have changes is in the geopoint (with maps UI) and select one from map question types - the crash should no longer occur and there will no longer be a notification shown about location tracking.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
