### PR TITLE
Fix select choices showing another choice's media

### DIFF
--- a/audio-clips/src/main/java/org/odk/collect/audioclips/AudioPlayer.kt
+++ b/audio-clips/src/main/java/org/odk/collect/audioclips/AudioPlayer.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.audioclips
 
 import androidx.lifecycle.LiveData
+import org.odk.collect.async.Cancellable
 import java.util.function.Consumer
 
 interface AudioPlayer {
@@ -12,7 +13,7 @@ interface AudioPlayer {
 
     fun setPosition(clipId: String, position: Int)
 
-    fun onPlayingChanged(clipID: String, playingConsumer: Consumer<Boolean>)
+    fun onPlayingChanged(clipID: String, playingConsumer: Consumer<Boolean>): Cancellable
 
     fun onPositionChanged(clipID: String, positionConsumer: Consumer<Int>)
 

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -242,9 +242,9 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
                 if (bigImageURI != null) {
                     audioVideoImageTextLabel.setBigImage(new File(referenceManager.deriveReference(bigImageURI).getLocalURI()));
                 }
-                if (videoURI != null) {
-                    audioVideoImageTextLabel.setVideo(new File(referenceManager.deriveReference(videoURI).getLocalURI()));
-                }
+                audioVideoImageTextLabel.setVideo(videoURI == null
+                        ? null
+                        : new File(referenceManager.deriveReference(videoURI).getLocalURI()));
                 audioVideoImageTextLabel.setAudio(audioURI, audioPlayer);
             } catch (InvalidReferenceException e) {
                 Timber.d(e, "Invalid media reference due to %s ", e.getMessage());

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -239,9 +239,9 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
                 audioVideoImageTextLabel.setImage(imageURI == null
                         ? null
                         : new File(referenceManager.deriveReference(imageURI).getLocalURI()), new GlideImageLoader());
-                if (bigImageURI != null) {
-                    audioVideoImageTextLabel.setBigImage(new File(referenceManager.deriveReference(bigImageURI).getLocalURI()));
-                }
+                audioVideoImageTextLabel.setBigImage(bigImageURI == null
+                        ? null
+                        : new File(referenceManager.deriveReference(bigImageURI).getLocalURI()));
                 audioVideoImageTextLabel.setVideo(videoURI == null
                         ? null
                         : new File(referenceManager.deriveReference(videoURI).getLocalURI()));

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -236,9 +236,9 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
             String bigImageURI = prompt.getSpecialFormSelectChoiceText(item, "big-image");
             String audioURI = getPlayableAudioURI(prompt, item, referenceManager);
             try {
-                if (imageURI != null) {
-                    audioVideoImageTextLabel.setImage(new File(referenceManager.deriveReference(imageURI).getLocalURI()), new GlideImageLoader());
-                }
+                audioVideoImageTextLabel.setImage(imageURI == null
+                        ? null
+                        : new File(referenceManager.deriveReference(imageURI).getLocalURI()), new GlideImageLoader());
                 if (bigImageURI != null) {
                     audioVideoImageTextLabel.setBigImage(new File(referenceManager.deriveReference(bigImageURI).getLocalURI()));
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -245,9 +245,7 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
                 if (videoURI != null) {
                     audioVideoImageTextLabel.setVideo(new File(referenceManager.deriveReference(videoURI).getLocalURI()));
                 }
-                if (audioURI != null) {
-                    audioVideoImageTextLabel.setAudio(audioURI, audioPlayer);
-                }
+                audioVideoImageTextLabel.setAudio(audioURI, audioPlayer);
             } catch (InvalidReferenceException e) {
                 Timber.d(e, "Invalid media reference due to %s ", e.getMessage());
             }

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -18,6 +18,7 @@ package org.odk.collect.android.adapters;
 
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getClip;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getClipID;
+import static org.odk.collect.android.formentry.media.FormMediaUtils.getMediaFile;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getPlayableAudioURI;
 
 import android.content.Context;
@@ -235,20 +236,10 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
             String videoURI = prompt.getSpecialFormSelectChoiceText(item, "video");
             String bigImageURI = prompt.getSpecialFormSelectChoiceText(item, "big-image");
             String audioURI = getPlayableAudioURI(prompt, item, referenceManager);
-            try {
-                audioVideoImageTextLabel.setImage(imageURI == null
-                        ? null
-                        : new File(referenceManager.deriveReference(imageURI).getLocalURI()), new GlideImageLoader());
-                audioVideoImageTextLabel.setBigImage(bigImageURI == null
-                        ? null
-                        : new File(referenceManager.deriveReference(bigImageURI).getLocalURI()));
-                audioVideoImageTextLabel.setVideo(videoURI == null
-                        ? null
-                        : new File(referenceManager.deriveReference(videoURI).getLocalURI()));
-                audioVideoImageTextLabel.setAudio(audioURI, audioPlayer);
-            } catch (InvalidReferenceException e) {
-                Timber.d(e, "Invalid media reference due to %s ", e.getMessage());
-            }
+            audioVideoImageTextLabel.setImage(getMediaFile(imageURI, referenceManager), new GlideImageLoader());
+            audioVideoImageTextLabel.setBigImage(getMediaFile(bigImageURI, referenceManager));
+            audioVideoImageTextLabel.setVideo(getMediaFile(videoURI, referenceManager));
+            audioVideoImageTextLabel.setAudio(audioURI, audioPlayer);
 
             textView.setGravity(Gravity.CENTER_VERTICAL);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/media/FormMediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/media/FormMediaUtils.java
@@ -12,6 +12,8 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.utilities.ThemeUtils;
 import org.odk.collect.audioclips.Clip;
 
+import java.io.File;
+
 import timber.log.Timber;
 
 public final class FormMediaUtils {
@@ -52,6 +54,12 @@ public final class FormMediaUtils {
         );
 
         return deriveReference(selectAudioURI, referenceManager);
+    }
+
+    @Nullable
+    public static File getMediaFile(@Nullable String originalURI, ReferenceManager referenceManager) {
+        String localURI = deriveReference(originalURI, referenceManager);
+        return localURI == null ? null : new File(localURI);
     }
 
     @Nullable

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -152,8 +152,13 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
         this.bigImageFile = bigImageFile;
     }
 
-    public void setVideo(@NonNull File videoFile) {
+    public void setVideo(@Nullable File videoFile) {
         this.videoFile = videoFile;
+
+        if (videoFile == null) {
+            binding.videoButton.setVisibility(GONE);
+            return;
+        }
 
         binding.videoButton.setVisibility(VISIBLE);
         binding.mediaButtons.setVisibility(VISIBLE);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -143,6 +143,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
             binding.imageView.setVisibility(VISIBLE);
             binding.imageView.setOnClickListener(this);
         } else {
+            binding.imageView.setVisibility(GONE);
             binding.missingImage.setVisibility(VISIBLE);
             binding.missingImage.setText(getContext().getString(org.odk.collect.strings.R.string.file_missing, imageFile));
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -129,7 +129,6 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
         });
 
         binding.audioButton.setVisibility(VISIBLE);
-        binding.mediaButtons.setVisibility(VISIBLE);
     }
 
     public void setImage(@Nullable File imageFile, ImageLoader imageLoader) {
@@ -163,7 +162,6 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
         }
 
         binding.videoButton.setVisibility(VISIBLE);
-        binding.mediaButtons.setVisibility(VISIBLE);
         binding.videoButton.setOnClickListener(this);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -142,6 +142,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
             imageLoader.loadImage(binding.imageView, imageFile, ImageView.ScaleType.CENTER_INSIDE, null);
             binding.imageView.setVisibility(VISIBLE);
             binding.imageView.setOnClickListener(this);
+            binding.missingImage.setVisibility(GONE);
         } else {
             binding.imageView.setVisibility(GONE);
             binding.missingImage.setVisibility(VISIBLE);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -97,7 +97,12 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
         }
     }
 
-    public void setAudio(String audioURI, AudioPlayer audioPlayer) {
+    public void setAudio(@Nullable String audioURI, AudioPlayer audioPlayer) {
+        if (audioURI == null) {
+            binding.audioButton.setVisibility(GONE);
+            return;
+        }
+
         String clipID = getTag() != null ? getTag().toString() : "";
 
         originalTextColor = textLabel.getTextColors().getDefaultColor();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -29,6 +29,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.audio.AudioButton;
@@ -126,8 +127,10 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
         binding.mediaButtons.setVisibility(VISIBLE);
     }
 
-    public void setImage(@NonNull File imageFile, ImageLoader imageLoader) {
-        if (imageFile.exists()) {
+    public void setImage(@Nullable File imageFile, ImageLoader imageLoader) {
+        if (imageFile == null) {
+            binding.imageView.setVisibility(GONE);
+        } else if (imageFile.exists()) {
             ImageViewUtils.resetSizeForNewImage(binding.imageView);
 
             imageLoader.loadImage(binding.imageView, imageFile, ImageView.ScaleType.CENTER_INSIDE, null);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -28,7 +28,6 @@ import android.widget.RadioButton;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.odk.collect.android.R;
@@ -156,7 +155,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
         }
     }
 
-    public void setBigImage(@NonNull File bigImageFile) {
+    public void setBigImage(@Nullable File bigImageFile) {
         this.bigImageFile = bigImageFile;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -38,6 +38,7 @@ import org.odk.collect.android.listeners.SelectItemClickListener;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.androidshared.system.ContextExt;
+import org.odk.collect.async.Cancellable;
 import org.odk.collect.audioclips.AudioPlayer;
 import org.odk.collect.audioclips.Clip;
 import org.odk.collect.imageloader.ImageLoader;
@@ -58,6 +59,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
     private File videoFile;
     private File bigImageFile;
     private MediaUtils mediaUtils;
+    private Cancellable playingChangedObserver;
 
     public AudioVideoImageTextLabel(Context context) {
         super(context);
@@ -98,6 +100,11 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
     }
 
     public void setAudio(@Nullable String audioURI, AudioPlayer audioPlayer) {
+        if (playingChangedObserver != null) {
+            playingChangedObserver.cancel();
+            playingChangedObserver = null;
+        }
+
         if (audioURI == null) {
             binding.audioButton.setVisibility(GONE);
             return;
@@ -106,7 +113,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
         String clipID = getTag() != null ? getTag().toString() : "";
 
         originalTextColor = textLabel.getTextColors().getDefaultColor();
-        audioPlayer.onPlayingChanged(clipID, isPlaying -> {
+        playingChangedObserver = audioPlayer.onPlayingChanged(clipID, isPlaying -> {
             binding.audioButton.setPlaying(isPlaying);
 
             if (isPlaying) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -130,6 +130,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
     public void setImage(@Nullable File imageFile, ImageLoader imageLoader) {
         if (imageFile == null) {
             binding.imageView.setVisibility(GONE);
+            binding.missingImage.setVisibility(GONE);
         } else if (imageFile.exists()) {
             ImageViewUtils.resetSizeForNewImage(binding.imageView);
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/NoButtonsItem.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/NoButtonsItem.java
@@ -30,12 +30,14 @@ public class NoButtonsItem extends FrameLayout {
         if (imageFile != null && imageFile.exists()) {
             ImageViewUtils.resetSizeForNewImage(binding.imageView);
             binding.imageView.setVisibility(View.VISIBLE);
+            binding.label.setVisibility(View.GONE);
             if (isInGridView) {
                 imageLoader.loadImage(binding.imageView, imageFile, ImageView.ScaleType.FIT_CENTER, null);
             } else {
                 imageLoader.loadImage(binding.imageView, imageFile, ImageView.ScaleType.CENTER_INSIDE, null);
             }
         } else {
+            binding.imageView.setVisibility(View.GONE);
             binding.label.setVisibility(View.VISIBLE);
             binding.label.setTextSize(TypedValue.COMPLEX_UNIT_DIP, QuestionFontSizeUtils.getQuestionFontSize());
             binding.label.setText(choiceText == null || choiceText.isEmpty() ? errorMsg : choiceText);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -15,6 +15,7 @@
 package org.odk.collect.android.widgets;
 
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getClipID;
+import static org.odk.collect.android.formentry.media.FormMediaUtils.getMediaFile;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getPlayColor;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getPlayableAudioURI;
 import static org.odk.collect.android.injection.DaggerUtils.getComponent;
@@ -34,7 +35,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 
-import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
@@ -59,12 +59,9 @@ import org.odk.collect.settings.SettingsProvider;
 import org.odk.collect.settings.enums.GuidanceHintMode;
 import org.odk.collect.shared.settings.Settings;
 
-import java.io.File;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.inject.Inject;
-
-import timber.log.Timber;
 
 public abstract class QuestionWidget extends FrameLayout implements Widget {
 
@@ -192,22 +189,10 @@ public abstract class QuestionWidget extends FrameLayout implements Widget {
         String videoURI = formEntryPrompt.getSpecialFormQuestionText("video");
         String bigImageURI = formEntryPrompt.getSpecialFormQuestionText("big-image");
         String playableAudioURI = getPlayableAudioURI(formEntryPrompt, referenceManager);
-        try {
-            if (imageURI != null) {
-                audioVideoImageTextLabel.setImage(new File(referenceManager.deriveReference(imageURI).getLocalURI()), imageLoader);
-            }
-            if (bigImageURI != null) {
-                audioVideoImageTextLabel.setBigImage(new File(referenceManager.deriveReference(bigImageURI).getLocalURI()));
-            }
-            if (videoURI != null) {
-                audioVideoImageTextLabel.setVideo(new File(referenceManager.deriveReference(videoURI).getLocalURI()));
-            }
-            if (playableAudioURI != null) {
-                audioVideoImageTextLabel.setAudio(playableAudioURI, audioPlayer);
-            }
-        } catch (InvalidReferenceException e) {
-            Timber.d(e, "Invalid media reference due to %s ", e.getMessage());
-        }
+        audioVideoImageTextLabel.setImage(getMediaFile(imageURI, referenceManager), imageLoader);
+        audioVideoImageTextLabel.setBigImage(getMediaFile(bigImageURI, referenceManager));
+        audioVideoImageTextLabel.setVideo(getMediaFile(videoURI, referenceManager));
+        audioVideoImageTextLabel.setAudio(playableAudioURI, audioPlayer);
 
         audioVideoImageTextLabel.setPlayTextColor(getPlayColor(formEntryPrompt, themeUtils));
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ViewModelAudioPlayer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ViewModelAudioPlayer.kt
@@ -4,8 +4,10 @@ import android.media.MediaPlayer
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.androidshared.data.consume
+import org.odk.collect.async.Cancellable
 import org.odk.collect.async.Scheduler
 import org.odk.collect.audioclips.AudioClipViewModel
 import org.odk.collect.audioclips.AudioPlayer
@@ -33,9 +35,16 @@ class ViewModelAudioPlayer(
         viewModel.setPosition(clipId, position)
     }
 
-    override fun onPlayingChanged(clipID: String, playingConsumer: Consumer<Boolean>) {
-        viewModel.isPlaying(clipID).observe(lifecycleOwner) {
-            playingConsumer.accept(it)
+    override fun onPlayingChanged(clipID: String, playingConsumer: Consumer<Boolean>): Cancellable {
+        val isPlaying = viewModel.isPlaying(clipID)
+        val observer = Observer<Boolean> { playingConsumer.accept(it) }
+        isPlaying.observe(lifecycleOwner, observer)
+
+        return object : Cancellable {
+            override fun cancel(): Boolean {
+                isPlaying.removeObserver(observer)
+                return true
+            }
         }
     }
 

--- a/collect_app/src/main/res/layout/audio_video_image_text_label.xml
+++ b/collect_app/src/main/res/layout/audio_video_image_text_label.xml
@@ -59,9 +59,7 @@
         android:layout_alignParentTop="true"
         android:layout_alignParentEnd="true"
         android:gravity="end"
-        android:orientation="vertical"
-        android:visibility="gone"
-        tools:visibility="visible">
+        android:orientation="vertical">
 
         <org.odk.collect.android.audio.AudioButton
             android:id="@+id/audioButton"

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/AudioVideoImageTextLabelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/AudioVideoImageTextLabelTest.java
@@ -75,6 +75,19 @@ public class AudioVideoImageTextLabelTest {
     }
 
     @Test
+    public void settingAudioAgain_stopsListeningToThePreviousClip() {
+        AudioVideoImageTextLabel label = new AudioVideoImageTextLabel(activity);
+        label.setTag("clip1");
+        label.setAudio("file://audio1.mp3", audioPlayer);
+
+        label.setTag("clip2");
+        label.setAudio("file://audio2.mp3", audioPlayer);
+
+        assertThat(audioPlayer.isListeningTo("clip1"), is(false));
+        assertThat(audioPlayer.isListeningTo("clip2"), is(true));
+    }
+
+    @Test
     public void withText_andAudio_playingAudio_highlightsText() {
         AudioVideoImageTextLabel audioVideoImageTextLabel = new AudioVideoImageTextLabel(activity);
         audioVideoImageTextLabel.setTag("blah");

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/AudioVideoImageTextLabelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/AudioVideoImageTextLabelTest.java
@@ -75,7 +75,7 @@ public class AudioVideoImageTextLabelTest {
     }
 
     @Test
-    public void settingAudioAgain_stopsListeningToThePreviousClip() {
+    public void settingAudioAgain_stopsObservingThePreviousClip() {
         AudioVideoImageTextLabel label = new AudioVideoImageTextLabel(activity);
         label.setTag("clip1");
         label.setAudio("file://audio1.mp3", audioPlayer);
@@ -83,8 +83,8 @@ public class AudioVideoImageTextLabelTest {
         label.setTag("clip2");
         label.setAudio("file://audio2.mp3", audioPlayer);
 
-        assertThat(audioPlayer.isListeningTo("clip1"), is(false));
-        assertThat(audioPlayer.isListeningTo("clip2"), is(true));
+        assertThat(audioPlayer.isBeingObserved("clip1"), is(false));
+        assertThat(audioPlayer.isBeingObserved("clip2"), is(true));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/NoButtonsItemTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/NoButtonsItemTest.java
@@ -1,0 +1,40 @@
+package org.odk.collect.android.formentry;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import android.view.View;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.R;
+import org.odk.collect.android.formentry.questions.NoButtonsItem;
+import org.odk.collect.imageloader.ImageLoader;
+import org.odk.collect.shared.TempFiles;
+
+@RunWith(AndroidJUnit4.class)
+public class NoButtonsItemTest {
+    @Test
+    public void settingUpAChoiceWithoutAnImage_hidesTheImageOfThePreviousChoice() {
+        NoButtonsItem item = new NoButtonsItem(ApplicationProvider.getApplicationContext(), true, mock(ImageLoader.class));
+        item.setUpNoButtonsItem(TempFiles.createTempFile(".jpg"), "AAA", "", false);
+
+        item.setUpNoButtonsItem(null, "BBB", "", false);
+
+        assertThat(item.findViewById(R.id.imageView).getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void settingUpAChoiceWithAnImage_hidesTheTextOfThePreviousChoice() {
+        NoButtonsItem item = new NoButtonsItem(ApplicationProvider.getApplicationContext(), true, mock(ImageLoader.class));
+        item.setUpNoButtonsItem(null, "AAA", "", false);
+
+        item.setUpNoButtonsItem(TempFiles.createTempFile(".jpg"), "BBB", "", false);
+
+        assertThat(item.findViewById(R.id.label).getVisibility(), is(View.GONE));
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/support/CollectHelpers.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/CollectHelpers.java
@@ -50,7 +50,7 @@ public final class CollectHelpers {
         return referenceManager;
     }
 
-    private static String createFakeReference(ReferenceManager referenceManager, String referenceURI, String localURI) throws InvalidReferenceException {
+    public static String createFakeReference(ReferenceManager referenceManager, String referenceURI, String localURI) throws InvalidReferenceException {
         Reference reference = mock(Reference.class);
         when(reference.getLocalURI()).thenReturn(localURI);
         when(referenceManager.deriveReference(referenceURI)).thenReturn(reference);

--- a/collect_app/src/test/java/org/odk/collect/android/support/CollectHelpers.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/CollectHelpers.java
@@ -50,12 +50,10 @@ public final class CollectHelpers {
         return referenceManager;
     }
 
-    public static String createFakeReference(ReferenceManager referenceManager, String referenceURI, String localURI) throws InvalidReferenceException {
+    public static void createFakeReference(ReferenceManager referenceManager, String referenceURI, String localURI) throws InvalidReferenceException {
         Reference reference = mock(Reference.class);
         when(reference.getLocalURI()).thenReturn(localURI);
         when(referenceManager.deriveReference(referenceURI)).thenReturn(reference);
-
-        return localURI;
     }
 
     public static AppDependencyComponent overrideAppDependencyModule(AppDependencyModule appDependencyModule) {

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -487,7 +487,7 @@ public class ChoicesRecyclerViewTest {
     }
 
     @Test
-    public void whenAChoiceWithoutAnImageReusesAView_shouldTheImageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+    public void whenAChoiceWithoutAnImageReusesAView_theImageOfThePreviousChoiceIsHidden() throws InvalidReferenceException {
         String imageURI = "jr://images/present.jpg";
         SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
         SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
@@ -507,7 +507,7 @@ public class ChoicesRecyclerViewTest {
     }
 
     @Test
-    public void whenAChoiceWithoutAnImageReusesAView_shouldTheMissingImageMessageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+    public void whenAChoiceWithoutAnImageReusesAView_theMissingImageMessageOfThePreviousChoiceIsHidden() throws InvalidReferenceException {
         String missingImageURI = "jr://images/missing.jpg";
         SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
         SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
@@ -527,7 +527,7 @@ public class ChoicesRecyclerViewTest {
     }
 
     @Test
-    public void whenAChoiceWithAMissingImageReusesAView_shouldTheImageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+    public void whenAChoiceWithAMissingImageReusesAView_theImageOfThePreviousChoiceIsHidden() throws InvalidReferenceException {
         String imageURI = "jr://images/present.jpg";
         String missingImageURI = "jr://images/missing.jpg";
         SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
@@ -550,7 +550,7 @@ public class ChoicesRecyclerViewTest {
     }
 
     @Test
-    public void whenAChoiceWithAnImageReusesAView_shouldTheMissingImageMessageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+    public void whenAChoiceWithAnImageReusesAView_theMissingImageMessageOfThePreviousChoiceIsHidden() throws InvalidReferenceException {
         String missingImageURI = "jr://images/missing.jpg";
         String imageURI = "jr://images/present.jpg";
         SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
@@ -573,7 +573,7 @@ public class ChoicesRecyclerViewTest {
     }
 
     @Test
-    public void whenAChoiceWithoutAudioReusesAView_shouldTheAudioButtonOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+    public void whenAChoiceWithoutAudioReusesAView_theAudioButtonOfThePreviousChoiceIsHidden() throws InvalidReferenceException {
         String audioURI = "jr://audio/audio.mp3";
         SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
         SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
@@ -593,7 +593,7 @@ public class ChoicesRecyclerViewTest {
     }
 
     @Test
-    public void whenAChoiceWithoutAVideoReusesAView_shouldTheVideoButtonOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+    public void whenAChoiceWithoutAVideoReusesAView_theVideoButtonOfThePreviousChoiceIsHidden() throws InvalidReferenceException {
         String videoURI = "jr://video/video.mp4";
         SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
         SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
@@ -613,7 +613,7 @@ public class ChoicesRecyclerViewTest {
     }
 
     @Test
-    public void whenAChoiceWithoutABigImageReusesAView_shouldClickingItsImageNotOpenTheBigImageOfThePreviousChoice() throws InvalidReferenceException {
+    public void whenAChoiceWithoutABigImageReusesAView_clickingItsImageDoesNotOpenTheBigImageOfThePreviousChoice() throws InvalidReferenceException {
         String imageURI = "jr://images/image.jpg";
         String bigImageURI = "jr://images/big-image.jpg";
         SelectChoice firstChoice = new SelectChoice("AAA", "AAA");

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -498,9 +498,7 @@ public class ChoicesRecyclerViewTest {
                 ))
                 .build();
 
-        Reference reference = mock(Reference.class);
-        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
-        when(referenceManager.deriveReference(imageURI)).thenReturn(reference);
+        CollectHelpers.createFakeReference(referenceManager, imageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
 
         AudioVideoImageTextLabel view = bindThenRebind(items);
 
@@ -519,9 +517,7 @@ public class ChoicesRecyclerViewTest {
                 ))
                 .build();
 
-        Reference reference = mock(Reference.class);
-        when(reference.getLocalURI()).thenReturn(new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
-        when(referenceManager.deriveReference(missingImageURI)).thenReturn(reference);
+        CollectHelpers.createFakeReference(referenceManager, missingImageURI, new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
 
         AudioVideoImageTextLabel view = bindThenRebind(items);
 
@@ -541,13 +537,8 @@ public class ChoicesRecyclerViewTest {
                 ))
                 .build();
 
-        Reference reference = mock(Reference.class);
-        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
-        when(referenceManager.deriveReference(imageURI)).thenReturn(reference);
-
-        Reference missingReference = mock(Reference.class);
-        when(missingReference.getLocalURI()).thenReturn(new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
-        when(referenceManager.deriveReference(missingImageURI)).thenReturn(missingReference);
+        CollectHelpers.createFakeReference(referenceManager, imageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
+        CollectHelpers.createFakeReference(referenceManager, missingImageURI, new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
 
         AudioVideoImageTextLabel view = bindThenRebind(items);
 
@@ -568,13 +559,8 @@ public class ChoicesRecyclerViewTest {
                 ))
                 .build();
 
-        Reference missingReference = mock(Reference.class);
-        when(missingReference.getLocalURI()).thenReturn(new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
-        when(referenceManager.deriveReference(missingImageURI)).thenReturn(missingReference);
-
-        Reference reference = mock(Reference.class);
-        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
-        when(referenceManager.deriveReference(imageURI)).thenReturn(reference);
+        CollectHelpers.createFakeReference(referenceManager, missingImageURI, new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
+        CollectHelpers.createFakeReference(referenceManager, imageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
 
         AudioVideoImageTextLabel view = bindThenRebind(items);
 
@@ -594,9 +580,7 @@ public class ChoicesRecyclerViewTest {
                 ))
                 .build();
 
-        Reference reference = mock(Reference.class);
-        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".mp3").getAbsolutePath());
-        when(referenceManager.deriveReference(audioURI)).thenReturn(reference);
+        CollectHelpers.createFakeReference(referenceManager, audioURI, TempFiles.createTempFile(".mp3").getAbsolutePath());
 
         AudioVideoImageTextLabel view = bindThenRebind(items);
 
@@ -615,9 +599,7 @@ public class ChoicesRecyclerViewTest {
                 ))
                 .build();
 
-        Reference reference = mock(Reference.class);
-        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".mp4").getAbsolutePath());
-        when(referenceManager.deriveReference(videoURI)).thenReturn(reference);
+        CollectHelpers.createFakeReference(referenceManager, videoURI, TempFiles.createTempFile(".mp4").getAbsolutePath());
 
         AudioVideoImageTextLabel view = bindThenRebind(items);
 
@@ -641,13 +623,8 @@ public class ChoicesRecyclerViewTest {
                 ))
                 .build();
 
-        Reference reference = mock(Reference.class);
-        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
-        when(referenceManager.deriveReference(imageURI)).thenReturn(reference);
-
-        Reference bigImageReference = mock(Reference.class);
-        when(bigImageReference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
-        when(referenceManager.deriveReference(bigImageURI)).thenReturn(bigImageReference);
+        CollectHelpers.createFakeReference(referenceManager, imageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
+        CollectHelpers.createFakeReference(referenceManager, bigImageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
 
         AudioVideoImageTextLabel view = bindThenRebind(items);
         view.getImageView().performClick();

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -555,6 +555,33 @@ public class ChoicesRecyclerViewTest {
     }
 
     @Test
+    public void whenAChoiceWithAnImageReusesAView_shouldTheMissingImageMessageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+        String missingImageURI = "jr://images/missing.jpg";
+        String imageURI = "jr://images/present.jpg";
+        List<SelectChoice> items = getTestChoices();
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(items)
+                .withSpecialFormSelectChoiceText(asList(
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, missingImageURI),
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI)
+                ))
+                .build();
+
+        Reference missingReference = mock(Reference.class);
+        when(missingReference.getLocalURI()).thenReturn(new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
+        when(referenceManager.deriveReference(missingImageURI)).thenReturn(missingReference);
+
+        Reference reference = mock(Reference.class);
+        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
+        when(referenceManager.deriveReference(imageURI)).thenReturn(reference);
+
+        AudioVideoImageTextLabel view = bindThenRebind(items);
+
+        assertThat(view.getMissingImage().getVisibility(), is(View.GONE));
+        assertThat(view.getImageView().getVisibility(), is(View.VISIBLE));
+    }
+
+    @Test
     public void whenAChoiceWithoutAudioReusesAView_shouldTheAudioButtonOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
         String audioURI = "jr://audio/audio.mp3";
         List<SelectChoice> items = getTestChoices();

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -528,6 +528,33 @@ public class ChoicesRecyclerViewTest {
     }
 
     @Test
+    public void whenAChoiceWithAMissingImageReusesAView_shouldTheImageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+        String imageURI = "jr://images/present.jpg";
+        String missingImageURI = "jr://images/missing.jpg";
+        List<SelectChoice> items = getTestChoices();
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(items)
+                .withSpecialFormSelectChoiceText(asList(
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI),
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, missingImageURI)
+                ))
+                .build();
+
+        Reference reference = mock(Reference.class);
+        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
+        when(referenceManager.deriveReference(imageURI)).thenReturn(reference);
+
+        Reference missingReference = mock(Reference.class);
+        when(missingReference.getLocalURI()).thenReturn(new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
+        when(referenceManager.deriveReference(missingImageURI)).thenReturn(missingReference);
+
+        AudioVideoImageTextLabel view = bindThenRebind(items);
+
+        assertThat(view.getImageView().getVisibility(), is(View.GONE));
+        assertThat(view.getMissingImage().getVisibility(), is(View.VISIBLE));
+    }
+
+    @Test
     public void whenAChoiceWithoutAudioReusesAView_shouldTheAudioButtonOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
         String audioURI = "jr://audio/audio.mp3";
         List<SelectChoice> items = getTestChoices();

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -68,6 +68,7 @@ public class ChoicesRecyclerViewTest {
 
     private FormEntryPrompt formEntryPrompt;
     private ReferenceManager referenceManager;
+    private final MediaUtils mediaUtils = mock(MediaUtils.class);
 
     @Before
     public void setUp() throws InvalidReferenceException {
@@ -623,13 +624,44 @@ public class ChoicesRecyclerViewTest {
         assertThat(view.getVideoButton().getVisibility(), is(View.GONE));
     }
 
+    @Test
+    public void whenAChoiceWithoutABigImageReusesAView_shouldClickingItsImageNotOpenTheBigImageOfThePreviousChoice() throws InvalidReferenceException {
+        String imageURI = "jr://images/image.jpg";
+        String bigImageURI = "jr://images/big-image.jpg";
+        List<SelectChoice> items = getTestChoices();
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(items)
+                .withSpecialFormSelectChoiceText(asList(
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI),
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI)
+                ))
+                .withSpecialFormSelectChoiceText(asList(
+                        Pair.create("big-image", bigImageURI),
+                        Pair.create("big-image", null)
+                ))
+                .build();
+
+        Reference reference = mock(Reference.class);
+        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
+        when(referenceManager.deriveReference(imageURI)).thenReturn(reference);
+
+        Reference bigImageReference = mock(Reference.class);
+        when(bigImageReference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
+        when(referenceManager.deriveReference(bigImageURI)).thenReturn(bigImageReference);
+
+        AudioVideoImageTextLabel view = bindThenRebind(items);
+        view.getImageView().performClick();
+
+        verify(mediaUtils, never()).openFile(any(), any(), any());
+    }
+
     /**
      * Binds a view holder to one choice and then rebinds the same view to another, which is what the
      * list does to a view that gets recycled while scrolling.
      */
     private AudioVideoImageTextLabel bindThenRebind(List<SelectChoice> items) {
         SelectOneListAdapter adapter = new SelectOneListAdapter(null, null, activityController.get(),
-                items, formEntryPrompt, referenceManager, new FakeAudioPlayer(), 0, 1, false, mock(MediaUtils.class));
+                items, formEntryPrompt, referenceManager, new FakeAudioPlayer(), 0, 1, false, mediaUtils);
         initRecyclerView(adapter, false);
 
         RecyclerView.Adapter recyclerViewAdapter = adapter;

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -548,6 +548,27 @@ public class ChoicesRecyclerViewTest {
         assertThat(view.getAudioButton().getVisibility(), is(View.GONE));
     }
 
+    @Test
+    public void whenAChoiceWithoutAVideoReusesAView_shouldTheVideoButtonOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+        String videoURI = "jr://video/video.mp4";
+        List<SelectChoice> items = getTestChoices();
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(items)
+                .withSpecialFormSelectChoiceText(asList(
+                        Pair.create("video", videoURI),
+                        Pair.create("video", null)
+                ))
+                .build();
+
+        Reference reference = mock(Reference.class);
+        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".mp4").getAbsolutePath());
+        when(referenceManager.deriveReference(videoURI)).thenReturn(reference);
+
+        AudioVideoImageTextLabel view = bindThenRebind(items);
+
+        assertThat(view.getVideoButton().getVisibility(), is(View.GONE));
+    }
+
     /**
      * Binds a view holder to one choice and then rebinds the same view to another, which is what the
      * list does to a view that gets recycled while scrolling.

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -52,6 +52,7 @@ import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.imageloader.ImageLoader;
 import org.odk.collect.shared.TempFiles;
+import org.odk.collect.testshared.FakeAudioPlayer;
 import org.odk.collect.testshared.RobolectricHelpers;
 import org.robolectric.android.controller.ActivityController;
 
@@ -526,13 +527,34 @@ public class ChoicesRecyclerViewTest {
         assertThat(view.getMissingImage().getVisibility(), is(View.GONE));
     }
 
+    @Test
+    public void whenAChoiceWithoutAudioReusesAView_shouldTheAudioButtonOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+        String audioURI = "jr://audio/audio.mp3";
+        List<SelectChoice> items = getTestChoices();
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(items)
+                .withSpecialFormSelectChoiceText(asList(
+                        Pair.create(FormEntryCaption.TEXT_FORM_AUDIO, audioURI),
+                        Pair.create(FormEntryCaption.TEXT_FORM_AUDIO, null)
+                ))
+                .build();
+
+        Reference reference = mock(Reference.class);
+        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".mp3").getAbsolutePath());
+        when(referenceManager.deriveReference(audioURI)).thenReturn(reference);
+
+        AudioVideoImageTextLabel view = bindThenRebind(items);
+
+        assertThat(view.getAudioButton().getVisibility(), is(View.GONE));
+    }
+
     /**
      * Binds a view holder to one choice and then rebinds the same view to another, which is what the
      * list does to a view that gets recycled while scrolling.
      */
     private AudioVideoImageTextLabel bindThenRebind(List<SelectChoice> items) {
         SelectOneListAdapter adapter = new SelectOneListAdapter(null, null, activityController.get(),
-                items, formEntryPrompt, referenceManager, null, 0, 1, false, mock(MediaUtils.class));
+                items, formEntryPrompt, referenceManager, new FakeAudioPlayer(), 0, 1, false, mock(MediaUtils.class));
         initRecyclerView(adapter, false);
 
         RecyclerView.Adapter recyclerViewAdapter = adapter;

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -489,9 +489,10 @@ public class ChoicesRecyclerViewTest {
     @Test
     public void whenAChoiceWithoutAnImageReusesAView_shouldTheImageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
         String imageURI = "jr://images/present.jpg";
-        List<SelectChoice> items = getTestChoices();
+        SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
+        SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withSelectChoices(items)
+                .withSelectChoices(asList(firstChoice, secondChoice))
                 .withSpecialFormSelectChoiceText(asList(
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI),
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, null)
@@ -500,7 +501,7 @@ public class ChoicesRecyclerViewTest {
 
         CollectHelpers.createFakeReference(referenceManager, imageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
 
-        AudioVideoImageTextLabel view = bindThenRebind(items);
+        AudioVideoImageTextLabel view = bindThenRebind(firstChoice, secondChoice);
 
         assertThat(view.getImageView().getVisibility(), is(View.GONE));
     }
@@ -508,9 +509,10 @@ public class ChoicesRecyclerViewTest {
     @Test
     public void whenAChoiceWithoutAnImageReusesAView_shouldTheMissingImageMessageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
         String missingImageURI = "jr://images/missing.jpg";
-        List<SelectChoice> items = getTestChoices();
+        SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
+        SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withSelectChoices(items)
+                .withSelectChoices(asList(firstChoice, secondChoice))
                 .withSpecialFormSelectChoiceText(asList(
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, missingImageURI),
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, null)
@@ -519,7 +521,7 @@ public class ChoicesRecyclerViewTest {
 
         CollectHelpers.createFakeReference(referenceManager, missingImageURI, new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
 
-        AudioVideoImageTextLabel view = bindThenRebind(items);
+        AudioVideoImageTextLabel view = bindThenRebind(firstChoice, secondChoice);
 
         assertThat(view.getMissingImage().getVisibility(), is(View.GONE));
     }
@@ -528,9 +530,10 @@ public class ChoicesRecyclerViewTest {
     public void whenAChoiceWithAMissingImageReusesAView_shouldTheImageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
         String imageURI = "jr://images/present.jpg";
         String missingImageURI = "jr://images/missing.jpg";
-        List<SelectChoice> items = getTestChoices();
+        SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
+        SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withSelectChoices(items)
+                .withSelectChoices(asList(firstChoice, secondChoice))
                 .withSpecialFormSelectChoiceText(asList(
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI),
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, missingImageURI)
@@ -540,7 +543,7 @@ public class ChoicesRecyclerViewTest {
         CollectHelpers.createFakeReference(referenceManager, imageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
         CollectHelpers.createFakeReference(referenceManager, missingImageURI, new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
 
-        AudioVideoImageTextLabel view = bindThenRebind(items);
+        AudioVideoImageTextLabel view = bindThenRebind(firstChoice, secondChoice);
 
         assertThat(view.getImageView().getVisibility(), is(View.GONE));
         assertThat(view.getMissingImage().getVisibility(), is(View.VISIBLE));
@@ -550,9 +553,10 @@ public class ChoicesRecyclerViewTest {
     public void whenAChoiceWithAnImageReusesAView_shouldTheMissingImageMessageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
         String missingImageURI = "jr://images/missing.jpg";
         String imageURI = "jr://images/present.jpg";
-        List<SelectChoice> items = getTestChoices();
+        SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
+        SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withSelectChoices(items)
+                .withSelectChoices(asList(firstChoice, secondChoice))
                 .withSpecialFormSelectChoiceText(asList(
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, missingImageURI),
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI)
@@ -562,7 +566,7 @@ public class ChoicesRecyclerViewTest {
         CollectHelpers.createFakeReference(referenceManager, missingImageURI, new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
         CollectHelpers.createFakeReference(referenceManager, imageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
 
-        AudioVideoImageTextLabel view = bindThenRebind(items);
+        AudioVideoImageTextLabel view = bindThenRebind(firstChoice, secondChoice);
 
         assertThat(view.getMissingImage().getVisibility(), is(View.GONE));
         assertThat(view.getImageView().getVisibility(), is(View.VISIBLE));
@@ -571,9 +575,10 @@ public class ChoicesRecyclerViewTest {
     @Test
     public void whenAChoiceWithoutAudioReusesAView_shouldTheAudioButtonOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
         String audioURI = "jr://audio/audio.mp3";
-        List<SelectChoice> items = getTestChoices();
+        SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
+        SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withSelectChoices(items)
+                .withSelectChoices(asList(firstChoice, secondChoice))
                 .withSpecialFormSelectChoiceText(asList(
                         Pair.create(FormEntryCaption.TEXT_FORM_AUDIO, audioURI),
                         Pair.create(FormEntryCaption.TEXT_FORM_AUDIO, null)
@@ -582,7 +587,7 @@ public class ChoicesRecyclerViewTest {
 
         CollectHelpers.createFakeReference(referenceManager, audioURI, TempFiles.createTempFile(".mp3").getAbsolutePath());
 
-        AudioVideoImageTextLabel view = bindThenRebind(items);
+        AudioVideoImageTextLabel view = bindThenRebind(firstChoice, secondChoice);
 
         assertThat(view.getAudioButton().getVisibility(), is(View.GONE));
     }
@@ -590,9 +595,10 @@ public class ChoicesRecyclerViewTest {
     @Test
     public void whenAChoiceWithoutAVideoReusesAView_shouldTheVideoButtonOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
         String videoURI = "jr://video/video.mp4";
-        List<SelectChoice> items = getTestChoices();
+        SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
+        SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withSelectChoices(items)
+                .withSelectChoices(asList(firstChoice, secondChoice))
                 .withSpecialFormSelectChoiceText(asList(
                         Pair.create("video", videoURI),
                         Pair.create("video", null)
@@ -601,7 +607,7 @@ public class ChoicesRecyclerViewTest {
 
         CollectHelpers.createFakeReference(referenceManager, videoURI, TempFiles.createTempFile(".mp4").getAbsolutePath());
 
-        AudioVideoImageTextLabel view = bindThenRebind(items);
+        AudioVideoImageTextLabel view = bindThenRebind(firstChoice, secondChoice);
 
         assertThat(view.getVideoButton().getVisibility(), is(View.GONE));
     }
@@ -610,9 +616,10 @@ public class ChoicesRecyclerViewTest {
     public void whenAChoiceWithoutABigImageReusesAView_shouldClickingItsImageNotOpenTheBigImageOfThePreviousChoice() throws InvalidReferenceException {
         String imageURI = "jr://images/image.jpg";
         String bigImageURI = "jr://images/big-image.jpg";
-        List<SelectChoice> items = getTestChoices();
+        SelectChoice firstChoice = new SelectChoice("AAA", "AAA");
+        SelectChoice secondChoice = new SelectChoice("BBB", "BBB");
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withSelectChoices(items)
+                .withSelectChoices(asList(firstChoice, secondChoice))
                 .withSpecialFormSelectChoiceText(asList(
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI),
                         Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI)
@@ -626,7 +633,7 @@ public class ChoicesRecyclerViewTest {
         CollectHelpers.createFakeReference(referenceManager, imageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
         CollectHelpers.createFakeReference(referenceManager, bigImageURI, TempFiles.createTempFile(".jpg").getAbsolutePath());
 
-        AudioVideoImageTextLabel view = bindThenRebind(items);
+        AudioVideoImageTextLabel view = bindThenRebind(firstChoice, secondChoice);
         view.getImageView().performClick();
 
         verify(mediaUtils, never()).openFile(any(), any(), any());
@@ -636,9 +643,9 @@ public class ChoicesRecyclerViewTest {
      * Binds a view holder to one choice and then rebinds the same view to another, which is what the
      * list does to a view that gets recycled while scrolling.
      */
-    private AudioVideoImageTextLabel bindThenRebind(List<SelectChoice> items) {
+    private AudioVideoImageTextLabel bindThenRebind(SelectChoice firstChoice, SelectChoice secondChoice) {
         SelectOneListAdapter adapter = new SelectOneListAdapter(null, null, activityController.get(),
-                items, formEntryPrompt, referenceManager, new FakeAudioPlayer(), 0, 1, false, mediaUtils);
+                asList(firstChoice, secondChoice), formEntryPrompt, referenceManager, new FakeAudioPlayer(), 0, 1, false, mediaUtils);
         initRecyclerView(adapter, false);
 
         RecyclerView.Adapter recyclerViewAdapter = adapter;

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -505,6 +505,27 @@ public class ChoicesRecyclerViewTest {
         assertThat(view.getImageView().getVisibility(), is(View.GONE));
     }
 
+    @Test
+    public void whenAChoiceWithoutAnImageReusesAView_shouldTheMissingImageMessageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+        String missingImageURI = "jr://images/missing.jpg";
+        List<SelectChoice> items = getTestChoices();
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(items)
+                .withSpecialFormSelectChoiceText(asList(
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, missingImageURI),
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, null)
+                ))
+                .build();
+
+        Reference reference = mock(Reference.class);
+        when(reference.getLocalURI()).thenReturn(new File(TempFiles.createTempDir(), "missing.jpg").getAbsolutePath());
+        when(referenceManager.deriveReference(missingImageURI)).thenReturn(reference);
+
+        AudioVideoImageTextLabel view = bindThenRebind(items);
+
+        assertThat(view.getMissingImage().getVisibility(), is(View.GONE));
+    }
+
     /**
      * Binds a view holder to one choice and then rebinds the same view to another, which is what the
      * list does to a view that gets recycled while scrolling.

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -21,8 +21,10 @@ import android.widget.FrameLayout;
 import android.widget.RadioButton;
 import android.widget.TextView;
 
+import androidx.core.util.Pair;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.google.android.flexbox.FlexboxLayoutManager;
@@ -32,6 +34,7 @@ import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,6 +51,7 @@ import org.odk.collect.android.support.WidgetTestActivity;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.imageloader.ImageLoader;
+import org.odk.collect.shared.TempFiles;
 import org.odk.collect.testshared.RobolectricHelpers;
 import org.robolectric.android.controller.ActivityController;
 
@@ -478,6 +482,44 @@ public class ChoicesRecyclerViewTest {
         assertThat(getAudioVideoImageTextLabelView(0).getImageView().getVisibility(), is(View.GONE));
         assertThat(getAudioVideoImageTextLabelView(0).getVideoButton().getVisibility(), is(View.GONE));
         assertThat(getAudioVideoImageTextLabelView(0).getAudioButton().getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenAChoiceWithoutAnImageReusesAView_shouldTheImageOfThePreviousChoiceBeHidden() throws InvalidReferenceException {
+        String imageURI = "jr://images/present.jpg";
+        List<SelectChoice> items = getTestChoices();
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(items)
+                .withSpecialFormSelectChoiceText(asList(
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, imageURI),
+                        Pair.create(FormEntryCaption.TEXT_FORM_IMAGE, null)
+                ))
+                .build();
+
+        Reference reference = mock(Reference.class);
+        when(reference.getLocalURI()).thenReturn(TempFiles.createTempFile(".jpg").getAbsolutePath());
+        when(referenceManager.deriveReference(imageURI)).thenReturn(reference);
+
+        AudioVideoImageTextLabel view = bindThenRebind(items);
+
+        assertThat(view.getImageView().getVisibility(), is(View.GONE));
+    }
+
+    /**
+     * Binds a view holder to one choice and then rebinds the same view to another, which is what the
+     * list does to a view that gets recycled while scrolling.
+     */
+    private AudioVideoImageTextLabel bindThenRebind(List<SelectChoice> items) {
+        SelectOneListAdapter adapter = new SelectOneListAdapter(null, null, activityController.get(),
+                items, formEntryPrompt, referenceManager, null, 0, 1, false, mock(MediaUtils.class));
+        initRecyclerView(adapter, false);
+
+        RecyclerView.Adapter recyclerViewAdapter = adapter;
+        RecyclerView.ViewHolder holder = recyclerViewAdapter.createViewHolder(recyclerView, recyclerViewAdapter.getItemViewType(0));
+        recyclerViewAdapter.bindViewHolder(holder, 0);
+        recyclerViewAdapter.bindViewHolder(holder, 1);
+
+        return (AudioVideoImageTextLabel) holder.itemView;
     }
 
     private void setUpReferenceManager() throws InvalidReferenceException {

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeAudioPlayer.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeAudioPlayer.kt
@@ -53,7 +53,7 @@ class FakeAudioPlayer : AudioPlayer {
         }
     }
 
-    fun isListeningTo(clipID: String): Boolean {
+    fun isBeingObserved(clipID: String): Boolean {
         return playingChangedListeners.containsKey(clipID)
     }
 

--- a/test-shared/src/main/java/org/odk/collect/testshared/FakeAudioPlayer.kt
+++ b/test-shared/src/main/java/org/odk/collect/testshared/FakeAudioPlayer.kt
@@ -4,6 +4,7 @@ import androidx.activity.ComponentActivity
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import org.odk.collect.async.Cancellable
 import org.odk.collect.audioclips.AudioPlayer
 import org.odk.collect.audioclips.AudioPlayerFactory
 import org.odk.collect.audioclips.Clip
@@ -42,8 +43,18 @@ class FakeAudioPlayer : AudioPlayer {
         positionChangedListeners[clipId]!!.accept(position)
     }
 
-    override fun onPlayingChanged(clipID: String, playingConsumer: Consumer<Boolean>) {
+    override fun onPlayingChanged(clipID: String, playingConsumer: Consumer<Boolean>): Cancellable {
         playingChangedListeners[clipID] = playingConsumer
+
+        return object : Cancellable {
+            override fun cancel(): Boolean {
+                return playingChangedListeners.remove(clipID) != null
+            }
+        }
+    }
+
+    fun isListeningTo(clipID: String): Boolean {
+        return playingChangedListeners.containsKey(clipID)
     }
 
     override fun onPositionChanged(clipID: String, positionConsumer: Consumer<Int>) {


### PR DESCRIPTION
Closes #7393 

#### Why is this the best possible solution? Were any other approaches considered?
Every media element in a choice row is now set explicitly on each bind. The setters take a nullable value and handle both the "show" and the "hide" case, so a reused row always reflects the choice it currently shows.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test lists carefully. Every row should now show only its own image, error message and media buttons, however much the list is scrolled. `AudioVideoImageTextLabel`, the view being fixed here, is used not only for choices in a list but also for question labels, which can contain media as well, so those need to be covered by regression testing too.  Please also test playing audio and video to make sure the correct media files are started.                                               
                                                                                                                                               
#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
