### PR TITLE
Apply the keyboard inset to the choices list, not the dialog root

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialog.java
@@ -91,7 +91,7 @@ public abstract class SelectMinimalDialog extends MaterialFullScreenDialogFragme
 
         initRecyclerView();
         initToolbar();
-        applyBottomInsets(view);
+        applyBottomInsets(binding.choicesRecyclerView);
     }
 
     @Override


### PR DESCRIPTION
Closes #7374 

#### Why is this the best possible solution? Were any other approaches considered?
The previous placement on the dialog root resized the whole content area whenever the keyboard came up, and that resize is what caused the issue: the list re-positioned its items without re-measuring them, so an image that hadn't been measured yet stayed at zero height. Nothing is resized any more, so there's nothing to re-measure. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Only the minimal select dialog is touched, and only how the keyboard inset is applied - worth checking that choices (with and without images) stay reachable above the keyboard in both orientations. No other screen uses this dialog, so there's no risk elsewhere. 

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached to the issue. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
