### PR TITLE
Fix error in select multiples that use search()

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
@@ -91,9 +91,7 @@ class ExternalSelectsTest {
             // Start a new form to verify that the answers from the previous one are retained
             .startBlankForm("Search with last-saved")
             .clickGoToArrow()
-            .assertText("Select fruit")
             .assertAnswer("Mango")
-            .assertText("Select numbers")
             .assertAnswer("One, Two")
 
             // Change the answers in a field-list and verify no errors occur
@@ -101,9 +99,7 @@ class ExternalSelectsTest {
             .clickOnText("Strawberries")
             .clickOnText("Three")
             .clickGoToArrow()
-            .assertText("Select fruit")
             .assertAnswer("Strawberries")
-            .assertText("Select numbers")
             .assertAnswer("One, Two, Three")
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
@@ -76,27 +76,34 @@ class ExternalSelectsTest {
             .assertText("File: $formsDirPath/dynamic_and_static_choices-media/numbers.csv is missing.")
     }
 
-    @Test // https://github.com/getodk/collect/issues/6801
+    @Test // https://github.com/getodk/collect/issues/6801 and https://github.com/getodk/collect/issues/7387
     fun searchFunctionWorksWellWithLastSaved() {
         rule.startAtMainMenu()
             // Fill out and finalize a form so that there is a last-saved instance
-            .copyForm("search-with-last-saved.xml", listOf("fruits.csv"))
+            .copyForm("search-with-last-saved.xml", listOf("fruits.csv", "external_data.csv"))
             .startBlankForm("Search with last-saved")
             .clickOnText("Mango")
+            .clickOnText("One")
+            .clickOnText("Two")
             .swipeToEndScreen()
             .clickFinalize()
 
-            // Start a new form to verify that the answer from the previous one is retained
+            // Start a new form to verify that the answers from the previous one are retained
             .startBlankForm("Search with last-saved")
             .clickGoToArrow()
             .assertText("Select fruit")
             .assertAnswer("Mango")
+            .assertText("Select numbers")
+            .assertAnswer("One, Two")
 
-            // Change the answer in a field-list and verify no errors occur
+            // Change the answers in a field-list and verify no errors occur
             .clickOnQuestion("Select fruit")
             .clickOnText("Strawberries")
+            .clickOnText("Three")
             .clickGoToArrow()
             .assertText("Select fruit")
             .assertAnswer("Strawberries")
+            .assertText("Select numbers")
+            .assertAnswer("One, Two, Three")
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalSelectsTest.kt
@@ -79,31 +79,24 @@ class ExternalSelectsTest {
     @Test // https://github.com/getodk/collect/issues/6801
     fun searchFunctionWorksWellWithLastSaved() {
         rule.startAtMainMenu()
-            // Fill out and finalize the first form
+            // Fill out and finalize a form so that there is a last-saved instance
             .copyForm("search-with-last-saved.xml", listOf("fruits.csv"))
             .startBlankForm("Search with last-saved")
             .clickOnText("Mango")
-            .swipeToNextQuestion("Select fruit 2")
-            .clickOnText("Oranges")
             .swipeToEndScreen()
             .clickFinalize()
 
-            // Start a new form to verify that answers from the previous form are retained
+            // Start a new form to verify that the answer from the previous one is retained
             .startBlankForm("Search with last-saved")
-            .swipeToNextQuestion("Select fruit 2")
             .clickGoToArrow()
-            .assertText("Select fruit 1")
+            .assertText("Select fruit")
             .assertAnswer("Mango")
-            .assertText("Select fruit 2")
-            .assertAnswer("Oranges")
 
-            // Change an answer in a field-list and verify no errors occur
-            .clickOnQuestion("Select fruit 2")
+            // Change the answer in a field-list and verify no errors occur
+            .clickOnQuestion("Select fruit")
             .clickOnText("Strawberries")
             .clickGoToArrow()
-            .assertText("Select fruit 1")
-            .assertAnswer("Mango")
-            .assertText("Select fruit 2")
+            .assertText("Select fruit")
             .assertAnswer("Strawberries")
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dynamicpreload/ExternalDataUtil.java
@@ -23,6 +23,8 @@ import android.widget.Toast;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.MultipleItemsData;
+import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.form.api.FormEntryCaption;
@@ -40,6 +42,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -168,11 +171,7 @@ public final class ExternalDataUtil {
     public static ArrayList<SelectChoice> populateExternalChoices(FormEntryPrompt formEntryPrompt,
             XPathFuncExpr xpathfuncexpr, FormController formController) throws FileNotFoundException {
         try {
-            IAnswerData selectedValue = formEntryPrompt.getAnswerValue();
-            Selection selection = null;
-            if (selectedValue != null) {
-                selection = (Selection) selectedValue.getValue();
-            }
+            List<Selection> selections = getSelections(formEntryPrompt.getAnswerValue());
             List<SelectChoice> selectChoices = formEntryPrompt.getSelectChoices();
             if (!containsConfigurationChoice(selectChoices)) {
                 String filePath = getFilePath(xpathfuncexpr, formController);
@@ -183,7 +182,7 @@ public final class ExternalDataUtil {
                 String value = selectChoice.getValue();
                 if (isAnInteger(value)) {
                     // treat this as a static choice
-                    attachChoiceToSelectionIfMatch(selection, selectChoice);
+                    attachChoiceToSelectionIfMatch(selections, selectChoice);
                     returnedChoices.add(selectChoice);
                 } else {
                     String displayColumns = formEntryPrompt.getSelectChoiceText(selectChoice);
@@ -213,7 +212,7 @@ public final class ExternalDataUtil {
                         @SuppressWarnings("unchecked")
                         List<SelectChoice> dynamicChoices = (ArrayList<SelectChoice>) eval;
                         for (SelectChoice dynamicChoice : dynamicChoices) {
-                            attachChoiceToSelectionIfMatch(selection, dynamicChoice);
+                            attachChoiceToSelectionIfMatch(selections, dynamicChoice);
                             returnedChoices.add(dynamicChoice);
                         }
                     } else {
@@ -234,13 +233,21 @@ public final class ExternalDataUtil {
         }
     }
 
-    private static void attachChoiceToSelectionIfMatch(Selection selection, SelectChoice selectChoice) {
-        if (selection == null || selection.index != -1) {
-            return;
+    private static List<Selection> getSelections(IAnswerData answer) {
+        if (answer instanceof SelectOneData) {
+            return Collections.singletonList((Selection) answer.getValue());
+        } else if (answer instanceof MultipleItemsData) {
+            return (List<Selection>) answer.getValue();
+        } else {
+            return Collections.emptyList();
         }
+    }
 
-        if (selection.getValue().equals(selectChoice.getValue())) {
-            selection.attachChoice(selectChoice);
+    private static void attachChoiceToSelectionIfMatch(List<Selection> selections, SelectChoice selectChoice) {
+        for (Selection selection : selections) {
+            if (selection.index == -1 && selection.getValue().equals(selectChoice.getValue())) {
+                selection.attachChoice(selectChoice);
+            }
         }
     }
 

--- a/test-forms/src/main/resources/forms/search-with-last-saved.xml
+++ b/test-forms/src/main/resources/forms/search-with-last-saved.xml
@@ -14,6 +14,7 @@
                 <data id="search-with-last-saved">
                     <group>
                         <fruit/>
+                        <number/>
                     </group>
                     <meta>
                         <instanceID/>
@@ -23,6 +24,8 @@
             <instance id="__last-saved" src="jr://instance/last-saved"/>
             <bind nodeset="/data/group/fruit" type="string"/>
             <setvalue ref="/data/group/fruit" value=" instance('__last-saved')/data/group/fruit " event="odk-instance-first-load"/>
+            <bind nodeset="/data/group/number" type="string"/>
+            <setvalue ref="/data/group/number" value=" instance('__last-saved')/data/group/number " event="odk-instance-first-load"/>
             <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
         </model>
     </h:head>
@@ -35,6 +38,13 @@
                     <value>name_key</value>
                 </item>
             </select1>
+            <select ref="/data/group/number" appearance="search('external_data')">
+                <label>Select numbers</label>
+                <item>
+                    <label>label</label>
+                    <value>name</value>
+                </item>
+            </select>
         </group>
     </h:body>
 </h:html>

--- a/test-forms/src/main/resources/forms/search-with-last-saved.xml
+++ b/test-forms/src/main/resources/forms/search-with-last-saved.xml
@@ -12,10 +12,8 @@
         <model odk:xforms-version="1.0.0">
             <instance>
                 <data id="search-with-last-saved">
-                    <fruit/>
                     <group>
-                        <fruit2/>
-                        <details/>
+                        <fruit/>
                     </group>
                     <meta>
                         <instanceID/>
@@ -23,33 +21,20 @@
                 </data>
             </instance>
             <instance id="__last-saved" src="jr://instance/last-saved"/>
-            <bind nodeset="/data/fruit" type="string"/>
-            <setvalue ref="/data/fruit" value=" instance('__last-saved')/data/fruit " event="odk-instance-first-load"/>
-            <bind nodeset="/data/group/fruit2" type="string"/>
-            <setvalue ref="/data/group/fruit2" value=" instance('__last-saved')/data/group/fruit2 " event="odk-instance-first-load"/>
-            <bind nodeset="/data/group/details" type="string"/>
+            <bind nodeset="/data/group/fruit" type="string"/>
+            <setvalue ref="/data/group/fruit" value=" instance('__last-saved')/data/group/fruit " event="odk-instance-first-load"/>
             <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
         </model>
     </h:head>
     <h:body>
-        <select1 ref="/data/fruit" appearance="search('fruits')">
-            <label>Select fruit 1</label>
-            <item>
-                <label>name</label>
-                <value>name_key</value>
-            </item>
-        </select1>
         <group appearance="field-list" ref="/data/group">
-            <select1 ref="/data/group/fruit2" appearance="search('fruits')">
-                <label>Select fruit 2</label>
+            <select1 ref="/data/group/fruit" appearance="search('fruits')">
+                <label>Select fruit</label>
                 <item>
                     <label>name</label>
                     <value>name_key</value>
                 </item>
             </select1>
-            <input ref="/data/group/details">
-                <label>Fruit details</label>
-            </input>
         </group>
     </h:body>
 </h:html>


### PR DESCRIPTION
Closes #7387 

#### Why is this the best possible solution? Were any other approaches considered?
`populateExternalChoices` assumed the answer was always a single `Selection`, which is only true for select one, but `search()` works with `select_multiple` as well, where the answer is a `List<Selection>`. That unconditional cast was the crash. Now the code handles both shapes, so the `attachChoice` mechanism from #6802 applies to all of them.  

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Both types of selects (one and multiple) should work well now with `last-saved` and `search()`. Regression risk is low and confined to those question types.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] added or modified tests for any new or changed behavior
- [x] run `./gradlew connectedAndroidTest` (or `./gradlew testLab`) and confirmed all checks still pass
- [x] added a comment above any new strings describing it for translators
- [x] added any new strings with date formatting to `DateFormatsTest`
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
