### PR TITLE
Track when form open is blocked by an update

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -121,4 +121,9 @@ object AnalyticsEvents {
      * `columns-n`
      */
     const val GALLERY_SELECT = "GallerySelect"
+
+    /**
+     * Logged whenever a form open is blocked due to an in-progress update
+     */
+    const val FORM_OPEN_DURING_UPDATE = "FromUpdateDuringUpdate"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.kt
@@ -25,6 +25,11 @@ object AnalyticsUtils {
     }
 
     @JvmStatic
+    fun logFormEvent(event: String, form: Form) {
+        Analytics.log(event, "form", getFormHash(form))
+    }
+
+    @JvmStatic
     fun logServerEvent(event: String, generalSettings: Settings) {
         Analytics.log(event, "server", getServerHash(generalSettings)!!)
     }

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -344,6 +344,7 @@ private class FormUriViewModel(
             return if (isLocAcquired) {
                 null
             } else {
+                Analytics.log(AnalyticsEvents.FORM_OPEN_DURING_UPDATE)
                 resources.getString(string.cannot_open_form_because_of_forms_update)
             }
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -17,6 +17,7 @@ import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.analytics.AnalyticsEvents
+import org.odk.collect.android.analytics.AnalyticsUtils
 import org.odk.collect.android.formentry.FormOpeningMode
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.instancemanagement.InstanceDeleter
@@ -344,7 +345,7 @@ private class FormUriViewModel(
             return if (isLocAcquired) {
                 null
             } else {
-                Analytics.log(AnalyticsEvents.FORM_OPEN_DURING_UPDATE)
+                AnalyticsUtils.logFormEvent(AnalyticsEvents.FORM_OPEN_DURING_UPDATE, form)
                 resources.getString(string.cannot_open_form_because_of_forms_update)
             }
         } else {


### PR DESCRIPTION
Should help us make decisions about needing to hint users around waiting for updates etc.