### PR TITLE
Fix images disappearing from the choices list

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -129,6 +129,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
     public void setImage(@NonNull File imageFile, ImageLoader imageLoader) {
         if (imageFile.exists()) {
             binding.imageView.layout(0, 0, 0, 0);
+            binding.imageView.requestLayout();
 
             imageLoader.loadImage(binding.imageView, imageFile, ImageView.ScaleType.CENTER_INSIDE, null);
             binding.imageView.setVisibility(VISIBLE);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -128,8 +128,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
 
     public void setImage(@NonNull File imageFile, ImageLoader imageLoader) {
         if (imageFile.exists()) {
-            binding.imageView.layout(0, 0, 0, 0);
-            binding.imageView.requestLayout();
+            ImageViewUtils.resetSizeForNewImage(binding.imageView);
 
             imageLoader.loadImage(binding.imageView, imageFile, ImageView.ScaleType.CENTER_INSIDE, null);
             binding.imageView.setVisibility(VISIBLE);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/ImageViewUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/ImageViewUtils.kt
@@ -1,0 +1,21 @@
+package org.odk.collect.android.formentry.questions
+
+import android.widget.ImageView
+
+object ImageViewUtils {
+
+    /**
+     * Clears the size a recycled view's [ImageView] still has from the previous choice and then
+     * asks for a fresh layout pass.
+     *
+     * Zeroing the frame stops the previous image from being shown at its old size while the new
+     * one loads. On its own that is not enough though: laying a view out also marks it as laid
+     * out, so a recycled view can then never be measured again and the new image stays 0x0,
+     * which is what made images look like they randomly disappeared while scrolling.
+     */
+    @JvmStatic
+    fun resetSizeForNewImage(imageView: ImageView) {
+        imageView.layout(0, 0, 0, 0)
+        imageView.requestLayout()
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/NoButtonsItem.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/NoButtonsItem.java
@@ -29,6 +29,7 @@ public class NoButtonsItem extends FrameLayout {
     public void setUpNoButtonsItem(File imageFile, String choiceText, String errorMsg, boolean isInGridView) {
         if (imageFile != null && imageFile.exists()) {
             binding.imageView.layout(0, 0, 0, 0);
+            binding.imageView.requestLayout();
             binding.imageView.setVisibility(View.VISIBLE);
             if (isInGridView) {
                 imageLoader.loadImage(binding.imageView, imageFile, ImageView.ScaleType.FIT_CENTER, null);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/NoButtonsItem.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/NoButtonsItem.java
@@ -28,8 +28,7 @@ public class NoButtonsItem extends FrameLayout {
 
     public void setUpNoButtonsItem(File imageFile, String choiceText, String errorMsg, boolean isInGridView) {
         if (imageFile != null && imageFile.exists()) {
-            binding.imageView.layout(0, 0, 0, 0);
-            binding.imageView.requestLayout();
+            ImageViewUtils.resetSizeForNewImage(binding.imageView);
             binding.imageView.setVisibility(View.VISIBLE);
             if (isInGridView) {
                 imageLoader.loadImage(binding.imageView, imageFile, ImageView.ScaleType.FIT_CENTER, null);


### PR DESCRIPTION
Closes #7382 

#### Why is this the best possible solution? Were any other approaches considered?
`requestLayout()` undoes the side effect of the `layout(0, 0, 0, 0)` above it. Zeroing the frame hides the previous choice's image, but it also marks the view as already laid out, so a recycled row can end up never being measured again and the image stays at 0x0. Whether that happens depends on what else touches the row while it is bound, which is why it looks random. Asking for a layout right after makes it deterministic. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Images in select choices no longer disappear when the list is scrolled or the screen is rotated.  Nothing else changes
Every select with images ends up in one of the two views the fix touches, so the appearance does not really matter for testing  - it is worth going through selects with images in general, both displayed directly in the question and in the minimal dialog.        

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] added or modified tests for any new or changed behavior
- [ ] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [ ] added a comment above any new strings describing it for translators
- [ ] added any new strings with date formatting to `DateFormatsTest`
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
